### PR TITLE
BUG: fetchVarianceDocumentCategoryOptions was not being called 

### DIFF
--- a/frontend/src/components/mine/MineDashboard.js
+++ b/frontend/src/components/mine/MineDashboard.js
@@ -163,12 +163,12 @@ export class MineDashboard extends Component {
       this.props.fetchApplicationStatusOptions();
       this.props.fetchMineIncidentFollowActionOptions();
       this.props.fetchMineIncidentDeterminationOptions();
-      this.props.fetchVarianceDocumentCategoryOptions();
       this.props.setOptionsLoaded();
     }
     this.props.fetchMineComplianceCodes();
     this.props.fetchPartyRelationships({ mine_guid: id, relationships: "party" });
     this.props.fetchSubscribedMinesByUser();
+    this.props.fetchVarianceDocumentCategoryOptions();
     this.props.fetchVarianceStatusOptions();
     this.props.fetchInspectors();
     if (activeTab) {

--- a/frontend/src/components/modalContent/ViewVarianceModal.js
+++ b/frontend/src/components/modalContent/ViewVarianceModal.js
@@ -3,7 +3,6 @@ import PropTypes from "prop-types";
 import CustomPropTypes from "@/customPropTypes";
 import { Button } from "antd";
 import * as Strings from "@/constants/strings";
-import { ELLIPSE, RED_ELLIPSE } from "@/constants/assets";
 import { VarianceDetails } from "../mine/Variances/VarianceDetails";
 
 const propTypes = {
@@ -30,28 +29,12 @@ export const ViewVarianceModal = (props) => {
         </div>
         <div className="flex-tablet">
           <p className="field-title">Application Status</p>
-          <div className="inline-flex--inline">
-            <img
-              className="padding-small--right icon-sm--img"
-              src={isApproved ? ELLIPSE : RED_ELLIPSE}
-              alt="status"
-            />
-            <p>
-              {props.varianceStatusOptionsHash[props.variance.variance_application_status_code]}
-            </p>
-          </div>
+          <p>{props.varianceStatusOptionsHash[props.variance.variance_application_status_code]}</p>
         </div>
         {isApproved && (
           <div className="flex-tablet">
             <p className="field-title">Approval Status</p>
-            <div className="inline-flex--inline">
-              <img
-                className="padding-small--right icon-sm--img"
-                src={isOverdue ? RED_ELLIPSE : ELLIPSE}
-                alt="status"
-              />
-              <p>{isOverdue ? "Expired" : "Active"}</p>
-            </div>
+            <p>{isOverdue ? "Expired" : "Active"}</p>
           </div>
         )}
       </div>


### PR DESCRIPTION
Due to the `optionsLoaded` condition, `fetchVarianceDocumentCategoryOptions()` was not being called when the user navigated from the dashboard to the mine summary page. 
-There is a ticket in this sprint to address the issues with the staticContentActionCreators

Also, In preparation for user testing, removed the status icons as per new designs.