### PR TITLE
Fix/incident form and core users

### DIFF
--- a/frontend/src/components/mine/Incidents/MineIncidents.js
+++ b/frontend/src/components/mine/Incidents/MineIncidents.js
@@ -104,7 +104,7 @@ export class MineIncidents extends Component {
 const mapStateToProps = (state) => ({
   mineIncidents: getMineIncidents(state),
   followupActions: getIncidentFollowupActionOptions(state),
-  followupActionsDropDown: getDropdownIncidentFollowupActionOptions(state),
+  followupActionsDropdown: getDropdownIncidentFollowupActionOptions(state),
 });
 
 const mapDispatchToProps = (dispatch) =>

--- a/python-backend/app/api/users/core/resources/core_user.py
+++ b/python-backend/app/api/users/core/resources/core_user.py
@@ -41,9 +41,6 @@ class CoreUserListResource(Resource, UserMixin):
         else:
             core_users = CoreUser.query.filter_by(active_ind=True).all()
 
-        if not core_users:
-            raise NotFound('No users found.')
-
         return core_users
 
 


### PR DESCRIPTION
prop name had a typo, and /users/core no longer throws an exception if empty. 