### PR TITLE
Fix/ Update frontend-public to new endpoint

### DIFF
--- a/frontend-public/src/actionCreators/userDashboardActionCreator.js
+++ b/frontend-public/src/actionCreators/userDashboardActionCreator.js
@@ -12,7 +12,7 @@ export const fetchUserMineInfo = () => (dispatch) => {
   dispatch(showLoading());
   dispatch(request(reducerTypes.GET_USER_MINE_INFO));
   return axios
-    .get(`${ENVIRONMENT.apiUrl + API.MINE_NAME_LIST}`, createRequestHeader())
+    .get(`${ENVIRONMENT.apiUrl + API.USER_MINE_INFO}`, createRequestHeader())
     .then((response) => {
       dispatch(success(reducerTypes.GET_USER_MINE_INFO));
       dispatch(userMineInfoActions.storeUserMineInfo(response.data));

--- a/frontend-public/src/constants/API.js
+++ b/frontend-public/src/constants/API.js
@@ -1,6 +1,6 @@
 // Network URL's
 export const MINE = "/mines";
-export const MINE_NAME_LIST = "/mines/names";
+export const USER_MINE_INFO = "/mines/search";
 
 export const DOCUMENT_STATUS = "/documents/expected/status";
 export const MINE_DOCUMENTS = "/documents/mines";

--- a/frontend-public/src/tests/actionCreators/userDashboardActionCreator.spec.js
+++ b/frontend-public/src/tests/actionCreators/userDashboardActionCreator.spec.js
@@ -77,7 +77,7 @@ describe("`updateExpectedDocument` action creator", () => {
 });
 
 describe("`fetchUserMineInfo` action creator", () => {
-  const url = ENVIRONMENT.apiUrl + API.MINE_NAME_LIST;
+  const url = ENVIRONMENT.apiUrl + API.USER_MINE_INFO;
   it("Request successful, dispatches `success` with correct response", () => {
     const mockResponse = { data: { success: true } };
     mockAxios.onGet(url).reply(200, mockResponse);

--- a/frontend-public/src/tests/mocks/dataMocks.js
+++ b/frontend-public/src/tests/mocks/dataMocks.js
@@ -320,7 +320,7 @@ export const PARTY = {
   },
 };
 
-export const MINE_NAME_LIST = [
+export const USER_MINE_INFO = [
   {
     guid: "fc72863d-83e8-46ba-90f9-87b0ed78823f",
     mine_name: "New Mine",


### PR DESCRIPTION
Frontend-public used the `/mines/names/` search endpoint to pull all mines. This endpoint was recently deprecated in favour of a search endpoint. This should be refactored, but this patch will resolve the issue in the meantime.