### PR TITLE
bug/mds 1276 null mine locations causing issues

### DIFF
--- a/frontend-public/src/tests/mocks/dataMocks.js
+++ b/frontend-public/src/tests/mocks/dataMocks.js
@@ -127,12 +127,12 @@ export const MINE_RESPONSE = {
         effective_date: "2018-10-16",
         expiry_date: "9999-12-31",
       },
-      mine_location: [
+      mine_location: 
         {
           longitude: null,
           latitude: null,
-        },
-      ],
+        }
+      ,
       mine_tailings_storage_facility: [
         {
           mine_guid: "18145c75-49ad-0101-85f3-a43e45ae989a",
@@ -171,7 +171,7 @@ export const MINES = {
           tenure_number_id: "1234567",
         },
       ],
-      mine_location: [{ longitude: null, latitude: null }],
+      mine_location: { longitude: null, latitude: null },
       mine_tailings_storage_facility: [
         {
           mine_guid: "18133c75-49ad-4101-85f3-a43e35ae989a",
@@ -277,12 +277,11 @@ export const MINES = {
         effective_date: "2018-10-16",
         expiry_date: "9999-12-31",
       },
-      mine_location: [
+      mine_location: 
         {
           longitude: null,
           latitude: null,
         },
-      ],
       mine_tailings_storage_facility: [
         {
           mine_guid: "18145c75-49ad-0101-85f3-a43e45ae989a",

--- a/frontend/src/components/maps/MineMap.js
+++ b/frontend/src/components/maps/MineMap.js
@@ -131,10 +131,10 @@ class MineMap extends Component {
           mapProperties={{ basemap: "topo" }}
           viewProperties={{
             center: [
-              mine.mine_location[0] ? mine.mine_location[0].longitude : String.DEFAULT_LONG,
-              mine.mine_location[0] ? mine.mine_location[0].latitude : String.DEFAULT_LAT,
+              mine.mine_location ? mine.mine_location.longitude : String.DEFAULT_LONG,
+              mine.mine_location ? mine.mine_location.latitude : String.DEFAULT_LAT,
             ],
-            zoom: mine.mine_location[0] ? 8 : 5,
+            zoom: mine.mine_location ? 8 : 5,
             constraints: { minZoom: 5 },
           }}
           onLoad={this.handleLoadMap}

--- a/frontend/src/components/maps/MinePin.js
+++ b/frontend/src/components/maps/MinePin.js
@@ -39,11 +39,11 @@ export class MinePin extends Component {
   }
 
   points = (id) => {
-    if (this.props.mines[id].mine_location[0]) {
+    if (this.props.mines[id].mine_location) {
       return {
         type: "point",
-        longitude: this.props.mines[id].mine_location[0].longitude,
-        latitude: this.props.mines[id].mine_location[0].latitude,
+        longitude: this.props.mines[id].mine_location.longitude,
+        latitude: this.props.mines[id].mine_location.latitude,
       };
     }
     return null;

--- a/frontend/src/components/mine/MineHeader.js
+++ b/frontend/src/components/mine/MineHeader.js
@@ -236,14 +236,14 @@ class MineHeader extends Component {
             <div className="inline-flex between">
               <p className="p-white">
                 Lat:{" "}
-                {this.props.mine.mine_location[0]
-                  ? this.props.mine.mine_location[0].latitude
+                {this.props.mine.mine_location
+                  ? this.props.mine.mine_location.latitude
                   : String.EMPTY_FIELD}
               </p>
               <p className="p-white">
                 Long:{" "}
-                {this.props.mine.mine_location[0]
-                  ? this.props.mine.mine_location[0].longitude
+                {this.props.mine.mine_location
+                  ? this.props.mine.mine_location.longitude
                   : String.EMPTY_FIELD}
               </p>
             </div>

--- a/frontend/src/tests/mocks/dataMocks.js
+++ b/frontend/src/tests/mocks/dataMocks.js
@@ -21,7 +21,7 @@ export const MINE_RESPONSE = {
           tenure_number_id: "1234567",
         },
       ],
-      mine_location: [{ longitude: null, latitude: null }],
+      mine_location: { longitude: null, latitude: null },
       mine_status: {
         statusvalue: ["CLD", "CM"],
         status_labels: ["Closed", "Care & Maintenance"],
@@ -127,12 +127,10 @@ export const MINE_RESPONSE = {
         effective_date: "2018-10-16",
         expiry_date: "9999-12-31",
       },
-      mine_location: [
-        {
-          longitude: null,
-          latitude: null,
-        },
-      ],
+      mine_location: {
+        longitude: null,
+        latitude: null,
+      },
       mine_tailings_storage_facility: [
         {
           mine_guid: "18145c75-49ad-0101-85f3-a43e45ae989a",
@@ -171,7 +169,7 @@ export const MINES = {
           tenure_number_id: "1234567",
         },
       ],
-      mine_location: [{ longitude: null, latitude: null }],
+      mine_location: { longitude: null, latitude: null },
       mine_tailings_storage_facility: [
         {
           mine_guid: "18133c75-49ad-4101-85f3-a43e35ae989a",
@@ -277,12 +275,10 @@ export const MINES = {
         effective_date: "2018-10-16",
         expiry_date: "9999-12-31",
       },
-      mine_location: [
-        {
-          longitude: null,
-          latitude: null,
-        },
-      ],
+      mine_location: {
+        longitude: null,
+        latitude: null,
+      },
       mine_tailings_storage_facility: [
         {
           mine_guid: "18145c75-49ad-0101-85f3-a43e45ae989a",

--- a/python-backend/app/api/mines/location/models/mine_location.py
+++ b/python-backend/app/api/mines/location/models/mine_location.py
@@ -22,13 +22,15 @@ class MineLocation(AuditMixin, Base):
         return '<MineLocation %r>' % self.mine_guid
 
     def json(self):
+        if not self.latitude:
+            return None
         lat = self.latitude
         lon = self.longitude
         return {
             'mine_location_guid': str(self.mine_location_guid),
             'mine_guid': str(self.mine_guid),
-            'latitude': str(lat) if lat else '',
-            'longitude': str(lon) if lon else '',
+            'latitude': str(lat),
+            'longitude': str(lon),
         }
 
     @classmethod

--- a/python-backend/app/api/mines/location/models/mine_location.py
+++ b/python-backend/app/api/mines/location/models/mine_location.py
@@ -27,8 +27,8 @@ class MineLocation(AuditMixin, Base):
         return {
             'mine_location_guid': str(self.mine_location_guid),
             'mine_guid': str(self.mine_guid),
-            'latitude': str(lat) if lat else None,
-            'longitude': str(lon) if lon else None,
+            'latitude': str(lat) if lat else '',
+            'longitude': str(lon) if lon else '',
         }
 
     @classmethod

--- a/python-backend/app/api/mines/location/models/mine_map_view_location.py
+++ b/python-backend/app/api/mines/location/models/mine_map_view_location.py
@@ -34,8 +34,8 @@ class MineMapViewLocation(Base):
             'guid': str(self.mine_guid),
             'mine_name': str(self.mine_name),
             'mine_no': str(self.mine_no),
-            'mine_location': [{
+            'mine_location': {
                 'latitude': str(self.latitude),
                 'longitude': str(self.longitude)
-            }]
+            }
         }

--- a/python-backend/app/api/mines/location/resources/location.py
+++ b/python-backend/app/api/mines/location/resources/location.py
@@ -25,6 +25,7 @@ class MineLocationResource(Resource, ErrorMixin):
             return {
                 'mines':
                 list(
-                    map(lambda x: x.json_by_location(),
-                        [x for x in Mine.query.all() if x.latitude]))
+                    map(lambda x: x.json_by_location(), [
+                        x for x in Mine.query.all() if x.mine_location and x.mine_location.latitude
+                    ]))
             }

--- a/python-backend/app/api/mines/location/resources/location.py
+++ b/python-backend/app/api/mines/location/resources/location.py
@@ -21,4 +21,10 @@ class MineLocationResource(Resource, ErrorMixin):
                 return mine_location.json()
             return self.create_error_payload(404, 'Mine Location not found'), 404
         else:
-            return {'mines': list(map(lambda x: x.json_by_location(), Mine.query.all()))}
+            #only return results where lat is populated
+            return {
+                'mines':
+                list(
+                    map(lambda x: x.json_by_location(),
+                        [x for x in Mine.query.all() if x.latitude]))
+            }

--- a/python-backend/app/api/mines/mine/models/mine.py
+++ b/python-backend/app/api/mines/mine/models/mine.py
@@ -57,7 +57,7 @@ class Mine(AuditMixin, Base):
             self.mine_region,
             'mineral_tenure_xref': [item.json() for item in self.mineral_tenure_xref],
             'mine_location':
-            self.mine_location.json(),
+            self.mine_location.json() if self.mine_location else None,
             'mine_permit': [item.json() for item in self.mine_permit],
             'mine_status': [item.json() for item in self.mine_status],
             'mine_tailings_storage_facility':
@@ -95,18 +95,24 @@ class Mine(AuditMixin, Base):
             'mine_note': self.mine_note,
             'major_mine_ind': self.major_mine_ind,
             'region_code': self.mine_region,
-            'mine_location': self.mine_location.json()
+            'mine_location': self.mine_location.json() if self.mine_location else None
         }
 
     def json_by_name(self):
         return {'guid': str(self.mine_guid), 'mine_name': self.mine_name, 'mine_no': self.mine_no}
 
     def json_by_location(self):
-        return {
-            'guid': str(self.mine_guid),
-            'latitude': str(self.mine_location.latitude) if self.mine_location else '',
-            'longitude': str(self.mine_location.longitude) if self.mine_location else ''
-        }
+        #this will get cleaned up when mine_location and mine are merged
+        result = {'guid': str(self.mine_guid)}
+        if self.mine_location:
+            result['latitude'] = str(
+                self.mine_location.latitude) if self.mine_location.latitude else ''
+            result['longitude'] = str(
+                self.mine_location.longitude) if self.mine_location.longitude else ''
+        else:
+            result['latitude'] = ''
+            result['longitude'] = ''
+        return result
 
     def json_by_permit(self):
         return {

--- a/python-backend/app/api/mines/mine/resources/mine.py
+++ b/python-backend/app/api/mines/mine/resources/mine.py
@@ -296,7 +296,6 @@ class MineResource(Resource, UserMixin, ErrorMixin):
             self.raise_error(400, 'latitude and longitude must both be empty, or both provided')
         if mine.mine_location:
             #update existing record
-            #raise Exception("update the mine_location")
             if "latitude" in data.keys():
                 mine.mine_location.latitude = lat
             if "longitude" in data.keys():

--- a/python-backend/app/api/mines/mine/resources/mine.py
+++ b/python-backend/app/api/mines/mine/resources/mine.py
@@ -60,7 +60,7 @@ class MineResource(Resource, UserMixin, ErrorMixin):
             # Handle MapView request
             _map = request.args.get('map', None, type=str)
             if _map and _map.lower() == 'true':
-                records = MineMapViewLocation.query.all()
+                records = MineMapViewLocation.query.filter(MineMapViewLocation.latitude != None)
                 result = list((map(lambda x: x.json_for_map(), records)))
                 return {'mines': result}
 
@@ -296,12 +296,13 @@ class MineResource(Resource, UserMixin, ErrorMixin):
             self.raise_error(400, 'latitude and longitude must both be empty, or both provided')
         if mine.mine_location:
             #update existing record
+            #raise Exception("update the mine_location")
             if "latitude" in data.keys():
                 mine.mine_location.latitude = lat
             if "longitude" in data.keys():
                 mine.mine_location.longitude = lon
             mine.mine_location.save()
-        if lat or lon and not mine.mine_location:
+        if lat and lon and not mine.mine_location:
             location = MineLocation(
                 mine_location_guid=uuid.uuid4(),
                 mine_guid=mine.mine_guid,


### PR DESCRIPTION
backend nulls mine_location if lat is not populated. Makes two cases instead of three for the front end to handle. other cases where it was expecting list. modified view query to match normal querys. 