### PR TITLE
sql to drop old tables.

### DIFF
--- a/migrations/sql/V1.34__drop_permittee_and_mgr_appointment.sql
+++ b/migrations/sql/V1.34__drop_permittee_and_mgr_appointment.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS permittee;
+DROP TABLE IF EXISTS mgr_appointment;


### PR DESCRIPTION
dropping tables as they are obsolete after party/contact refactor. 

I found that these two tables have foreign keys, but there are no tables that have foreign keys to this table. Should be simple DROP. 