### PR TITLE
Use npm ci to decrease build times

### DIFF
--- a/docker-images/nodejs-8-public/Dockerfile
+++ b/docker-images/nodejs-8-public/Dockerfile
@@ -3,7 +3,6 @@ FROM "__FROM_IMAGE_STREAM_DEFINED_IN_TEMPLATE__"
 # Install OS dependencies for NPM build success
 USER 0
 RUN yum install -y nasm build-base libtool libpng-dev autoconf automake
-RUN source ${APP_ROOT}/etc/scl_enable && curl https://www.npmjs.com/install.sh | sh
 USER 1001
 
 # Install sonar-scanner
@@ -17,4 +16,4 @@ RUN curl -sLo /tmp/sonar-scanner-cli.zip https://dl.bintray.com/sonarsource/Sona
 # Install project dependencies
 COPY package.json ${APP_ROOT}/src
 COPY package-lock.json ${APP_ROOT}/src
-RUN source ${APP_ROOT}/etc/scl_enable && cd ${APP_ROOT}/src && npm set progress=false && npm ci
+RUN source ${APP_ROOT}/etc/scl_enable && cd ${APP_ROOT}/src && npm set progress=false && curl https://www.npmjs.com/install.sh | sh && npm ci

--- a/docker-images/nodejs-8-public/Dockerfile
+++ b/docker-images/nodejs-8-public/Dockerfile
@@ -3,7 +3,7 @@ FROM "__FROM_IMAGE_STREAM_DEFINED_IN_TEMPLATE__"
 # Install OS dependencies for NPM build success
 USER 0
 RUN yum install -y nasm build-base libtool libpng-dev autoconf automake
-RUN source ${APP_ROOT}/etc/scl_enable && npm i npm@latest -g
+RUN source ${APP_ROOT}/etc/scl_enable && cd ${APP_ROOT}/src && npm set progress=false && npm i npm@latest
 USER 1001
 
 # Install sonar-scanner

--- a/docker-images/nodejs-8-public/Dockerfile
+++ b/docker-images/nodejs-8-public/Dockerfile
@@ -3,6 +3,7 @@ FROM "__FROM_IMAGE_STREAM_DEFINED_IN_TEMPLATE__"
 # Install OS dependencies for NPM build success
 USER 0
 RUN yum install -y nasm build-base libtool libpng-dev autoconf automake
+RUN curl https://www.npmjs.com/install.sh | sh
 USER 1001
 
 # Install sonar-scanner
@@ -16,6 +17,4 @@ RUN curl -sLo /tmp/sonar-scanner-cli.zip https://dl.bintray.com/sonarsource/Sona
 # Install project dependencies
 COPY package.json ${APP_ROOT}/src
 COPY package-lock.json ${APP_ROOT}/src
-RUN which npm && whereis npm
-RUN find / -name npm
-RUN source ${APP_ROOT}/etc/scl_enable && cd ${APP_ROOT}/src && npm set progress=false && npm i npm@latest && npm ci
+RUN source ${APP_ROOT}/etc/scl_enable && cd ${APP_ROOT}/src && npm set progress=false && npm ci

--- a/docker-images/nodejs-8-public/Dockerfile
+++ b/docker-images/nodejs-8-public/Dockerfile
@@ -16,4 +16,4 @@ RUN curl -sLo /tmp/sonar-scanner-cli.zip https://dl.bintray.com/sonarsource/Sona
 # Install project dependencies
 COPY package.json ${APP_ROOT}/src
 COPY package-lock.json ${APP_ROOT}/src
-RUN source ${APP_ROOT}/etc/scl_enable && cd ${APP_ROOT}/src && npm set progress=false && npm install
+RUN source ${APP_ROOT}/etc/scl_enable && cd ${APP_ROOT}/src && npm set progress=false && npm ci

--- a/docker-images/nodejs-8-public/Dockerfile
+++ b/docker-images/nodejs-8-public/Dockerfile
@@ -18,7 +18,7 @@ COPY package.json ${APP_ROOT}/src
 COPY package-lock.json ${APP_ROOT}/src
 
 # Install latest npm to /tmp
