### PR TITLE
set reference policy local to copy remote images

### DIFF
--- a/microservices/nris_api/openshift/_python36_oracle.bc.json
+++ b/microservices/nris_api/openshift/_python36_oracle.bc.json
@@ -64,7 +64,7 @@
             },
             "importPolicy": {},
             "referencePolicy": {
-              "type": "Source"
+              "type": "Local"
             }
           }
         ]

--- a/openshift/_nodejs.bc.json
+++ b/openshift/_nodejs.bc.json
@@ -83,7 +83,7 @@
             },
             "importPolicy": {},
             "referencePolicy": {
-              "type": "Source"
+              "type": "Local"
             }
           }
         ]

--- a/openshift/_python36.bc.json
+++ b/openshift/_python36.bc.json
@@ -64,7 +64,7 @@
             },
             "importPolicy": {},
             "referencePolicy": {
-              "type": "Source"
+              "type": "Local"
             }
           }
         ]

--- a/openshift/dbbackup.bc.json
+++ b/openshift/dbbackup.bc.json
@@ -33,7 +33,7 @@
             },
             "importPolicy": {},
             "referencePolicy": {
-              "type": "Source"
+              "type": "Local"
             }
           }
         ]

--- a/openshift/flyway.bc.json
+++ b/openshift/flyway.bc.json
@@ -63,7 +63,7 @@
             },
             "importPolicy": {},
             "referencePolicy": {
-              "type": "Source"
+              "type": "Local"
             }
           }
         ]

--- a/openshift/postgresql.bc.json
+++ b/openshift/postgresql.bc.json
@@ -50,7 +50,7 @@
             "generation": 1,
             "importPolicy": {},
             "referencePolicy": {
-              "type": "Source"
+              "type": "Local"
             }
           }
         ]

--- a/openshift/tools/jenkins/_jenkins.bc.json
+++ b/openshift/tools/jenkins/_jenkins.bc.json
@@ -73,7 +73,7 @@
             "generation": 1,
             "importPolicy": {},
             "referencePolicy": {
-              "type": "Source"
+              "type": "Local"
             }
           }
         ]

--- a/openshift/tools/logstash.bc.json
+++ b/openshift/tools/logstash.bc.json
@@ -30,7 +30,7 @@
             },
             "importPolicy": {},
             "referencePolicy": {
-              "type": "Source"
+              "type": "Local"
             }
           }
         ]

--- a/openshift/tools/metabase.bc.json
+++ b/openshift/tools/metabase.bc.json
@@ -30,7 +30,7 @@
             },
             "importPolicy": {},
             "referencePolicy": {
-              "type": "Source"
+              "type": "Local"
             }
           }
         ]

--- a/openshift/tools/schemaspy.bc.json
+++ b/openshift/tools/schemaspy.bc.json
@@ -31,7 +31,7 @@
               "name": "openjdk:jre-alpine"
             },
             "referencePolicy": {
-              "type": "Source"
+              "type": "Local"
             }
           }
         ]

