### PR TITLE
safety around lat and lon on update

### DIFF
--- a/frontend/src/components/mine/MineHeader.js
+++ b/frontend/src/components/mine/MineHeader.js
@@ -79,8 +79,8 @@ class MineHeader extends Component {
     event.preventDefault();
     const initialValues = {
       name: mine.mine_name ? mine.mine_name : null,
-      latitude: mine.mine_location[0] ? mine.mine_location[0].latitude : null,
-      longitude: mine.mine_location[0] ? mine.mine_location[0].longitude : null,
+      latitude: mine.mine_location ? mine.mine_location.latitude : null,
+      longitude: mine.mine_location ? mine.mine_location.longitude : null,
       mine_status: mine.mine_status[0] ? mine.mine_status[0].status_values : null,
       major_mine_ind: mine.major_mine_ind ? mine.major_mine_ind : false,
       mine_region: mine.region_code ? mine.region_code : null,

--- a/migrations/sql/V2019.01.28.10.13__drop_not_null_lat_long.sql
+++ b/migrations/sql/V2019.01.28.10.13__drop_not_null_lat_long.sql
@@ -1,0 +1,2 @@
+ALTER TABLE mine_location ALTER COLUMN latitude DROP NOT NULL;
+ALTER TABLE mine_location ALTER COLUMN longitude DROP NOT NULL;

--- a/python-backend/app/api/mines/location/models/mine_location.py
+++ b/python-backend/app/api/mines/location/models/mine_location.py
@@ -11,8 +11,8 @@ class MineLocation(AuditMixin, Base):
     __tablename__ = "mine_location"
     mine_location_guid = db.Column(UUID(as_uuid=True), primary_key=True)
     mine_guid = db.Column(UUID(as_uuid=True), db.ForeignKey('mine.mine_guid'))
-    latitude = db.Column(db.Numeric(9, 7), nullable=False)
-    longitude = db.Column(db.Numeric(11, 7), nullable=False)
+    latitude = db.Column(db.Numeric(9, 7))
+    longitude = db.Column(db.Numeric(11, 7))
     geom = db.Column(Geometry('POINT', 3005))
     effective_date = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
     expiry_date = db.Column(
@@ -27,8 +27,8 @@ class MineLocation(AuditMixin, Base):
         return {
             'mine_location_guid': str(self.mine_location_guid),
             'mine_guid': str(self.mine_guid),
-            'latitude': str(lat),
-            'longitude': str(lon),
+            'latitude': str(lat) if lat else None,
+            'longitude': str(lon) if lon else None,
         }
 
     @classmethod
@@ -46,7 +46,8 @@ class MineLocation(AuditMixin, Base):
             mine_guid=mine.mine_guid,
             latitude=random_location.get('latitude', 0),
             longitude=random_location.get('longitude', 0),
-            geom='SRID=3005;POINT(%f %f)' % (float(random_location.get('longitude', 0)), float(random_location.get('latitude', 0))),
+            geom='SRID=3005;POINT(%f %f)' % (float(random_location.get('longitude', 0)),
+                                             float(random_location.get('latitude', 0))),
             effective_date=datetime.today(),
             expiry_date=datetime.today(),
             **user_kwargs)

--- a/python-backend/app/api/mines/mine/models/mine.py
+++ b/python-backend/app/api/mines/mine/models/mine.py
@@ -17,11 +17,7 @@ class Mine(AuditMixin, Base):
     mine_region = db.Column(db.String(2), db.ForeignKey('mine_region_code.mine_region_code'))
     # Relationships
     mineral_tenure_xref = db.relationship('MineralTenureXref', backref='mine', lazy='joined')
-    mine_location = db.relationship(
-        'MineLocation',
-        backref='mine=',
-        order_by='desc(MineLocation.update_timestamp)',
-        lazy='joined')
+    mine_location = db.relationship('MineLocation', backref='mine', uselist=False, lazy='joined')
     mine_permit = db.relationship(
         'Permit', backref='mine', order_by='desc(Permit.issue_date)', lazy='joined')
     mine_status = db.relationship(
@@ -40,11 +36,7 @@ class Mine(AuditMixin, Base):
         lazy='joined')
     mine_type = db.relationship(
         'MineType', backref='mine', order_by='desc(MineType.update_timestamp)', lazy='joined')
-    mine_party_appt = db.relationship(
-        'MinePartyAppointment',
-        backref="mine",
-        lazy='joined')
-
+    mine_party_appt = db.relationship('MinePartyAppointment', backref="mine", lazy='joined')
 
     def __repr__(self):
         return '<Mine %r>' % self.mine_guid
@@ -64,7 +56,8 @@ class Mine(AuditMixin, Base):
             'region_code':
             self.mine_region,
             'mineral_tenure_xref': [item.json() for item in self.mineral_tenure_xref],
-            'mine_location': [item.json() for item in self.mine_location],
+            'mine_location':
+            self.mine_location.json(),
             'mine_permit': [item.json() for item in self.mine_permit],
             'mine_status': [item.json() for item in self.mine_status],
             'mine_tailings_storage_facility':
@@ -102,18 +95,17 @@ class Mine(AuditMixin, Base):
             'mine_note': self.mine_note,
             'major_mine_ind': self.major_mine_ind,
             'region_code': self.mine_region,
-            'mine_location': [item.json() for item in self.mine_location]
+            'mine_location': self.mine_location.json()
         }
 
     def json_by_name(self):
         return {'guid': str(self.mine_guid), 'mine_name': self.mine_name, 'mine_no': self.mine_no}
 
     def json_by_location(self):
-        mine_location = self.mine_location[0] if self.mine_location else None
         return {
             'guid': str(self.mine_guid),
-            'latitude': str(mine_location.latitude) if mine_location else '',
-            'longitude': str(mine_location.longitude) if mine_location else ''
+            'latitude': str(self.mine_location.latitude) if self.mine_location else '',
+            'longitude': str(self.mine_location.longitude) if self.mine_location else ''
         }
 
     def json_by_permit(self):

--- a/python-backend/app/api/mines/mine/resources/mine.py
+++ b/python-backend/app/api/mines/mine/resources/mine.py
@@ -1,4 +1,4 @@
-import decimal
+from decimal import Decimal
 import uuid
 from datetime import datetime
 
@@ -28,8 +28,10 @@ class MineResource(Resource, UserMixin, ErrorMixin):
     parser.add_argument('name', type=str, help='Name of the mine.')
     parser.add_argument('note', type=str, help='Any additional notes to be added to the mine.')
     parser.add_argument('tenure_number_id', type=int, help='Tenure number for the mine.')
-    parser.add_argument('longitude', type=decimal.Decimal, help='Longitude point for the mine.')
-    parser.add_argument('latitude', type=decimal.Decimal, help='Latitude point for the mine.')
+    parser.add_argument(
+        'longitude', type=lambda x: Decimal(x) if x else None, help='Longitude point for the mine.')
+    parser.add_argument(
+        'latitude', type=lambda x: Decimal(x) if x else None, help='Latitude point for the mine.')
     parser.add_argument(
         'mine_status',
         action='split',
@@ -290,8 +292,16 @@ class MineResource(Resource, UserMixin, ErrorMixin):
                 self.raise_error(400, 'Error: {}'.format(e))
             tenure.save()
 
-        # Location validation
-        if lat and lon:
+        if (lat and not lon) or (lon and not lat):
+            self.raise_error(400, 'latitude and longitude must both be empty, or both provided')
+        if mine.mine_location:
+            #update existing record
+            if "latitude" in data.keys():
+                mine.mine_location.latitude = lat
+            if "longitude" in data.keys():
+                mine.mine_location.longitude = lon
+            mine.mine_location.save()
+        if lat or lon and not mine.mine_location:
             location = MineLocation(
                 mine_location_guid=uuid.uuid4(),
                 mine_guid=mine.mine_guid,


### PR DESCRIPTION
if lat and long were on a mine, and the user tried to remove them it would not remove them. 

updated db to allow nullable lat and lon 
updated code to not use mine_location as a list. 

add backend validation so that lat and long are both there or neither. 