-RUN source ${APP_ROOT}/etc/scl_enable && npm install --prefix /tmp npm
+RUN source ${APP_ROOT}/etc/scl_enable && npm install --prefix /tmp npm@6.9.0
 
 # Install dependencies
 RUN source ${APP_ROOT}/etc/scl_enable && cd ${APP_ROOT}/src && npm set progress=false && /tmp/node_modules/.bin/npm ci

--- a/docker-images/nodejs-8-public/Dockerfile
+++ b/docker-images/nodejs-8-public/Dockerfile
@@ -3,6 +3,7 @@ FROM "__FROM_IMAGE_STREAM_DEFINED_IN_TEMPLATE__"
 # Install OS dependencies for NPM build success
 USER 0
 RUN yum install -y nasm build-base libtool libpng-dev autoconf automake
+RUN npm i npm@latest -g
 USER 1001
 
 # Install sonar-scanner

--- a/docker-images/nodejs-8-public/Dockerfile
+++ b/docker-images/nodejs-8-public/Dockerfile
@@ -3,7 +3,7 @@ FROM "__FROM_IMAGE_STREAM_DEFINED_IN_TEMPLATE__"
 # Install OS dependencies for NPM build success
 USER 0
 RUN yum install -y nasm build-base libtool libpng-dev autoconf automake
-RUN curl https://www.npmjs.com/install.sh | sh
+RUN source ${APP_ROOT}/etc/scl_enable && curl https://www.npmjs.com/install.sh | sh
 USER 1001
 
 # Install sonar-scanner

--- a/docker-images/nodejs-8-public/Dockerfile
+++ b/docker-images/nodejs-8-public/Dockerfile
@@ -4,7 +4,7 @@ FROM "__FROM_IMAGE_STREAM_DEFINED_IN_TEMPLATE__"
 USER 0
 RUN yum install -y nasm build-base libtool libpng-dev autoconf automake
 RUN source ${APP_ROOT}/etc/scl_enable && npm set progress=false && npm i npm@latest
-RUN chown -R 1001:1001 /opt/app-root/src/.config
+RUN chown -R 1001:1001 /opt/app-root/src/.config /opt/app-root/src/.npmrc
 USER 1001
 
 # Install sonar-scanner

--- a/docker-images/nodejs-8-public/Dockerfile
+++ b/docker-images/nodejs-8-public/Dockerfile
@@ -3,7 +3,8 @@ FROM "__FROM_IMAGE_STREAM_DEFINED_IN_TEMPLATE__"
 # Install OS dependencies for NPM build success
 USER 0
 RUN yum install -y nasm build-base libtool libpng-dev autoconf automake
-RUN source ${APP_ROOT}/etc/scl_enable && cd ${APP_ROOT}/src && npm set progress=false && npm i npm@latest
+RUN source ${APP_ROOT}/etc/scl_enable && npm set progress=false && npm i npm@latest
+RUN chown -R 1001:1001 /opt/app-root/src/.config
 USER 1001
 
 # Install sonar-scanner

--- a/docker-images/nodejs-8-public/Dockerfile
+++ b/docker-images/nodejs-8-public/Dockerfile
@@ -16,4 +16,4 @@ RUN curl -sLo /tmp/sonar-scanner-cli.zip https://dl.bintray.com/sonarsource/Sona
 # Install project dependencies
 COPY package.json ${APP_ROOT}/src
 COPY package-lock.json ${APP_ROOT}/src
-RUN source ${APP_ROOT}/etc/scl_enable && cd ${APP_ROOT}/src && npm set progress=false && curl https://www.npmjs.com/install.sh | sh && npm ci
+RUN source ${APP_ROOT}/etc/scl_enable && cd ${APP_ROOT}/src && npm set progress=false && npm update npm && npm ci

