### PR TITLE
Fix/ Populate processed_* with non-null values in ETL

### DIFF
--- a/migrations/etl/2_Mine_manager.sql
+++ b/migrations/etl/2_Mine_manager.sql
@@ -496,7 +496,9 @@ BEGIN
             create_user         ,
             create_timestamp    ,
             update_user         ,
-            update_timestamp
+            update_timestamp    ,
+            processed_by        ,
+            processed_on
         )
         SELECT
             gen_random_uuid()   ,-- Generate a random UUID for mgr_appointment_guid
@@ -505,6 +507,8 @@ BEGIN
             'MMG'               ,
             new.effective_date  ,
             '9999-12-31'::date  ,
+            'mms_migration'     ,
+            now()               ,
             'mms_migration'     ,
             now()               ,
             'mms_migration'     ,

--- a/migrations/etl/3_Mine_permit_permitee.sql
+++ b/migrations/etl/3_Mine_permit_permitee.sql
@@ -793,7 +793,9 @@ BEGIN
             update_user              ,
             update_timestamp         ,
             start_date               ,
-            end_date
+            end_date                 ,
+            processed_by             ,
+            processed_on
         )
         SELECT
             ETL_PERMIT.mine_party_appt_guid,
@@ -806,7 +808,9 @@ BEGIN
             'mms_migration'                ,
             now()                          ,
             issue_date                     ,
-            authorization_end_date
+            authorization_end_date         ,
+            'mms_migration'                ,
+            now()
         FROM ETL_PERMIT
         INNER JOIN ETL_MINE ON
             ETL_PERMIT.mine_guid = ETL_MINE.mine_guid


### PR DESCRIPTION
This came up in preparation for the demo. The expectation is apparently
that these columns will be populated with values by the ETL process.
This PR makes that update