### PR TITLE
Small fix to VSCode Intellisense (and others?) on frontends

### DIFF
--- a/frontend-public/jsconfig.json
+++ b/frontend-public/jsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  }
+}

--- a/frontend/jsconfig.json
+++ b/frontend/jsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  }
+}


### PR DESCRIPTION
Adding jsconfig.json file that allows VS code to Peek and Traverse definitions.