### PR TITLE
Ability to create and delete dummy mines

### DIFF
--- a/python-backend/app/__init__.py
+++ b/python-backend/app/__init__.py
@@ -1,11 +1,17 @@
+from datetime import datetime
 import sys
+import uuid
 
+import click
 from flask import Flask
 from flask_cors import CORS
 from flask_restplus import Api
+from .mines.models.mines import MineIdentity, MineDetail
+from .mines.models.location import MineLocation
 from .mines.resources.mine import Mine, MineList, MineListByName
 from .mines.resources.person import ManagerResource, PersonResource, PersonList
 from .mines.resources.location import MineLocationResource, MineLocationListResource
+from .mines.utils.random import generate_mine_no, generate_name, random_geo
 from .config import Config
 
 from .extensions import db, jwt
@@ -25,7 +31,7 @@ def create_app(test_config=None):
 
     register_extensions(app)
     register_routes(app, api)
-
+    register_commands(app)
     return app
 
 
@@ -61,3 +67,40 @@ def register_routes(app, api):
     def default_error_handler(error):
         _, value, traceback = sys.exc_info()
         raise value(None).with_traceback(traceback)
+
+
+def register_commands(app):
+    # in terminal you can run $flask <cmd> <arg>
+    @app.cli.command()
+    @click.argument('num')
+    def create_data(num):
+        DUMMY_USER_KWARGS = {'create_user': 'DummyUser', 'update_user': 'DummyUser'}
+        for i in range(int(num)):
+            random_location = random_geo()
+            mine_identity = MineIdentity(mine_guid=uuid.uuid4(), **DUMMY_USER_KWARGS)
+            mine_detail = MineDetail(
+                mine_detail_guid=uuid.uuid4(),
+                mine_guid=mine_identity.mine_guid,
+                mine_no=generate_mine_no(),
+                mine_name=generate_name(),
+                **DUMMY_USER_KWARGS
+            )
+            mine_location = MineLocation(
+                mine_location_guid=uuid.uuid4(),
+                mine_guid=mine_identity.mine_guid,
+                latitude=random_location.get('latitude', 0),
+                longitude=random_location.get('longitude', 0),
+                effective_date=datetime.today(),
+                expiry_date=datetime.today(),
+                **DUMMY_USER_KWARGS,
+            )
+            mine_identity.save()
+            mine_detail.save()
+            mine_location.save()
+
+    @app.cli.command()
+    def delete_data():
+        meta = db.metadata
+        for table in reversed(meta.sorted_tables):
+            db.session.execute(table.delete())
+        db.session.commit()

--- a/python-backend/app/mines/resources/mine.py
+++ b/python-backend/app/mines/resources/mine.py
@@ -33,6 +33,7 @@ class Mine(Resource):
         name = data['name']
         lat = data['latitude']
         lon = data['longitude']
+        location = None
         if not name:
             return {'error': 'Must specify a name.'}, 400
         if len(name) > 60:

--- a/python-backend/app/mines/utils/random.py
+++ b/python-backend/app/mines/utils/random.py
@@ -1,7 +1,17 @@
+import math
 import random
 import string
 
 from ..models.mines import MineDetail
+
+VOWELS = "aeiou"
+CONSONANTS = "".join(set(string.ascii_lowercase) - set(VOWELS))
+RANDOM_CENTERS = [
+    {'latitude': 51.283958, 'longitude': -120.608253, 'radius_in_m': 221000},
+    {'latitude': 54.124806, 'longitude': -124.155545, 'radius_in_m': 221000},
+    {'latitude': 57.810546, 'longitude': -128.198514, 'radius_in_m': 221000},
+    {'latitude': 57.810546, 'longitude': -123.891873, 'radius_in_m': 221000}
+]
 
 
 def random_key_gen(prefix='', key_length=10, numbers=True, letters=True):
@@ -18,3 +28,36 @@ def generate_mine_no():
     while MineDetail.find_by_mine_no(mine_no):
         mine_no = random_key_gen(prefix='BLAH', key_length=4, letters=False)
     return mine_no
+
+
+def generate_name():
+    names = []
+    for i in range(random.randint(1, 2)):
+        word = ""
+        for j in range(random.randint(3, 11)):
+            if j % 2 == 0:
+                word += random.choice(CONSONANTS)
+            else:
+                word += random.choice(VOWELS)
+        names.append(word.capitalize())
+    return ' '.join(names)
+
+
+def random_geo():
+    random_center = random.choice(RANDOM_CENTERS)
+    y0 = random_center.get('latitude')
+    x0 = random_center.get('longitude')
+    rd = random_center.get('radius_in_m') / 111300
+
+    u = random.random()
+    v = random.random()
+
+    w = rd * math.sqrt(u)
+    t = 2 * math.pi * v
+    x = w * math.cos(t)
+    y = w * math.sin(t)
+
+    return {
+        'latitude': y + y0,
+        'longitude': x + x0
+    }

