### PR TITLE
Got rid of the 0 random mines created message

### DIFF
--- a/python-backend/app/commands.py
+++ b/python-backend/app/commands.py
@@ -82,8 +82,9 @@ def register_commands(app):
                 # E.g. 520 -> [100, 100, 100, 100, 100, 20]
                 full_batches = int(num / batch_size)
                 batches = [batch_size] * full_batches
-                batches.append(num % batch_size)
-
+                if 0 < num % batch_size:
+                    batches.append(num % batch_size)
+                
                 task_list = []
                 for batch in batches:
                     task_list.append(executor.submit(_create_data, batch))


### PR DESCRIPTION
This message appears during the random data generation stage of make targets generate-rand100, generate-rand1000 and rebuild-all-local.