--- a/openshift/tools/sonarqube/postgresql.bc.json
+++ b/openshift/tools/sonarqube/postgresql.bc.json
@@ -1,68 +1,68 @@
 {
-    "kind": "Template",
-    "apiVersion": "v1",
-    "metadata": {
-        "name": "postgresql",
-        "creationTimestamp": null
+  "kind": "Template",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "postgresql",
+    "creationTimestamp": null
+  },
+  "parameters": [
+    {
+      "name": "NAME",
+      "displayName": "Name",
+      "description": "A name used for all objects",
+      "required": true
     },
-    "parameters": [
-        {
-            "name": "NAME",
-            "displayName": "Name",
-            "description": "A name used for all objects",
-            "required": true
+    {
+      "name": "VERSION",
+      "displayName": "Name",
+      "description": "The output/built ImageStream tag names",
+      "required": true
+    },
+    {
+      "name": "RHSCL_PG_DOCKER_IMAGE",
+      "required": true,
+      "value": "registry.access.redhat.com/rhscl/postgresql-96-rhel7:1-14"
+    },
+    {
+      "name": "RHSCL_PG_IMAGE_TAG",
+      "required": true,
+      "value": "9.6.1-14"
+    }
+  ],
+  "objects": [
+    {
+      "kind": "ImageStream",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "${NAME}",
+        "creationTimestamp": null,
+        "labels": {
+          "shared": "true"
         },
-        {
-            "name": "VERSION",
-            "displayName": "Name",
-            "description": "The output/built ImageStream tag names",
-            "required": true
-        },
-        {
-            "name": "RHSCL_PG_DOCKER_IMAGE",
-            "required": true,
-            "value": "registry.access.redhat.com/rhscl/postgresql-96-rhel7:1-14"
-        },
-        {
-            "name": "RHSCL_PG_IMAGE_TAG",
-            "required": true,
-            "value": "9.6.1-14"
+        "annotations": {
+          "template.alpha.openshift.io/wait-for-ready": "true"
         }
-    ],
-    "objects": [
-        {
-            "kind": "ImageStream",
-            "apiVersion": "v1",
-            "metadata": {
-                "name": "${NAME}",
-                "creationTimestamp": null,
-                "labels": {
-                    "shared": "true"
-                },
-                "annotations": {
-                    "template.alpha.openshift.io/wait-for-ready": "true"
-                }
-            },  
-            "spec": {
-                "lookupPolicy": {
-                    "local": false
-                },
-                "tags":[
-                    {
-                        "name": "${VERSION}",
-                        "annotations": null,
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/rhscl/postgresql-96-rhel7:1-14"
-                        },
-                        "generation": 1,
-                        "importPolicy": {},
-                        "referencePolicy": {
-                            "type": "Source"
-                        }
-                    }
-                ]
+      },
+      "spec": {
+        "lookupPolicy": {
+          "local": false
+        },
+        "tags": [
+          {
+            "name": "${VERSION}",
+            "annotations": null,
+            "from": {
+              "kind": "DockerImage",
+              "name": "registry.access.redhat.com/rhscl/postgresql-96-rhel7:1-14"
+            },
+            "generation": 1,
+            "importPolicy": {},
+            "referencePolicy": {
+              "type": "Local"
             }
-        }
-    ]
+          }
+        ]
+      }
+    }
+  ]
 }

--- a/openshift/tools/sonarqube/sonarqube.bc.json
+++ b/openshift/tools/sonarqube/sonarqube.bc.json
@@ -1,191 +1,191 @@
 {
-    "kind": "Template",
-    "apiVersion": "v1",
-    "metadata": {
-        "name": "sonarqube",
-        "creationTimestamp": null
+  "kind": "Template",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "sonarqube",
+    "creationTimestamp": null
+  },
+  "parameters": [
+    {
+      "name": "NAME",
+      "displayName": "Name",
+      "description": "A name used for all objects",
+      "required": true
     },
-    "parameters": [
-        {
-            "name": "NAME",
-            "displayName": "Name",
-            "description": "A name used for all objects",
-            "required": true
+    {
+      "name": "NAME_SUFFIX",
+      "displayName": "Name",
+      "description": "A name used for all objects",
+      "required": false
+    },
+    {
+      "name": "VERSION",
+      "displayName": "Name",
+      "description": "The output/built ImageStream tag names",
+      "required": true
+    },
+    {
+      "name": "SONARQUBE_DOCKER_IMAGE",
+      "required": true,
+      "value": "docker-registry.default.svc:5000/openshift/sonarqube:6.7.1"
+    },
+    {
+      "name": "SONARQUBE_IMAGE_TAG",
+      "required": true,
+      "value": "6.7.1"
+    },
+    {
+      "name": "SOURCE_REPOSITORY_URL",
+      "required": true
+    },
+    {
+      "name": "SOURCE_REPOSITORY_REF",
+      "required": false,
+      "value": "master"
+    }
+  ],
+  "objects": [
+    {
+      "kind": "ImageStream",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "${NAME}",
+        "creationTimestamp": null,
+        "labels": {
+          "shared": "true"
         },
-        {
-            "name": "NAME_SUFFIX",
-            "displayName": "Name",
-            "description": "A name used for all objects",
-            "required": false
+        "annotations": {}
+      },
+      "spec": {
+        "lookupPolicy": {
+          "local": false
         },
-        {
-            "name": "VERSION",
-            "displayName": "Name",
-            "description": "The output/built ImageStream tag names",
-            "required": true
+        "tags": [
+          {
+            "name": "${VERSION}",
+            "annotations": {
+              "source": "openshift/sonarqube:6.7.1"
+            },
+            "from": {
+              "kind": "ImageStreamImage",
+              "namespace": "openshift",
+              "name": "sonarqube@sha256:6f42c766e3db030f154f1ebca7188191a3717990537e0c7dc08bf0a680d4b1f1"
+            },
+            "generation": 1,
+            "importPolicy": {},
+            "referencePolicy": {
+              "type": "Local"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "ImageStream",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "rhel",
+        "creationTimestamp": null,
+        "labels": {
+          "shared": "true"
         },
-        {
-            "name": "SONARQUBE_DOCKER_IMAGE",
-            "required": true,
-            "value": "docker-registry.default.svc:5000/openshift/sonarqube:6.7.1"
+        "annotations": {}
+      },
+      "spec": {
+        "lookupPolicy": {
+          "local": false
         },
-        {
-            "name": "SONARQUBE_IMAGE_TAG",
-            "required": true,
-            "value": "6.7.1"
+        "tags": [
+          {
+            "name": "7.5-409",
+            "from": {
+              "kind": "DockerImage",
+              "name": "registry.access.redhat.com/rhel7:7.5-409"
+            },
+            "importPolicy": {},
+            "referencePolicy": {
+              "type": "Local"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "kind": "ImageStream",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "${NAME}-client",
+        "creationTimestamp": null,
+        "labels": {
+          "shared": "true"
         },
-        {
-            "name": "SOURCE_REPOSITORY_URL",
-            "required": true
-        },
-        {
-            "name": "SOURCE_REPOSITORY_REF",
-            "required": false,
-            "value": "master"
+        "annotations": {}
+      },
+      "spec": {
+        "lookupPolicy": {
+          "local": false
         }
-    ],
-    "objects": [
-        {
-            "kind": "ImageStream",
-            "apiVersion": "v1",
-            "metadata": {
-                "name": "${NAME}",
-                "creationTimestamp": null,
-                "labels": {
-                    "shared": "true"
-                },
-                "annotations": {}
-            },
-            "spec": {
-                "lookupPolicy": {
-                    "local": false
-                },
-                "tags":[
-                    {
-                        "name": "${VERSION}",
-                        "annotations": {
-                            "source": "openshift/sonarqube:6.7.1"
-                        },
-                        "from": {
-                            "kind": "ImageStreamImage",
-                            "namespace": "openshift",
-                            "name": "sonarqube@sha256:6f42c766e3db030f154f1ebca7188191a3717990537e0c7dc08bf0a680d4b1f1"
-                        },
-                        "generation": 1,
-                        "importPolicy": {},
-                        "referencePolicy": {
-                            "type": "Source"
-                        }
-                    }
-                ]
-            }
+      }
+    },
+    {
+      "kind": "BuildConfig",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "${NAME}${NAME_SUFFIX}-client",
+        "creationTimestamp": null,
+        "labels": {},
+        "annotations": {}
+      },
+      "spec": {
+        "completionDeadlineSeconds": 1440,
+        "successfulBuildsHistoryLimit": 3,
+        "failedBuildsHistoryLimit": 3,
+        "triggers": [
+          {
+            "type": "ImageChange",
+            "imageChange": {}
+          },
+          {
+            "type": "ConfigChange"
+          }
+        ],
+        "runPolicy": "SerialLatestOnly",
+        "source": {
+          "contextDir": "docker-images/sonar-scanner",
+          "git": {
+            "ref": "${SOURCE_REPOSITORY_REF}",
+            "uri": "${SOURCE_REPOSITORY_URL}"
+          },
+          "type": "Git"
         },
-        {
-            "kind": "ImageStream",
-            "apiVersion": "v1",
-            "metadata": {
-                "name": "rhel",
-                "creationTimestamp": null,
-                "labels": {
-                    "shared": "true"
-                },
-                "annotations": {}
-            },
-            "spec": {
-                "lookupPolicy": {
-                    "local": false
-                },
-                "tags":[
-                    {
-                        "name": "7.5-409",
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.access.redhat.com/rhel7:7.5-409"
-                        },
-                        "importPolicy": {},
-                        "referencePolicy": {
-                            "type": "Source"
-                        }
-                    }
-                ]
+        "strategy": {
+          "type": "Docker",
+          "dockerStrategy": {
+            "from": {
+              "kind": "ImageStreamTag",
+              "name": "rhel:7.5-409"
             }
+          }
         },
-        {
-            "kind": "ImageStream",
-            "apiVersion": "v1",
-            "metadata": {
-                "name": "${NAME}-client",
-                "creationTimestamp": null,
-                "labels": {
-                    "shared": "true"
-                },
-                "annotations": {}
-            },
-            "spec": {
-                "lookupPolicy": {
-                    "local": false
-                }
-            }
+        "output": {
+          "to": {
+            "kind": "ImageStreamTag",
+            "name": "${NAME}${NAME_SUFFIX}-client:${VERSION}"
+          }
         },
-        {
-            "kind": "BuildConfig",
-            "apiVersion": "v1",
-            "metadata": {
-                "name": "${NAME}${NAME_SUFFIX}-client",
-                "creationTimestamp": null,
-                "labels": { },
-                "annotations": { }
-            },
-            "spec": {
-                "completionDeadlineSeconds": 1440,
-                "successfulBuildsHistoryLimit": 3,
-                "failedBuildsHistoryLimit": 3,
-                "triggers": [
-                    {
-                        "type": "ImageChange",
-                        "imageChange": {}
-                    },
-                    {
-                        "type": "ConfigChange"
-                    }
-                ],
-                "runPolicy": "SerialLatestOnly",
-                "source": {
-                    "contextDir": "docker-images/sonar-scanner",
-                    "git": {
-                        "ref": "${SOURCE_REPOSITORY_REF}",
-                        "uri": "${SOURCE_REPOSITORY_URL}"
-                    },
-                    "type": "Git"
-                },
-                "strategy": {
-                    "type": "Docker",
-                    "dockerStrategy": {
-                        "from": {
-                            "kind": "ImageStreamTag",
-                            "name": "rhel:7.5-409"
-                        }
-                    }
-                },
-                "output": {
-                    "to": {
-                        "kind": "ImageStreamTag",
-                        "name": "${NAME}${NAME_SUFFIX}-client:${VERSION}"
-                    }
-                },
-                "resources": {
-                    "limits": {
-                        "cpu": "500m",
-                        "memory": "1Gi"
-                    },
-                    "requests": {
-                        "cpu": "250m",
-                        "memory": "1Gi"
-                    }
-                },
-                "postCommit": {},
-                "nodeSelector": null
-            }
-        }
-    ]
+        "resources": {
+          "limits": {
+            "cpu": "500m",
+            "memory": "1Gi"
+          },
+          "requests": {
+            "cpu": "250m",
+            "memory": "1Gi"
+          }
+        },
+        "postCommit": {},
+        "nodeSelector": null
+      }
+    }
+  ]
 }


### PR DESCRIPTION
Clecio made a point of saying we should be coping these locally rather than downloading them. this is done by changing the `reference policy` to `local`