--- a/docker-images/nodejs-8-public/Dockerfile
+++ b/docker-images/nodejs-8-public/Dockerfile
@@ -3,8 +3,6 @@ FROM "__FROM_IMAGE_STREAM_DEFINED_IN_TEMPLATE__"
 # Install OS dependencies for NPM build success
 USER 0
 RUN yum install -y nasm build-base libtool libpng-dev autoconf automake
-RUN source ${APP_ROOT}/etc/scl_enable && npm set progress=false && npm i npm@latest
-RUN chown -R 1001:1001 /opt/app-root/src/.config /opt/app-root/src/.npmrc
 USER 1001
 
 # Install sonar-scanner
@@ -18,4 +16,5 @@ RUN curl -sLo /tmp/sonar-scanner-cli.zip https://dl.bintray.com/sonarsource/Sona
 # Install project dependencies
 COPY package.json ${APP_ROOT}/src
 COPY package-lock.json ${APP_ROOT}/src
+RUN source ${APP_ROOT}/etc/scl_enable && npm set progress=false && npm i npm@latest -g
 RUN source ${APP_ROOT}/etc/scl_enable && cd ${APP_ROOT}/src && npm set progress=false && npm ci

--- a/docker-images/nodejs-8-public/Dockerfile
+++ b/docker-images/nodejs-8-public/Dockerfile
@@ -16,4 +16,10 @@ RUN curl -sLo /tmp/sonar-scanner-cli.zip https://dl.bintray.com/sonarsource/Sona
 # Install project dependencies
 COPY package.json ${APP_ROOT}/src
 COPY package-lock.json ${APP_ROOT}/src
+
+# Install latest npm
+RUN source ${APP_ROOT}/etc/scl_enable && npm install --prefix /tmp npm
+ENV PATH="/tmp/node_modules/.bin:${PATH}"
+
+# Install dependencies
 RUN source ${APP_ROOT}/etc/scl_enable && cd ${APP_ROOT}/src && npm set progress=false && npm update npm && npm ci

--- a/docker-images/nodejs-8-public/Dockerfile
+++ b/docker-images/nodejs-8-public/Dockerfile
@@ -3,7 +3,7 @@ FROM "__FROM_IMAGE_STREAM_DEFINED_IN_TEMPLATE__"
 # Install OS dependencies for NPM build success
 USER 0
 RUN yum install -y nasm build-base libtool libpng-dev autoconf automake
-RUN npm i npm@latest -g
+RUN source ${APP_ROOT}/etc/scl_enable && npm i npm@latest -g
 USER 1001
 
 # Install sonar-scanner

--- a/docker-images/nodejs-8-public/Dockerfile
+++ b/docker-images/nodejs-8-public/Dockerfile
@@ -16,5 +16,6 @@ RUN curl -sLo /tmp/sonar-scanner-cli.zip https://dl.bintray.com/sonarsource/Sona
 # Install project dependencies
 COPY package.json ${APP_ROOT}/src
 COPY package-lock.json ${APP_ROOT}/src
-RUN source ${APP_ROOT}/etc/scl_enable && npm set progress=false && npm i npm@latest -g
-RUN source ${APP_ROOT}/etc/scl_enable && cd ${APP_ROOT}/src && npm set progress=false && npm ci
+RUN which npm && whereis npm
+RUN find / -name npm
+RUN source ${APP_ROOT}/etc/scl_enable && cd ${APP_ROOT}/src && npm set progress=false && npm i npm@latest && npm ci

--- a/docker-images/nodejs-8-public/Dockerfile
+++ b/docker-images/nodejs-8-public/Dockerfile
@@ -19,7 +19,6 @@ COPY package-lock.json ${APP_ROOT}/src
 
 # Install latest npm
 RUN source ${APP_ROOT}/etc/scl_enable && npm install --prefix /tmp npm
-ENV PATH="/tmp/node_modules/.bin:${PATH}"
 
 # Install dependencies
