### PR TITLE
Bug/MDS-1779 fix interceptors

### DIFF
--- a/frontend/src/customAxios.js
+++ b/frontend/src/customAxios.js
@@ -10,10 +10,14 @@ const CustomAxios = (errorToastMessage) => {
   instance.interceptors.response.use(
     (response) => response,
     (error) => {
-      const { status } = error.response;
-      if (status === UNAUTHORIZED || status === MAINTENANCE) {
-        window.location.reload(false);
-      } else if (errorToastMessage === "default" || errorToastMessage === undefined) {
+      if (error.response) {
+        const { status } = error.response;
+        if (status === UNAUTHORIZED || status === MAINTENANCE) {
+          window.location.reload(false);
+        }
+      }
+
+      if (errorToastMessage === "default" || errorToastMessage === undefined) {
         notification.error({
           message: error.response ? error.response.data.error.message : String.ERROR,
           duration: 10,

--- a/frontend/src/customAxios.js
+++ b/frontend/src/customAxios.js
@@ -10,11 +10,9 @@ const CustomAxios = (errorToastMessage) => {
   instance.interceptors.response.use(
     (response) => response,
     (error) => {
-      if (error.response) {
-        const { status } = error.response;
-        if (status === UNAUTHORIZED || status === MAINTENANCE) {
-          window.location.reload(false);
-        }
+      const status = error.response ? error.response.status : null;
+      if (status === UNAUTHORIZED || status === MAINTENANCE) {
+        window.location.reload(false);
       }
 
       if (errorToastMessage === "default" || errorToastMessage === undefined) {

--- a/frontend/src/customAxios.js
+++ b/frontend/src/customAxios.js
@@ -13,9 +13,7 @@ const CustomAxios = (errorToastMessage) => {
       const status = error.response ? error.response.status : null;
       if (status === UNAUTHORIZED || status === MAINTENANCE) {
         window.location.reload(false);
-      }
-
-      if (errorToastMessage === "default" || errorToastMessage === undefined) {
+      } else if (errorToastMessage === "default" || errorToastMessage === undefined) {
         notification.error({
           message: error.response ? error.response.data.error.message : String.ERROR,
           duration: 10,


### PR DESCRIPTION
The new Axios interceptor will error on some responses that my be returned from the backend. 

The interceptor crashes on the line {status} = error.response if error.response is null. This can happen when an error is returned outside of our Flask app formatting the error correctly, such as when the entire backend is down. It was incorrectly assumed when the code was written that this couldn't happen.