### PR TITLE
Added the ablity to search for multiple names in the party name search.

### DIFF
--- a/python-backend/app/api/party/models/party.py
+++ b/python-backend/app/api/party/models/party.py
@@ -108,7 +108,7 @@ class PartyTypeCode(AuditMixin, Base):
     display_order = db.Column(db.Integer, nullable=False)
 
     def __repr__(self):
-        return '<Permit %r>' % self.permit_guid
+        return '<Permit %r>' % self.party_type_code
 
     def json(self):
         return {


### PR DESCRIPTION
The issue was that the query searched for first name and party name separately.
So if a person searched a Bob Smith, it would look for a Bob Smith as a first name
and Bob Smith as a party name and return no results.

To solve this, I split the incoming search string into separate word and search
for each word individually. So Bob and Smith would be searched in the first_name
and party_name.