### PR TITLE
parser refactor missed a mapping.

### DIFF
--- a/frontend/src/components/mine/Tailings/MineTailingsInfo.js
+++ b/frontend/src/components/mine/Tailings/MineTailingsInfo.js
@@ -73,9 +73,8 @@ export class MineTailingsInfo extends Component {
     updatedDocument.exp_document_name = value.tsf_report_name;
     updatedDocument.due_date = value.tsf_report_due_date;
     updatedDocument.received_date = value.tsf_report_received_date;
-    updatedDocument.exp_document_status = this.props.expectedDocumentStatusOptions.find(
-      ({ exp_document_status_code }) => exp_document_status_code === value.tsf_report_status
-    );
+    updatedDocument.exp_document_status_code = value.tsf_report_status;
+
     return this.props
       .updateExpectedDocument(updatedDocument.exp_document_guid, updatedDocument)
       .then(() => {


### PR DESCRIPTION
backend wasn't using the object that was being updated by form. had to change the mapping to send back the code. 