### PR TITLE
Improvement/MDS-1445 Increase Mine Document file name limit

### DIFF
--- a/migrations/sql/V2019.02.19.16.05__increase_mine_document_file_name_limits.sql
+++ b/migrations/sql/V2019.02.19.16.05__increase_mine_document_file_name_limits.sql
@@ -1,0 +1,1 @@
+ALTER TABLE mine_document ALTER COLUMN document_name TYPE VARCHAR(255);


### PR DESCRIPTION
Missed form PR #535. Increases the file name limit on mine documents from 40 to 255 characters.