### PR TITLE
Bug/ Fix variance document upload failing once one variance w/ docs is created

### DIFF
--- a/python-backend/app/api/mines/variances/resources/variance_document_upload.py
+++ b/python-backend/app/api/mines/variances/resources/variance_document_upload.py
@@ -17,14 +17,13 @@ from app.api.mines.mine_api_models import VARIANCE_MODEL
 
 
 class VarianceDocumentUploadResource(Resource, UserMixin, ErrorMixin):
-    # Methods don't share any common parser args, so none are defined here
-    parser = CustomReqparser()
-
     @api.doc(description='Request a document_manager_guid for uploading a document')
     @requires_any_of([MINE_CREATE, MINESPACE_PROPONENT])
     def post(self, mine_guid, variance_id):
+        parser = CustomReqparser()
+
         # DocumentManager requires parser data, but no arguments are required
-        data = self.parser.parse_args()
+        data = parser.parse_args()
         metadata = self._parse_request_metadata()
         if not metadata or not metadata.get('filename'):
             raise BadRequest('Filename not found in request metadata header')
@@ -60,13 +59,14 @@ class VarianceDocumentUploadResource(Resource, UserMixin, ErrorMixin):
     @api.marshal_with(VARIANCE_MODEL, code=200)
     @requires_any_of([MINE_CREATE, MINESPACE_PROPONENT])
     def put(self, mine_guid, variance_id):
+        parser = CustomReqparser()
         # Arguments required by MineDocument
-        self.parser.add_argument('document_name', type=str, required=True)
-        self.parser.add_argument('document_manager_guid', type=str, required=True)
+        parser.add_argument('document_name', type=str, required=True)
+        parser.add_argument('document_manager_guid', type=str, required=True)
 
         variance = Variance.find_by_variance_id(variance_id)
 
-        data = self.parser.parse_args()
+        data = parser.parse_args()
         document_name = data.get('document_name')
         document_manager_guid = data.get('document_manager_guid')
 


### PR DESCRIPTION
It seems that a CustomReqparser declared on the class is not properly cleaned up between requests.

Bug being addressed:
- Create a variance with documents
- Attempt to upload documents to a new variance -- document upload fails