### PR TITLE
VS Code ESLint path alias fix

### DIFF
--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -1,28 +1,30 @@
-{
-  "parser": "babel-eslint",
-  "env": {
-    "browser": true,
-    "node": true,
+const path = require("path");
+
+module.exports = {
+  parser: "babel-eslint",
+  env: {
+    browser: true,
+    node: true,
     "jest/globals": true,
-    "es6": true
+    es6: true,
   },
-  "plugins": ["jest"],
-  "extends": [
+  plugins: ["jest"],
+  extends: [
     "eslint:recommended",
     "plugin:react/recommended",
     "airbnb",
     "prettier",
-    "prettier/react"
+    "prettier/react",
   ],
-  "settings": {
+  settings: {
     "import/resolver": {
-      "alias": {
-        "map": [["@", "./src"]],
-        "extensions": [".js", ".json"]
-      }
-    }
+      alias: {
+        map: [["@", path.join(__dirname, "src")]],
+        extensions: [".js", ".json"],
+      },
+    },
   },
-  "rules": {
+  rules: {
     "react/jsx-filename-extension": "off",
     "no-case-declarations": 0,
     "react/display-name": 0,
@@ -30,6 +32,6 @@
     "import/no-named-as-default": 0,
     "jsx-a11y/anchor-is-valid": 0,
     "react/destructuring-assignment": ["error", "never"],
-    "camelcase": 0
-  }
-}
+    camelcase: 0,
+  },
+};


### PR DESCRIPTION
Using an absolute path instead of a relative path.