### PR TITLE
MDS-2030 Feature/ Update Variances to accommodate user-requested workflow

### DIFF
--- a/frontend/src/actionCreators/varianceActionCreator.js
+++ b/frontend/src/actionCreators/varianceActionCreator.js
@@ -76,7 +76,8 @@ export const addDocumentToVariance = ({ mineGuid, varianceGuid }, payload) => (d
   return CustomAxios()
     .put(
       ENVIRONMENT.apiUrl + API.VARIANCE_DOCUMENTS(mineGuid, varianceGuid),
-      payload,
+      // TODO: Remove hardcoded value when fully-integrated with form inputs
+      { ...payload, variance_document_category_code: "REQ" },
       createRequestHeader()
     )
     .then((response) => {

--- a/migrations/sql/V2019.06.12.10.40__add_variance_document_categories_and_parties_notified_ind.sql
+++ b/migrations/sql/V2019.06.12.10.40__add_variance_document_categories_and_parties_notified_ind.sql
@@ -1,0 +1,73 @@
+-- 1) Add new status code option
+INSERT INTO variance_application_status_code (
+    variance_application_status_code,
+    description,
+    create_user,
+    update_user
+) VALUES (
+    'RFD',
+    'Ready for Decision',
+    'system-mds',
+    'system-mds'
+);
+
+
+-- 2) Update variance table to track notification state
+ALTER TABLE variance
+ADD COLUMN parties_notified_ind boolean DEFAULT FALSE NOT NULL;
+
+
+-- 3) Add categories to variance documents
+CREATE TABLE IF NOT EXISTS variance_document_category_code
+(
+    variance_document_category_code varchar(3)   PRIMARY KEY                        ,
+    description                     varchar(100)                            NOT NULL,
+    active_ind                      boolean                  DEFAULT TRUE   NOT NULL,
+    create_user                     character varying(60)                   NOT NULL,
+    create_timestamp                timestamp with time zone DEFAULT now()  NOT NULL,
+    update_user                     character varying(60)                   NOT NULL,
+    update_timestamp                timestamp with time zone DEFAULT now()  NOT NULL
+);
+
+ALTER TABLE variance_document_category_code OWNER TO mds;
+
+COMMENT ON TABLE variance_document_category_code IS 'Contains a list of values used to describe the relationship between a document and a variance.';
+
+INSERT INTO variance_document_category_code (
+    variance_document_category_code,
+    description,
+    create_user,
+    update_user
+) VALUES (
+    'REQ',
+    'Request',
+    'system-mds',
+    'system-mds'
+),
+(
+    'REC',
+    'Recommendation',
+    'system-mds',
+    'system-mds'
+),
+(
+    'DEC',
+    'Decision',
+    'system-mds',
+    'system-mds'
+);
+
+
+-- Create category column and migrate existing data
+ALTER TABLE variance_document_xref
+ADD COLUMN variance_document_category_code varchar(3) DEFAULT 'REQ' NOT NULL;
+
+-- Drop column default for all future records
+ALTER TABLE variance_document_xref
+ALTER COLUMN variance_document_category_code DROP DEFAULT;
+
+
+ALTER TABLE ONLY variance_document_xref
+    ADD CONSTRAINT variance_document_xref_category_code
+    FOREIGN KEY (variance_document_category_code)
+    REFERENCES variance_document_category_code(variance_document_category_code);

--- a/migrations/sql/V2019.06.12.10.40__add_variance_document_categories_and_parties_notified_ind.sql
+++ b/migrations/sql/V2019.06.12.10.40__add_variance_document_categories_and_parties_notified_ind.sql
@@ -20,7 +20,7 @@ ADD COLUMN parties_notified_ind boolean DEFAULT FALSE NOT NULL;
 -- 3) Add categories to variance documents
 CREATE TABLE IF NOT EXISTS variance_document_category_code
 (
-    variance_document_category_code varchar(3)   PRIMARY KEY                        ,
+    variance_document_category_code varchar(3)               PRIMARY KEY            ,
     description                     varchar(100)                            NOT NULL,
     active_ind                      boolean                  DEFAULT TRUE   NOT NULL,
     create_user                     character varying(60)                   NOT NULL,

--- a/python-backend/app/api/documents/variances/models/variance.py
+++ b/python-backend/app/api/documents/variances/models/variance.py
@@ -15,6 +15,7 @@ class VarianceDocumentXref(Base):
     variance_id = db.Column(db.Integer,
                             db.ForeignKey('variance.variance_id'),
                             server_default=FetchedValue())
+    variance_document_category_code = db.Column(db.String, nullable=False)
     created_at = db.Column(db.DateTime, server_default=FetchedValue())
 
     mine_document = db.relationship('MineDocument', lazy='joined')

--- a/python-backend/app/api/documents/variances/models/variance.py
+++ b/python-backend/app/api/documents/variances/models/variance.py
@@ -15,7 +15,9 @@ class VarianceDocumentXref(Base):
     variance_id = db.Column(db.Integer,
                             db.ForeignKey('variance.variance_id'),
                             server_default=FetchedValue())
-    variance_document_category_code = db.Column(db.String, nullable=False)
+    variance_document_category_code = db.Column(db.String,
+                                                db.ForeignKey('variance_document_category_code.variance_document_category_code'),
+                                                nullable=False)
     created_at = db.Column(db.DateTime, server_default=FetchedValue())
 
     mine_document = db.relationship('MineDocument', lazy='joined')

--- a/python-backend/app/api/mines/mine_api_models.py
+++ b/python-backend/app/api/mines/mine_api_models.py
@@ -207,6 +207,7 @@ VARIANCE_MODEL = api.model(
         'applicant_guid': fields.String,
         'inspector_party_guid': fields.String,
         'note': fields.String,
+        'parties_notified_ind': fields.Boolean,
         'issue_date': fields.Date,
         'received_date': fields.Date,
         'expiry_date': fields.Date,

--- a/python-backend/app/api/mines/mine_api_models.py
+++ b/python-backend/app/api/mines/mine_api_models.py
@@ -194,7 +194,8 @@ MINE_INCIDENT_DETERMINATION_TYPE_MODEL = api.model(
 
 VARIANCE_DOCUMENT_MODEL = api.inherit(
     'VarianceDocumentModel', MINE_DOCUMENT_MODEL, {
-        'created_at': fields.Date
+        'created_at': fields.Date,
+        'variance_document_category_code': fields.String
     })
 
 VARIANCE_MODEL = api.model(

--- a/python-backend/app/api/mines/variances/resources/variance.py
+++ b/python-backend/app/api/mines/variances/resources/variance.py
@@ -49,6 +49,11 @@ class MineVarianceResource(Resource, UserMixin, ErrorMixin):
         store_missing=False,
         help='A note to include on the variance. Limited to 300 characters.')
     parser.add_argument(
+        'parties_notified_ind',
+        type=bool,
+        store_missing=False,
+        help='Indicates if the relevant parties have been notified of variance request and decision.')
+    parser.add_argument(
         'issue_date', store_missing=False, help='The date on which the variance was issued.')
     parser.add_argument(
         'expiry_date', store_missing=False, help='The date on which the variance expires.')

--- a/python-backend/app/api/mines/variances/resources/variance_list.py
+++ b/python-backend/app/api/mines/variances/resources/variance_list.py
@@ -49,6 +49,11 @@ class MineVarianceListResource(Resource, UserMixin, ErrorMixin):
         store_missing=False,
         help='A note to include on the variance. Limited to 300 characters.')
     parser.add_argument(
+        'parties_notified_ind',
+        type=bool,
+        store_missing=False,
+        help='Indicates if the relevant parties have been notified of variance request and decision.')
+    parser.add_argument(
         'issue_date', store_missing=False, help='The date on which the variance was issued.')
     parser.add_argument(
         'expiry_date', store_missing=False, help='The date on which the variance expires.')
@@ -109,6 +114,7 @@ class MineVarianceListResource(Resource, UserMixin, ErrorMixin):
             applicant_guid=data.get('applicant_guid'),
             inspector_party_guid=inspector_party_guid,
             note=data.get('note'),
+            parties_notified_ind=data.get('parties_notified_ind'),
             issue_date=issue_date,
             expiry_date=expiry_date)
 

--- a/python-backend/app/api/variances/models/variance.py
+++ b/python-backend/app/api/variances/models/variance.py
@@ -36,6 +36,7 @@ class Variance(AuditMixin, Base):
         server_default=FetchedValue())
     inspector_party_guid = db.Column(UUID(as_uuid=True), db.ForeignKey('party.party_guid'))
     note = db.Column(db.String, nullable=False, server_default=FetchedValue())
+    parties_notified_ind = db.Column(db.Boolean, nullable=False, server_default=FetchedValue())
     issue_date = db.Column(db.DateTime)
     received_date = db.Column(db.DateTime, nullable=False)
     expiry_date = db.Column(db.DateTime)
@@ -59,6 +60,7 @@ class Variance(AuditMixin, Base):
             variance_application_status_code=None,
             inspector_party_guid=None,
             note=None,
+            parties_notified_ind=None,
             issue_date=None,
             expiry_date=None,
             add_to_session=True):
@@ -69,6 +71,7 @@ class Variance(AuditMixin, Base):
             applicant_guid=applicant_guid,
             inspector_party_guid=inspector_party_guid,
             note=note,
+            parties_notified_ind=parties_notified_ind,
             issue_date=issue_date,
             received_date=received_date,
             expiry_date=expiry_date)