-RUN source ${APP_ROOT}/etc/scl_enable && cd ${APP_ROOT}/src && npm set progress=false && npm update npm && npm ci
+RUN source ${APP_ROOT}/etc/scl_enable && cd ${APP_ROOT}/src && npm set progress=false && /tmp/node_modules/.bin/npm ci

--- a/docker-images/nodejs-8-public/Dockerfile
+++ b/docker-images/nodejs-8-public/Dockerfile
@@ -13,11 +13,11 @@ RUN curl -sLo /tmp/sonar-scanner-cli.zip https://dl.bintray.com/sonarsource/Sona
     rm /tmp/sonar-scanner-cli.zip && \
     chmod -R 755 ${APP_ROOT}/sonar-scanner-cli
 
-# Install project dependencies
+# Copy project dependencies
 COPY package.json ${APP_ROOT}/src
 COPY package-lock.json ${APP_ROOT}/src
 
-# Install latest npm
+# Install latest npm to /tmp
 RUN source ${APP_ROOT}/etc/scl_enable && npm install --prefix /tmp npm
 
 # Install dependencies

--- a/docker-images/nodejs-8/Dockerfile
+++ b/docker-images/nodejs-8/Dockerfile
@@ -3,7 +3,6 @@ FROM "__FROM_IMAGE_STREAM_DEFINED_IN_TEMPLATE__"
 # Install OS dependencies for NPM build success
 USER 0
 RUN yum install -y nasm build-base libtool libpng-dev autoconf automake
-RUN source ${APP_ROOT}/etc/scl_enable && curl https://www.npmjs.com/install.sh | sh
 USER 1001
 
 # Install sonar-scanner
@@ -17,4 +16,4 @@ RUN curl -sLo /tmp/sonar-scanner-cli.zip https://dl.bintray.com/sonarsource/Sona
 # Install project dependencies
 COPY package.json ${APP_ROOT}/src
 COPY package-lock.json ${APP_ROOT}/src
-RUN source ${APP_ROOT}/etc/scl_enable && cd ${APP_ROOT}/src && npm set progress=false && npm ci
+RUN source ${APP_ROOT}/etc/scl_enable && cd ${APP_ROOT}/src && npm set progress=false && curl https://www.npmjs.com/install.sh | sh && npm ci

--- a/docker-images/nodejs-8/Dockerfile
+++ b/docker-images/nodejs-8/Dockerfile
@@ -13,7 +13,13 @@ RUN curl -sLo /tmp/sonar-scanner-cli.zip https://dl.bintray.com/sonarsource/Sona
     rm /tmp/sonar-scanner-cli.zip && \
     chmod -R 755 ${APP_ROOT}/sonar-scanner-cli
 
-# Install project dependencies
+# Copy project dependencies
 COPY package.json ${APP_ROOT}/src
 COPY package-lock.json ${APP_ROOT}/src
+
+# Install latest npm
+RUN source ${APP_ROOT}/etc/scl_enable && npm install --prefix /tmp npm
+ENV PATH="/tmp/node_modules/.bin:${PATH}"
+
+# Install dependencies
 RUN source ${APP_ROOT}/etc/scl_enable && cd ${APP_ROOT}/src && npm set progress=false && npm update npm && npm ci

--- a/docker-images/nodejs-8/Dockerfile
+++ b/docker-images/nodejs-8/Dockerfile
@@ -3,7 +3,7 @@ FROM "__FROM_IMAGE_STREAM_DEFINED_IN_TEMPLATE__"
 # Install OS dependencies for NPM build success
 USER 0
 RUN yum install -y nasm build-base libtool libpng-dev autoconf automake
-RUN source ${APP_ROOT}/etc/scl_enable && npm i npm@latest -g
+RUN source ${APP_ROOT}/etc/scl_enable && cd ${APP_ROOT}/src && npm set progress=false && npm i npm@latest
 USER 1001
 
 # Install sonar-scanner

