### PR TITLE
Fix/ Add constraint to mine status seed data

### DIFF
--- a/migrations/sql/V2019.02.05.08.51__add_constraint_mine_status_xref.sql
+++ b/migrations/sql/V2019.02.05.08.51__add_constraint_mine_status_xref.sql
@@ -1,0 +1,15 @@
+-- Unique Index
+ALTER TABLE mine_status_xref
+ADD UNIQUE (mine_operation_status_code, mine_operation_status_reason_code, mine_operation_status_sub_reason_code);
+
+-- Unique Partial Indexes
+CREATE UNIQUE INDEX unique_status_reason_idx
+ON mine_status_xref (mine_operation_status_code, mine_operation_status_reason_code)
+WHERE mine_operation_status_sub_reason_code IS NULL;
+
+CREATE UNIQUE INDEX unique_status_idx
+ON mine_status_xref (mine_operation_status_code)
+WHERE
+    mine_operation_status_reason_code IS NULL
+    AND
+    mine_operation_status_sub_reason_code IS NULL;


### PR DESCRIPTION
This prevents duplicate records from being created every time that we deploy