### PR TITLE
Remove variance business rules from db

### DIFF
--- a/migrations/sql/V2019.04.25.11.30__add_variance_applications_metadata.sql
+++ b/migrations/sql/V2019.04.25.11.30__add_variance_applications_metadata.sql
@@ -33,28 +33,4 @@ ADD CONSTRAINT variance_status_variance_application_status_code_fkey
     REFERENCES variance_application_status_code(variance_application_status_code)
     DEFERRABLE INITIALLY DEFERRED,
 ADD CONSTRAINT variance_inspector_core_user_fkey
-    FOREIGN KEY (inspector_id) REFERENCES core_user(core_user_id) DEFERRABLE INITIALLY DEFERRED,
-
--- Business Rule Constraints
-
-  -- inspector_id
-ADD CONSTRAINT inspector_required_on_reviewed_application
-    CHECK (NOT (inspector_id IS NULL AND (
-              variance_application_status_code = 'APP' OR variance_application_status_code = 'DEN'
-          ) ) ),
-
-  -- issue_date
-ADD CONSTRAINT issue_date_required_on_approved_variance_else_forbidden
-    CHECK (
-        (NOT (issue_date IS NULL AND variance_application_status_code = 'APP') )
-        AND
-        (NOT (issue_date IS NOT NULL AND variance_application_status_code != 'APP') )
-    ),
-
-  -- expiry_date
-ADD CONSTRAINT expiry_date_required_on_approved_variance_else_forbidden
-    CHECK (
-        (NOT (expiry_date IS NULL AND variance_application_status_code = 'APP') )
-        AND
-        (NOT (expiry_date IS NOT NULL AND variance_application_status_code != 'APP') )
-    );
+    FOREIGN KEY (inspector_id) REFERENCES core_user(core_user_id) DEFERRABLE INITIALLY DEFERRED;


### PR DESCRIPTION
These rules are implemented in the resource layer of PR 698. Having them in the database immediately started conflicted with existing data.