--- a/docker-images/nodejs-8/Dockerfile
+++ b/docker-images/nodejs-8/Dockerfile
@@ -3,6 +3,7 @@ FROM "__FROM_IMAGE_STREAM_DEFINED_IN_TEMPLATE__"
 # Install OS dependencies for NPM build success
 USER 0
 RUN yum install -y nasm build-base libtool libpng-dev autoconf automake
+RUN curl https://www.npmjs.com/install.sh | sh
 USER 1001
 
 # Install sonar-scanner
@@ -16,6 +17,4 @@ RUN curl -sLo /tmp/sonar-scanner-cli.zip https://dl.bintray.com/sonarsource/Sona
 # Install project dependencies
 COPY package.json ${APP_ROOT}/src
 COPY package-lock.json ${APP_ROOT}/src
-RUN which npm && whereis npm
-RUN find / -name npm
-RUN source ${APP_ROOT}/etc/scl_enable && cd ${APP_ROOT}/src && npm set progress=false && npm i npm@latest && npm ci
+RUN source ${APP_ROOT}/etc/scl_enable && cd ${APP_ROOT}/src && npm set progress=false && npm ci

--- a/docker-images/nodejs-8/Dockerfile
+++ b/docker-images/nodejs-8/Dockerfile
@@ -18,7 +18,7 @@ COPY package.json ${APP_ROOT}/src
 COPY package-lock.json ${APP_ROOT}/src
 
 # Install latest npm to /tmp
-RUN source ${APP_ROOT}/etc/scl_enable && npm install --prefix /tmp npm
+RUN source ${APP_ROOT}/etc/scl_enable && npm install --prefix /tmp npm@6.9.0
 
 # Install dependencies
 RUN source ${APP_ROOT}/etc/scl_enable && cd ${APP_ROOT}/src && npm set progress=false && /tmp/node_modules/.bin/npm ci

--- a/docker-images/nodejs-8/Dockerfile
+++ b/docker-images/nodejs-8/Dockerfile
@@ -3,7 +3,7 @@ FROM "__FROM_IMAGE_STREAM_DEFINED_IN_TEMPLATE__"
 # Install OS dependencies for NPM build success
 USER 0
 RUN yum install -y nasm build-base libtool libpng-dev autoconf automake
-RUN curl https://www.npmjs.com/install.sh | sh
+RUN source ${APP_ROOT}/etc/scl_enable && curl https://www.npmjs.com/install.sh | sh
 USER 1001
 
 # Install sonar-scanner

--- a/docker-images/nodejs-8/Dockerfile
+++ b/docker-images/nodejs-8/Dockerfile
@@ -4,7 +4,7 @@ FROM "__FROM_IMAGE_STREAM_DEFINED_IN_TEMPLATE__"
 USER 0
 RUN yum install -y nasm build-base libtool libpng-dev autoconf automake
 RUN source ${APP_ROOT}/etc/scl_enable && npm set progress=false && npm i npm@latest
-RUN chown -R 1001:1001 /opt/app-root/src/.config
+RUN chown -R 1001:1001 /opt/app-root/src/.config /opt/app-root/src/.npmrc
 USER 1001
 
 # Install sonar-scanner

--- a/docker-images/nodejs-8/Dockerfile
+++ b/docker-images/nodejs-8/Dockerfile
@@ -3,7 +3,8 @@ FROM "__FROM_IMAGE_STREAM_DEFINED_IN_TEMPLATE__"
 # Install OS dependencies for NPM build success
 USER 0
 RUN yum install -y nasm build-base libtool libpng-dev autoconf automake
-RUN source ${APP_ROOT}/etc/scl_enable && cd ${APP_ROOT}/src && npm set progress=false && npm i npm@latest
+RUN source ${APP_ROOT}/etc/scl_enable && npm set progress=false && npm i npm@latest
+RUN chown -R 1001:1001 /opt/app-root/src/.config
 USER 1001
 
 # Install sonar-scanner

