### PR TITLE
Added the ability to update mine_details

### DIFF
--- a/python-backend/app/api/mine/models/mines.py
+++ b/python-backend/app/api/mine/models/mines.py
@@ -77,7 +77,7 @@ class MineDetail(AuditMixin, Base):
     __tablename__ = "mine_detail"
     mine_detail_guid = db.Column(UUID(as_uuid=True), primary_key=True)
     mine_guid = db.Column(UUID(as_uuid=True), db.ForeignKey('mine_identity.mine_guid'))
-    mine_no = db.Column(db.String(10), unique=True)
+    mine_no = db.Column(db.String(10))
     mine_name = db.Column(db.String(60), nullable=False)
     mine_note = db.Column(db.String(300), default='')
 

--- a/python-backend/app/api/mine/resources/mine.py
+++ b/python-backend/app/api/mine/resources/mine.py
@@ -90,7 +90,9 @@ class Mine(Resource, UserMixin):
         tenure = data['tenure_number_id']
         lat = data['latitude']
         lon = data['longitude']
-        if not tenure and not (lat and lon):
+        mine_name = data['name']
+        mine_note = data['note']
+        if not tenure and not (lat and lon) and not mine_name and not mine_note:
             return {
                 'error': {
                     'status': 400,
@@ -105,6 +107,30 @@ class Mine(Resource, UserMixin):
                     'message': 'Mine not found'
                 }
             }, 404
+        # Mine Detail
+        if mine_name or mine_note:
+            mine_detail = mine.mine_detail[0]
+            try:
+                new_mine_detail = MineDetail(
+                    mine_detail_guid=uuid.uuid4(),
+                    mine_guid=mine.mine_guid,
+                    mine_no=mine_detail.mine_no,
+                    mine_name=mine_detail.mine_name,
+                    mine_note=mine_detail.mine_note,
+                    **self.get_create_update_dict()
+                )
+                if mine_name:
+                    new_mine_detail.mine_name = mine_name
+                if mine_note:
+                    new_mine_detail.mine_note = mine_note
+            except AssertionError as e:
+                return {
+                    'error': {
+                        'status': 400,
+                        'message': 'Error: {}'.format(e)
+                    }
+                }, 400
+            new_mine_detail.save()
         # Tenure validation
         if tenure:
             tenure_exists = MineralTenureXref.find_by_tenure(tenure)

--- a/python-backend/tests/mines/resources/test_mine_resource.py
+++ b/python-backend/tests/mines/resources/test_mine_resource.py
@@ -212,3 +212,23 @@ def test_put_mine_tenure_guid(test_client, auth_headers):
     put_data = json.loads(put_resp.data.decode())
     assert test_tenure_data['tenure_number_id'] in [x['tenure_number_id'] for x in put_data['mineral_tenure_xref']]
     assert put_resp.status_code == 200
+
+
+def test_put_mine_name(test_client, auth_headers):
+    test_tenure_data = {
+        "name": "name"
+    }
+    put_resp = test_client.put('/mine/' + TEST_MINE_GUID, data=test_tenure_data, headers=auth_headers['full_auth_header'])
+    put_data = json.loads(put_resp.data.decode())
+    assert test_tenure_data['name'] in [x['mine_name'] for x in put_data['mine_detail']]
+    assert put_resp.status_code == 200
+
+
+def test_put_mine_note(test_client, auth_headers):
+    test_tenure_data = {
+        "note": "new_note"
+    }
+    put_resp = test_client.put('/mine/' + TEST_MINE_GUID, data=test_tenure_data, headers=auth_headers['full_auth_header'])
+    put_data = json.loads(put_resp.data.decode())
+    assert test_tenure_data['note'] in [x['mine_note'] for x in put_data['mine_detail']]
+    assert put_resp.status_code == 200


### PR DESCRIPTION
    Added the ability to update mine_details
    This is required as some tombstone data needs to be updated.
    I had to remove the unique trait of mine_no as updating mine_details
    merely creates a new mine_detail with the changes and the mine_identity
    uses the latest updated mine_detail.
