### PR TITLE
MDS-927 Feature/Align table headers to bottom

### DIFF
--- a/frontend/src/styles/components/Tables.scss
+++ b/frontend/src/styles/components/Tables.scss
@@ -13,3 +13,7 @@
     background: #fbfbfb;
   }
 }
+
+.ant-table-thead > tr > th {
+  vertical-align: bottom;
+}


### PR DESCRIPTION
This is meant to make tables easier to read. The other acceptance criteria (such as left-alignment) were already present on the base branch.