### PR TITLE
"transformData" declared at line 60 expects 3 arguments, but 4 were provided.

### DIFF
--- a/frontend/src/components/common/PartySelectField.js
+++ b/frontend/src/components/common/PartySelectField.js
@@ -111,13 +111,12 @@ export class PartySelectField extends Component {
         );
       }
 
-      this.setState((prevState) => {
+      this.setState(() => {
         const newPartyDataSource = transformData(
           createItemIdsArray(filteredParties, "party_guid"),
           createItemMap(filteredParties, "party_guid"),
           this.props.allowAddingParties &&
-            renderAddPartyFooter(this.showAddPartyForm, this.props.partyLabel),
-          prevState.selectedOption.label
+            renderAddPartyFooter(this.showAddPartyForm, this.props.partyLabel)
         );
         return { partyDataSource: newPartyDataSource };
       });


### PR DESCRIPTION
SonarQube bug - "transformData" declared at line 60 expects 3 arguments, but 4 were provided.
-Removed unused param, all seems to be working as it should.