### PR TITLE
Drop inspector_id on variane; V2019.06.03.15.44__alter_variance_drop_inspector_id.sql

### DIFF
--- a/migrations/sql/V2019.06.03.15.44__alter_variance_drop_inspector_id.sql
+++ b/migrations/sql/V2019.06.03.15.44__alter_variance_drop_inspector_id.sql
@@ -1,0 +1,1 @@
+alter table variance drop column inspector_id;


### PR DESCRIPTION
This is the followup script after data migration scripts were successfully run in prod to migrate inspector_id to inspector_party_guid.

Alll inspectors were successfully migrated, and this will drop the now defunct column.