### PR TITLE
Bug/MDS-1399 Update mine manager etl to set end date to null

### DIFF
--- a/migrations/etl/2_Mine_manager.sql
+++ b/migrations/etl/2_Mine_manager.sql
@@ -506,7 +506,7 @@ BEGIN
             new.party_guid      ,
             'MMG'               ,
             new.effective_date  ,
-            '9999-12-31'::date  ,
+            null                ,
             'mms_migration'     ,
             now()               ,
             'mms_migration'     ,


### PR DESCRIPTION
Originally, mine managers used year 9999 to represent an unknown or unspecified end date. This is now specified using null, so the etl has been updated to set end_date to null by default (rather than '9999-12-31')

The party table still uses '9999-12-31' as the default for expiry_date.