### PR TITLE
MDS-714 Feature/ View unique permit numbers & propTypes cleanup

### DIFF
--- a/frontend/src/components/Forms/AdvancedSearchForm.js
+++ b/frontend/src/components/Forms/AdvancedSearchForm.js
@@ -4,15 +4,15 @@ import { Field, reduxForm } from "redux-form";
 import { Form, Button, Col, Row } from "antd";
 import * as FORM from "@/constants/forms";
 import { renderConfig } from "@/components/common/config";
-import { optionsType } from "@/customPropTypes";
+import CustomPropTypes from "@/customPropTypes";
 
 const propTypes = {
   handleSubmit: PropTypes.func.isRequired,
   reset: PropTypes.func.isRequired,
   handleSearch: PropTypes.func.isRequired,
-  mineTenureTypes: optionsType.isRequired,
-  mineRegionOptions: optionsType.isRequired,
-  mineStatusOptions: optionsType.isRequired,
+  mineTenureTypes: CustomPropTypes.options.isRequired,
+  mineRegionOptions: CustomPropTypes.options.isRequired,
+  mineStatusOptions: CustomPropTypes.options.isRequired,
 };
 
 export class AdvancedSearchForm extends Component {

--- a/frontend/src/components/dashboard/MineList.js
+++ b/frontend/src/components/dashboard/MineList.js
@@ -2,6 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import { Link } from "react-router-dom";
 import { Table } from "antd";
+import { uniqBy } from "lodash";
 import * as router from "@/constants/routes";
 import * as String from "@/constants/strings";
 import NullScreen from "@/components/common/NullScreen";
@@ -41,7 +42,10 @@ const columns = [
     width: 150,
     render: (text, record) => (
       <div>
-        {text && text.map(({ permit_no, permit_guid }) => <div key={permit_guid}>{permit_no}</div>)}
+        {text &&
+          uniqBy(text, "permit_no").map(({ permit_no, permit_guid }) => (
+            <div key={permit_guid}>{permit_no}</div>
+          ))}
         {!text && <div>{record.emptyField}</div>}
       </div>
     ),

--- a/frontend/src/components/dashboard/MineList.js
+++ b/frontend/src/components/dashboard/MineList.js
@@ -1,5 +1,5 @@
 import React from "react";
-import PropTypes from "prop-types";
+import { objectOf, arrayOf, string } from "prop-types";
 import { Link } from "react-router-dom";
 import { Table } from "antd";
 import { uniqBy } from "lodash";
@@ -12,7 +12,6 @@ import CustomPropTypes from "@/customPropTypes";
  * @class MineList - paginated list of mines
  */
 
-const { objectOf, arrayOf, string } = PropTypes;
 const propTypes = {
   mines: objectOf(CustomPropTypes.mine).isRequired,
   mineIds: arrayOf(string).isRequired,

--- a/frontend/src/components/dashboard/MineList.js
+++ b/frontend/src/components/dashboard/MineList.js
@@ -4,19 +4,21 @@ import { Link } from "react-router-dom";
 import { Table } from "antd";
 import { uniqBy } from "lodash";
 import * as router from "@/constants/routes";
-import * as String from "@/constants/strings";
+import * as Strings from "@/constants/strings";
 import NullScreen from "@/components/common/NullScreen";
+import CustomPropTypes from "@/customPropTypes";
 
 /**
  * @class MineList - paginated list of mines
  */
 
+const { objectOf, arrayOf, string } = PropTypes;
 const propTypes = {
-  mines: PropTypes.object.isRequired,
-  mineIds: PropTypes.array.isRequired,
-  mineRegionHash: PropTypes.object.isRequired,
-  mineTenureHash: PropTypes.object.isRequired,
-  mineCommodityOptionsHash: PropTypes.object.isRequired,
+  mines: objectOf(CustomPropTypes.mine).isRequired,
+  mineIds: arrayOf(string).isRequired,
+  mineRegionHash: objectOf(string).isRequired,
+  mineTenureHash: objectOf(string).isRequired,
+  mineCommodityOptionsHash: objectOf(string).isRequired,
 };
 
 const columns = [
@@ -82,7 +84,7 @@ const columns = [
             <div key={mine_type_guid}>
               {mine_type_detail.map(({ mine_commodity_code, mine_type_detail_guid }) => (
                 <span key={mine_type_detail_guid}>
-                  {mine_commodity_code && record.commodityHash[mine_commodity_code] + ", "}
+                  {mine_commodity_code && `${record.commodityHash[mine_commodity_code]},`}
                 </span>
               ))}
             </div>
@@ -100,23 +102,23 @@ const columns = [
 const transformRowData = (mines, mineIds, mineRegionHash, mineTenureHash, mineCommodityHash) =>
   mineIds.map((id) => ({
     key: id,
-    emptyField: String.EMPTY_FIELD,
-    mineName: mines[id].mine_detail[0] ? mines[id].mine_detail[0].mine_name : String.EMPTY_FIELD,
-    mineNo: mines[id].mine_detail[0] ? mines[id].mine_detail[0].mine_no : String.EMPTY_FIELD,
+    emptyField: Strings.EMPTY_FIELD,
+    mineName: mines[id].mine_detail[0] ? mines[id].mine_detail[0].mine_name : Strings.EMPTY_FIELD,
+    mineNo: mines[id].mine_detail[0] ? mines[id].mine_detail[0].mine_no : Strings.EMPTY_FIELD,
     operationalStatus: mines[id].mine_status[0]
       ? mines[id].mine_status[0].status_labels[0]
-      : String.EMPTY_FIELD,
+      : Strings.EMPTY_FIELD,
     permit: mines[id].mine_permit[0] ? mines[id].mine_permit : null,
     region: mines[id].mine_detail[0].region_code
       ? mineRegionHash[mines[id].mine_detail[0].region_code]
-      : String.EMPTY_FIELD,
+      : Strings.EMPTY_FIELD,
     commodity: mines[id].mine_type[0] ? mines[id].mine_type : null,
     commodityHash: mineCommodityHash,
     tenure: mines[id].mine_type[0] ? mines[id].mine_type : null,
     tenureHash: mineTenureHash,
     tsf: mines[id].mine_tailings_storage_facility
       ? mines[id].mine_tailings_storage_facility.length
-      : String.EMPTY_FIELD,
+      : Strings.EMPTY_FIELD,
   }));
 
 export const MineList = (props) => (

--- a/frontend/src/components/dashboard/MineSearch.js
+++ b/frontend/src/components/dashboard/MineSearch.js
@@ -16,9 +16,13 @@ const propTypes = {
   fetchMineNameList: PropTypes.func.isRequired,
   handleMineSearch: PropTypes.func,
   handleCoordinateSearch: PropTypes.func,
-  mineNameList: PropTypes.array.isRequired,
+  mineNameList: PropTypes.array,
   isMapView: PropTypes.bool,
   searchValue: PropTypes.string,
+};
+
+const defaultProps = {
+  mineNameList: [],
 };
 
 const checkAdvancedSearch = ({ status, region, tenure, commodity, tsf, major }) =>
@@ -150,6 +154,7 @@ const mapDispatchToProps = (dispatch) =>
   );
 
 MineSearch.propTypes = propTypes;
+MineSearch.defaultProps = defaultProps;
 
 export default connect(
   mapStateToProps,

--- a/frontend/src/components/mine/ContactInfo/PartyRelationships/DefaultContact.js
+++ b/frontend/src/components/mine/ContactInfo/PartyRelationships/DefaultContact.js
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import * as CustomPropTypes from "@/customPropTypes";
+import CustomPropTypes from "@/customPropTypes";
 import { Button, Icon, Popconfirm } from "antd";
 import { GREEN_PENCIL } from "@/constants/assets";
 

--- a/frontend/src/components/mine/ContactInfo/PartyRelationships/EngineerOfRecord.js
+++ b/frontend/src/components/mine/ContactInfo/PartyRelationships/EngineerOfRecord.js
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import * as CustomPropTypes from "@/customPropTypes";
+import CustomPropTypes from "@/customPropTypes";
 import { DefaultContact } from "@/components/mine/ContactInfo/PartyRelationships/DefaultContact";
 
 const propTypes = {

--- a/frontend/src/components/mine/ContactInfo/ViewPartyRelationships.js
+++ b/frontend/src/components/mine/ContactInfo/ViewPartyRelationships.js
@@ -2,7 +2,7 @@ import React, { Component } from "react";
 import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
 import PropTypes from "prop-types";
-import * as CustomPropTypes from "@/customPropTypes";
+import CustomPropTypes from "@/customPropTypes";
 import { Card, Row, Col, Menu, Icon, Popconfirm } from "antd";
 import { modalConfig } from "@/components/modalContent/config";
 import * as ModalContent from "@/constants/modalContent";
@@ -22,7 +22,7 @@ import { createTailingsStorageFacility } from "@/actionCreators/mineActionCreato
 import { getPartyRelationshipTypes, getPartyRelationships } from "@/selectors/partiesSelectors";
 
 const propTypes = {
-  mine: PropTypes.object.isRequired,
+  mine: CustomPropTypes.mine.isRequired,
   openModal: PropTypes.func.isRequired,
   closeModal: PropTypes.func.isRequired,
   handleChange: PropTypes.func.isRequired,

--- a/frontend/src/components/mine/MineDashboard.js
+++ b/frontend/src/components/mine/MineDashboard.js
@@ -54,7 +54,7 @@ const propTypes = {
   mineStatusOptions: PropTypes.array,
   mineRegionOptions: PropTypes.array,
   mineTenureTypes: PropTypes.array,
-  mineTenureHash: PropTypes.obj,
+  mineTenureHash: PropTypes.objectOf(PropTypes.string),
 };
 
 const defaultProps = {

--- a/frontend/src/components/mine/Permit/MinePermitInfo.js
+++ b/frontend/src/components/mine/Permit/MinePermitInfo.js
@@ -1,14 +1,14 @@
 import React from "react";
-import PropTypes from "prop-types";
 import { Table } from "antd";
 import NullScreen from "@/components/common/NullScreen";
 import * as String from "@/constants/strings";
+import CustomPropTypes from "@/customPropTypes";
 /**
  * @class  MinePermitInfo - contains all permit information
  */
 
 const propTypes = {
-  mine: PropTypes.object.isRequired,
+  mine: CustomPropTypes.mine.isRequired,
 };
 
 const columns = [

--- a/frontend/src/components/mine/Permit/MinePermitInfo.js
+++ b/frontend/src/components/mine/Permit/MinePermitInfo.js
@@ -53,8 +53,8 @@ const groupPermits = (permits) =>
   }, {});
 
 const transformRowData = (permits) => {
-  const first = permits[0];
-  const latest = permits[permits.length - 1];
+  const latest = permits[0];
+  const first = permits[permits.length - 1];
   return {
     key: latest.permit_guid,
     lastAmended: latest.issue_date,

--- a/frontend/src/components/mine/Summary/MineSummary.js
+++ b/frontend/src/components/mine/Summary/MineSummary.js
@@ -1,7 +1,8 @@
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
-import { Card } from 'antd';
-import NullScreen from '@/components/common/NullScreen';
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import { Card } from "antd";
+import { uniqBy } from "lodash";
+import NullScreen from "@/components/common/NullScreen";
 /**
  * @class MineSummary.js contains all content located under the 'Summary' tab on the MineDashboard.
  */
@@ -9,7 +10,7 @@ import NullScreen from '@/components/common/NullScreen';
 const propTypes = {
   mine: PropTypes.object.isRequired,
   permittees: PropTypes.object,
-  permitteeIds: PropTypes.array
+  permitteeIds: PropTypes.array,
 };
 
 const defaultProps = {
@@ -20,8 +21,10 @@ class MineSummary extends Component {
   render() {
     const { mine, permittees, permitteeIds } = this.props;
     if (!mine.mgr_appointment[0] && !mine.mine_permit[0]) {
-      return (<NullScreen type="generic" />);
+      return <NullScreen type="generic" />;
     }
+
+    const uniquePermits = uniqBy(mine.mine_permit, "permit_no");
 
     return (
       <div>
@@ -30,54 +33,91 @@ class MineSummary extends Component {
             {mine.mgr_appointment[0] && (
               <tbody>
                 <tr>
-                  <th scope="col"><h4>Mine Manager</h4></th>
-                  <th scope="col"><h4>Email</h4></th>
-                  <th scope="col"><h4>Manager Since</h4></th>
+                  <th scope="col">
+                    <h4>Mine Manager</h4>
+                  </th>
+                  <th scope="col">
+                    <h4>Email</h4>
+                  </th>
+                  <th scope="col">
+                    <h4>Manager Since</h4>
+                  </th>
                 </tr>
                 <tr>
-                  <td data-label="Mine Manager"><p className="p-large">{mine.mgr_appointment[0] ? mine.mgr_appointment[0].name : "-"}</p></td>
-                  <td data-label="Email"><p className="p-large">{mine.mgr_appointment[0] ? mine.mgr_appointment[0].email : "-"}</p></td>
-                  <td data-label="Manager Since"><p className="p-large">{mine.mgr_appointment[0] ? mine.mgr_appointment[0].effective_date : "-"}</p></td>
+                  <td data-label="Mine Manager">
+                    <p className="p-large">
+                      {mine.mgr_appointment[0] ? mine.mgr_appointment[0].name : "-"}
+                    </p>
+                  </td>
+                  <td data-label="Email">
+                    <p className="p-large">
+                      {mine.mgr_appointment[0] ? mine.mgr_appointment[0].email : "-"}
+                    </p>
+                  </td>
+                  <td data-label="Manager Since">
+                    <p className="p-large">
+                      {mine.mgr_appointment[0] ? mine.mgr_appointment[0].effective_date : "-"}
+                    </p>
+                  </td>
                 </tr>
               </tbody>
-)}
+            )}
             {mine.mine_permit[0] && (
               <tbody>
                 <tr>
-                  <th scope="col"><h4>Permittee</h4></th>
-                  <th scope="col"><h4>Email</h4></th>
-                  <th scope="col"><h4>Permittee Since</h4></th>
+                  <th scope="col">
+                    <h4>Permittee</h4>
+                  </th>
+                  <th scope="col">
+                    <h4>Email</h4>
+                  </th>
+                  <th scope="col">
+                    <h4>Permittee Since</h4>
+                  </th>
                 </tr>
                 {permitteeIds.map((id) => (
                   <tr key={id}>
-                    <td data-label="Permittee"><p className="p-large">{permittees[id].party.name}</p></td>
-                    <td data-label="Email"><p className="p-large">{permittees[id].party.email}</p></td>
-                    <td data-label="Effective Date"><p className="p-large">{permittees[id].effective_date}</p></td>
+                    <td data-label="Permittee">
+                      <p className="p-large">{permittees[id].party.name}</p>
+                    </td>
+                    <td data-label="Email">
+                      <p className="p-large">{permittees[id].party.email}</p>
+                    </td>
+                    <td data-label="Effective Date">
+                      <p className="p-large">{permittees[id].effective_date}</p>
+                    </td>
                   </tr>
-                        ))}
+                ))}
               </tbody>
-)}
+            )}
           </table>
         </Card>
         {mine.mine_permit[0] && (
-        <Card>
-          <table>
-            <tbody>
-              <tr>
-                <th scope="col"><h4>Permit</h4></th>
-                <th scope="col"><h4>Date Issued</h4></th>
-              </tr> 
-              {mine.mine_permit.map((permit) => (
-                <tr key={permit.permit_guid}>
-                  <td data-label="Permit"><p className="p-large">{permit.permit_no}</p></td>
-                  <td data-label="Date Issued"><p className="p-large">{permit.issue_date}</p></td>
+          <Card>
+            <table>
+              <tbody>
+                <tr>
+                  <th scope="col">
+                    <h4>Permit</h4>
+                  </th>
+                  <th scope="col">
+                    <h4>Last Amended</h4>
+                  </th>
                 </tr>
-                  ))
-                }
-            </tbody>
-          </table>
-        </Card>
-)}
+                {uniquePermits.map((permit) => (
+                  <tr key={permit.permit_guid}>
+                    <td data-label="Permit">
+                      <p className="p-large">{permit.permit_no}</p>
+                    </td>
+                    <td data-label="Date Issued">
+                      <p className="p-large">{permit.issue_date}</p>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </Card>
+        )}
       </div>
     );
   }

--- a/frontend/src/components/mine/Summary/MineSummary.js
+++ b/frontend/src/components/mine/Summary/MineSummary.js
@@ -1,5 +1,5 @@
-import React, { Component } from "react";
-import PropTypes from "prop-types";
+import React from "react";
+import { objectOf, arrayOf, string } from "prop-types";
 import { Card } from "antd";
 import { uniqBy } from "lodash";
 import NullScreen from "@/components/common/NullScreen";
@@ -10,8 +10,8 @@ import CustomPropTypes from "@/customPropTypes";
 
 const propTypes = {
   mine: CustomPropTypes.mine.isRequired,
-  permittees: PropTypes.objectOf(CustomPropTypes.permittee),
-  permitteeIds: PropTypes.arrayOf(PropTypes.string),
+  permittees: objectOf(CustomPropTypes.permittee),
+  permitteeIds: arrayOf(string),
 };
 
 const defaultProps = {
@@ -19,116 +19,110 @@ const defaultProps = {
   permitteeIds: [],
 };
 
-class MineSummary extends Component {
-  render() {
-    if (!this.props.mine.mgr_appointment[0] && !this.props.mine.mine_permit[0]) {
-      return <NullScreen type="generic" />;
-    }
+const MineSummary = (props) => {
+  if (!props.mine.mgr_appointment[0] && !props.mine.mine_permit[0]) {
+    return <NullScreen type="generic" />;
+  }
 
-    const uniquePermits = uniqBy(this.props.mine.mine_permit, "permit_no");
+  const uniquePermits = uniqBy(props.mine.mine_permit, "permit_no");
 
-    return (
-      <div>
-        <Card>
-          <table>
-            {this.props.mine.mgr_appointment[0] && (
-              <tbody>
-                <tr>
-                  <th scope="col">
-                    <h4>Mine Manager</h4>
-                  </th>
-                  <th scope="col">
-                    <h4>Email</h4>
-                  </th>
-                  <th scope="col">
-                    <h4>Manager Since</h4>
-                  </th>
-                </tr>
-                <tr>
-                  <td data-label="Mine Manager">
-                    <p className="p-large">
-                      {this.props.mine.mgr_appointment[0]
-                        ? this.props.mine.mgr_appointment[0].name
-                        : "-"}
-                    </p>
+  return (
+    <div>
+      <Card>
+        <table>
+          {props.mine.mgr_appointment[0] && (
+            <tbody>
+              <tr>
+                <th scope="col">
+                  <h4>Mine Manager</h4>
+                </th>
+                <th scope="col">
+                  <h4>Email</h4>
+                </th>
+                <th scope="col">
+                  <h4>Manager Since</h4>
+                </th>
+              </tr>
+              <tr>
+                <td data-label="Mine Manager">
+                  <p className="p-large">
+                    {props.mine.mgr_appointment[0] ? props.mine.mgr_appointment[0].name : "-"}
+                  </p>
+                </td>
+                <td data-label="Email">
+                  <p className="p-large">
+                    {props.mine.mgr_appointment[0] ? props.mine.mgr_appointment[0].email : "-"}
+                  </p>
+                </td>
+                <td data-label="Manager Since">
+                  <p className="p-large">
+                    {props.mine.mgr_appointment[0]
+                      ? props.mine.mgr_appointment[0].effective_date
+                      : "-"}
+                  </p>
+                </td>
+              </tr>
+            </tbody>
+          )}
+          {props.mine.mine_permit[0] && (
+            <tbody>
+              <tr>
+                <th scope="col">
+                  <h4>Permittee</h4>
+                </th>
+                <th scope="col">
+                  <h4>Email</h4>
+                </th>
+                <th scope="col">
+                  <h4>Permittee Since</h4>
+                </th>
+              </tr>
+              {props.permitteeIds.map((id) => (
+                <tr key={id}>
+                  <td data-label="Permittee">
+                    <p className="p-large">{props.permittees[id].party.name}</p>
                   </td>
                   <td data-label="Email">
-                    <p className="p-large">
-                      {this.props.mine.mgr_appointment[0]
-                        ? this.props.mine.mgr_appointment[0].email
-                        : "-"}
-                    </p>
+                    <p className="p-large">{props.permittees[id].party.email}</p>
                   </td>
-                  <td data-label="Manager Since">
-                    <p className="p-large">
-                      {this.props.mine.mgr_appointment[0]
-                        ? this.props.mine.mgr_appointment[0].effective_date
-                        : "-"}
-                    </p>
+                  <td data-label="Effective Date">
+                    <p className="p-large">{props.permittees[id].effective_date}</p>
                   </td>
                 </tr>
-              </tbody>
-            )}
-            {this.props.mine.mine_permit[0] && (
-              <tbody>
-                <tr>
-                  <th scope="col">
-                    <h4>Permittee</h4>
-                  </th>
-                  <th scope="col">
-                    <h4>Email</h4>
-                  </th>
-                  <th scope="col">
-                    <h4>Permittee Since</h4>
-                  </th>
+              ))}
+            </tbody>
+          )}
+        </table>
+      </Card>
+      {props.mine.mine_permit[0] && (
+        <Card>
+          <table>
+            <tbody>
+              <tr>
+                <th scope="col">
+                  <h4>Permit</h4>
+                </th>
+                <th scope="col">
+                  <h4>Last Amended</h4>
+                </th>
+              </tr>
+              {uniquePermits.map((permit) => (
+                <tr key={permit.permit_guid}>
+                  <td data-label="Permit">
+                    <p className="p-large">{permit.permit_no}</p>
+                  </td>
+                  <td data-label="Date Issued">
+                    <p className="p-large">{permit.issue_date}</p>
+                  </td>
                 </tr>
-                {this.props.permitteeIds.map((id) => (
-                  <tr key={id}>
-                    <td data-label="Permittee">
-                      <p className="p-large">{this.props.permittees[id].party.name}</p>
-                    </td>
-                    <td data-label="Email">
-                      <p className="p-large">{this.props.permittees[id].party.email}</p>
-                    </td>
-                    <td data-label="Effective Date">
-                      <p className="p-large">{this.props.permittees[id].effective_date}</p>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            )}
+              ))}
+            </tbody>
           </table>
         </Card>
-        {this.props.mine.mine_permit[0] && (
-          <Card>
-            <table>
-              <tbody>
-                <tr>
-                  <th scope="col">
-                    <h4>Permit</h4>
-                  </th>
-                  <th scope="col">
-                    <h4>Last Amended</h4>
-                  </th>
-                </tr>
-                {uniquePermits.map((permit) => (
-                  <tr key={permit.permit_guid}>
-                    <td data-label="Permit">
-                      <p className="p-large">{permit.permit_no}</p>
-                    </td>
-                    <td data-label="Date Issued">
-                      <p className="p-large">{permit.issue_date}</p>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </Card>
-        )}
-      </div>
-    );
-  }
-}
+      )}
+    </div>
+  );
+};
 
 MineSummary.propTypes = propTypes;
 MineSummary.defaultProps = defaultProps;

--- a/frontend/src/components/mine/Summary/MineSummary.js
+++ b/frontend/src/components/mine/Summary/MineSummary.js
@@ -3,34 +3,35 @@ import PropTypes from "prop-types";
 import { Card } from "antd";
 import { uniqBy } from "lodash";
 import NullScreen from "@/components/common/NullScreen";
+import CustomPropTypes from "@/customPropTypes";
 /**
  * @class MineSummary.js contains all content located under the 'Summary' tab on the MineDashboard.
  */
 
 const propTypes = {
-  mine: PropTypes.object.isRequired,
-  permittees: PropTypes.object,
-  permitteeIds: PropTypes.array,
+  mine: CustomPropTypes.mine.isRequired,
+  permittees: PropTypes.objectOf(CustomPropTypes.permittee),
+  permitteeIds: PropTypes.arrayOf(PropTypes.string),
 };
 
 const defaultProps = {
-  mine: {},
+  permittees: {},
+  permitteeIds: [],
 };
 
 class MineSummary extends Component {
   render() {
-    const { mine, permittees, permitteeIds } = this.props;
-    if (!mine.mgr_appointment[0] && !mine.mine_permit[0]) {
+    if (!this.props.mine.mgr_appointment[0] && !this.props.mine.mine_permit[0]) {
       return <NullScreen type="generic" />;
     }
 
-    const uniquePermits = uniqBy(mine.mine_permit, "permit_no");
+    const uniquePermits = uniqBy(this.props.mine.mine_permit, "permit_no");
 
     return (
       <div>
         <Card>
           <table>
-            {mine.mgr_appointment[0] && (
+            {this.props.mine.mgr_appointment[0] && (
               <tbody>
                 <tr>
                   <th scope="col">
@@ -46,23 +47,29 @@ class MineSummary extends Component {
                 <tr>
                   <td data-label="Mine Manager">
                     <p className="p-large">
-                      {mine.mgr_appointment[0] ? mine.mgr_appointment[0].name : "-"}
+                      {this.props.mine.mgr_appointment[0]
+                        ? this.props.mine.mgr_appointment[0].name
+                        : "-"}
                     </p>
                   </td>
                   <td data-label="Email">
                     <p className="p-large">
-                      {mine.mgr_appointment[0] ? mine.mgr_appointment[0].email : "-"}
+                      {this.props.mine.mgr_appointment[0]
+                        ? this.props.mine.mgr_appointment[0].email
+                        : "-"}
                     </p>
                   </td>
                   <td data-label="Manager Since">
                     <p className="p-large">
-                      {mine.mgr_appointment[0] ? mine.mgr_appointment[0].effective_date : "-"}
+                      {this.props.mine.mgr_appointment[0]
+                        ? this.props.mine.mgr_appointment[0].effective_date
+                        : "-"}
                     </p>
                   </td>
                 </tr>
               </tbody>
             )}
-            {mine.mine_permit[0] && (
+            {this.props.mine.mine_permit[0] && (
               <tbody>
                 <tr>
                   <th scope="col">
@@ -75,16 +82,16 @@ class MineSummary extends Component {
                     <h4>Permittee Since</h4>
                   </th>
                 </tr>
-                {permitteeIds.map((id) => (
+                {this.props.permitteeIds.map((id) => (
                   <tr key={id}>
                     <td data-label="Permittee">
-                      <p className="p-large">{permittees[id].party.name}</p>
+                      <p className="p-large">{this.props.permittees[id].party.name}</p>
                     </td>
                     <td data-label="Email">
-                      <p className="p-large">{permittees[id].party.email}</p>
+                      <p className="p-large">{this.props.permittees[id].party.email}</p>
                     </td>
                     <td data-label="Effective Date">
-                      <p className="p-large">{permittees[id].effective_date}</p>
+                      <p className="p-large">{this.props.permittees[id].effective_date}</p>
                     </td>
                   </tr>
                 ))}
@@ -92,7 +99,7 @@ class MineSummary extends Component {
             )}
           </table>
         </Card>
-        {mine.mine_permit[0] && (
+        {this.props.mine.mine_permit[0] && (
           <Card>
             <table>
               <tbody>

--- a/frontend/src/components/navigation/NavBar.js
+++ b/frontend/src/components/navigation/NavBar.js
@@ -14,7 +14,7 @@ import Logout from "../authentication/Logout";
  */
 
 const propTypes = {
-  userInfo: { preferred_username: PropTypes.string.isRequired },
+  userInfo: PropTypes.shape({ preferred_username: PropTypes.string.isRequired }).isRequired,
 };
 
 export const NavBar = (props) => (

--- a/frontend/src/customPropTypes/common.js
+++ b/frontend/src/customPropTypes/common.js
@@ -1,0 +1,8 @@
+import { PropTypes, shape, arrayOf } from "prop-types";
+
+export const dropdownListItem = shape({
+  value: PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
+});
+
+export const options = arrayOf(dropdownListItem);

--- a/frontend/src/customPropTypes/index.js
+++ b/frontend/src/customPropTypes/index.js
@@ -1,33 +1,10 @@
 // types/index.js
-import { PropTypes, shape, arrayOf } from "prop-types";
+import * as CommonTypes from "@/customPropTypes/common";
+import * as MineTypes from "@/customPropTypes/mines";
+import * as PermitTypes from "@/customPropTypes/permits";
 
-export const dropdownListItem = shape({
-  value: PropTypes.string.isRequired,
-  label: PropTypes.string.isRequired,
-});
-
-export const optionsType = arrayOf(dropdownListItem);
-
-export const party = shape({
-  party_guid: PropTypes.string,
-  party_type_code: PropTypes.string,
-  phone_no: PropTypes.string,
-  phone_ext: PropTypes.any,
-  email: PropTypes.string,
-  effective_date: PropTypes.string,
-  expiry_date: PropTypes.string,
-  party_name: PropTypes.string,
-  name: PropTypes.string,
-  first_name: PropTypes.string,
-});
-
-export const partyRelationship = shape({
-  mine_party_appt_guid: PropTypes.string,
-  mine_guid: PropTypes.string,
-  party: PropTypes.party,
-  mine_party_appt_type_code: PropTypes.string,
-  mine_tailings_storage_facility_guid: PropTypes.string,
-  permit_guid: PropTypes.string,
-  start_date: PropTypes.string,
-  end_date: PropTypes.string,
-});
+export default {
+  ...CommonTypes,
+  ...MineTypes,
+  ...PermitTypes,
+};

--- a/frontend/src/customPropTypes/mines.js
+++ b/frontend/src/customPropTypes/mines.js
@@ -1,0 +1,7 @@
+import { PropTypes, shape, arrayOf } from "prop-types";
+import { minePermit } from "@/customPropTypes/permits";
+
+export const mine = shape({
+  guid: PropTypes.string.isRequired,
+  mine_permit: arrayOf(minePermit),
+});

--- a/frontend/src/customPropTypes/permits.js
+++ b/frontend/src/customPropTypes/permits.js
@@ -1,0 +1,42 @@
+import { PropTypes, shape, arrayOf } from "prop-types";
+
+export const party = shape({
+  party_guid: PropTypes.string,
+  party_type_code: PropTypes.string,
+  phone_no: PropTypes.string,
+  phone_ext: PropTypes.any,
+  email: PropTypes.string,
+  effective_date: PropTypes.string,
+  expiry_date: PropTypes.string,
+  party_name: PropTypes.string,
+  name: PropTypes.string,
+  first_name: PropTypes.string,
+});
+
+export const permittee = shape({
+  effective_date: PropTypes.string,
+  expiry_date: PropTypes.string,
+  party,
+  party_guid: PropTypes.string,
+  permit_guid: PropTypes.string,
+  permittee_guid: PropTypes.string,
+});
+
+export const minePermit = shape({
+  permit_guid: PropTypes.string.isRequired,
+  issue_date: PropTypes.string.isRequired,
+  permit_no: PropTypes.string.isRequired,
+  permittee: arrayOf(permittee),
+  expiry_date: PropTypes.string.isRequired,
+});
+
+export const partyRelationship = shape({
+  mine_party_appt_guid: PropTypes.string,
+  mine_guid: PropTypes.string,
+  party,
+  mine_party_appt_type_code: PropTypes.string,
+  mine_tailings_storage_facility_guid: PropTypes.string,
+  permit_guid: PropTypes.string,
+  start_date: PropTypes.string,
+  end_date: PropTypes.string,
+});


### PR DESCRIPTION
This is a partial implementation of MDS-714. A follow-up PR will add the option to expand the permit on the Permit tab to show amendment history.

Open for discussion on how I have separated the CustomPropTypes. The goal is to provide the convenience of an index file with the maintainability of separate files. The separation so far is inspired by the backend namespaces.