### PR TITLE
Fix/party search limit

### DIFF
--- a/frontend/src/components/common/RenderLargeSelect.js
+++ b/frontend/src/components/common/RenderLargeSelect.js
@@ -50,7 +50,6 @@ const RenderLargeSelect = ({
         id={id} 
         defaultActiveFirstOption={false}
         notFoundContent={'Not Found'}
-        allowClear
         dropdownMatchSelectWidth={true}
         backfill={true}
         style={{ width: '100%' }}

--- a/python-backend/app/api/parties/party/models/party.py
+++ b/python-backend/app/api/parties/party/models/party.py
@@ -80,12 +80,12 @@ class Party(AuditMixin, Base):
         return cls.query.filter(func.lower(cls.first_name) == func.lower(first_name), func.lower(cls.party_name) == func.lower(party_name), cls.party_type_code == PARTY_STATUS_CODE['per']).first()
 
     @classmethod
-    def search_by_name(cls, search_term, party_type=None):
+    def search_by_name(cls, search_term, party_type=None, query_limit=50):
         _filter_by_name = func.upper(cls.name).contains(func.upper(search_term))
         if party_type:
-            return cls.query.filter(cls.party_type_code==party_type).filter(_filter_by_name)
+            return cls.query.filter(cls.party_type_code==party_type).filter(_filter_by_name).limit(query_limit)
         else:
-            return cls.query.filter(_filter_by_name)
+            return cls.query.filter(_filter_by_name).limit(query_limit)
 
     @classmethod
     def create_party(cls, generated_first_name, generated_last_name, user_kwargs, save=True):

--- a/python-backend/app/api/parties/party/resources/party.py
+++ b/python-backend/app/api/parties/party/resources/party.py
@@ -21,7 +21,7 @@ class PartyResource(Resource, UserMixin, ErrorMixin):
     parser.add_argument('email', type=str, help='The email of the party.')
     parser.add_argument('type', type=str, help='The type of the party. Ex: PER')
 
-    PARTY_LIST_RESULT_LIMIT = 100
+    PARTY_LIST_RESULT_LIMIT = 25
 
     @api.doc(params={
         'party_guid': 'Party guid. If not provided a list of 100 parties will be returned.',
@@ -41,9 +41,9 @@ class PartyResource(Resource, UserMixin, ErrorMixin):
             search_type = request.args.get('type').upper() if request.args.get('type') else None
             if search_term:
                 if search_type in ['PER', 'ORG']:
-                    parties = Party.search_by_name(search_term, search_type)
+                    parties = Party.search_by_name(search_term, search_type, self.PARTY_LIST_RESULT_LIMIT)
                 else:
-                    parties = Party.search_by_name(search_term)
+                    parties = Party.search_by_name(search_term, query_limit=self.PARTY_LIST_RESULT_LIMIT)
             else:
                 parties = Party.query.limit(self.PARTY_LIST_RESULT_LIMIT).all()
             return {'parties': list(map(lambda x: x.json(), parties))}


### PR DESCRIPTION
Add query limit for party search.

During the implementation of a party search fix, the limit
for the query was left out. The limit has been introduced,
and further more reduced from 100 to 25.

Remove allowClear from RenderLargeSelect.js.