### PR TITLE
Remove invalid commodity type code from constants file

### DIFF
--- a/python-backend/app/api/constants.py
+++ b/python-backend/app/api/constants.py
@@ -3,7 +3,6 @@
 # codes under the same tenure
 METALS_AND_MINERALS = [
     'AE',
-    'AT',
     'AL',
     'AI',
     'AM',


### PR DESCRIPTION
`AT` is not a valid commodity code (as per the "real" data in the seed data migration file). The constants file contains this value, which is used by the factory and intermittently throws an error in `flask create_data`.