### PR TITLE
Add permit no as a search filter in mine search.

### DIFF
--- a/python-backend/app/api/mine/models/mines.py
+++ b/python-backend/app/api/mine/models/mines.py
@@ -54,6 +54,12 @@ class MineIdentity(AuditMixin, Base):
             'longitude': str(mine_location.longitude) if mine_location else ''
         }
 
+    def json_by_permit(self):
+        return {
+            'guid': str(self.mine_guid),
+            'mine_permit': [item.json() for item in self.mine_permit]
+        }
+
     @classmethod
     def find_by_mine_guid(cls, _id):
         try:

--- a/python-backend/app/api/mine/resources/mine.py
+++ b/python-backend/app/api/mine/resources/mine.py
@@ -6,6 +6,7 @@ from flask_restplus import Resource, reqparse
 
 from ...status.models.status import MineStatus, MineStatusXref
 from ..models.mines import MineIdentity, MineDetail, MineralTenureXref
+from ...permit.models.permit import Permit
 from ...location.models.location import MineLocation
 from ...utils.random import generate_mine_no
 from app.extensions import jwt
@@ -196,7 +197,8 @@ class MineListByName(Resource):
         if search_term:
             name_filter = MineDetail.mine_name.ilike('%{}%'.format(search_term))
             number_filter = MineDetail.mine_no.ilike('%{}%'.format(search_term))
-            mines = MineIdentity.query.join(MineDetail).filter(name_filter | number_filter).limit(self.MINE_LIST_RESULT_LIMIT).all()
+            permit_filter = Permit.permit_no.ilike('%{}%'.format(search_term))
+            mines = MineIdentity.query.join(MineDetail).filter(name_filter | number_filter | permit_filter).limit(self.MINE_LIST_RESULT_LIMIT).all()
         else:
             mines = MineIdentity.query.limit(self.MINE_LIST_RESULT_LIMIT).all()
 

--- a/python-backend/tests/mines/resources/test_mine_list_by_name_resource.py
+++ b/python-backend/tests/mines/resources/test_mine_list_by_name_resource.py
@@ -28,3 +28,17 @@ def test_get_mines_by_list_search(test_client, auth_headers):
     }
     assert get_resp.status_code == 200
     assert get_data['mines'][0] == context
+
+
+def test_get_mines_by_list_search_by_permit_no(test_client, auth_headers):
+    get_resp = test_client.get('/mines/names?search=TEST56789012', headers=auth_headers['full_auth_header'])
+    get_data = json.loads(get_resp.data.decode())
+    context = {
+        'guid': TEST_MINE_GUID,
+        'mine_name': TEST_MINE_NAME,
+        'mine_no': TEST_MINE_NO,
+        'latitude': TEST_LAT_1,
+        'longitude': TEST_LONG_1
+    }
+    assert get_resp.status_code == 200
+    assert get_data['mines'][0] == context


### PR DESCRIPTION
Added the permit no in the mine list search filter.
The new updated search now will search all strings looking
into mine no, mine name, and now permit no. A test has been added
to search by permit no and verifying that the correct mine is returned.