### PR TITLE
Frontend Code cleanup

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -124,7 +124,7 @@ npm run lint ./filepath
 Lint all files
 
 ```
-npm run lint .
+npm run lint ./src
 ```
 
 Apply linting rules to one file

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -56,6 +56,7 @@
     "cross-env": "^5.2.0",
     "css-loader": "^0.28.11",
     "cssnano": "^3.10.0",
+    "enzyme": "^3.3.0",
     "eslint": "^5.9.0",
     "eslint-config-airbnb": "^17.1.0",
     "eslint-config-prettier": "^3.3.0",
@@ -84,7 +85,6 @@
     "webpack-merge": "^4.1.2"
   },
   "optionalDependencies": {
-    "enzyme": "^3.3.0",
     "enzyme-adapter-react-16": "^1.1.1",
     "jest": "^22.4.3",
     "jest-junit": "^3.7.0",

--- a/frontend/src/actionCreators/complianceActionCreator.js
+++ b/frontend/src/actionCreators/complianceActionCreator.js
@@ -9,6 +9,8 @@ import * as API from "@/constants/API";
 import { ENVIRONMENT } from "@/constants/environment";
 import { createRequestHeader } from "@/utils/RequestHeaders";
 
+// This file is anticipated to have multiple exports
+// eslint-disable-next-line import/prefer-default-export
 export const fetchMineComplianceInfo = (mineNo) => (dispatch) => {
   dispatch(showLoading());
   dispatch(request(reducerTypes.GET_MINE_COMPLIANCE_INFO));

--- a/frontend/src/actionCreators/partiesActionCreator.js
+++ b/frontend/src/actionCreators/partiesActionCreator.js
@@ -240,7 +240,7 @@ export const removePartyRelationship = (mine_party_appt_guid) => (dispatch) => {
       dispatch(hideLoading());
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       notification.error({ message: String.ERROR, duration: 10 });
       dispatch(error(reducerTypes.REMOVE_PARTY_RELATIONSHIP));
       dispatch(hideLoading());

--- a/frontend/src/actions/complianceActions.js
+++ b/frontend/src/actions/complianceActions.js
@@ -1,5 +1,7 @@
 import * as ActionTypes from "../constants/actionTypes";
 
+// This file is anticipated to have multiple exports
+// eslint-disable-next-line import/prefer-default-export
 export const storeMineComplianceInfo = (payload) => ({
   type: ActionTypes.STORE_MINE_COMPLIANCE_INFO,
   payload,

--- a/frontend/src/actions/genericActions.js
+++ b/frontend/src/actions/genericActions.js
@@ -11,10 +11,10 @@ export const request = (reducer) => ({
   type: ActionTypes.REQUEST,
 });
 
-export const error = (reducer, error) => ({
+export const error = (reducer, err) => ({
   name: reducer,
   type: ActionTypes.ERROR,
-  errorMessage: error,
+  errorMessage: err,
 });
 
 export const clear = (reducer) => ({

--- a/frontend/src/components/mine/MineHeader.js
+++ b/frontend/src/components/mine/MineHeader.js
@@ -72,7 +72,7 @@ class MineHeader extends Component {
               type.mine_type_detail.map(({ mine_commodity_code }) => (
                 <span>
                   {mine_commodity_code &&
-                    this.props.mineCommodityOptionsHash[mine_commodity_code] + ", "}
+                    `${this.props.mineCommodityOptionsHash[mine_commodity_code]  }, `}
                 </span>
               ))}
           </div>
@@ -86,7 +86,7 @@ class MineHeader extends Component {
               type.mine_type_detail.map(({ mine_disturbance_code }) => (
                 <span>
                   {mine_disturbance_code &&
-                    this.props.mineDisturbanceOptionsHash[mine_disturbance_code] + ", "}
+                    `${this.props.mineDisturbanceOptionsHash[mine_disturbance_code]  }, `}
                 </span>
               ))}
           </div>

--- a/frontend/src/components/modalContent/AddTailingsReportModal.js
+++ b/frontend/src/components/modalContent/AddTailingsReportModal.js
@@ -12,13 +12,11 @@ const defaultProps = {
   title: "",
 };
 
-export const AddTailingsReportModal = (props) => {
-  return (
+export const AddTailingsReportModal = (props) => (
     <div>
       <AddTailingsReportForm {...props} />
     </div>
   );
-};
 
 AddTailingsReportModal.propTypes = propTypes;
 AddTailingsReportModal.defaultProps = defaultProps;

--- a/frontend/src/customPropTypes/mines.js
+++ b/frontend/src/customPropTypes/mines.js
@@ -1,6 +1,8 @@
 import { PropTypes, shape, arrayOf } from "prop-types";
 import { minePermit } from "@/customPropTypes/permits";
 
+// This file is anticipated to have multiple exports
+// eslint-disable-next-line import/prefer-default-export
 export const mine = shape({
   guid: PropTypes.string.isRequired,
   mine_permit: arrayOf(minePermit),

--- a/frontend/src/routes/Routes.js
+++ b/frontend/src/routes/Routes.js
@@ -1,8 +1,8 @@
 import React from "react";
-import { Route, Switch } from "react-router";
+import { Route, Switch } from "react-router-dom";
 import RedirectRoute from "./routeWrappers/RedirectRoute";
 import * as routes from "@/constants/routes";
-import * as String from "@/constants/strings";
+import * as Strings from "@/constants/strings";
 
 const Routes = () => (
   <div>
@@ -11,8 +11,8 @@ const Routes = () => (
         exact
         path={routes.DASHBOARD.route}
         redirectTo={routes.MINE_DASHBOARD.dynamicRoute({
-          page: String.DEFAULT_PAGE,
-          per_page: String.DEFAULT_PER_PAGE,
+          page: Strings.DEFAULT_PAGE,
+          per_page: Strings.DEFAULT_PER_PAGE,
         })}
       />
       <Route path={routes.DASHBOARD.route} component={routes.DASHBOARD.component} />

--- a/frontend/src/routes/routeWrappers/RedirectRoute.js
+++ b/frontend/src/routes/routeWrappers/RedirectRoute.js
@@ -1,13 +1,13 @@
 import React from "react";
 import { Route, Redirect } from "react-router-dom";
 
-const RedirectRoute = ({ redirectTo, ...rest }) => (
+const RedirectRoute = (props) => (
   <Route
-    {...rest}
-    render={(props) => (
+    {...props}
+    render={() => (
       <Redirect
         to={{
-          pathname: redirectTo,
+          pathname: props.redirectTo,
           state: {
             from: props.location,
           },

--- a/frontend/src/selectors/authenticationSelectors.js
+++ b/frontend/src/selectors/authenticationSelectors.js
@@ -1,6 +1,8 @@
 import * as authenticationReducer from "@/reducers/authenticationReducer";
 
-export const isAuthenticated = (state) => authenticationReducer.isAuthenticated(state);
-export const getUserAccessData = (state) => authenticationReducer.getUserAccessData(state);
-export const getUserInfo = (state) => authenticationReducer.getUserInfo(state);
-export const getKeycloak = (state) => authenticationReducer.getKeycloak(state);
+export const {
+  isAuthenticated,
+  getUserAccessData,
+  getUserInfo,
+  getKeycloak,
+} = authenticationReducer;

--- a/frontend/src/selectors/complianceSelectors.js
+++ b/frontend/src/selectors/complianceSelectors.js
@@ -1,3 +1,5 @@
 import * as complianceReducer from "@/reducers/complianceReducer";
 
-export const getMineComplianceInfo = (state) => complianceReducer.getMineComplianceInfo(state);
+// This file is anticipated to have multiple exports
+// eslint-disable-next-line import/prefer-default-export
+export const { getMineComplianceInfo } = complianceReducer;

--- a/frontend/src/selectors/mineSelectors.js
+++ b/frontend/src/selectors/mineSelectors.js
@@ -12,8 +12,9 @@ export const getCurrentPermittees = createSelector(
   (mines, mineGuid) => {
     const permitteeObj = {};
     if (mineGuid) {
-      mines[mineGuid].mine_permit.map((permit) => {
-        permitteeObj[permit.permittee[0].party_guid] = permit.permittee[0];
+      mines[mineGuid].mine_permit.forEach((permit) => {
+        const permittee = permit.permittee[0];
+        permitteeObj[permittee.party_guid] = permittee;
       });
     }
     return permitteeObj;
@@ -24,13 +25,11 @@ export const getCurrentPermitteeIds = createSelector(
   [getMines, getMineGuid],
   (mines, mineGuid) => {
     const permitteeIds = [];
-    let unique;
     if (mineGuid) {
-      mines[mineGuid].mine_permit.map((permit) => {
+      mines[mineGuid].mine_permit.forEach((permit) => {
         permitteeIds.push(permit.permittee[0].party_guid);
       });
     }
-    unique = [...new Set(permitteeIds)];
-    return unique;
+    return [...new Set(permitteeIds)];
   }
 );

--- a/frontend/src/selectors/modalSelectors.js
+++ b/frontend/src/selectors/modalSelectors.js
@@ -1,6 +1,3 @@
 import * as modalReducer from "@/reducers/modalReducer";
 
-export const getIsModalOpen = (state) => modalReducer.getIsModalOpen(state);
-export const getProps = (state) => modalReducer.getProps(state);
-export const getContent = (state) => modalReducer.getContent(state);
-export const getClearOnSubmit = (state) => modalReducer.getClearOnSubmit(state);
+export const { getIsModalOpen, getProps, getContent, getClearOnSubmit } = modalReducer;

--- a/frontend/src/selectors/partiesSelectors.js
+++ b/frontend/src/selectors/partiesSelectors.js
@@ -1,6 +1,8 @@
 import * as partiesReducer from "@/reducers/partiesReducer";
 
-export const getParties = (state) => partiesReducer.getParties(state);
-export const getPartyIds = (state) => partiesReducer.getPartyIds(state);
-export const getPartyRelationshipTypes = (state) => partiesReducer.getPartyRelationshipTypes(state);
-export const getPartyRelationships = (state) => partiesReducer.getPartyRelationships(state);
+export const {
+  getParties,
+  getPartyIds,
+  getPartyRelationshipTypes,
+  getPartyRelationships,
+} = partiesReducer;

--- a/frontend/src/selectors/staticContentSelectors.js
+++ b/frontend/src/selectors/staticContentSelectors.js
@@ -2,17 +2,15 @@ import * as staticContentReducer from "@/reducers/staticContentReducer";
 import { createSelector } from "reselect";
 import { createLabelHash } from "@/utils/helpers";
 
-export const getMineStatusOptions = (state) => staticContentReducer.getMineStatusOptions(state);
-export const getMineRegionOptions = (state) => staticContentReducer.getMineRegionOptions(state);
-export const getMineTenureTypes = (state) => staticContentReducer.getMineTenureTypes(state);
-export const getMineDisturbanceOptions = (state) =>
-  staticContentReducer.getMineDisturbanceOptions(state);
-export const getMineCommodityOptions = (state) =>
-  staticContentReducer.getMineCommodityOptions(state);
-export const getExpectedDocumentStatusOptions = (state) =>
-  staticContentReducer.getExpectedDocumentStatusOptions(state);
-export const getMineTSFRequiredReports = (state) =>
-  staticContentReducer.getMineTSFRequiredReports(state);
+export const {
+  getMineStatusOptions,
+  getMineRegionOptions,
+  getMineTenureTypes,
+  getMineDisturbanceOptions,
+  getMineCommodityOptions,
+  getExpectedDocumentStatusOptions,
+  getMineTSFRequiredReports,
+} = staticContentReducer;
 
 export const getMineTenureTypesHash = createSelector(
   [getMineTenureTypes],
@@ -51,26 +49,24 @@ export const getConditionalCommodityOptions = createSelector(
 
 export const getDisturbanceOptionHash = createSelector(
   [getMineDisturbanceOptions],
-  (options) => {
-    return options.reduce(
+  (options) =>
+    options.reduce(
       (map, { description, mine_disturbance_code }) => ({
         [mine_disturbance_code]: description,
         ...map,
       }),
       {}
-    );
-  }
+    )
 );
 
 export const getCommodityOptionHash = createSelector(
   [getMineCommodityOptions],
-  (options) => {
-    return options.reduce(
+  (options) =>
+    options.reduce(
       (map, { description, mine_commodity_code }) => ({
         [mine_commodity_code]: description,
         ...map,
       }),
       {}
-    );
-  }
+    )
 );

--- a/frontend/src/tests/components/maps/LocationPin.spec.js
+++ b/frontend/src/tests/components/maps/LocationPin.spec.js
@@ -1,22 +1,22 @@
-import React from 'react';
-import { shallow } from 'enzyme';
-import { LocationPin } from '@/components/maps/LocationPin';
-import * as MOCK from '@/tests/mocks/dataMocks';
+import React from "react";
+import { shallow } from "enzyme";
+import { LocationPin } from "@/components/maps/LocationPin";
+import * as MOCK from "@/tests/mocks/dataMocks";
 
 const props = {};
 
 const setupProps = () => {
   props.center = MOCK.COORDINATES;
-  props.map = {},
-  props.view = {}
+  props.map = {};
+  props.view = {};
 };
 
 beforeEach(() => {
   setupProps();
 });
 
-describe('LocationPin', () => {
-  it('renders properly', () => {
+describe("LocationPin", () => {
+  it("renders properly", () => {
     const component = shallow(<LocationPin {...props} />);
     expect(component).toMatchSnapshot();
   });

--- a/frontend/src/tests/components/maps/MinePin.spec.js
+++ b/frontend/src/tests/components/maps/MinePin.spec.js
@@ -1,29 +1,26 @@
-import React from 'react';
-import { shallow } from 'enzyme';
-import { MinePin } from '@/components/maps/MinePin';
-import * as MOCK from '@/tests/mocks/dataMocks';
+import React from "react";
+import { shallow } from "enzyme";
+import { MinePin } from "@/components/maps/MinePin";
+import * as MOCK from "@/tests/mocks/dataMocks";
 
 const props = {};
 
 const setupProps = () => {
   props.mineIds = MOCK.MINES.mineIds;
   props.mines = MOCK.MINES.mines;
-  props.match = {},
-  props.view = {}
+  props.match = {};
+  props.view = {};
 };
 
 beforeEach(() => {
   setupProps();
 });
 
-describe('MinePin', () => {
-  it('renders properly', () => {
+describe("MinePin", () => {
+  it("renders properly", () => {
     const component = shallow(
-      <MinePin 
-        {...props}
-        match={{ params: { id: 1 }, isExact: true, path: "", url: "" }}
-      />
-  );
+      <MinePin {...props} match={{ params: { id: 1 }, isExact: true, path: "", url: "" }} />
+    );
     expect(component).toMatchSnapshot();
   });
 });

--- a/frontend/src/tests/components/modalContent/MineRecordModal.spec.js
+++ b/frontend/src/tests/components/modalContent/MineRecordModal.spec.js
@@ -1,29 +1,29 @@
-import React from 'react';
-import { shallow } from 'enzyme';
-import { MineRecordModal } from '@/components/modalContent/MineRecordModal';
-import * as MOCK from '@/tests/mocks/dataMocks';
+import React from "react";
+import { shallow } from "enzyme";
+import { MineRecordModal } from "@/components/modalContent/MineRecordModal";
+import * as MOCK from "@/tests/mocks/dataMocks";
 
 const dispatchProps = {};
-const props = {}
+const props = {};
 
 const setupDispatchProps = () => {
   dispatchProps.onSubmit = jest.fn();
 };
 
 const setupProps = () => {
-  props.title = 'mockTitle',
+  props.title = "mockTitle";
   props.mineStatusOptions = MOCK.STATUS_OPTIONS.options;
   props.mineRegionOptions = MOCK.REGION_OPTIONS.options;
-  props.initialValues = {}
-}
+  props.initialValues = {};
+};
 
 beforeEach(() => {
   setupDispatchProps();
   setupProps();
 });
 
-describe('MineRecordModal', () => {
-  it('renders properly', () => {
+describe("MineRecordModal", () => {
+  it("renders properly", () => {
     const component = shallow(<MineRecordModal {...dispatchProps} {...props} />);
     expect(component).toMatchSnapshot();
   });

--- a/frontend/src/tests/components/modalContent/UpdatePermitteeModal.spec.js
+++ b/frontend/src/tests/components/modalContent/UpdatePermitteeModal.spec.js
@@ -1,10 +1,10 @@
-import React from 'react';
-import { shallow } from 'enzyme';
-import { UpdatePermitteeModal } from '@/components/modalContent/UpdatePermitteeModal';
-import * as MOCK from '@/tests/mocks/dataMocks';
+import React from "react";
+import { shallow } from "enzyme";
+import { UpdatePermitteeModal } from "@/components/modalContent/UpdatePermitteeModal";
+import * as MOCK from "@/tests/mocks/dataMocks";
 
 const dispatchProps = {};
-const props = {}
+const props = {};
 
 const setupDispatchProps = () => {
   dispatchProps.onSubmit = jest.fn();
@@ -13,20 +13,20 @@ const setupDispatchProps = () => {
 };
 
 const setupProps = () => {
-  props.permit = MOCK.MINES.mines[MOCK.MINES.mineIds[1]].mine_permit[0];
+  [props.permit] = MOCK.MINES.mines[MOCK.MINES.mineIds[1]].mine_permit;
   props.parties = MOCK.PARTY.parties;
   props.partyIds = MOCK.PARTY.partyIds;
   props.permittees = MOCK.PERMITTEE.permittees;
   props.permitteeIds = MOCK.PERMITTEE.permitteeIds;
-}
+};
 
 beforeEach(() => {
   setupDispatchProps();
   setupProps();
 });
 
-describe('UpdatePermitteeModal', () => {
-  it('renders properly', () => {
+describe("UpdatePermitteeModal", () => {
+  it("renders properly", () => {
     const component = shallow(<UpdatePermitteeModal {...dispatchProps} {...props} />);
     expect(component).toMatchSnapshot();
   });

--- a/frontend/src/tests/selectors/complianceSelectors.spec.js
+++ b/frontend/src/tests/selectors/complianceSelectors.spec.js
@@ -15,9 +15,9 @@ describe("complianceSelectors", () => {
   it("`getMineComplianceInfo` calls `complianceReducer.getMineComplianceInfo`", () => {
     const storeAction = storeMineComplianceInfo(mockResponse);
     const storeState = complianceReducer({}, storeAction);
-    const mockState = {
+    const localMockState = {
       [COMPLIANCE]: storeState,
     };
-    expect(getMineComplianceInfo(mockState)).toEqual(mineComplianceInfo);
+    expect(getMineComplianceInfo(localMockState)).toEqual(mineComplianceInfo);
   });
 });

--- a/frontend/src/tests/selectors/mineSelectors.spec.js
+++ b/frontend/src/tests/selectors/mineSelectors.spec.js
@@ -24,73 +24,73 @@ const mockState = {
 
 describe("mineSelectors", () => {
   const { mineIds, mineNameList, minesPageData } = mockState;
-  let { mines, mineGuid } = mockState;
+  const { mines, mineGuid } = mockState;
 
   it("`getMines` calls `mineReducer.getMines`", () => {
     const storeAction = storeMineList(mockResponse);
     const storeState = mineReducer({}, storeAction);
-    const mockState = {
+    const localMockState = {
       [MINES]: storeState,
     };
-    expect(getMines(mockState)).toEqual(mines);
+    expect(getMines(localMockState)).toEqual(mines);
   });
 
   it("`getMineGuid` calls `mineReducer.getMineGuid` when `storeMineList` is dispatched", () => {
     const storeAction = storeMineList(mockResponse);
     const storeState = mineReducer({}, storeAction);
-    const mockState = {
+    const localMockState = {
       [MINES]: storeState,
     };
-    expect(getMineGuid(mockState)).toEqual(mineGuid);
+    expect(getMineGuid(localMockState)).toEqual(mineGuid);
   });
 
   it("`getMineGuid` calls `mineReducer.getMineGuid` when `storeMine` is dispatched", () => {
     const storeAction = storeMine(mineResponse, "18145c75-49ad-0101-85f3-a43e45ae989a");
     const storeState = mineReducer({}, storeAction);
-    const mockState = {
+    const localMockState = {
       [MINES]: storeState,
     };
-    expect(getMineGuid(mockState)).toEqual("18145c75-49ad-0101-85f3-a43e45ae989a");
+    expect(getMineGuid(localMockState)).toEqual("18145c75-49ad-0101-85f3-a43e45ae989a");
   });
 
   it("`getMineIds` calls `mineReducer.getMineIds`", () => {
     const storeAction = storeMineList(mockResponse);
     const storeState = mineReducer({}, storeAction);
-    const mockState = {
+    const localMockState = {
       [MINES]: storeState,
     };
-    expect(getMineIds(mockState)).toEqual(mineIds);
+    expect(getMineIds(localMockState)).toEqual(mineIds);
   });
 
   it("`getMineNames` calls `mineReducer.getMineNames`", () => {
     const storeAction = storeMineNameList(Mock.MINE_NAME_LIST);
     const storeState = mineReducer({}, storeAction);
-    const mockState = {
+    const localMockState = {
       [MINES]: storeState,
     };
-    expect(getMineNames(mockState)).toEqual(mineNameList);
+    expect(getMineNames(localMockState)).toEqual(mineNameList);
   });
 
   it("`getMinesPageData` calls `mineReducer.getMinesPageData`", () => {
     const storeAction = storeMineList(Mock.PAGE_DATA);
     const storeState = mineReducer({}, storeAction);
-    const mockState = {
+    const localMockState = {
       [MINES]: storeState,
     };
-    expect(getMinesPageData(mockState)).toEqual(minesPageData);
+    expect(getMinesPageData(localMockState)).toEqual(minesPageData);
   });
 
   it("`getCurrentPermittees` calls `mineReducer.getCurrentPermittees`", () => {
-    mines = Mock.MINES.mines;
-    mineGuid = Mock.MINES.mineIds[1];
-    const selected = getCurrentPermittees.resultFunc(mines, mineGuid);
+    const localMines = Mock.MINES.mines;
+    const localMineGuid = Mock.MINES.mineIds[1];
+    const selected = getCurrentPermittees.resultFunc(localMines, localMineGuid);
     expect(selected).toEqual(Mock.PERMITTEE.permittees);
   });
 
   it("`getCurrentPermitteeIds` calls `mineReducer.getCurrentPermitteeIds`", () => {
-    mines = Mock.MINES.mines;
-    mineGuid = Mock.MINES.mineIds[1];
-    const selected = getCurrentPermitteeIds.resultFunc(mines, mineGuid);
+    const localMines = Mock.MINES.mines;
+    const localMineGuid = Mock.MINES.mineIds[1];
+    const selected = getCurrentPermitteeIds.resultFunc(localMines, localMineGuid);
     expect(selected).toEqual(["1c7da2c4-10d5-4c9f-994a-96427aa0c69b"]);
   });
 });

--- a/frontend/src/tests/selectors/staticContentSelectors.spec.js
+++ b/frontend/src/tests/selectors/staticContentSelectors.spec.js
@@ -32,33 +32,34 @@ const mockState = {
 
 describe("mineSelectors", () => {
   const { mineStatusOptions, mineDisturbanceOptions, mineCommodityOptions } = mockState;
-  let { mineRegionOptions, mineTSFRequiredReports, mineTenureTypes } = mockState;
+  const { mineTSFRequiredReports } = mockState;
+  let { mineRegionOptions, mineTenureTypes } = mockState;
 
   it("`getMineStatusOptions` calls `staticContentReducer.getMineStatusOptions`", () => {
     const storeAction = storeStatusOptions(Mock.STATUS_OPTIONS);
     const storeState = staticContentReducer({}, storeAction);
-    const mockState = {
+    const localMockState = {
       [STATIC_CONTENT]: storeState,
     };
-    expect(getMineStatusOptions(mockState)).toEqual(mineStatusOptions);
+    expect(getMineStatusOptions(localMockState)).toEqual(mineStatusOptions);
   });
 
   it("`getMineRegionOptions` calls `staticContentReducer.getMineRegionOptions`", () => {
     const storeAction = storeRegionOptions(Mock.REGION_OPTIONS);
     const storeState = staticContentReducer({}, storeAction);
-    const mockState = {
+    const localMockState = {
       [STATIC_CONTENT]: storeState,
     };
-    expect(getMineRegionOptions(mockState)).toEqual(mineRegionOptions);
+    expect(getMineRegionOptions(localMockState)).toEqual(mineRegionOptions);
   });
 
   it("`getMineTSFRequiredReports` calls `staticContentReducer.getMineTSFRequiredReports`", () => {
     const storeAction = storeMineTSFRequiredDocuments(Mock.MINE_TSF_REQUIRED_REPORTS_RESPONSE);
     const storeState = staticContentReducer({}, storeAction);
-    const mockState = {
+    const localMockState = {
       [STATIC_CONTENT]: storeState,
     };
-    expect(getMineTSFRequiredReports(mockState)).toEqual(mineTSFRequiredReports);
+    expect(getMineTSFRequiredReports(localMockState)).toEqual(mineTSFRequiredReports);
   });
 
   it("`getMineRegionHash` converts `staticContentReducer.getMineRegionOptions`", () => {
@@ -76,27 +77,27 @@ describe("mineSelectors", () => {
   it("`getMineTenureTypes` calls `staticContentReducer.getMineTenureTypes`", () => {
     const storeAction = storeTenureTypes(Mock.TENURE_TYPES);
     const storeState = staticContentReducer({}, storeAction);
-    const mockState = {
+    const localMockState = {
       [STATIC_CONTENT]: storeState,
     };
-    expect(getMineTenureTypes(mockState)).toEqual(mineTenureTypes);
+    expect(getMineTenureTypes(localMockState)).toEqual(mineTenureTypes);
   });
 
   it("`getMineDisturbanceOptions` calls `staticContentReducer.getMineDisturbanceOptions`", () => {
     const storeAction = storeDisturbanceOptions(Mock.DISTURBANCE_OPTIONS);
     const storeState = staticContentReducer({}, storeAction);
-    const mockState = {
+    const localMockState = {
       [STATIC_CONTENT]: storeState,
     };
-    expect(getMineDisturbanceOptions(mockState)).toEqual(mineDisturbanceOptions);
+    expect(getMineDisturbanceOptions(localMockState)).toEqual(mineDisturbanceOptions);
   });
 
   it("`getMineCommodityOptions` calls `staticContentReducer.getMineCommodityOptions`", () => {
     const storeAction = storeCommodityOptions(Mock.COMMODITY_OPTIONS);
     const storeState = staticContentReducer({}, storeAction);
-    const mockState = {
+    const localMockState = {
       [STATIC_CONTENT]: storeState,
     };
-    expect(getMineCommodityOptions(mockState)).toEqual(mineCommodityOptions);
+    expect(getMineCommodityOptions(localMockState)).toEqual(mineCommodityOptions);
   });
 });


### PR DESCRIPTION
Some code cleanup for just about everything other than the components (to avoid merge conflicts for in-progress work).

This is almost entirely based on the ESLint rules. The exception to this is the selectors, which I refactored after having mentioned it in past code reviews.