--- a/python-backend/app/api/variances/models/variance_document_category_code.py
+++ b/python-backend/app/api/variances/models/variance_document_category_code.py
@@ -1,0 +1,19 @@
+from sqlalchemy.schema import FetchedValue
+from app.extensions import db
+
+from ...utils.models_mixins import AuditMixin, Base
+
+
+class VarianceDocumentCategoryCode(AuditMixin, Base):
+    __tablename__ = "variance_document_category_code"
+    variance_document_category_code = db.Column(db.String, primary_key=True, nullable=False)
+    description = db.Column(db.String, nullable=False)
+    active_ind = db.Column(db.Boolean, nullable=False, server_default=FetchedValue())
+
+    def __repr__(self):
+        return '<VarianceDocumentCategoryCode %r>' % self.variance_document_category_code
+
+
+    @classmethod
+    def active(cls):
+        return cls.query.filter_by(active_ind=True).all()

--- a/python-backend/app/api/variances/namespace/variances.py
+++ b/python-backend/app/api/variances/namespace/variances.py
@@ -1,9 +1,11 @@
 from flask_restplus import Namespace
 
-from ..resources.variance_application_status_code import VarianceApplicationStatusCodeResource
 from ..resources.variance_resource import VarianceResource
+from ..resources.variance_application_status_code import VarianceApplicationStatusCodeResource
+from ..resources.variance_document_category_code import VarianceDocumentCategoryCodeResource
 
 api = Namespace('variances', description='Variances actions/options')
 
 api.add_resource(VarianceResource, '')
 api.add_resource(VarianceApplicationStatusCodeResource, '/status-codes')
+api.add_resource(VarianceDocumentCategoryCodeResource, '/document-categories')

--- a/python-backend/app/api/variances/resources/variance_document_category_code.py
+++ b/python-backend/app/api/variances/resources/variance_document_category_code.py
@@ -9,7 +9,7 @@ from ...utils.resources_mixins import UserMixin, ErrorMixin
 
 class VarianceDocumentCategoryCodeResource(Resource, UserMixin, ErrorMixin):
     @api.doc(
-        description='Get a list of all active variance document category codes.',
+        description='Get a list of all variance document category codes.',
         params={})
     @requires_any_of([MINE_VIEW])
     @api.marshal_with(VARIANCE_DOCUMENT_CATEGORY_CODE, code=200, envelope='records')

--- a/python-backend/app/api/variances/resources/variance_document_category_code.py
+++ b/python-backend/app/api/variances/resources/variance_document_category_code.py
@@ -1,0 +1,17 @@
+from flask_restplus import Resource
+from app.extensions import api
+
+from ..models.variance_document_category_code import VarianceDocumentCategoryCode
+from ..response_models import VARIANCE_DOCUMENT_CATEGORY_CODE
+from ...utils.access_decorators import requires_any_of, MINE_VIEW
+from ...utils.resources_mixins import UserMixin, ErrorMixin
+
+
+class VarianceDocumentCategoryCodeResource(Resource, UserMixin, ErrorMixin):
+    @api.doc(
+        description='Get a list of all active variance document category codes.',
+        params={})
+    @requires_any_of([MINE_VIEW])
+    @api.marshal_with(VARIANCE_DOCUMENT_CATEGORY_CODE, code=200, envelope='records')
+    def get(self):
+        return VarianceDocumentCategoryCode.active()

--- a/python-backend/app/api/variances/response_models.py
+++ b/python-backend/app/api/variances/response_models.py
@@ -9,8 +9,13 @@ MINE_DOCUMENT_MODEL = api.model(
         'document_name': fields.String,
     })
 
