### PR TITLE
Conditionally Run Frontend Tests pre-push

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -114,6 +114,9 @@
     "format:write": "prettier --config .prettierrc.json --write",
     "format:write-all": "prettier --config .prettierrc.json src/*.js --write && prettier --config .prettierrc.json src/**/*.js --write && prettier --config .prettierrc.json src/**/**/*.js --write",
     "test": "jest --env=jsdom --runInBand",
+    "test:conditional": "ls && npm run test:conditional-unix || npm run test:conditional-windows",
+    "test:conditional-unix": "git status -sb | sed 's/## //' | sed 's/\\?\\? .*//g' | sed 's/.*\\(\\.\\.\\.origin\\/\\).*/y/' | head -1 | xargs -I {} bash -c 'if [ {} != \"y\" ]; then npm test; else exit 0; fi' || git branch | grep -o '* .*' | sed 's/\\* //' | xargs -I{} git diff --name-only origin/{} | sed 's/.*\\(frontend\\).*/y/g' | xargs -I {} bash -c 'if [ {} == \"y\" ]; then npm test; else exit 0 ; fi'",
+    "test:conditional-windows": "npm test",
     "test:coverage": "npm test src -- --testResultsProcessor=jest-junit",
     "test:updateAll": "npm test -- -u",
     "test:watch": "npm test -- --watch"
@@ -154,7 +157,7 @@
   ],
   "husky": {
     "hooks": {
-      "pre-push": "npm test",
+      "pre-push": "npm run test:conditional",
       "pre-commit": "lint-staged"
     }
   },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -115,7 +115,7 @@
     "format:write-all": "prettier --config .prettierrc.json src/*.js --write && prettier --config .prettierrc.json src/**/*.js --write && prettier --config .prettierrc.json src/**/**/*.js --write",
     "test": "jest --env=jsdom --runInBand",
     "test:conditional": "ls && npm run test:conditional-unix || npm run test:conditional-windows",
-    "test:conditional-unix": "git status -sb | sed 's/## //' | sed 's/\\?\\? .*//g' | sed 's/.*\\(\\.\\.\\.origin\\/\\).*/y/' | head -1 | xargs -I {} bash -c 'if [ {} != \"y\" ]; then npm test; else exit 0; fi' || git branch | grep -o '* .*' | sed 's/\\* //' | xargs -I{} git diff --name-only origin/{} | sed 's/.*\\(frontend\\).*/y/g' | xargs -I {} bash -c 'if [ {} == \"y\" ]; then npm test; else exit 0 ; fi'",
+    "test:conditional-unix": "git status -sb | sed 's/## //' | sed 's/\\?\\? .*//g' | sed 's/.*\\(\\.\\.\\.origin\\/\\).*/y/' | head -1 | xargs -I {} bash -c 'if [ {} != \"y\" ]; then npm test; else exit 1; fi' || git branch | grep -o '* .*' | sed 's/\\* //' | xargs -I{} git diff --name-only origin/{} | sed 's/.*\\(frontend\\).*/y/g' | xargs -I {} bash -c 'if [ {} == \"y\" ]; then npm test; else exit 0 ; fi'",
     "test:conditional-windows": "npm test",
     "test:coverage": "npm test src -- --testResultsProcessor=jest-junit",
     "test:updateAll": "npm test -- -u",


### PR DESCRIPTION
A quick solution built using on git version `2.19.1` on MacOS

This implements the following logic:
Check if remote exists.
If it doesn't, run the tests. If it does exist, compare local changes to remote branch and see if there are frontend changes.
If there are frontend changes, run tests. If there aren't frontend changes, exit with a success status code (allowing you to chain additional commands)

Caveats
This uses the `git` CLI output and parses it as a stdin. This assumes a lot about the git version, terminal type (bash, fish, whatever else), and standard formatting of the output.

This is largely just a discussion/starting point for what a solution _might_ look like.