--- a/docker-images/nodejs-8/Dockerfile
+++ b/docker-images/nodejs-8/Dockerfile
@@ -16,4 +16,4 @@ RUN curl -sLo /tmp/sonar-scanner-cli.zip https://dl.bintray.com/sonarsource/Sona
 # Install project dependencies
 COPY package.json ${APP_ROOT}/src
 COPY package-lock.json ${APP_ROOT}/src
-RUN source ${APP_ROOT}/etc/scl_enable && cd ${APP_ROOT}/src && npm set progress=false && curl https://www.npmjs.com/install.sh | sh && npm ci
+RUN source ${APP_ROOT}/etc/scl_enable && cd ${APP_ROOT}/src && npm set progress=false && npm update npm && npm ci

--- a/docker-images/nodejs-8/Dockerfile
+++ b/docker-images/nodejs-8/Dockerfile
@@ -3,6 +3,7 @@ FROM "__FROM_IMAGE_STREAM_DEFINED_IN_TEMPLATE__"
 # Install OS dependencies for NPM build success
 USER 0
 RUN yum install -y nasm build-base libtool libpng-dev autoconf automake
+RUN npm i npm@latest -g
 USER 1001
 
 # Install sonar-scanner
@@ -16,4 +17,4 @@ RUN curl -sLo /tmp/sonar-scanner-cli.zip https://dl.bintray.com/sonarsource/Sona
 # Install project dependencies
 COPY package.json ${APP_ROOT}/src
 COPY package-lock.json ${APP_ROOT}/src
-RUN source ${APP_ROOT}/etc/scl_enable && cd ${APP_ROOT}/src && npm set progress=false && npm install
+RUN source ${APP_ROOT}/etc/scl_enable && cd ${APP_ROOT}/src && npm set progress=false && npm ci

--- a/docker-images/nodejs-8/Dockerfile
+++ b/docker-images/nodejs-8/Dockerfile
@@ -3,8 +3,6 @@ FROM "__FROM_IMAGE_STREAM_DEFINED_IN_TEMPLATE__"
 # Install OS dependencies for NPM build success
 USER 0
 RUN yum install -y nasm build-base libtool libpng-dev autoconf automake
-RUN source ${APP_ROOT}/etc/scl_enable && npm set progress=false && npm i npm@latest
-RUN chown -R 1001:1001 /opt/app-root/src/.config /opt/app-root/src/.npmrc
 USER 1001
 
 # Install sonar-scanner
@@ -18,4 +16,5 @@ RUN curl -sLo /tmp/sonar-scanner-cli.zip https://dl.bintray.com/sonarsource/Sona
 # Install project dependencies
 COPY package.json ${APP_ROOT}/src
 COPY package-lock.json ${APP_ROOT}/src
+RUN source ${APP_ROOT}/etc/scl_enable && npm set progress=false && npm i npm@latest -g
 RUN source ${APP_ROOT}/etc/scl_enable && cd ${APP_ROOT}/src && npm set progress=false && npm ci

--- a/docker-images/nodejs-8/Dockerfile
+++ b/docker-images/nodejs-8/Dockerfile
@@ -3,7 +3,7 @@ FROM "__FROM_IMAGE_STREAM_DEFINED_IN_TEMPLATE__"
 # Install OS dependencies for NPM build success
 USER 0
 RUN yum install -y nasm build-base libtool libpng-dev autoconf automake
-RUN npm i npm@latest -g
+RUN source ${APP_ROOT}/etc/scl_enable && npm i npm@latest -g
 USER 1001
 
 # Install sonar-scanner

--- a/docker-images/nodejs-8/Dockerfile
+++ b/docker-images/nodejs-8/Dockerfile
@@ -16,5 +16,6 @@ RUN curl -sLo /tmp/sonar-scanner-cli.zip https://dl.bintray.com/sonarsource/Sona
 # Install project dependencies
 COPY package.json ${APP_ROOT}/src
 COPY package-lock.json ${APP_ROOT}/src
