### PR TITLE
Refactor FE Reducer Unittests

### DIFF
--- a/frontend/src/tests/reducers/authenticationReducer.spec.js
+++ b/frontend/src/tests/reducers/authenticationReducer.spec.js
@@ -6,57 +6,45 @@ import {
   storeUserAccessData,
 } from "@/actions/authenticationActions";
 
+const baseExpectedValue = {
+  isAuthenticated: false,
+  userAccessData: [],
+  userInfo: {},
+  keycloak: {},
+};
+
+// Creates deep copy of javascript object instead of setting a reference
+const getBaseExpectedValue = () => JSON.parse(JSON.stringify(baseExpectedValue));
+
 describe("authReducer", () => {
   it("receives undefined", () => {
-    const expectedValue = {
-      isAuthenticated: false,
-      userAccessData: [],
-      userInfo: {},
-      keycloak: {},
-    };
+    const expectedValue = getBaseExpectedValue();
     expect(authenticationReducer(undefined, {})).toEqual(expectedValue);
   });
 
   it("receives AUTHENTICATE_USER", () => {
-    const expectedValue = {
-      isAuthenticated: true,
-      userAccessData: [],
-      userInfo: {},
-      keycloak: {},
-    };
+    const expectedValue = getBaseExpectedValue();
+    expectedValue.isAuthenticated = true;
     const result = authenticationReducer(undefined, authenticateUser({}));
     expect(result).toEqual(expectedValue);
   });
 
   it("receives STORE_KEYCLOAK_DATA", () => {
-    const expectedValue = {
-      isAuthenticated: false,
-      userAccessData: [],
-      userInfo: {},
-      keycloak: { test: "test" },
-    };
+    const expectedValue = getBaseExpectedValue();
+    expectedValue.keycloak = { test: "test" };
     const result = authenticationReducer(undefined, storeKeycloakData({ test: "test" }));
     expect(result).toEqual(expectedValue);
   });
 
   it("receives STORE_USER_ACCESS_DATA", () => {
-    const expectedValue = {
-      isAuthenticated: false,
-      userAccessData: ["role1", "role2"],
-      userInfo: {},
-      keycloak: {},
-    };
+    const expectedValue = getBaseExpectedValue();
+    expectedValue.userAccessData = ["role1", "role2"];
     const result = authenticationReducer(undefined, storeUserAccessData(["role1", "role2"]));
     expect(result).toEqual(expectedValue);
   });
 
   it("receives LOGOUT", () => {
-    const expectedValue = {
-      isAuthenticated: false,
-      userAccessData: [],
-      userInfo: {},
-      keycloak: {},
-    };
+    const expectedValue = getBaseExpectedValue();
     const result = authenticationReducer(undefined, logoutUser());
     expect(result).toEqual(expectedValue);
   });

--- a/frontend/src/tests/reducers/mineReducer.spec.js
+++ b/frontend/src/tests/reducers/mineReducer.spec.js
@@ -1,32 +1,32 @@
 import mineReducer from "@/reducers/mineReducer";
 import { storeMine, storeMineList, storeMineNameList } from "@/actions/mineActions";
 
+const baseExpectedValue = {
+  mines: {},
+  mineIds: [],
+  mineNameList: [],
+  minesPageData: {},
+  mineGuid: false,
+};
+
+// Creates deep copy of javascript object instead of setting a reference
+const getBaseExpectedValue = () => JSON.parse(JSON.stringify(baseExpectedValue));
+
 describe("mineReducer", () => {
   it("receives undefined", () => {
-    const expectedValue = {
-      mines: {},
-      mineIds: [],
-      mineNameList: [],
-      minesPageData: {},
-      mineGuid: false,
-    };
+    const expectedValue = getBaseExpectedValue();
     const result = mineReducer(undefined, {});
     expect(result).toEqual(expectedValue);
   });
 
   it("receives STORE_MINE_LIST", () => {
-    const expectedValue = {
-      mines: {},
-      mineIds: [],
-      mineNameList: [],
-      minesPageData: {
-        mines: [],
-        current_page: 1,
-        total_pages: 1,
-        items_per_page: 50,
-        total: 1,
-      },
-      mineGuid: false,
+    const expectedValue = getBaseExpectedValue();
+    expectedValue.minesPageData = {
+      mines: [],
+      current_page: 1,
+      total_pages: 1,
+      items_per_page: 50,
+      total: 1,
     };
     const result = mineReducer(
       undefined,
@@ -42,24 +42,18 @@ describe("mineReducer", () => {
   });
 
   it("receives STORE_MINE", () => {
-    const expectedValue = {
-      mines: { test123: { guid: "test123" } },
-      mineIds: ["test123"],
-      mineNameList: [],
-      minesPageData: {},
-      mineGuid: "test123",
-    };
+    const expectedValue = getBaseExpectedValue();
+    expectedValue.mines = { test123: { guid: "test123" } };
+    expectedValue.mineIds = ["test123"];
+    expectedValue.mineGuid = "test123";
     const result = mineReducer(undefined, storeMine({ guid: "test123" }, "test123"));
     expect(result).toEqual(expectedValue);
   });
 
   it("receives STORE_MINE_NAME_LIST", () => {
-    const expectedValue = {
-      mines: {},
-      mineIds: [],
-      mineNameList: { mines: [{ guid: "test123", mine_name: "mineName", mine_no: "2039" }] },
-      minesPageData: {},
-      mineGuid: false,
+    const expectedValue = getBaseExpectedValue();
+    expectedValue.mineNameList = {
+      mines: [{ guid: "test123", mine_name: "mineName", mine_no: "2039" }],
     };
     const result = mineReducer(
       undefined,

--- a/frontend/src/tests/reducers/networkReducer.spec.js
+++ b/frontend/src/tests/reducers/networkReducer.spec.js
@@ -1,50 +1,46 @@
 import networkReducer from "@/reducers/networkReducer";
 import { request, success, error } from "@/actions/genericActions";
 
+const baseExpectedValue = {
+  isFetching: false,
+  isSuccessful: false,
+  error: null,
+  requestType: null,
+};
+
+// Creates deep copy of javascript object instead of setting a reference
+const getBaseExpectedValue = () => JSON.parse(JSON.stringify(baseExpectedValue));
+
 describe("networkReducer", () => {
   it("receives undefined", () => {
-    const expectedValue = {
-      isFetching: false,
-      isSuccessful: false,
-      error: null,
-      requestType: null,
-    };
-
+    const expectedValue = getBaseExpectedValue();
     const result = networkReducer(undefined, {});
     expect(result).toEqual(expectedValue);
   });
 
   it("receives REQUEST", () => {
-    const expectedValue = {
-      isFetching: true,
-      isSuccessful: false,
-      error: null,
-      requestType: "REQUEST",
-    };
+    const expectedValue = getBaseExpectedValue();
+    expectedValue.isFetching = true;
+    expectedValue.requestType = "REQUEST";
 
     const result = networkReducer(undefined, request());
     expect(result).toEqual(expectedValue);
   });
 
   it("receives SUCCESS", () => {
-    const expectedValue = {
-      isFetching: false,
-      isSuccessful: true,
-      error: false,
-      requestType: "SUCCESS",
-    };
+    const expectedValue = getBaseExpectedValue();
+    expectedValue.isSuccessful = true;
+    expectedValue.error = false;
+    expectedValue.requestType = "SUCCESS";
 
     const result = networkReducer(undefined, success());
     expect(result).toEqual(expectedValue);
   });
 
   it("receives ERROR", () => {
-    const expectedValue = {
-      isFetching: false,
-      isSuccessful: false,
-      error: undefined,
-      requestType: "ERROR",
-    };
+    const expectedValue = getBaseExpectedValue();
+    expectedValue.error = undefined;
+    expectedValue.requestType = "ERROR";
 
     const result = networkReducer(undefined, error());
     expect(result).toEqual(expectedValue);

--- a/frontend/src/tests/reducers/partieslReducer.spec.js
+++ b/frontend/src/tests/reducers/partieslReducer.spec.js
@@ -8,16 +8,19 @@ const baseExpectedValue = {
   partyRelationshipTypes: [],
 };
 
+// Creates deep copy of javascript object instead of setting a reference
+const getBaseExpectedValue = () => JSON.parse(JSON.stringify(baseExpectedValue));
+
 describe("partiesReducer", () => {
   it("receives undefined", () => {
-    const expectedValue = baseExpectedValue;
+    const expectedValue = getBaseExpectedValue();
 
     const result = partiesReducer(undefined, {});
     expect(result).toEqual(expectedValue);
   });
 
   it("receives STORE_PARTY", () => {
-    const expectedValue = baseExpectedValue;
+    const expectedValue = getBaseExpectedValue();
     expectedValue.parties = { test123: { party_guid: "test123" } };
     expectedValue.partyIds = ["test123"];
 
@@ -26,7 +29,7 @@ describe("partiesReducer", () => {
   });
 
   it("receives STORE_PARTY", () => {
-    const expectedValue = baseExpectedValue;
+    const expectedValue = getBaseExpectedValue();
     expectedValue.parties = {
       test123: { party_guid: "test123" },
       test456: { party_guid: "test456" },

--- a/frontend/src/tests/reducers/staticContentReducer.spec.js
+++ b/frontend/src/tests/reducers/staticContentReducer.spec.js
@@ -10,59 +10,43 @@ import {
 } from "@/actions/staticContentActions";
 import * as MOCK from "@/tests/mocks/dataMocks";
 
+const baseExpectedValue = {
+  mineStatusOptions: [],
+  mineRegionOptions: [],
+  mineDisturbanceOptions: [],
+  expectedDocumentStatusOptions: [],
+  mineTSFRequiredReports: [],
+  mineTenureTypes: [],
+  mineCommodityOptions: [],
+};
+
+// Creates deep copy of javascript object instead of setting a reference
+const getBaseExpectedValue = () => JSON.parse(JSON.stringify(baseExpectedValue));
+
 describe("staticContentReducer", () => {
   it("receives undefined", () => {
-    const expectedValue = {
-      mineStatusOptions: [],
-      mineRegionOptions: [],
-      mineDisturbanceOptions: [],
-      expectedDocumentStatusOptions: [],
-      mineTSFRequiredReports: [],
-      mineTenureTypes: [],
-      mineCommodityOptions: [],
-    };
+    const expectedValue = getBaseExpectedValue();
     const result = staticContentReducer(undefined, {});
     expect(result).toEqual(expectedValue);
   });
 
   it("receives STORE_STATUS_OPTIONS", () => {
-    const expectedValue = {
-      mineStatusOptions: MOCK.STATUS_OPTIONS.options,
-      mineRegionOptions: [],
-      mineDisturbanceOptions: [],
-      expectedDocumentStatusOptions: [],
-      mineTSFRequiredReports: [],
-      mineTenureTypes: [],
-      mineCommodityOptions: [],
-    };
+    const expectedValue = getBaseExpectedValue();
+    expectedValue.mineStatusOptions = MOCK.STATUS_OPTIONS.options;
     const result = staticContentReducer(undefined, storeStatusOptions(MOCK.STATUS_OPTIONS));
     expect(result).toEqual(expectedValue);
   });
 
   it("receives STORE_REGION_OPTIONS", () => {
-    const expectedValue = {
-      mineStatusOptions: [],
-      mineRegionOptions: MOCK.REGION_OPTIONS.options,
-      mineDisturbanceOptions: [],
-      expectedDocumentStatusOptions: [],
-      mineTSFRequiredReports: [],
-      mineTenureTypes: [],
-      mineCommodityOptions: [],
-    };
+    const expectedValue = getBaseExpectedValue();
+    expectedValue.mineRegionOptions = MOCK.REGION_OPTIONS.options;
     const result = staticContentReducer(undefined, storeRegionOptions(MOCK.REGION_OPTIONS));
     expect(result).toEqual(expectedValue);
   });
 
   it("receives STORE_DOCUMENT_STATUS_OPTIONS", () => {
-    const expectedValue = {
-      mineStatusOptions: [],
-      mineRegionOptions: [],
-      mineDisturbanceOptions: [],
-      expectedDocumentStatusOptions: MOCK.EXPECTED_DOCUMENT_STATUS_OPTIONS.options,
-      mineTSFRequiredReports: [],
-      mineTenureTypes: [],
-      mineCommodityOptions: [],
-    };
+    const expectedValue = getBaseExpectedValue();
+    expectedValue.expectedDocumentStatusOptions = MOCK.EXPECTED_DOCUMENT_STATUS_OPTIONS.options;
     const result = staticContentReducer(
       undefined,
       storeDocumentStatusOptions(MOCK.EXPECTED_DOCUMENT_STATUS_OPTIONS)
@@ -71,15 +55,9 @@ describe("staticContentReducer", () => {
   });
 
   it("receives STORE_MINE_TSF_REQUIRED_DOCUMENTS", () => {
-    const expectedValue = {
-      mineStatusOptions: [],
-      mineRegionOptions: [],
-      mineDisturbanceOptions: [],
-      expectedDocumentStatusOptions: [],
-      mineTSFRequiredReports: MOCK.MINE_TSF_REQUIRED_REPORTS_RESPONSE.required_documents,
-      mineTenureTypes: [],
-      mineCommodityOptions: [],
-    };
+    const expectedValue = getBaseExpectedValue();
+    expectedValue.mineTSFRequiredReports =
+      MOCK.MINE_TSF_REQUIRED_REPORTS_RESPONSE.required_documents;
     const result = staticContentReducer(
       undefined,
       storeMineTSFRequiredDocuments(MOCK.MINE_TSF_REQUIRED_REPORTS_RESPONSE)
@@ -88,29 +66,15 @@ describe("staticContentReducer", () => {
   });
 
   it("receives STORE_TENURE_TYPES", () => {
-    const expectedValue = {
-      mineStatusOptions: [],
-      mineRegionOptions: [],
-      mineDisturbanceOptions: [],
-      mineTSFRequiredReports: [],
-      expectedDocumentStatusOptions: [],
-      mineTenureTypes: MOCK.TENURE_TYPES.options,
-      mineCommodityOptions: [],
-    };
+    const expectedValue = getBaseExpectedValue();
+    expectedValue.mineTenureTypes = MOCK.TENURE_TYPES.options;
     const result = staticContentReducer(undefined, storeTenureTypes(MOCK.TENURE_TYPES));
     expect(result).toEqual(expectedValue);
   });
 
   it("receives STORE_DISTURBANCE_OPTIONS", () => {
-    const expectedValue = {
-      mineStatusOptions: [],
-      mineRegionOptions: [],
-      mineDisturbanceOptions: MOCK.DISTURBANCE_OPTIONS.options,
-      mineTSFRequiredReports: [],
-      expectedDocumentStatusOptions: [],
-      mineTenureTypes: [],
-      mineCommodityOptions: [],
-    };
+    const expectedValue = getBaseExpectedValue();
+    expectedValue.mineDisturbanceOptions = MOCK.DISTURBANCE_OPTIONS.options;
     const result = staticContentReducer(
       undefined,
       storeDisturbanceOptions(MOCK.DISTURBANCE_OPTIONS)
@@ -119,15 +83,8 @@ describe("staticContentReducer", () => {
   });
 
   it("receives STORE_COMMODITY_OPTIONS", () => {
-    const expectedValue = {
-      mineStatusOptions: [],
-      mineRegionOptions: [],
-      mineDisturbanceOptions: [],
-      mineTSFRequiredReports: [],
-      expectedDocumentStatusOptions: [],
-      mineTenureTypes: [],
-      mineCommodityOptions: MOCK.COMMODITY_OPTIONS.options,
-    };
+    const expectedValue = getBaseExpectedValue();
+    expectedValue.mineCommodityOptions = MOCK.COMMODITY_OPTIONS.options;
     const result = staticContentReducer(undefined, storeCommodityOptions(MOCK.COMMODITY_OPTIONS));
     expect(result).toEqual(expectedValue);
   });


### PR DESCRIPTION
Refactor of all FE Reducer tests to use a common/base definition of the expected state returned by the reducer. Each test then initializes a local variable and only sets the properties it cares about.