### PR TITLE
Adding default data to Dev and Test deployments

### DIFF
--- a/openshift/_python36.dc.json
+++ b/openshift/_python36.dc.json
@@ -87,6 +87,9 @@
     {
       "name": "MEMORY_REQUEST",
       "value": "768Mi"
+    },
+    {
+      "name": "DEPLOYMENT_ENVIRONMENT"
     }
   ],
   "objects": [
@@ -344,6 +347,10 @@
                   {
                     "name": "UPLOADED_DOCUMENT_DEST",
                     "value": "${UPLOADED_DOCUMENT_DEST}"
+                  },
+                  {
+                    "name": "DEPLOYMENT_ENVIRONMENT",
+                    "value": "${DEPLOYMENT_ENVIRONMENT}"
                   }
                 ],
                 "resources": {

--- a/pipeline/config.groovy
+++ b/pipeline/config.groovy
@@ -179,7 +179,8 @@ app {
                             'BASE_PATH': "${vars.modules.'mds-python-backend'.PATH}",
                             'ROUTE': "${vars.modules.'mds-python-backend'.ROUTE}",
                             'DB_CONFIG_NAME': "mds-postgresql${vars.deployment.suffix}",
-                            'DOCUMENT_CAPACITY':"${vars.DOCUMENT_PVC_SIZE}"
+                            'DOCUMENT_CAPACITY':"${vars.DOCUMENT_PVC_SIZE}",
+                            'DEPLOYMENT_ENVIRONMENT': "${vars.deployment.env.name}"
                     ]
                 ],
                 [

--- a/python-backend/app.sh
+++ b/python-backend/app.sh
@@ -1,3 +1,7 @@
 #!/bin/bash
 
+if(($DEPLOYMENT_ENVIRONMENT == "dev") || ($DEPLOYMENT_ENVIRONMENT == "test")) 
+then flask create_data 100
+fi
+
 uwsgi uwsgi.ini


### PR DESCRIPTION
Dev and Test deployments will now be seeded with default data using flask create_data.

This is not intended to be a permanent solution. A more robust solution involving pulling some prod data into dev and test would be more ideal. 

The number of records generated was not made configurable due to the fact that this is not intended to be a permanent solution.