### PR TITLE
Fix breaking API change & update FE category param

### DIFF
--- a/frontend-public/src/tests/mocks/dataMocks.js
+++ b/frontend-public/src/tests/mocks/dataMocks.js
@@ -552,19 +552,19 @@ export const MINE_TSF_REQUIRED_REPORTS_RESPONSE = {
       req_document_guid: "05388944-afb3-4ef4-9db1-94db72f6060e",
       req_document_name: "Annual Reclamation",
       req_document_description: "10.4.4a",
-      req_document_category: "MINE_TAILINGS",
+      req_document_category: "TSF",
     },
     {
       req_document_guid: "ca3f5a58-d7ea-4620-a064-507450f082de",
       req_document_name: "Annual DSI",
       req_document_description: "10.4.4b",
-      req_document_category: "MINE_TAILINGS",
+      req_document_category: "TSF",
     },
     {
       req_document_guid: "faa99067-3639-4d9c-a3e5-5401df15ad4b",
       req_document_name: "5 year DSR",
       req_document_description: "10.5.4",
-      req_document_category: "MINE_TAILINGS",
+      req_document_category: "TSF",
     },
   ],
 };

--- a/frontend/src/constants/API.js
+++ b/frontend/src/constants/API.js
@@ -27,7 +27,7 @@ export const UPLOAD_MINE_EXPECTED_DOCUMENT_FILE = (expectedDocumentGuid) =>
   `/documents/expected/${expectedDocumentGuid}/document`;
 export const DOCUMENT_STATUS = "/documents/expected/status";
 export const MINE_DOCUMENTS = "/documents/mines";
-export const MINE_TSF_REQUIRED_DOCUMENTS = "/documents/required?category=MINE_TAILINGS";
+export const MINE_TSF_REQUIRED_DOCUMENTS = "/documents/required?category=TSF";
 export const EXPECTED_DOCUMENT = "/documents/expected";
 export const MINE_TENURE_TYPES = "/mines/mine-tenure-type-codes";
 export const MINE_TYPES = "/mines/mine-types";

--- a/frontend/src/tests/mocks/dataMocks.js
+++ b/frontend/src/tests/mocks/dataMocks.js
@@ -573,19 +573,19 @@ export const MINE_TSF_REQUIRED_REPORTS_RESPONSE = {
       req_document_guid: "05388944-afb3-4ef4-9db1-94db72f6060e",
       req_document_name: "Annual Reclamation",
       req_document_description: "10.4.4a",
-      req_document_category: "MINE_TAILINGS",
+      req_document_category: "TSF",
     },
     {
       req_document_guid: "ca3f5a58-d7ea-4620-a064-507450f082de",
       req_document_name: "Annual DSI",
       req_document_description: "10.4.4b",
-      req_document_category: "MINE_TAILINGS",
+      req_document_category: "TSF",
     },
     {
       req_document_guid: "faa99067-3639-4d9c-a3e5-5401df15ad4b",
       req_document_name: "5 year DSR",
       req_document_description: "10.5.4",
-      req_document_category: "MINE_TAILINGS",
+      req_document_category: "TSF",
     },
   ],
 };

--- a/python-backend/app/api/documents/required/resources/required_documents.py
+++ b/python-backend/app/api/documents/required/resources/required_documents.py
@@ -18,7 +18,7 @@ class RequiredDocumentResource(Resource, UserMixin, ErrorMixin):
             result = req_doc.json()
 
         else:
-            search_category = request.args.get('category', None, type=str)
+            search_category = request.args.get('category')
             if search_category:
                 req_docs = RequiredDocument.find_by_req_doc_category(search_category.upper())
             else:

--- a/python-backend/app/api/documents/required/resources/required_documents.py
+++ b/python-backend/app/api/documents/required/resources/required_documents.py
@@ -18,10 +18,10 @@ class RequiredDocumentResource(Resource, UserMixin, ErrorMixin):
             result = req_doc.json()
 
         else:
-            search_category = request.args.get('category')
+            search_category = request.args.get('category', None, type=str)
             if search_category:
                 req_docs = RequiredDocument.find_by_req_doc_category(search_category.upper())
             else:
                 req_docs = RequiredDocument.query.all()
-            result = [x.json() for x in req_docs]
+            result = { 'required_documents': [x.json() for x in req_docs] }
         return result

--- a/python-backend/app/api/mines/tailings/resources/tailings.py
+++ b/python-backend/app/api/mines/tailings/resources/tailings.py
@@ -66,7 +66,7 @@ class MineTailingsStorageFacilityResource(Resource, UserMixin, ErrorMixin):
                             500,
                             'get_tsf_req_docs returned error' + str(get_tsf_docs_resp.status_code))
 
-                    tsf_required_documents = get_tsf_docs_resp.json()
+                    tsf_required_documents = get_tsf_docs_resp.json()['required_documents']
                     new_expected_documents = []
                     for tsf_req_doc in tsf_required_documents:
                         new_expected_documents.append({

--- a/python-backend/tests/documents/required/resources/test_required_documents_resource.py
+++ b/python-backend/tests/documents/required/resources/test_required_documents_resource.py
@@ -7,7 +7,7 @@ def test_get_all_required_documents(test_client, auth_headers):
     get_resp = test_client.get('/documents/required', headers=auth_headers['full_auth_header'])
     get_data = json.loads(get_resp.data.decode())
     assert get_resp.status_code == 200
-    assert len(get_data) == 3
+    assert len(get_data['required_documents']) == 3
 
 
 # GET
@@ -27,6 +27,6 @@ def test_get_all_required_documents_by_category(test_client, auth_headers):
         headers=auth_headers['full_auth_header'])
     get_data = json.loads(get_resp.data.decode())
     assert get_resp.status_code == 200
-    assert len(get_data) == 2
+    assert len(get_data['required_documents']) == 2
     assert all(
-        rd['req_document_category'] == TEST_REQUIRED_REPORT_CATEGORY_TAILINGS for rd in get_data)
+        rd['req_document_category'] == TEST_REQUIRED_REPORT_CATEGORY_TAILINGS for rd in get_data['required_documents'])


### PR DESCRIPTION
A regression was spotted during a smoke test today where a button stopped working. This was caused by a breaking API change. This PR fixes that breaking change and updates the frontend to use the required docs code (TSF) instead of name.