### PR TITLE
find mine by guid or num then use number

### DIFF
--- a/python-backend/app/api/mines/compliance/resources/compliance.py
+++ b/python-backend/app/api/mines/compliance/resources/compliance.py
@@ -60,24 +60,24 @@ class MineComplianceSummaryResource(Resource, UserMixin, ErrorMixin):
     @api.marshal_with(MINE_COMPLIANCE_RESPONSE_MODEL, code=200)
     @requires_role_mine_view
     def get(self, mine_no):
-        result = cache.get(NRIS_COMPLIANCE_DATA(mine_no))
-        if result is None:
-            mine = Mine.find_by_mine_no_or_guid(mine_no)
-            if not mine:
-                raise NotFound("No mine record in CORE.")
+        mine = Mine.find_by_mine_no_or_guid(mine_no)
+        if not mine:
+            raise NotFound("No mine record in CORE.")
 
+        result = cache.get(NRIS_COMPLIANCE_DATA(mine.mine_no))
+        if result is None:
             try:
                 raw_data = NRIS_API_service._get_NRIS_data_by_mine(
-                    request.headers.get('Authorization'), mine_no)
+                    request.headers.get('Authorization'), mine.mine_no)
             except requests.exceptions.Timeout:
-                current_app.logger.error(f'NRIS_API Connection Timeout <mine_no={mine_no}>')
+                current_app.logger.error(f'NRIS_API Connection Timeout <mine_no={mine.mine_no}>')
                 raise
             except requests.exceptions.HTTPError as e:
                 current_app.logger.error(
-                    f'NRIS_API Connection HTTPError <mine_no={mine_no}>, {str(e)}')
+                    f'NRIS_API Connection HTTPError <mine_no={mine.mine_no}>, {str(e)}')
                 raise
 
             result = NRIS_API_service._process_NRIS_data(raw_data)
             if len(result['orders']) > 0:
-                cache.set(NRIS_COMPLIANCE_DATA(mine_no), result, timeout=TIMEOUT_60_MINUTES)
+                cache.set(NRIS_COMPLIANCE_DATA(mine.mine_no), result, timeout=TIMEOUT_60_MINUTES)
         return result


### PR DESCRIPTION
fixing a bug that passes through the url parameter, which isn't going to work. We need to use the guid or number to fetch the mine and use it's number.