--- a/python-backend/tests/auth/test_mines_auth.py
+++ b/python-backend/tests/auth/test_mines_auth.py
@@ -53,8 +53,8 @@ def test_get_mine_full_auth(test_client, auth_headers):
 def test_post_mine_no_auth(test_client):
     test_mine_data = {
         "name": "test_create_mine",
-        "latitude": "123.123",
-        "longitude": "49.49"
+        "latitude": "49.49",
+        "longitude": "123.124"
     }
     post_resp = test_client.post('/mine', data=test_mine_data, headers={})
     assert post_resp.status_code == 401
@@ -63,8 +63,8 @@ def test_post_mine_no_auth(test_client):
 def test_post_mine_view_only(test_client, auth_headers):
     test_mine_data = {
         "name": "test_create_mine",
-        "latitude": "123.123",
-        "longitude": "49.49"
+        "latitude": "49.49",
+        "longitude": "123.124"
     }
     post_resp = test_client.post('/mine', data=test_mine_data, headers=auth_headers['view_only_auth_header'])
     assert post_resp.status_code == 401
@@ -73,8 +73,8 @@ def test_post_mine_view_only(test_client, auth_headers):
 def test_post_mine_full_auth(test_client, auth_headers):
     test_mine_data = {
         "name": "test_create_mine",
-        "latitude": "123.123",
-        "longitude": "49.49"
+        "latitude": "49.49",
+        "longitude": "123.124"
     }
     post_resp = test_client.post('/mine', data=test_mine_data, headers=auth_headers['full_auth_header'])
     assert post_resp.status_code == 200
@@ -84,8 +84,8 @@ def test_post_mine_full_auth(test_client, auth_headers):
 def test_put_mine_no_auth(test_client):
     test_tenure_data = {
         "tenure_number_id": "1234568",
-        "latitude": "123.124",
-        "longitude": "49.478"
+        "latitude": "49.49",
+        "longitude": "123.123"
     }
     put_resp = test_client.put('/mine/' + TEST_MINE_NO, data=test_tenure_data, headers={})
     assert put_resp.status_code == 401
@@ -94,8 +94,8 @@ def test_put_mine_no_auth(test_client):
 def test_put_mine_view_only(test_client, auth_headers):
     test_tenure_data = {
         "tenure_number_id": "1234568",
-        "latitude": "123.124",
-        "longitude": "49.478"
+        "latitude": "49.49",
+        "longitude": "123.123"
     }
     put_resp = test_client.put('/mine/' + TEST_MINE_NO, data=test_tenure_data, headers=auth_headers['view_only_auth_header'])
     assert put_resp.status_code == 401
@@ -104,8 +104,8 @@ def test_put_mine_view_only(test_client, auth_headers):
 def test_put_mine_full_auth(test_client, auth_headers):
     test_tenure_data = {
         "tenure_number_id": "1234568",
-        "latitude": "123.124",
-        "longitude": "49.478"
+        "latitude": "49.49",
+        "longitude": "123.125"
     }
     put_resp = test_client.put('/mine/' + TEST_MINE_NO, data=test_tenure_data, headers=auth_headers['full_auth_header'])
     assert put_resp.status_code == 200

--- a/python-backend/tests/mines/resources/test_mine_resource.py
+++ b/python-backend/tests/mines/resources/test_mine_resource.py
@@ -53,6 +53,16 @@ def test_post_mine_guid(test_client, auth_headers):
     assert post_resp.status_code == 400
 
 
+def test_post_mine_name_only_success(test_client, auth_headers):
+    test_mine_data = {
+        "name": "test_create_mine2",
+    }
+    post_resp = test_client.post('/mine', data=test_mine_data, headers=auth_headers['full_auth_header'])
+    post_data = json.loads(post_resp.data.decode())
+    assert post_data['mine_name'] == test_mine_data['name']
+    assert post_resp.status_code == 200
+
+
 def test_post_mine_success(test_client, auth_headers):
     test_mine_data = {
         "name": "test_create_mine",

--- a/python-backend/tests/mines/utils/test_utils_random.py
+++ b/python-backend/tests/mines/utils/test_utils_random.py
@@ -1,0 +1,28 @@
+from app.mines.utils.random import random_key_gen, generate_mine_no, generate_name, random_geo
+
+
+def test_utils_random_key_gen():
+    random_key = random_key_gen(prefix='BLAH', key_length=4)
+    assert 'BLAH' in random_key
+    assert len(random_key) == 8
+
+
+def test_generate_mine_no(test_client):
+    random_mine_no = generate_mine_no()
+    assert 'BLAH' in random_mine_no
+    assert len(random_mine_no) == 8
+
+
+def test_generate_name():
+    random_name = generate_name()
+    name_list = random_name.split()
+    name_list_length = len(name_list)
+    assert name_list_length < 3 and name_list_length > 0
+
+
+def test_random_geo():
+    random_location = random_geo()
+    latitude = random_location.get('latitude')
+    longitude = random_location.get('longitude')
+    assert latitude is not None
+    assert longitude is not None


### PR DESCRIPTION
Added ability to create mine and delete mine through flask management.
Inside the container running flask, you can run `flask create_data <number_of_mines_to_create>`
also can run `flask delete_data` and will delete all data.

Also added a fix where the POST of mine without location data, saved correctly to db, but throws an error due to a variable not declared before use.