-VARIANCE_DOCUMENT = api.inherit('VarianceDocumentModel', MINE_DOCUMENT_MODEL,
-                                {'created_at': fields.Date})
+VARIANCE_DOCUMENT = api.inherit(
+    'VarianceDocumentModel',
+    MINE_DOCUMENT_MODEL,
+    {
+        'created_at': fields.Date,
+        'variance_document_category_code': fields.String
+    })
 
 VARIANCE = api.model(
     'Variance', {
@@ -41,5 +46,10 @@ PAGINATED_VARIANCE_LIST = api.inherit('VarianceList', PAGINATED_LIST, {
 
 VARIANCE_APPLICATION_STATUS_CODE = api.model('VarianceApplicationStatusCode', {
     'variance_application_status_code': fields.String,
+    'description': fields.String
+})
+
+VARIANCE_DOCUMENT_CATEGORY_CODE = api.model('VarianceDocumentCategoryCode', {
+    'variance_document_category_code': fields.String,
     'description': fields.String
 })

--- a/python-backend/app/api/variances/response_models.py
+++ b/python-backend/app/api/variances/response_models.py
@@ -26,6 +26,7 @@ VARIANCE = api.model(
         'applicant_guid': fields.String,
         'inspector_party_guid': fields.String,
         'note': fields.String,
+        'parties_notified_ind': fields.Boolean,
         'issue_date': fields.Date,
         'received_date': fields.Date,
         'expiry_date': fields.Date,

--- a/python-backend/tests/factories.py
+++ b/python-backend/tests/factories.py
@@ -262,6 +262,7 @@ class VarianceDocumentFactory(BaseFactory):
     variance_document_xref_guid = GUID
     mine_document_guid = factory.SelfAttribute('mine_document.mine_document_guid')
     variance_id = factory.SelfAttribute('variance.variance_id')
+    variance_document_category_code = factory.LazyFunction(RandomVarianceDocumentCategoryCode)
 
 
 def RandomPermitNumber():

--- a/python-backend/tests/factories.py
+++ b/python-backend/tests/factories.py
@@ -231,10 +231,10 @@ class VarianceFactory(BaseFactory):
         not_applicable = factory.Trait(variance_application_status_code='NAP')
 
     variance_guid = GUID
-    variance_application_status_code = factory.LazyFunction(RandomVarianceApplicationStatusCode)
     compliance_article_id = factory.LazyFunction(RandomComplianceArticleId)
     mine_guid = factory.SelfAttribute('mine.mine_guid')
     note = factory.Faker('sentence', nb_words=6, variable_nb_words=True)
+    parties_notified_ind = factory.Faker('boolean', chance_of_getting_true=50)
     received_date = TODAY
     documents = []
 

--- a/python-backend/tests/mines/variances/resources/test_variance_document_upload_resource.py
+++ b/python-backend/tests/mines/variances/resources/test_variance_document_upload_resource.py
@@ -1,5 +1,6 @@
 import json
 
+from tests.status_code_gen import RandomVarianceDocumentCategoryCode
 from tests.factories import (
     VarianceFactory,
     MineFactory,
@@ -16,7 +17,8 @@ def test_put_file(test_client, db_session, auth_headers):
     document_count = len(variance.documents)
     data = {
         'document_manager_guid': str(new_doc.document_guid),
-        'document_name': 'my_document.pdf'
+        'document_name': 'my_document.pdf',
+        'variance_document_category_code': RandomVarianceDocumentCategoryCode()
     }
 
     put_resp = test_client.put(

--- a/python-backend/tests/mines/variances/resources/test_variance_list_resource.py
+++ b/python-backend/tests/mines/variances/resources/test_variance_list_resource.py
@@ -6,347 +6,359 @@ from tests.status_code_gen import RandomComplianceArticleId
 from app.api.utils.custom_reqparser import DEFAULT_MISSING_REQUIRED
 
 
-# GET
-def test_get_variances_for_a_mine(test_client, db_session, auth_headers):
-    batch_size = 3
-    mine = MineFactory(minimal=True)
-    VarianceFactory.create_batch(size=batch_size, mine=mine)
-    VarianceFactory.create_batch(size=batch_size)
+class TestGetMineVariances:
+    """GET /mines/{mine_guid}/variances"""
 
-    get_resp = test_client.get(
-        f'/mines/{mine.mine_guid}/variances', headers=auth_headers['full_auth_header'])
-    get_data = json.loads(get_resp.data.decode())
-    assert get_resp.status_code == 200
-    assert len(get_data['records']) == batch_size
+    def test_get_variances_for_a_mine(self, test_client, db_session, auth_headers):
+        """Should return the correct number of records and a 200 staus code"""
 
+        batch_size = 3
+        mine = MineFactory(minimal=True)
+        VarianceFactory.create_batch(size=batch_size, mine=mine)
+        VarianceFactory.create_batch(size=batch_size)
 
-def test_get_variances_invalid_mine_guid(test_client, db_session, auth_headers):
-    batch_size = 3
-    VarianceFactory.create_batch(size=batch_size)
-
-    get_resp = test_client.get(f'/mines/abc123/variances', headers=auth_headers['full_auth_header'])
-    get_data = json.loads(get_resp.data.decode())
-    assert get_resp.status_code == 400
+        get_resp = test_client.get(
+            f'/mines/{mine.mine_guid}/variances', headers=auth_headers['full_auth_header'])
+        get_data = json.loads(get_resp.data.decode())
+        assert get_resp.status_code == 200
+        assert len(get_data['records']) == batch_size
 
 
-def test_get_variances_non_existent_mine_guid(test_client, db_session, auth_headers):
-    batch_size = 3
-    fake_guid = uuid.uuid4()
-    VarianceFactory.create_batch(size=batch_size)
+    def test_get_variances_invalid_mine_guid(self, test_client, db_session, auth_headers):
+        """Should return a 400 when an invalid mine guid is provided"""
 
-    get_resp = test_client.get(f'/mines/{fake_guid}/variances', headers=auth_headers['full_auth_header'])
-    get_data = json.loads(get_resp.data.decode())
-    assert get_resp.status_code == 404
+        batch_size = 3
+        VarianceFactory.create_batch(size=batch_size)
 
-
-# POST
-def test_post_variance_application(test_client, db_session, auth_headers):
-    mine = MineFactory()
-    party = PartyFactory(person=True)
-    test_variance_data = {
-        'compliance_article_id': RandomComplianceArticleId(),
-        'note': 'Biggest mine yet',
-        'received_date': '2019-04-23',
-        'applicant_guid': party.party_guid
-    }
-    post_resp = test_client.post(
-        f'/mines/{mine.mine_guid}/variances',
-        data=test_variance_data,
-        headers=auth_headers['full_auth_header'])
-    post_data = json.loads(post_resp.data.decode())
-    assert post_resp.status_code == 200, post_resp.response
-    assert post_data['compliance_article_id'] == test_variance_data['compliance_article_id']
-    assert post_data['note'] == test_variance_data['note']
-    assert post_data['received_date'] == test_variance_data['received_date']
-    assert post_data['applicant_guid'] == str(test_variance_data['applicant_guid'])
+        get_resp = test_client.get(f'/mines/abc123/variances', headers=auth_headers['full_auth_header'])
+        get_data = json.loads(get_resp.data.decode())
+        assert get_resp.status_code == 400
 
 
-def test_post_approved_variance(test_client, db_session, auth_headers):
-    approved_variance = VarianceFactory(approved=True)
-    test_variance_data = {
-        'compliance_article_id': approved_variance.compliance_article_id,
-        'received_date': approved_variance.received_date,
-        'variance_application_status_code': approved_variance.variance_application_status_code,
-        'inspector_party_guid': approved_variance.inspector_party_guid,
-        'note': 'Biggest mine yet',
-        'issue_date': approved_variance.issue_date,
-        'expiry_date': approved_variance.expiry_date
-    }
-    post_resp = test_client.post(
-        f'/mines/{approved_variance.mine_guid}/variances',
-        data=test_variance_data,
-        headers=auth_headers['full_auth_header'])
-    post_data = json.loads(post_resp.data.decode())
-    assert post_resp.status_code == 200, post_resp.response
-    assert post_data['compliance_article_id'] == test_variance_data['compliance_article_id']
-    assert post_data['received_date'] == test_variance_data['received_date'].strftime('%Y-%m-%d')
-    assert post_data['variance_application_status_code'] == test_variance_data[
-        'variance_application_status_code']
-    assert post_data['inspector_party_guid'] == str(test_variance_data['inspector_party_guid'])
-    assert post_data['note'] == test_variance_data['note']
-    assert post_data['issue_date'] == test_variance_data['issue_date'].strftime('%Y-%m-%d')
-    assert post_data['expiry_date'] == test_variance_data['expiry_date'].strftime('%Y-%m-%d')
+    def test_get_variances_non_existent_mine_guid(self, test_client, db_session, auth_headers):
+        """Should return a 404 when the provided mine guid does not exist"""
+
+        batch_size = 3
+        fake_guid = uuid.uuid4()
+        VarianceFactory.create_batch(size=batch_size)
+
+        get_resp = test_client.get(f'/mines/{fake_guid}/variances', headers=auth_headers['full_auth_header'])
+        get_data = json.loads(get_resp.data.decode())
+        assert get_resp.status_code == 404
 
 
-def test_post_approved_variance(test_client, db_session, auth_headers):
-    approved_variance = VarianceFactory(approved=True)
-    test_variance_data = {
-        'compliance_article_id': approved_variance.compliance_article_id,
-        'received_date': approved_variance.received_date,
-        'variance_application_status_code': approved_variance.variance_application_status_code,
-        'inspector_party_guid': approved_variance.inspector_party_guid,
-        'note': 'Biggest mine yet',
-        'issue_date': approved_variance.issue_date,
-        'expiry_date': approved_variance.expiry_date
-    }
-    post_resp = test_client.post(
-        f'/mines/{approved_variance.mine_guid}/variances',
-        data=test_variance_data,
-        headers=auth_headers['full_auth_header'])
-    post_data = json.loads(post_resp.data.decode())
-    assert post_resp.status_code == 200, post_resp.response
-    assert post_data['compliance_article_id'] == test_variance_data['compliance_article_id']
-    assert post_data['received_date'] == test_variance_data['received_date'].strftime('%Y-%m-%d')
-    assert post_data['variance_application_status_code'] == test_variance_data[
-        'variance_application_status_code']
-    assert post_data['inspector_party_guid'] == str(test_variance_data['inspector_party_guid'])
-    assert post_data['note'] == test_variance_data['note']
-    assert post_data['issue_date'] == test_variance_data['issue_date'].strftime('%Y-%m-%d')
-    assert post_data['expiry_date'] == test_variance_data['expiry_date'].strftime('%Y-%m-%d')
+class TestPostMineVariance:
+    """POST /mines/{mine_guid}/variances"""
+
+    def test_post_variance_application(self, test_client, db_session, auth_headers):
+        """Should return the new variance application record"""
+
+        mine = MineFactory()
+        party = PartyFactory(person=True)
+        test_variance_data = {
+            'compliance_article_id': RandomComplianceArticleId(),
+            'note': 'Biggest mine yet',
+            'received_date': '2019-04-23',
+            'applicant_guid': party.party_guid
+        }
+        post_resp = test_client.post(
+            f'/mines/{mine.mine_guid}/variances',
+            data=test_variance_data,
+            headers=auth_headers['full_auth_header'])
+        post_data = json.loads(post_resp.data.decode())
+        assert post_resp.status_code == 200, post_resp.response
+        assert post_data['compliance_article_id'] == test_variance_data['compliance_article_id']
+        assert post_data['note'] == test_variance_data['note']
+        assert post_data['received_date'] == test_variance_data['received_date']
+        assert post_data['applicant_guid'] == str(test_variance_data['applicant_guid'])
 
 
-def test_post_variance_missing_compliance_article_id(test_client, db_session, auth_headers):
-    mine = MineFactory()
-    test_variance_data = {
-        "note": "Biggest mine yet",
-        "issue_date": "2019-04-23",
-        "received_date": "2019-04-23",
-        "expiry_date": "2019-04-23",
-    }
-    post_resp = test_client.post(
-        f'/mines/{mine.mine_guid}/variances',
-        data=test_variance_data,
-        headers=auth_headers['full_auth_header'])
-    post_data = json.loads(post_resp.data.decode())
-    assert post_resp.status_code == 400, post_resp.response
-    assert DEFAULT_MISSING_REQUIRED in post_data['message']
+    def test_post_approved_variance(self, test_client, db_session, auth_headers):
+        """Should return the new variance record with all possible values set"""
+
+        approved_variance = VarianceFactory(approved=True)
+        test_variance_data = {
+            'compliance_article_id': approved_variance.compliance_article_id,
+            'received_date': approved_variance.received_date,
+            'variance_application_status_code': approved_variance.variance_application_status_code,
+            'inspector_party_guid': approved_variance.inspector_party_guid,
+            'note': 'Biggest mine yet',
+            'parties_notified_ind': approved_variance.parties_notified_ind,
+            'issue_date': approved_variance.issue_date,
+            'expiry_date': approved_variance.expiry_date
+        }
+        post_resp = test_client.post(
+            f'/mines/{approved_variance.mine_guid}/variances',
+            data=test_variance_data,
+            headers=auth_headers['full_auth_header'])
+        post_data = json.loads(post_resp.data.decode())
+        assert post_resp.status_code == 200, post_resp.response
+        assert post_data['compliance_article_id'] == test_variance_data['compliance_article_id']
+        assert post_data['received_date'] == test_variance_data['received_date'].strftime('%Y-%m-%d')
+        assert post_data['variance_application_status_code'] == test_variance_data[
+            'variance_application_status_code']
+        assert post_data['inspector_party_guid'] == str(test_variance_data['inspector_party_guid'])
+        assert post_data['note'] == test_variance_data['note']
+        assert post_data['issue_date'] == test_variance_data['issue_date'].strftime('%Y-%m-%d')
+        assert post_data['expiry_date'] == test_variance_data['expiry_date'].strftime('%Y-%m-%d')
 
 
-def test_post_variance_non_existent_mine_guid(test_client, db_session, auth_headers):
-    fake_guid = uuid.uuid4()
-    party = PartyFactory(person=True)
-    test_variance_data = {
-        'compliance_article_id': RandomComplianceArticleId(),
-        'note': 'Biggest mine yet',
-        'received_date': '2019-04-23',
-        'applicant_guid': party.party_guid
-    }
-    post_resp = test_client.post(
-        f'/mines/{fake_guid}/variances',
-        data=test_variance_data,
-        headers=auth_headers['full_auth_header'])
-    post_data = json.loads(post_resp.data.decode())
-    assert post_resp.status_code == 404, post_resp.response
+    def test_post_variance_missing_compliance_article_id(self, test_client, db_session, auth_headers):
+        """Should return a 400 with a missing parameter message when no compliance article is provided"""
+
+        mine = MineFactory()
+        test_variance_data = {
+            "note": "Biggest mine yet",
+            "issue_date": "2019-04-23",
+            "received_date": "2019-04-23",
+            "expiry_date": "2019-04-23",
+        }
+        post_resp = test_client.post(
+            f'/mines/{mine.mine_guid}/variances',
+            data=test_variance_data,
+            headers=auth_headers['full_auth_header'])
+        post_data = json.loads(post_resp.data.decode())
+        assert post_resp.status_code == 400, post_resp.response
+        assert DEFAULT_MISSING_REQUIRED in post_data['message']
 
 
-# Test the business logic
-def test_post_approved_variance_missing_expiry_date(test_client, db_session, auth_headers):
-    approved_variance = VarianceFactory(approved=True)
-    data = {
-        'compliance_article_id': approved_variance.compliance_article_id,
-        'received_date': approved_variance.received_date,
-        'variance_application_status_code': approved_variance.variance_application_status_code,
-        'inspector_party_guid': approved_variance.inspector_party_guid,
-        'note': approved_variance.note,
-        'issue_date': approved_variance.issue_date
-    }
+    def test_post_variance_non_existent_mine_guid(self, test_client, db_session, auth_headers):
+        """Should return a 404 when the provided mine guid does not exist"""
 
-    post_resp = test_client.post(
-        f'/mines/{approved_variance.mine_guid}/variances',
-        headers=auth_headers['full_auth_header'],
-        data=data)
-    post_data = json.loads(post_resp.data.decode())
-    assert post_resp.status_code == 400, post_resp.response
-    assert 'expiry' in post_data['message'].lower()
+        fake_guid = uuid.uuid4()
+        party = PartyFactory(person=True)
+        test_variance_data = {
+            'compliance_article_id': RandomComplianceArticleId(),
+            'note': 'Biggest mine yet',
+            'received_date': '2019-04-23',
+            'applicant_guid': party.party_guid
+        }
+        post_resp = test_client.post(
+            f'/mines/{fake_guid}/variances',
+            data=test_variance_data,
+            headers=auth_headers['full_auth_header'])
+        post_data = json.loads(post_resp.data.decode())
+        assert post_resp.status_code == 404, post_resp.response
 
 
-def test_post_approved_variance_missing_issue_date(test_client, db_session, auth_headers):
-    approved_variance = VarianceFactory(approved=True)
-    data = {
-        'compliance_article_id': approved_variance.compliance_article_id,
-        'received_date': approved_variance.received_date,
-        'variance_application_status_code': approved_variance.variance_application_status_code,
-        'inspector_party_guid': approved_variance.inspector_party_guid,
-        'note': approved_variance.note,
-        'expiry_date': approved_variance.expiry_date
-    }
+    # Test the business logic
+    def test_post_approved_variance_missing_expiry_date(self, test_client, db_session, auth_headers):
+        """Should return a 400 and a relevant error message if the variance is approved without an expiry date"""
 
-    post_resp = test_client.post(
-        f'/mines/{approved_variance.mine_guid}/variances',
-        headers=auth_headers['full_auth_header'],
-        data=data)
-    post_data = json.loads(post_resp.data.decode())
-    assert post_resp.status_code == 400, post_resp.response
-    assert 'issue' in post_data['message'].lower()
+        approved_variance = VarianceFactory(approved=True)
+        data = {
+            'compliance_article_id': approved_variance.compliance_article_id,
+            'received_date': approved_variance.received_date,
+            'variance_application_status_code': approved_variance.variance_application_status_code,
+            'inspector_party_guid': approved_variance.inspector_party_guid,
+            'note': approved_variance.note,
+            'issue_date': approved_variance.issue_date
+        }
 
-
-def test_post_approved_variance_missing_inspector_party_guid(test_client, db_session, auth_headers):
-    approved_variance = VarianceFactory(approved=True)
-    data = {
-        'compliance_article_id': approved_variance.compliance_article_id,
-        'received_date': approved_variance.received_date,
-        'variance_application_status_code': approved_variance.variance_application_status_code,
-        'note': approved_variance.note,
-        'issue_date': approved_variance.issue_date,
-        'expiry_date': approved_variance.expiry_date
-    }
-
-    post_resp = test_client.post(
-        f'/mines/{approved_variance.mine_guid}/variances',
-        headers=auth_headers['full_auth_header'],
-        data=data)
-    post_data = json.loads(post_resp.data.decode())
-    assert post_resp.status_code == 400, post_resp.response
-    assert 'inspector' in post_data['message'].lower()
+        post_resp = test_client.post(
+            f'/mines/{approved_variance.mine_guid}/variances',
+            headers=auth_headers['full_auth_header'],
+            data=data)
+        post_data = json.loads(post_resp.data.decode())
+        assert post_resp.status_code == 400, post_resp.response
+        assert 'expiry' in post_data['message'].lower()
 
 
-def test_post_denied_variance_missing_inspector_party_guid(test_client, db_session, auth_headers):
-    denied_variance = VarianceFactory(denied=True)
-    data = {
-        'compliance_article_id': denied_variance.compliance_article_id,
-        'received_date': denied_variance.received_date,
-        'variance_application_status_code': denied_variance.variance_application_status_code,
-        'note': denied_variance.note
-    }
+    def test_post_approved_variance_missing_issue_date(self, test_client, db_session, auth_headers):
+        """Should return a 400 and a relevant error message if the variance is approved without an issue date"""
 
-    post_resp = test_client.post(
-        f'/mines/{denied_variance.mine_guid}/variances',
-        headers=auth_headers['full_auth_header'],
-        data=data)
-    post_data = json.loads(post_resp.data.decode())
-    assert post_resp.status_code == 400, post_resp.response
-    assert 'inspector' in post_data['message'].lower()
+        approved_variance = VarianceFactory(approved=True)
+        data = {
+            'compliance_article_id': approved_variance.compliance_article_id,
+            'received_date': approved_variance.received_date,
+            'variance_application_status_code': approved_variance.variance_application_status_code,
+            'inspector_party_guid': approved_variance.inspector_party_guid,
+            'note': approved_variance.note,
+            'expiry_date': approved_variance.expiry_date
+        }
 
-
-def test_post_denied_variance_with_expiry_date(test_client, db_session, auth_headers):
-    approved_variance = VarianceFactory(approved=True)
-    denied_variance = VarianceFactory(denied=True)
-    data = {
-        'compliance_article_id': denied_variance.compliance_article_id,
-        'received_date': denied_variance.received_date,
-        'variance_application_status_code': denied_variance.variance_application_status_code,
-        'inspector_party_guid': approved_variance.inspector_party_guid,
-        'note': denied_variance.note,
-        'expiry_date': approved_variance.expiry_date
-    }
-
-    post_resp = test_client.post(
-        f'/mines/{denied_variance.mine_guid}/variances',
-        headers=auth_headers['full_auth_header'],
-        data=data)
-    post_data = json.loads(post_resp.data.decode())
-    assert post_resp.status_code == 400, post_resp.response
-    assert 'expiry' in post_data['message'].lower()
+        post_resp = test_client.post(
+            f'/mines/{approved_variance.mine_guid}/variances',
+            headers=auth_headers['full_auth_header'],
+            data=data)
+        post_data = json.loads(post_resp.data.decode())
+        assert post_resp.status_code == 400, post_resp.response
+        assert 'issue' in post_data['message'].lower()
 
 
-def test_post_denied_variance_with_issue_date(test_client, db_session, auth_headers):
-    denied_variance = VarianceFactory(denied=True)
-    approved_variance = VarianceFactory(approved=True)
-    data = {
-        'compliance_article_id': denied_variance.compliance_article_id,
-        'received_date': denied_variance.received_date,
-        'variance_application_status_code': denied_variance.variance_application_status_code,
-        'inspector_party_guid': approved_variance.inspector_party_guid,
-        'note': denied_variance.note,
-        'issue_date': approved_variance.issue_date
-    }
+    def test_post_approved_variance_missing_inspector_party_guid(self, test_client, db_session, auth_headers):
+        """Should return a 400 and a relevant error message if the variance is approved without an inspector"""
 
-    post_resp = test_client.post(
-        f'/mines/{denied_variance.mine_guid}/variances',
-        headers=auth_headers['full_auth_header'],
-        data=data)
-    post_data = json.loads(post_resp.data.decode())
-    assert post_resp.status_code == 400, post_resp.response
-    assert 'issue' in post_data['message'].lower()
+        approved_variance = VarianceFactory(approved=True)
+        data = {
+            'compliance_article_id': approved_variance.compliance_article_id,
+            'received_date': approved_variance.received_date,
+            'variance_application_status_code': approved_variance.variance_application_status_code,
+            'note': approved_variance.note,
+            'issue_date': approved_variance.issue_date,
+            'expiry_date': approved_variance.expiry_date
+        }
 
-
-def test_post_variance_application_with_expiry_date(test_client, db_session, auth_headers):
-    variance = VarianceFactory()
-    party = PartyFactory(person=True)
-    approved_variance = VarianceFactory(approved=True)
-    data = {
-        'compliance_article_id': variance.compliance_article_id,
-        'note': variance.note,
-        'received_date': variance.received_date,
-        'applicant_guid': party.party_guid,
-        'expiry_date': approved_variance.expiry_date
-    }
-
-    post_resp = test_client.post(
-        f'/mines/{variance.mine_guid}/variances',
-        headers=auth_headers['full_auth_header'],
-        data=data)
-    post_data = json.loads(post_resp.data.decode())
-    assert post_resp.status_code == 400, post_resp.response
-    assert 'expiry' in post_data['message'].lower()
+        post_resp = test_client.post(
+            f'/mines/{approved_variance.mine_guid}/variances',
+            headers=auth_headers['full_auth_header'],
+            data=data)
+        post_data = json.loads(post_resp.data.decode())
+        assert post_resp.status_code == 400, post_resp.response
+        assert 'inspector' in post_data['message'].lower()
 
 
-def test_post_variance_application_with_issue_date(test_client, db_session, auth_headers):
-    variance = VarianceFactory()
-    party = PartyFactory(person=True)
-    approved_variance = VarianceFactory(approved=True)
-    data = {
-        'compliance_article_id': variance.compliance_article_id,
-        'note': variance.note,
-        'received_date': variance.received_date,
-        'applicant_guid': party.party_guid,
-        'issue_date': approved_variance.issue_date
-    }
+    def test_post_denied_variance_missing_inspector_party_guid(self, test_client, db_session, auth_headers):
+        """Should return a 400 and a relevant error message if the variance is denied without an inspector"""
 
-    post_resp = test_client.post(
-        f'/mines/{variance.mine_guid}/variances',
-        headers=auth_headers['full_auth_header'],
-        data=data)
-    post_data = json.loads(post_resp.data.decode())
-    assert post_resp.status_code == 400, post_resp.response
-    assert 'issue' in post_data['message'].lower()
+        denied_variance = VarianceFactory(denied=True)
+        data = {
+            'compliance_article_id': denied_variance.compliance_article_id,
+            'received_date': denied_variance.received_date,
+            'variance_application_status_code': denied_variance.variance_application_status_code,
+            'note': denied_variance.note
+        }
 
-
-def test_post_not_applicable_variance_with_expiry_date(test_client, db_session, auth_headers):
-    approved_variance = VarianceFactory(approved=True)
-    nap_variance = VarianceFactory(not_applicable=True)
-    data = {
-        'compliance_article_id': nap_variance.compliance_article_id,
-        'received_date': nap_variance.received_date,
-        'variance_application_status_code': nap_variance.variance_application_status_code,
-        'note': nap_variance.note,
-        'expiry_date': approved_variance.expiry_date
-    }
-
-    post_resp = test_client.post(
-        f'/mines/{nap_variance.mine_guid}/variances',
-        headers=auth_headers['full_auth_header'],
-        data=data)
-    post_data = json.loads(post_resp.data.decode())
-    assert post_resp.status_code == 400, post_resp.response
-    assert 'expiry' in post_data['message'].lower()
+        post_resp = test_client.post(
+            f'/mines/{denied_variance.mine_guid}/variances',
+            headers=auth_headers['full_auth_header'],
+            data=data)
+        post_data = json.loads(post_resp.data.decode())
+        assert post_resp.status_code == 400, post_resp.response
+        assert 'inspector' in post_data['message'].lower()
 
 
-def test_post_not_applicable_variance_with_issue_date(test_client, db_session, auth_headers):
-    approved_variance = VarianceFactory(approved=True)
-    nap_variance = VarianceFactory(not_applicable=True)
-    data = {
-        'compliance_article_id': nap_variance.compliance_article_id,
-        'received_date': nap_variance.received_date,
-        'variance_application_status_code': nap_variance.variance_application_status_code,
-        'note': nap_variance.note,
-        'issue_date': approved_variance.issue_date
-    }
+    def test_post_denied_variance_with_expiry_date(self, test_client, db_session, auth_headers):
+        """Should return a 400 and a relevant error message if the variance is denied with an expiry date"""
 
-    post_resp = test_client.post(
-        f'/mines/{nap_variance.mine_guid}/variances',
-        headers=auth_headers['full_auth_header'],
-        data=data)
-    post_data = json.loads(post_resp.data.decode())
-    assert post_resp.status_code == 400, post_resp.response
-    assert 'issue' in post_data['message'].lower()
+        approved_variance = VarianceFactory(approved=True)
+        denied_variance = VarianceFactory(denied=True)
+        data = {
+            'compliance_article_id': denied_variance.compliance_article_id,
+            'received_date': denied_variance.received_date,
+            'variance_application_status_code': denied_variance.variance_application_status_code,
+            'inspector_party_guid': approved_variance.inspector_party_guid,
+            'note': denied_variance.note,
+            'expiry_date': approved_variance.expiry_date
+        }
+
+        post_resp = test_client.post(
+            f'/mines/{denied_variance.mine_guid}/variances',
+            headers=auth_headers['full_auth_header'],
+            data=data)
+        post_data = json.loads(post_resp.data.decode())
+        assert post_resp.status_code == 400, post_resp.response
+        assert 'expiry' in post_data['message'].lower()
+
+
+    def test_post_denied_variance_with_issue_date(self, test_client, db_session, auth_headers):
+        """Should return a 400 and a relevant error message if the variance is denied with an issue date"""
+
+        denied_variance = VarianceFactory(denied=True)
+        approved_variance = VarianceFactory(approved=True)
+        data = {
+            'compliance_article_id': denied_variance.compliance_article_id,
+            'received_date': denied_variance.received_date,
+            'variance_application_status_code': denied_variance.variance_application_status_code,
+            'inspector_party_guid': approved_variance.inspector_party_guid,
+            'note': denied_variance.note,
+            'issue_date': approved_variance.issue_date
+        }
+
+        post_resp = test_client.post(
+            f'/mines/{denied_variance.mine_guid}/variances',
+            headers=auth_headers['full_auth_header'],
+            data=data)
+        post_data = json.loads(post_resp.data.decode())
+        assert post_resp.status_code == 400, post_resp.response
+        assert 'issue' in post_data['message'].lower()
+
+
+    def test_post_variance_application_with_expiry_date(self, test_client, db_session, auth_headers):
+        """Should return a 400 and a relevant error message if the variance is in-review with an expiry date"""
+
+        variance = VarianceFactory()
+        party = PartyFactory(person=True)
+        approved_variance = VarianceFactory(approved=True)
+        data = {
+            'compliance_article_id': variance.compliance_article_id,
+            'note': variance.note,
+            'received_date': variance.received_date,
+            'applicant_guid': party.party_guid,
+            'expiry_date': approved_variance.expiry_date
+        }
+
+        post_resp = test_client.post(
+            f'/mines/{variance.mine_guid}/variances',
+            headers=auth_headers['full_auth_header'],
+            data=data)
+        post_data = json.loads(post_resp.data.decode())
+        assert post_resp.status_code == 400, post_resp.response
+        assert 'expiry' in post_data['message'].lower()
+
+
+    def test_post_variance_application_with_issue_date(self, test_client, db_session, auth_headers):
+        """Should return a 400 and a relevant error message if the variance is in-review with an issue date"""
+
+        variance = VarianceFactory()
+        party = PartyFactory(person=True)
+        approved_variance = VarianceFactory(approved=True)
+        data = {
+            'compliance_article_id': variance.compliance_article_id,
+            'note': variance.note,
+            'received_date': variance.received_date,
+            'applicant_guid': party.party_guid,
+            'issue_date': approved_variance.issue_date
+        }
+
+        post_resp = test_client.post(
+            f'/mines/{variance.mine_guid}/variances',
+            headers=auth_headers['full_auth_header'],
+            data=data)
+        post_data = json.loads(post_resp.data.decode())
+        assert post_resp.status_code == 400, post_resp.response
+        assert 'issue' in post_data['message'].lower()
+
+
+    def test_post_not_applicable_variance_with_expiry_date(self, test_client, db_session, auth_headers):
+        """Should return a 400 and a relevant error message if the variance is not-applicable with an expiry date"""
+
+        approved_variance = VarianceFactory(approved=True)
+        nap_variance = VarianceFactory(not_applicable=True)
+        data = {
+            'compliance_article_id': nap_variance.compliance_article_id,
+            'received_date': nap_variance.received_date,
+            'variance_application_status_code': nap_variance.variance_application_status_code,
+            'note': nap_variance.note,
+            'expiry_date': approved_variance.expiry_date
+        }
+
+        post_resp = test_client.post(
+            f'/mines/{nap_variance.mine_guid}/variances',
+            headers=auth_headers['full_auth_header'],
+            data=data)
+        post_data = json.loads(post_resp.data.decode())
+        assert post_resp.status_code == 400, post_resp.response
+        assert 'expiry' in post_data['message'].lower()
+
+
+    def test_post_not_applicable_variance_with_issue_date(self, test_client, db_session, auth_headers):
+        """Should return a 400 and a relevant error message if the variance is not-applicable with an issue date"""
+
+        approved_variance = VarianceFactory(approved=True)
+        nap_variance = VarianceFactory(not_applicable=True)
+        data = {
+            'compliance_article_id': nap_variance.compliance_article_id,
+            'received_date': nap_variance.received_date,
+            'variance_application_status_code': nap_variance.variance_application_status_code,
+            'note': nap_variance.note,
+            'issue_date': approved_variance.issue_date
+        }
+
+        post_resp = test_client.post(
+            f'/mines/{nap_variance.mine_guid}/variances',
+            headers=auth_headers['full_auth_header'],
+            data=data)
+        post_data = json.loads(post_resp.data.decode())
+        assert post_resp.status_code == 400, post_resp.response
+        assert 'issue' in post_data['message'].lower()

--- a/python-backend/tests/mines/variances/resources/test_variance_resource.py
+++ b/python-backend/tests/mines/variances/resources/test_variance_resource.py
@@ -5,305 +5,345 @@ from tests.factories import VarianceFactory, MineFactory
 from app.api.variances.models.variance import INVALID_MINE_GUID, INVALID_VARIANCE_GUID
 
 
-# GET
-def test_get_variance(test_client, db_session, auth_headers):
-    variance = VarianceFactory()
+class TestGetMineVariance:
+    """GET /mines/{mine_guid}/variances/{variance_guid}"""
 
-    get_resp = test_client.get(
-        f'/mines/{variance.mine_guid}/variances/{variance.variance_guid}',
-        headers=auth_headers['full_auth_header'])
-    get_data = json.loads(get_resp.data.decode())
-    assert get_resp.status_code == 200
-    assert get_data['variance_guid'] == str(variance.variance_guid)
+    def test_get_variance(self, test_client, db_session, auth_headers):
+        """Should return the correct variance and a 200 response code"""
 
+        variance = VarianceFactory()
 
-def test_get_variance_invalid_variance_guid(test_client, db_session, auth_headers):
-    variance = VarianceFactory()
-
-    get_resp = test_client.get(
-        f'/mines/{variance.mine_guid}/variances/1234',
-        headers=auth_headers['full_auth_header'])
-    get_data = json.loads(get_resp.data.decode())
-    assert get_resp.status_code == 400
-    assert get_data['message'] == INVALID_VARIANCE_GUID
+        get_resp = test_client.get(
+            f'/mines/{variance.mine_guid}/variances/{variance.variance_guid}',
+            headers=auth_headers['full_auth_header'])
+        get_data = json.loads(get_resp.data.decode())
+        assert get_resp.status_code == 200
+        assert get_data['variance_guid'] == str(variance.variance_guid)
 
 
-def test_get_variances_invalid_mine_guid(test_client, db_session, auth_headers):
-    variance = VarianceFactory()
+    def test_get_variance_invalid_variance_guid(self, test_client, db_session, auth_headers):
+        """Should return a 400 with relevant error message when an invalid variance guid is provided"""
 
-    get_resp = test_client.get(
-        f'/mines/abc123/variances/{variance.variance_guid}',
-        headers=auth_headers['full_auth_header'])
-    get_data = json.loads(get_resp.data.decode())
-    assert get_resp.status_code == 400
-    assert get_data['message'] == INVALID_MINE_GUID
+        variance = VarianceFactory()
 
-
-def test_get_variances_wrong_mine_guid(test_client, db_session, auth_headers):
-    variance = VarianceFactory()
-    mine = MineFactory()
-
-    get_resp = test_client.get(
-        f'/mines/{mine.mine_guid}/variances/{variance.variance_guid}',
-        headers=auth_headers['full_auth_header'])
-    assert get_resp.status_code == 404
+        get_resp = test_client.get(
+            f'/mines/{variance.mine_guid}/variances/1234',
+            headers=auth_headers['full_auth_header'])
+        get_data = json.loads(get_resp.data.decode())
+        assert get_resp.status_code == 400
+        assert get_data['message'] == INVALID_VARIANCE_GUID
 
 
-# PUT
-def test_put_variance(test_client, db_session, auth_headers):
-    variance = VarianceFactory()
-    approved_variance = VarianceFactory(approved=True)
-    data = {
-        'compliance_article_id': approved_variance.compliance_article_id,
-        'received_date': approved_variance.received_date,
-        'variance_application_status_code': approved_variance.variance_application_status_code,
-        'inspector_party_guid': approved_variance.inspector_party_guid,
-        'note': approved_variance.note,
-        'issue_date': approved_variance.issue_date,
-        'expiry_date': approved_variance.expiry_date
-    }
+    def test_get_variances_invalid_mine_guid(self, test_client, db_session, auth_headers):
+        """Should return a 400 with relevant error message when an invalid mine guid is provided"""
 
-    put_resp = test_client.put(
-        f'/mines/{variance.mine_guid}/variances/{variance.variance_guid}',
-        headers=auth_headers['full_auth_header'],
-        data=data)
-    put_data = json.loads(put_resp.data.decode())
-    assert put_resp.status_code == 200, put_resp.response
-    assert put_data['compliance_article_id'] == data['compliance_article_id']
-    assert put_data['received_date'] == data['received_date'].strftime('%Y-%m-%d')
-    assert put_data['variance_application_status_code'] == data['variance_application_status_code']
-    assert put_data['inspector_party_guid'] == str(data['inspector_party_guid'])
-    assert put_data['note'] == data['note']
-    assert put_data['issue_date'] == data['issue_date'].strftime('%Y-%m-%d')
-    assert put_data['expiry_date'] == data['expiry_date'].strftime('%Y-%m-%d')
+        variance = VarianceFactory()
+
+        get_resp = test_client.get(
+            f'/mines/abc123/variances/{variance.variance_guid}',
+            headers=auth_headers['full_auth_header'])
+        get_data = json.loads(get_resp.data.decode())
+        assert get_resp.status_code == 400
+        assert get_data['message'] == INVALID_MINE_GUID
 
 
-def test_put_variance_application_non_existent_variance_guid(test_client, db_session, auth_headers):
-    fake_guid = uuid.uuid4()
-    variance = VarianceFactory()
-    data = {
-        'note': 'This is my favourite variance.',
-    }
+    def test_get_variances_wrong_mine_guid(self, test_client, db_session, auth_headers):
+        """Should return a 404 when the variance does not exist on the provided mine"""
 
-    put_resp = test_client.put(
-        f'/mines/{variance.mine_guid}/variances/{fake_guid}',
-        headers=auth_headers['full_auth_header'],
-        data=data)
-    put_data = json.loads(put_resp.data.decode())
-    assert put_resp.status_code == 404
+        variance = VarianceFactory()
+        mine = MineFactory()
+
+        get_resp = test_client.get(
+            f'/mines/{mine.mine_guid}/variances/{variance.variance_guid}',
+            headers=auth_headers['full_auth_header'])
+        assert get_resp.status_code == 404
 
 
-def test_put_variance_application_invalid_variance_guid(test_client, db_session, auth_headers):
-    variance = VarianceFactory()
-    data = {
-        'note': 'This is my favourite variance.',
-    }
+class TestPutMineVariance:
+    """PUT /mines/{mine_guid}/variances/{variance_guid}"""
 
-    put_resp = test_client.put(
-        f'/mines/{variance.mine_guid}/variances/1234',
-        headers=auth_headers['full_auth_header'],
-        data=data)
-    put_data = json.loads(put_resp.data.decode())
-    assert put_resp.status_code == 400
+    def test_put_variance(self, test_client, db_session, auth_headers):
+        """Should return the updated variance record"""
 
+        variance = VarianceFactory()
+        approved_variance = VarianceFactory(approved=True)
+        data = {
+            'compliance_article_id': approved_variance.compliance_article_id,
+            'received_date': approved_variance.received_date,
+            'variance_application_status_code': approved_variance.variance_application_status_code,
+            'inspector_party_guid': approved_variance.inspector_party_guid,
+            'note': approved_variance.note,
+            'parties_notified_ind': True,
+            'issue_date': approved_variance.issue_date,
+            'expiry_date': approved_variance.expiry_date
+        }
 
-# Test the business logic
-def test_put_approved_variance_missing_expiry_date(test_client, db_session, auth_headers):
-    variance = VarianceFactory()
-    approved_variance = VarianceFactory(approved=True)
-    data = {
-        'compliance_article_id': approved_variance.compliance_article_id,
-        'received_date': approved_variance.received_date,
-        'variance_application_status_code': approved_variance.variance_application_status_code,
-        'inspector_party_guid': approved_variance.inspector_party_guid,
-        'note': approved_variance.note,
-        'issue_date': approved_variance.issue_date
-    }
-
-    put_resp = test_client.put(
-        f'/mines/{variance.mine_guid}/variances/{variance.variance_guid}',
-        headers=auth_headers['full_auth_header'],
-        data=data)
-    put_data = json.loads(put_resp.data.decode())
-    assert put_resp.status_code == 400, put_resp.response
-    assert 'expiry' in put_data['message'].lower()
-
-
-def test_put_approved_variance_missing_issue_date(test_client, db_session, auth_headers):
-    variance = VarianceFactory()
-    approved_variance = VarianceFactory(approved=True)
-    data = {
-        'compliance_article_id': approved_variance.compliance_article_id,
-        'received_date': approved_variance.received_date,
-        'variance_application_status_code': approved_variance.variance_application_status_code,
-        'inspector_party_guid': approved_variance.inspector_party_guid,
-        'note': approved_variance.note,
-        'expiry_date': approved_variance.expiry_date
-    }
-
-    put_resp = test_client.put(
-        f'/mines/{variance.mine_guid}/variances/{variance.variance_guid}',
-        headers=auth_headers['full_auth_header'],
-        data=data)
-    put_data = json.loads(put_resp.data.decode())
-    assert put_resp.status_code == 400, put_resp.response
-    assert 'issue' in put_data['message'].lower()
+        put_resp = test_client.put(
+            f'/mines/{variance.mine_guid}/variances/{variance.variance_guid}',
+            headers=auth_headers['full_auth_header'],
+            data=data)
+        put_data = json.loads(put_resp.data.decode())
+        assert put_resp.status_code == 200, put_resp.response
+        assert put_data['compliance_article_id'] == data['compliance_article_id']
+        assert put_data['received_date'] == data['received_date'].strftime('%Y-%m-%d')
+        assert put_data['variance_application_status_code'] == data['variance_application_status_code']
+        assert put_data['inspector_party_guid'] == str(data['inspector_party_guid'])
+        assert put_data['note'] == data['note']
+        assert put_data['parties_notified_ind'] == data['parties_notified_ind']
+        assert put_data['issue_date'] == data['issue_date'].strftime('%Y-%m-%d')
+        assert put_data['expiry_date'] == data['expiry_date'].strftime('%Y-%m-%d')
 
 
-def test_put_approved_variance_missing_inspector_party_guid(test_client, db_session, auth_headers):
-    variance = VarianceFactory()
-    approved_variance = VarianceFactory(approved=True)
-    data = {
-        'compliance_article_id': approved_variance.compliance_article_id,
-        'received_date': approved_variance.received_date,
-        'variance_application_status_code': approved_variance.variance_application_status_code,
-        'note': approved_variance.note,
-        'issue_date': approved_variance.issue_date,
-        'expiry_date': approved_variance.expiry_date
-    }
+    def test_put_variance_application_non_existent_variance_guid(self, test_client, db_session, auth_headers):
+        """Should return a 404 if the variance guid is not associated with a variance record"""
 
-    put_resp = test_client.put(
-        f'/mines/{variance.mine_guid}/variances/{variance.variance_guid}',
-        headers=auth_headers['full_auth_header'],
-        data=data)
-    put_data = json.loads(put_resp.data.decode())
-    assert put_resp.status_code == 400, put_resp.response
-    assert 'inspector' in put_data['message'].lower()
+        fake_guid = uuid.uuid4()
+        variance = VarianceFactory()
+        data = {
+            'note': 'This is my favourite variance.',
+        }
+
+        put_resp = test_client.put(
+            f'/mines/{variance.mine_guid}/variances/{fake_guid}',
+            headers=auth_headers['full_auth_header'],
+            data=data)
+        put_data = json.loads(put_resp.data.decode())
+        assert put_resp.status_code == 404
 
 
-def test_put_denied_variance_missing_inspector_party_guid(test_client, db_session, auth_headers):
-    variance = VarianceFactory()
-    denied_variance = VarianceFactory(denied=True)
-    data = {
-        'compliance_article_id': denied_variance.compliance_article_id,
-        'received_date': denied_variance.received_date,
-        'variance_application_status_code': denied_variance.variance_application_status_code,
-        'note': denied_variance.note
-    }
+    def test_put_variance_application_invalid_variance_guid(self, test_client, db_session, auth_headers):
+        """Should return a 400 if the variance guid is invalid"""
 
-    put_resp = test_client.put(
-        f'/mines/{variance.mine_guid}/variances/{variance.variance_guid}',
-        headers=auth_headers['full_auth_header'],
-        data=data)
-    put_data = json.loads(put_resp.data.decode())
-    assert put_resp.status_code == 400, put_resp.response
-    assert 'inspector' in put_data['message'].lower()
+        variance = VarianceFactory()
+        data = {
+            'note': 'This is my favourite variance.',
+        }
+
+        put_resp = test_client.put(
+            f'/mines/{variance.mine_guid}/variances/1234',
+            headers=auth_headers['full_auth_header'],
+            data=data)
+        put_data = json.loads(put_resp.data.decode())
+        assert put_resp.status_code == 400
 
 
-def test_put_denied_variance_with_expiry_date(test_client, db_session, auth_headers):
-    variance = VarianceFactory()
-    approved_variance = VarianceFactory(approved=True)
-    denied_variance = VarianceFactory(denied=True)
-    data = {
-        'compliance_article_id': denied_variance.compliance_article_id,
-        'received_date': denied_variance.received_date,
-        'variance_application_status_code': denied_variance.variance_application_status_code,
-        'inspector_party_guid': approved_variance.inspector_party_guid,
-        'note': denied_variance.note,
-        'expiry_date': approved_variance.expiry_date
-    }
+    # Test the business logic
+    def test_put_approved_variance_missing_expiry_date(self, test_client, db_session, auth_headers):
+        """Should return a 400 and a relevant error message if the variance is approved without an expiry date"""
 
-    put_resp = test_client.put(
-        f'/mines/{variance.mine_guid}/variances/{variance.variance_guid}',
-        headers=auth_headers['full_auth_header'],
-        data=data)
-    put_data = json.loads(put_resp.data.decode())
-    assert put_resp.status_code == 400, put_resp.response
-    assert 'expiry' in put_data['message'].lower()
+        variance = VarianceFactory()
+        approved_variance = VarianceFactory(approved=True)
+        data = {
+            'compliance_article_id': approved_variance.compliance_article_id,
+            'received_date': approved_variance.received_date,
+            'variance_application_status_code': approved_variance.variance_application_status_code,
+            'inspector_party_guid': approved_variance.inspector_party_guid,
+            'note': approved_variance.note,
+            'issue_date': approved_variance.issue_date
+        }
 
-
-def test_put_denied_variance_with_issue_date(test_client, db_session, auth_headers):
-    variance = VarianceFactory()
-    denied_variance = VarianceFactory(denied=True)
-    approved_variance = VarianceFactory(approved=True)
-    data = {
-        'compliance_article_id': denied_variance.compliance_article_id,
-        'received_date': denied_variance.received_date,
-        'variance_application_status_code': denied_variance.variance_application_status_code,
-        'inspector_party_guid': approved_variance.inspector_party_guid,
-        'note': denied_variance.note,
-        'issue_date': approved_variance.issue_date
-    }
-
-    put_resp = test_client.put(
-        f'/mines/{variance.mine_guid}/variances/{variance.variance_guid}',
-        headers=auth_headers['full_auth_header'],
-        data=data)
-    put_data = json.loads(put_resp.data.decode())
-    assert put_resp.status_code == 400, put_resp.response
-    assert 'issue' in put_data['message'].lower()
+        put_resp = test_client.put(
+            f'/mines/{variance.mine_guid}/variances/{variance.variance_guid}',
+            headers=auth_headers['full_auth_header'],
+            data=data)
+        put_data = json.loads(put_resp.data.decode())
+        assert put_resp.status_code == 400, put_resp.response
+        assert 'expiry' in put_data['message'].lower()
 
 
-def test_put_variance_application_with_expiry_date(test_client, db_session, auth_headers):
-    variance = VarianceFactory()
-    approved_variance = VarianceFactory(approved=True)
-    data = {
-        'expiry_date': approved_variance.expiry_date
-    }
+    def test_put_approved_variance_missing_issue_date(self, test_client, db_session, auth_headers):
+        """Should return a 400 and a relevant error message if the variance is approved without an issue date"""
 
-    put_resp = test_client.put(
-        f'/mines/{variance.mine_guid}/variances/{variance.variance_guid}',
-        headers=auth_headers['full_auth_header'],
-        data=data)
-    put_data = json.loads(put_resp.data.decode())
-    assert put_resp.status_code == 400, put_resp.response
-    assert 'expiry' in put_data['message'].lower()
+        variance = VarianceFactory()
+        approved_variance = VarianceFactory(approved=True)
+        data = {
+            'compliance_article_id': approved_variance.compliance_article_id,
+            'received_date': approved_variance.received_date,
+            'variance_application_status_code': approved_variance.variance_application_status_code,
+            'inspector_party_guid': approved_variance.inspector_party_guid,
+            'note': approved_variance.note,
+            'expiry_date': approved_variance.expiry_date
+        }
 
-
-def test_put_variance_application_with_issue_date(test_client, db_session, auth_headers):
-    variance = VarianceFactory()
-    denied_variance = VarianceFactory(denied=True)
-    approved_variance = VarianceFactory(approved=True)
-    data = {
-        'issue_date': approved_variance.issue_date
-    }
-
-    put_resp = test_client.put(
-        f'/mines/{variance.mine_guid}/variances/{variance.variance_guid}',
-        headers=auth_headers['full_auth_header'],
-        data=data)
-    put_data = json.loads(put_resp.data.decode())
-    assert put_resp.status_code == 400, put_resp.response
-    assert 'issue' in put_data['message'].lower()
+        put_resp = test_client.put(
+            f'/mines/{variance.mine_guid}/variances/{variance.variance_guid}',
+            headers=auth_headers['full_auth_header'],
+            data=data)
+        put_data = json.loads(put_resp.data.decode())
+        assert put_resp.status_code == 400, put_resp.response
+        assert 'issue' in put_data['message'].lower()
 
 
-def test_put_not_applicable_variance_with_expiry_date(test_client, db_session, auth_headers):
-    variance = VarianceFactory()
-    approved_variance = VarianceFactory(approved=True)
-    nap_variance = VarianceFactory(not_applicable=True)
-    data = {
-        'compliance_article_id': nap_variance.compliance_article_id,
-        'received_date': nap_variance.received_date,
-        'variance_application_status_code': nap_variance.variance_application_status_code,
-        'note': nap_variance.note,
-        'expiry_date': approved_variance.expiry_date
-    }
+    def test_put_approved_variance_missing_inspector_party_guid(self, test_client, db_session, auth_headers):
+        """Should return a 400 and a relevant error message if the variance is approved without an inspector"""
 
-    put_resp = test_client.put(
-        f'/mines/{variance.mine_guid}/variances/{variance.variance_guid}',
-        headers=auth_headers['full_auth_header'],
-        data=data)
-    put_data = json.loads(put_resp.data.decode())
-    assert put_resp.status_code == 400, put_resp.response
-    assert 'expiry' in put_data['message'].lower()
+        variance = VarianceFactory()
+        approved_variance = VarianceFactory(approved=True)
+        data = {
+            'compliance_article_id': approved_variance.compliance_article_id,
+            'received_date': approved_variance.received_date,
+            'variance_application_status_code': approved_variance.variance_application_status_code,
+            'note': approved_variance.note,
+            'issue_date': approved_variance.issue_date,
+            'expiry_date': approved_variance.expiry_date
+        }
+
+        put_resp = test_client.put(
+            f'/mines/{variance.mine_guid}/variances/{variance.variance_guid}',
+            headers=auth_headers['full_auth_header'],
+            data=data)
+        put_data = json.loads(put_resp.data.decode())
+        assert put_resp.status_code == 400, put_resp.response
+        assert 'inspector' in put_data['message'].lower()
 
 
-def test_put_not_applicable_variance_with_issue_date(test_client, db_session, auth_headers):
-    variance = VarianceFactory()
-    approved_variance = VarianceFactory(approved=True)
-    nap_variance = VarianceFactory(not_applicable=True)
-    data = {
-        'compliance_article_id': nap_variance.compliance_article_id,
-        'received_date': nap_variance.received_date,
-        'variance_application_status_code': nap_variance.variance_application_status_code,
-        'note': nap_variance.note,
-        'issue_date': approved_variance.issue_date
-    }
+    def test_put_denied_variance_missing_inspector_party_guid(self, test_client, db_session, auth_headers):
+        """Should return a 400 and a relevant error message if the variance is denied without an inspector"""
 
-    put_resp = test_client.put(
-        f'/mines/{variance.mine_guid}/variances/{variance.variance_guid}',
-        headers=auth_headers['full_auth_header'],
-        data=data)
-    put_data = json.loads(put_resp.data.decode())
-    assert put_resp.status_code == 400, put_resp.response
-    assert 'issue' in put_data['message'].lower()
+        variance = VarianceFactory()
+        denied_variance = VarianceFactory(denied=True)
+        data = {
+            'compliance_article_id': denied_variance.compliance_article_id,
+            'received_date': denied_variance.received_date,
+            'variance_application_status_code': denied_variance.variance_application_status_code,
+            'note': denied_variance.note
+        }
+
+        put_resp = test_client.put(
+            f'/mines/{variance.mine_guid}/variances/{variance.variance_guid}',
+            headers=auth_headers['full_auth_header'],
+            data=data)
+        put_data = json.loads(put_resp.data.decode())
+        assert put_resp.status_code == 400, put_resp.response
+        assert 'inspector' in put_data['message'].lower()
+
+
+    def test_put_denied_variance_with_expiry_date(self, test_client, db_session, auth_headers):
+        """Should return a 400 and a relevant error message if the variance is denied with an expiry date"""
+
+        variance = VarianceFactory()
+        approved_variance = VarianceFactory(approved=True)
+        denied_variance = VarianceFactory(denied=True)
+        data = {
+            'compliance_article_id': denied_variance.compliance_article_id,
+            'received_date': denied_variance.received_date,
+            'variance_application_status_code': denied_variance.variance_application_status_code,
+            'inspector_party_guid': approved_variance.inspector_party_guid,
+            'note': denied_variance.note,
+            'expiry_date': approved_variance.expiry_date
+        }
+
+        put_resp = test_client.put(
+            f'/mines/{variance.mine_guid}/variances/{variance.variance_guid}',
+            headers=auth_headers['full_auth_header'],
+            data=data)
+        put_data = json.loads(put_resp.data.decode())
+        assert put_resp.status_code == 400, put_resp.response
+        assert 'expiry' in put_data['message'].lower()
+
+
+    def test_put_denied_variance_with_issue_date(self, test_client, db_session, auth_headers):
+        """Should return a 400 and a relevant error message if the variance is denied with an issue date"""
+
+        variance = VarianceFactory()
+        denied_variance = VarianceFactory(denied=True)
+        approved_variance = VarianceFactory(approved=True)
+        data = {
+            'compliance_article_id': denied_variance.compliance_article_id,
+            'received_date': denied_variance.received_date,
+            'variance_application_status_code': denied_variance.variance_application_status_code,
+            'inspector_party_guid': approved_variance.inspector_party_guid,
+            'note': denied_variance.note,
+            'issue_date': approved_variance.issue_date
+        }
+
+        put_resp = test_client.put(
+            f'/mines/{variance.mine_guid}/variances/{variance.variance_guid}',
+            headers=auth_headers['full_auth_header'],
+            data=data)
+        put_data = json.loads(put_resp.data.decode())
+        assert put_resp.status_code == 400, put_resp.response
+        assert 'issue' in put_data['message'].lower()
+
+
+    def test_put_variance_application_with_expiry_date(self, test_client, db_session, auth_headers):
+        """Should return a 400 and a relevant error message if the variance is in-review with an expiry date"""
+
+        variance = VarianceFactory()
+        approved_variance = VarianceFactory(approved=True)
+        data = {
+            'expiry_date': approved_variance.expiry_date
+        }
+
+        put_resp = test_client.put(
+            f'/mines/{variance.mine_guid}/variances/{variance.variance_guid}',
+            headers=auth_headers['full_auth_header'],
+            data=data)
+        put_data = json.loads(put_resp.data.decode())
+        assert put_resp.status_code == 400, put_resp.response
+        assert 'expiry' in put_data['message'].lower()
+
+
+    def test_put_variance_application_with_issue_date(self, test_client, db_session, auth_headers):
+        """Should return a 400 and a relevant error message if the variance is in-review with an issue date"""
+
+        variance = VarianceFactory()
+        denied_variance = VarianceFactory(denied=True)
+        approved_variance = VarianceFactory(approved=True)
+        data = {
+            'issue_date': approved_variance.issue_date
+        }
+
+        put_resp = test_client.put(
+            f'/mines/{variance.mine_guid}/variances/{variance.variance_guid}',
+            headers=auth_headers['full_auth_header'],
+            data=data)
+        put_data = json.loads(put_resp.data.decode())
+        assert put_resp.status_code == 400, put_resp.response
+        assert 'issue' in put_data['message'].lower()
+
+
+    def test_put_not_applicable_variance_with_expiry_date(self, test_client, db_session, auth_headers):
+        """Should return a 400 and a relevant error message if the variance is not-applicable with an expiry date"""
+
+        variance = VarianceFactory()
+        approved_variance = VarianceFactory(approved=True)
+        nap_variance = VarianceFactory(not_applicable=True)
+        data = {
+            'compliance_article_id': nap_variance.compliance_article_id,
+            'received_date': nap_variance.received_date,
+            'variance_application_status_code': nap_variance.variance_application_status_code,
+            'note': nap_variance.note,
+            'expiry_date': approved_variance.expiry_date
+        }
+
+        put_resp = test_client.put(
+            f'/mines/{variance.mine_guid}/variances/{variance.variance_guid}',
+            headers=auth_headers['full_auth_header'],
+            data=data)
+        put_data = json.loads(put_resp.data.decode())
+        assert put_resp.status_code == 400, put_resp.response
+        assert 'expiry' in put_data['message'].lower()
+
+
+    def test_put_not_applicable_variance_with_issue_date(self, test_client, db_session, auth_headers):
+        """Should return a 400 and a relevant error message if the variance is not-applicable with an issue date"""
+
+        variance = VarianceFactory()
+        approved_variance = VarianceFactory(approved=True)
+        nap_variance = VarianceFactory(not_applicable=True)
+        data = {
+            'compliance_article_id': nap_variance.compliance_article_id,
+            'received_date': nap_variance.received_date,
+            'variance_application_status_code': nap_variance.variance_application_status_code,
+            'note': nap_variance.note,
+            'issue_date': approved_variance.issue_date
+        }
+
+        put_resp = test_client.put(
+            f'/mines/{variance.mine_guid}/variances/{variance.variance_guid}',
+            headers=auth_headers['full_auth_header'],
+            data=data)
+        put_data = json.loads(put_resp.data.decode())
+        assert put_resp.status_code == 400, put_resp.response
+        assert 'issue' in put_data['message'].lower()

--- a/python-backend/tests/status_code_gen.py
+++ b/python-backend/tests/status_code_gen.py
@@ -16,6 +16,7 @@ from app.api.mines.compliance.models.compliance_article import ComplianceArticle
 from app.api.parties.party.models.sub_division_code import SubDivisionCode
 from app.api.parties.party_appt.models.mine_party_appt_type import MinePartyAppointmentType
 from app.api.parties.party_appt.models.party_business_role_code import PartyBusinessRoleCode
+from app.api.variances.models.variance_document_category_code import VarianceDocumentCategoryCode
 
 
 def RandomApplicationStatusCode():
@@ -87,6 +88,12 @@ def RandomComplianceArticleId():
 def RandomIncidentDeterminationTypeCode():
     return random.choice([
         x.mine_incident_determination_type_code for x in MineIncidentDeterminationType.get_active()
+    ])
+
+
+def RandomVarianceDocumentCategoryCode():
+    return random.choice([
+        x.variance_document_category_code for x in VarianceDocumentCategoryCode.active()
     ])
 
 

--- a/python-backend/tests/variances/resources/test_variance_application_status_code_resource.py
+++ b/python-backend/tests/variances/resources/test_variance_application_status_code_resource.py
@@ -11,6 +11,7 @@ class TestGetVarianceApplicationStatusCode:
 
     def test_get_variance_application_status_codes(self, test_client, db_session, auth_headers):
         """Should return the correct number of records with a 200 response code"""
+
         get_resp = test_client.get(f'/variances/status-codes', headers=auth_headers['full_auth_header'])
         get_data = json.loads(get_resp.data.decode())
         assert get_resp.status_code == 200

--- a/python-backend/tests/variances/resources/test_variance_document_category_code_resource.py
+++ b/python-backend/tests/variances/resources/test_variance_document_category_code_resource.py
@@ -11,6 +11,7 @@ class TestGetVarianceDocumentCategoryCode:
 
     def test_get_variance_document_category_codes(self, test_client, db_session, auth_headers):
         """Should return the correct number of records with a 200 response code"""
+
         get_resp = test_client.get(f'/variances/document-categories', headers=auth_headers['full_auth_header'])
         get_data = json.loads(get_resp.data.decode())
         assert get_resp.status_code == 200

--- a/python-backend/tests/variances/resources/test_variance_document_category_code_resource.py
+++ b/python-backend/tests/variances/resources/test_variance_document_category_code_resource.py
@@ -1,0 +1,17 @@
+import json
+
+from tests.factories import VarianceFactory, MineFactory
+from tests.status_code_gen import RandomComplianceArticleId
+from app.api.utils.custom_reqparser import DEFAULT_MISSING_REQUIRED
+from app.api.variances.models.variance_document_category_code import VarianceDocumentCategoryCode
+
+
+class TestGetVarianceDocumentCategoryCode:
+    """GET /variances/document-categories"""
+
+    def test_get_variance_document_category_codes(self, test_client, db_session, auth_headers):
+        """Should return the correct number of records with a 200 response code"""
+        get_resp = test_client.get(f'/variances/document-categories', headers=auth_headers['full_auth_header'])
+        get_data = json.loads(get_resp.data.decode())
+        assert get_resp.status_code == 200
+        assert len(get_data['records']) == len(VarianceDocumentCategoryCode.active())


### PR DESCRIPTION
1. Add a new variance application status
2. Add categories to variance documents
3. Add an indicator for whether the relevant parties have been notified of the variance request & decision
4. Update test format to use docstrings

Note: There is a small frontend change to support categories in a backwards-compatible way. The full category-selection form integration will be in a separate PR.