-RUN source ${APP_ROOT}/etc/scl_enable && npm set progress=false && npm i npm@latest -g
-RUN source ${APP_ROOT}/etc/scl_enable && cd ${APP_ROOT}/src && npm set progress=false && npm ci
+RUN which npm && whereis npm
+RUN find / -name npm
+RUN source ${APP_ROOT}/etc/scl_enable && cd ${APP_ROOT}/src && npm set progress=false && npm i npm@latest && npm ci

--- a/docker-images/nodejs-8/Dockerfile
+++ b/docker-images/nodejs-8/Dockerfile
@@ -19,7 +19,6 @@ COPY package-lock.json ${APP_ROOT}/src
 
 # Install latest npm
 RUN source ${APP_ROOT}/etc/scl_enable && npm install --prefix /tmp npm
-ENV PATH="/tmp/node_modules/.bin:${PATH}"
 
 # Install dependencies
-RUN source ${APP_ROOT}/etc/scl_enable && cd ${APP_ROOT}/src && npm set progress=false && npm update npm && npm ci
+RUN source ${APP_ROOT}/etc/scl_enable && cd ${APP_ROOT}/src && npm set progress=false && /tmp/node_modules/.bin/npm ci

--- a/docker-images/nodejs-8/Dockerfile
+++ b/docker-images/nodejs-8/Dockerfile
@@ -17,7 +17,7 @@ RUN curl -sLo /tmp/sonar-scanner-cli.zip https://dl.bintray.com/sonarsource/Sona
 COPY package.json ${APP_ROOT}/src
 COPY package-lock.json ${APP_ROOT}/src
 
-# Install latest npm
+# Install latest npm to /tmp
 RUN source ${APP_ROOT}/etc/scl_enable && npm install --prefix /tmp npm
 
 # Install dependencies

--- a/frontend/.s2i/bin/assemble
+++ b/frontend/.s2i/bin/assemble
@@ -92,7 +92,8 @@ if ! mountpoint $NPM_TMP; then
     rm -rf $NPM_TMP/npm-*
 fi
 
-# Remove cache created by package installs
+# Remove package installs
+echo "---> Removing node_modules"
 rm -rf node_modules/
 
 # Just install express deps

--- a/frontend/.s2i/bin/assemble
+++ b/frontend/.s2i/bin/assemble
@@ -93,7 +93,11 @@ if ! mountpoint $NPM_TMP; then
 fi
 
 # Remove cache created by package installs
-rm -rf node_modules/.cache/
+rm -rf node_modules/
+
+# Just install express deps
+npm set progress=false
+npm install express express-cache-controller dotenv
 
 
 # Fix source directory permissions

--- a/frontend/.s2i/bin/assemble
+++ b/frontend/.s2i/bin/assemble
@@ -92,13 +92,8 @@ if ! mountpoint $NPM_TMP; then
     rm -rf $NPM_TMP/npm-*
 fi
 
-# Remove package installs
-echo "---> Removing node_modules"
-rm -rf node_modules/
-
-# Just install express deps
-npm set progress=false
-npm install express express-cache-controller dotenv
+# Remove cache created by package installs
+rm -rf node_modules/.cache/
 
 
 # Fix source directory permissions

--- a/openshift/_nodejs.bc.json
+++ b/openshift/_nodejs.bc.json
@@ -75,11 +75,11 @@
         },
         "tags": [
           {
-            "name": "8.1-41",
+            "name": "latest",
             "annotations": null,
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/rhscl/nodejs-8-rhel7:1-41"
+              "name": "registry.access.redhat.com/rhscl/nodejs-8-rhel7:latest"
             },
             "importPolicy": {},
             "referencePolicy": {
@@ -156,7 +156,7 @@
           "dockerStrategy": {
             "from": {
               "kind": "ImageStreamTag",
-              "name": "rhscl-nodejs-8-rhel7:8.1-41"
+              "name": "rhscl-nodejs-8-rhel7:latest"
             }
           }
         },


### PR DESCRIPTION
- Uses npm ci to speed up package installs
- Updated base image to get latest rhel support

Couldnt update npm ci at OS level without also updating Node version, hence the /tmp hack