### PR TITLE
MDS-1268 Fix/ Dynamically show permit no column & other bug fixes

### DIFF
--- a/frontend/src/components/parties/RelationshipProfile.js
+++ b/frontend/src/components/parties/RelationshipProfile.js
@@ -52,7 +52,12 @@ export class RelationshipProfile extends Component {
   componentDidMount() {
     const { id, typeCode } = this.props.match.params;
     this.props.fetchPartyRelationshipTypes();
-    this.props.fetchPartyRelationships({ mine_guid: id, types: typeCode });
+
+    // Only fetch relationships if not already in props (occurs if user did not
+    // come to this route from the Mine Dashboard)
+    if (this.props.partyRelationships.length === 0) {
+      this.props.fetchPartyRelationships({ mine_guid: id, types: typeCode });
+    }
 
     const mine = this.props.mines[id];
     if (!mine) {
@@ -78,12 +83,9 @@ export class RelationshipProfile extends Component {
   }
 
   render() {
-    const { id } = this.props.match.params;
+    const { id, typeCode } = this.props.match.params;
     const mine = this.props.mines[id];
-    const relationshipType = this.props.partyRelationships[0]
-      ? this.props.partyRelationships[0].mine_party_appt_type_code
-      : "";
-    const isPermittee = relationshipType === "PMT";
+    const isPermittee = typeCode === "PMT";
     const columnCount = 3 + (isPermittee ? 1 : 0);
     // 24 is the total span from Ant Design
     const width = 24 / columnCount;
@@ -92,6 +94,10 @@ export class RelationshipProfile extends Component {
       this.props.partyRelationshipTypes.length > 0 &&
       this.props.partyRelationships.length > 0 &&
       mine;
+
+    const filteredRelationships = this.props.partyRelationships.filter(
+      ({ mine_party_appt_type_code }) => mine_party_appt_type_code === typeCode
+    );
 
     if (isLoaded) {
       return (
@@ -134,7 +140,7 @@ export class RelationshipProfile extends Component {
                   </Row>
                   <Divider style={{ height: "2px", backgroundColor: "#013366", margin: "0" }} />
                 </div>
-                {this.props.partyRelationships.map((partyRelationship) => (
+                {filteredRelationships.map((partyRelationship) => (
                   <div key={`${partyRelationship.related_guid}${partyRelationship.start_date}`}>
                     <Row type="flex" style={{ textAlign: "center" }}>
                       <Col span={width}>

--- a/frontend/src/components/parties/RelationshipProfile.js
+++ b/frontend/src/components/parties/RelationshipProfile.js
@@ -80,6 +80,11 @@ export class RelationshipProfile extends Component {
   render() {
     const { id } = this.props.match.params;
     const mine = this.props.mines[id];
+    const [{ mine_party_appt_type_code }] = this.props.partyRelationships;
+    const isPermittee = mine_party_appt_type_code === "PMT";
+    const columnCount = 3 + (isPermittee ? 1 : 0);
+    // 24 is the total span from Ant Design
+    const width = 24 / columnCount;
 
     const isLoaded =
       this.props.partyRelationshipTypes.length > 0 &&
@@ -110,16 +115,18 @@ export class RelationshipProfile extends Component {
               <TabPane tab="History" key="history">
                 <div>
                   <Row type="flex" style={{ textAlign: "center" }}>
-                    <Col span={6}>
+                    <Col span={width}>
                       <h2>Contact</h2>
                     </Col>
-                    <Col span={6}>
+                    <Col span={width}>
                       <h2>Role</h2>
                     </Col>
-                    <Col span={6}>
-                      <h2>Permit No.</h2>
-                    </Col>
-                    <Col span={6}>
+                    {isPermittee && (
+                      <Col span={width}>
+                        <h2>Permit No.</h2>
+                      </Col>
+                    )}
+                    <Col span={width}>
                       <h2>Dates</h2>
                     </Col>
                   </Row>
@@ -128,18 +135,20 @@ export class RelationshipProfile extends Component {
                 {this.props.partyRelationships.map((partyRelationship) => (
                   <div key={partyRelationship.related_guid}>
                     <Row type="flex" style={{ textAlign: "center" }}>
-                      <Col span={6}>
+                      <Col span={width}>
                         <Link
                           to={router.PARTY_PROFILE.dynamicRoute(partyRelationship.party.party_guid)}
                         >
                           {partyRelationship.party.name}
                         </Link>
                       </Col>
-                      <Col span={6}>{this.getpartyRelationshipTitle(partyRelationship)}</Col>
-                      <Col span={6}>
-                        {this.state.permitsMapping[partyRelationship.related_guid]}
-                      </Col>
-                      <Col span={6}>
+                      <Col span={width}>{this.getpartyRelationshipTitle(partyRelationship)}</Col>
+                      {isPermittee && (
+                        <Col span={width}>
+                          {this.state.permitsMapping[partyRelationship.related_guid]}
+                        </Col>
+                      )}
+                      <Col span={width}>
                         <Icon type="clock-circle" />
                         &nbsp;&nbsp;
                         {partyRelationship.start_date || "Unknown"} -{" "}

--- a/frontend/src/components/parties/RelationshipProfile.js
+++ b/frontend/src/components/parties/RelationshipProfile.js
@@ -80,8 +80,10 @@ export class RelationshipProfile extends Component {
   render() {
     const { id } = this.props.match.params;
     const mine = this.props.mines[id];
-    const [{ mine_party_appt_type_code }] = this.props.partyRelationships;
-    const isPermittee = mine_party_appt_type_code === "PMT";
+    const relationshipType = this.props.partyRelationships[0]
+      ? this.props.partyRelationships[0].mine_party_appt_type_code
+      : "";
+    const isPermittee = relationshipType === "PMT";
     const columnCount = 3 + (isPermittee ? 1 : 0);
     // 24 is the total span from Ant Design
     const width = 24 / columnCount;
@@ -133,7 +135,7 @@ export class RelationshipProfile extends Component {
                   <Divider style={{ height: "2px", backgroundColor: "#013366", margin: "0" }} />
                 </div>
                 {this.props.partyRelationships.map((partyRelationship) => (
-                  <div key={partyRelationship.related_guid}>
+                  <div key={`${partyRelationship.related_guid}${partyRelationship.start_date}`}>
                     <Row type="flex" style={{ textAlign: "center" }}>
                       <Col span={width}>
                         <Link

--- a/frontend/src/tests/components/parties/RelationshipProfile.spec.js
+++ b/frontend/src/tests/components/parties/RelationshipProfile.spec.js
@@ -16,7 +16,7 @@ const setupDispatchProps = () => {
 
 const setupReducerProps = () => {
   reducerProps.parties = MOCK.PARTY.parties[MOCK.PARTY.partyIds[0]];
-  reducerProps.partyRelationships = {};
+  reducerProps.partyRelationships = [];
   reducerProps.partyRelationshipTypes = [];
   reducerProps.mines = MOCK.MINES;
 };


### PR DESCRIPTION
- The **Permit No** column is now only shown when the relationship type is for Permittees
- The full list of parties no longer flashes before the filtered list is rendered
- There is no longer a mix of Permittees and Mine Managers on the same list (incorrect party relationships rendering)
- The render method is now lighter
- API calls are only made when the data is needed, instead of on every component mount