### PR TITLE
Fix regional mines ETL updated_at issue

### DIFF
--- a/migrations/sql/R__stored_procedure_for_mine_information.sql
+++ b/migrations/sql/R__stored_procedure_for_mine_information.sql
@@ -136,7 +136,8 @@ CREATE OR REPLACE FUNCTION transfer_mine_information() RETURNS void AS $$
             WHERE ETL_MINE.mine_guid = mine.mine_guid
             AND (ETL_MINE.mine_name != mine.mine_name
                 OR ETL_MINE.mine_region != mine.mine_region
-                OR ETL_MINE.major_mine_ind != mine.major_mine_ind);
+                OR ETL_MINE.major_mine_ind != mine.major_mine_ind
+                AND mine.update_user = 'mms_migration');
             SELECT count(*) FROM mine, ETL_MINE WHERE ETL_MINE.mine_guid = mine.mine_guid INTO update_row;
             RAISE NOTICE '....# of mine records in MDS: %', old_row;
             RAISE NOTICE '....# of mine records updated in MDS: %', update_row;
@@ -487,7 +488,8 @@ CREATE OR REPLACE FUNCTION transfer_mine_information() RETURNS void AS $$
                     ETL_LOCATION.mine_guid = mine_location.mine_guid
                 AND (ETL_LOCATION.latitude != mine_location.latitude
                     OR ETL_LOCATION.longitude != mine_location.longitude
-                    OR ETL_LOCATION.mine_location_description != mine_location.mine_location_description)
+                    OR ETL_LOCATION.mine_location_description != mine_location.mine_location_description
+                    AND mine_location.update_user = 'mms_migration')
                 RETURNING 1
             )
             SELECT count(*) FROM updated_rows INTO update_row;

--- a/migrations/sql/R__stored_procedure_for_mine_information.sql
+++ b/migrations/sql/R__stored_procedure_for_mine_information.sql
@@ -134,9 +134,9 @@ CREATE OR REPLACE FUNCTION transfer_mine_information() RETURNS void AS $$
                 update_timestamp = now()
             FROM ETL_MINE
             WHERE ETL_MINE.mine_guid = mine.mine_guid
-            AND (ETL_MINE.mine_name != mine.mine_name
+            AND ((ETL_MINE.mine_name != mine.mine_name
                 OR ETL_MINE.mine_region != mine.mine_region
-                OR ETL_MINE.major_mine_ind != mine.major_mine_ind
+                OR ETL_MINE.major_mine_ind != mine.major_mine_ind)
                 AND mine.update_user = 'mms_migration');
             SELECT count(*) FROM mine, ETL_MINE WHERE ETL_MINE.mine_guid = mine.mine_guid INTO update_row;
             RAISE NOTICE '....# of mine records in MDS: %', old_row;
@@ -486,9 +486,9 @@ CREATE OR REPLACE FUNCTION transfer_mine_information() RETURNS void AS $$
                     ON ETL_LOCATION.mine_guid = ETL_MINE.mine_guid
                 WHERE
                     ETL_LOCATION.mine_guid = mine_location.mine_guid
-                AND (ETL_LOCATION.latitude != mine_location.latitude
+                AND ((ETL_LOCATION.latitude != mine_location.latitude
                     OR ETL_LOCATION.longitude != mine_location.longitude
-                    OR ETL_LOCATION.mine_location_description != mine_location.mine_location_description
+                    OR ETL_LOCATION.mine_location_description != mine_location.mine_location_description)
                     AND mine_location.update_user = 'mms_migration')
                 RETURNING 1
             )

--- a/migrations/sql/R__stored_procedure_for_mine_information.sql
+++ b/migrations/sql/R__stored_procedure_for_mine_information.sql
@@ -133,7 +133,11 @@ CREATE OR REPLACE FUNCTION transfer_mine_information() RETURNS void AS $$
                 update_user      = 'mms_migration'        ,
                 update_timestamp = now()
             FROM ETL_MINE
-            WHERE ETL_MINE.mine_guid = mine.mine_guid;
+            WHERE ETL_MINE.mine_guid = mine.mine_guid
+            AND ETL_MINE.mine_name != mine.mine_name
+            AND ETL_MINE.mine_region != mine.mine_region
+            AND ETL_MINE.major_mine_ind != mine.major_mine_ind
+            AND mine.update_user != 'mms_migration';
             SELECT count(*) FROM mine, ETL_MINE WHERE ETL_MINE.mine_guid = mine.mine_guid INTO update_row;
             RAISE NOTICE '....# of mine records in MDS: %', old_row;
             RAISE NOTICE '....# of mine records updated in MDS: %', update_row;

--- a/migrations/sql/R__stored_procedure_for_mine_information.sql
+++ b/migrations/sql/R__stored_procedure_for_mine_information.sql
@@ -134,9 +134,9 @@ CREATE OR REPLACE FUNCTION transfer_mine_information() RETURNS void AS $$
                 update_timestamp = now()
             FROM ETL_MINE
             WHERE ETL_MINE.mine_guid = mine.mine_guid
-            AND ETL_MINE.mine_name != mine.mine_name
-            AND ETL_MINE.mine_region != mine.mine_region
-            AND ETL_MINE.major_mine_ind != mine.major_mine_ind;
+            AND (ETL_MINE.mine_name != mine.mine_name
+                OR ETL_MINE.mine_region != mine.mine_region
+                OR ETL_MINE.major_mine_ind != mine.major_mine_ind);
             SELECT count(*) FROM mine, ETL_MINE WHERE ETL_MINE.mine_guid = mine.mine_guid INTO update_row;
             RAISE NOTICE '....# of mine records in MDS: %', old_row;
             RAISE NOTICE '....# of mine records updated in MDS: %', update_row;
@@ -485,9 +485,9 @@ CREATE OR REPLACE FUNCTION transfer_mine_information() RETURNS void AS $$
                     ON ETL_LOCATION.mine_guid = ETL_MINE.mine_guid
                 WHERE
                     ETL_LOCATION.mine_guid = mine_location.mine_guid
-                AND ETL_LOCATION.latitude != mine_location.latitude
-                AND ETL_LOCATION.longitude != mine_location.longitude
-                AND ETL_LOCATION.mine_location_description != mine_location.mine_location_description
+                AND (ETL_LOCATION.latitude != mine_location.latitude
+                    OR ETL_LOCATION.longitude != mine_location.longitude
+                    OR ETL_LOCATION.mine_location_description != mine_location.mine_location_description)
                 RETURNING 1
             )
             SELECT count(*) FROM updated_rows INTO update_row;

--- a/migrations/sql/R__stored_procedure_for_mine_information.sql
+++ b/migrations/sql/R__stored_procedure_for_mine_information.sql
@@ -136,8 +136,7 @@ CREATE OR REPLACE FUNCTION transfer_mine_information() RETURNS void AS $$
             WHERE ETL_MINE.mine_guid = mine.mine_guid
             AND ETL_MINE.mine_name != mine.mine_name
             AND ETL_MINE.mine_region != mine.mine_region
-            AND ETL_MINE.major_mine_ind != mine.major_mine_ind
-            AND mine.update_user != 'mms_migration';
+            AND ETL_MINE.major_mine_ind != mine.major_mine_ind;
             SELECT count(*) FROM mine, ETL_MINE WHERE ETL_MINE.mine_guid = mine.mine_guid INTO update_row;
             RAISE NOTICE '....# of mine records in MDS: %', old_row;
             RAISE NOTICE '....# of mine records updated in MDS: %', update_row;
@@ -486,6 +485,9 @@ CREATE OR REPLACE FUNCTION transfer_mine_information() RETURNS void AS $$
                     ON ETL_LOCATION.mine_guid = ETL_MINE.mine_guid
                 WHERE
                     ETL_LOCATION.mine_guid = mine_location.mine_guid
+                AND ETL_LOCATION.latitude != mine_location.latitude
+                AND ETL_LOCATION.longitude != mine_location.longitude
+                AND ETL_LOCATION.mine_location_description != mine_location.mine_location_description
                 RETURNING 1
             )
             SELECT count(*) FROM updated_rows INTO update_row;

--- a/migrations/sql/R__stored_procedure_for_mine_information.sql
+++ b/migrations/sql/R__stored_procedure_for_mine_information.sql
@@ -134,10 +134,9 @@ CREATE OR REPLACE FUNCTION transfer_mine_information() RETURNS void AS $$
                 update_timestamp = now()
             FROM ETL_MINE
             WHERE ETL_MINE.mine_guid = mine.mine_guid
-            AND ((ETL_MINE.mine_name != mine.mine_name
+            AND (ETL_MINE.mine_name != mine.mine_name
                 OR ETL_MINE.mine_region != mine.mine_region
-                OR ETL_MINE.major_mine_ind != mine.major_mine_ind)
-                AND mine.update_user = 'mms_migration');
+                OR ETL_MINE.major_mine_ind != mine.major_mine_ind);
             SELECT count(*) FROM mine, ETL_MINE WHERE ETL_MINE.mine_guid = mine.mine_guid INTO update_row;
             RAISE NOTICE '....# of mine records in MDS: %', old_row;
             RAISE NOTICE '....# of mine records updated in MDS: %', update_row;
@@ -486,10 +485,9 @@ CREATE OR REPLACE FUNCTION transfer_mine_information() RETURNS void AS $$
                     ON ETL_LOCATION.mine_guid = ETL_MINE.mine_guid
                 WHERE
                     ETL_LOCATION.mine_guid = mine_location.mine_guid
-                AND ((ETL_LOCATION.latitude != mine_location.latitude
+                AND (ETL_LOCATION.latitude != mine_location.latitude
                     OR ETL_LOCATION.longitude != mine_location.longitude
                     OR ETL_LOCATION.mine_location_description != mine_location.mine_location_description)
-                    AND mine_location.update_user = 'mms_migration')
                 RETURNING 1
             )
             SELECT count(*) FROM updated_rows INTO update_row;

--- a/migrations/sql/R__stored_procedure_for_mine_manager.sql
+++ b/migrations/sql/R__stored_procedure_for_mine_manager.sql
@@ -365,13 +365,11 @@ CREATE OR REPLACE FUNCTION transfer_mine_manager_information() RETURNS void AS $
                 party_type_code  = 'PER'
             FROM ETL_MANAGER etl
             WHERE party.party_guid = etl.party_guid
-            AND ((
-                party.first_name != etl.first_name
+            AND (party.first_name != etl.first_name
                 OR party.party_name != etl.party_name
                 OR party.phone_no != etl.phone_no
                 OR party.email != etl.email
-                OR party.effective_date != etl.effective_date
-            ) AND party.update_user = 'mms_migration')
+                OR party.effective_date != etl.effective_date)
             RETURNING 1
             )
             SELECT COUNT(*) FROM updated_rows INTO update_row;

--- a/migrations/sql/R__stored_procedure_for_mine_manager.sql
+++ b/migrations/sql/R__stored_procedure_for_mine_manager.sql
@@ -365,6 +365,13 @@ CREATE OR REPLACE FUNCTION transfer_mine_manager_information() RETURNS void AS $
                 party_type_code  = 'PER'
             FROM ETL_MANAGER etl
             WHERE party.party_guid = etl.party_guid
+            AND ((
+                party.first_name != etl.first_name
+                OR party.party_name != etl.party_name
+                OR party.phone_no != etl.phone_no
+                OR party.email != etl.email
+                OR party.effective_date != etl.effective_date
+            ) AND party.update_user = 'mms_migration')
             RETURNING 1
             )
             SELECT COUNT(*) FROM updated_rows INTO update_row;

--- a/migrations/sql/R__stored_procedure_for_permit_and_permitee_information.sql
+++ b/migrations/sql/R__stored_procedure_for_permit_and_permitee_information.sql
@@ -773,6 +773,14 @@ CREATE OR REPLACE FUNCTION transfer_permit_permitee_information() RETURNS void A
                 party_type_code  = etl.party_type
             FROM ETL_PERMIT etl
             WHERE party.party_guid = etl.party_guid
+            AND (
+                party.first_name != etl.first_name
+                OR party.party_name != etl.party_name
+                OR party.phone_no != etl.phone_no
+                OR party.email != etl.email
+                OR party.effective_date != etl.effective_date
+                OR party.party_type_code != etl.party_type
+            )
             RETURNING 1
             )
             SELECT COUNT(*) FROM updated_rows INTO update_row;

--- a/migrations/sql/R__stored_procedure_for_permit_and_permitee_information.sql
+++ b/migrations/sql/R__stored_procedure_for_permit_and_permitee_information.sql
@@ -607,7 +607,6 @@ CREATE OR REPLACE FUNCTION transfer_permit_permitee_information() RETURNS void A
                 permit.permit_guid = etl.permit_guid
 				AND
 				issue_date = (select max(issue_date) from ETL_PERMIT where etl.permit_no = ETL_PERMIT.permit_no)
-                AND ((permit.permit_status_code != etl.permit_status_code) AND permit.update_user = 'mms_migration')
             RETURNING 1
             )
             SELECT COUNT(*) FROM updated_rows INTO update_row;
@@ -774,7 +773,7 @@ CREATE OR REPLACE FUNCTION transfer_permit_permitee_information() RETURNS void A
                 party_type_code  = etl.party_type
             FROM ETL_PERMIT etl
             WHERE party.party_guid = etl.party_guid
-            AND ((
+            AND (
                 party.first_name != etl.first_name
                 OR party.party_name != etl.party_name
                 OR party.phone_no != etl.phone_no
@@ -782,7 +781,6 @@ CREATE OR REPLACE FUNCTION transfer_permit_permitee_information() RETURNS void A
                 OR party.effective_date != etl.effective_date
                 OR party.party_type_code != etl.party_type
             )
-            AND party.update_user = 'mms_migration')
             RETURNING 1
             )
             SELECT COUNT(*) FROM updated_rows INTO update_row;

--- a/migrations/sql/R__stored_procedure_for_permit_and_permitee_information.sql
+++ b/migrations/sql/R__stored_procedure_for_permit_and_permitee_information.sql
@@ -474,8 +474,8 @@ CREATE OR REPLACE FUNCTION transfer_permit_permitee_information() RETURNS void A
             INNER JOIN permittee_wContact permittee_info ON
                 permittee_info.permit_cid = permit_info.permit_cid
             WHERE permit_info.permit_no not in (
-                select permit_no from permit p 
-                join mine m on p.mine_guid=m.mine_guid 
+                select permit_no from permit p
+                join mine m on p.mine_guid=m.mine_guid
                 where m.major_mine_ind = true
                 );
 
@@ -702,7 +702,7 @@ CREATE OR REPLACE FUNCTION transfer_permit_permitee_information() RETURNS void A
 				  ETL_PERMIT
 				ON
 				  ETL_PERMIT.permit_no = original_permits.permit_no AND
-				  ETL_PERMIT.mine_guid = original_permits.mine_guid AND 
+				  ETL_PERMIT.mine_guid = original_permits.mine_guid AND
 				  ETL_PERMIT.issue_date = original_permits.min_issue_date
 			), inserted_rows AS (
                 INSERT INTO permit_amendment (
@@ -773,14 +773,6 @@ CREATE OR REPLACE FUNCTION transfer_permit_permitee_information() RETURNS void A
                 party_type_code  = etl.party_type
             FROM ETL_PERMIT etl
             WHERE party.party_guid = etl.party_guid
-            AND (
-                party.first_name != etl.first_name
-                OR party.party_name != etl.party_name
-                OR party.phone_no != etl.phone_no
-                OR party.email != etl.email
-                OR party.effective_date != etl.effective_date
-                OR party.party_type_code != etl.party_type
-            )
             RETURNING 1
             )
             SELECT COUNT(*) FROM updated_rows INTO update_row;
@@ -865,7 +857,7 @@ CREATE OR REPLACE FUNCTION transfer_permit_permitee_information() RETURNS void A
                     mine_guid IN (
                         SELECT mine_guid
                         FROM ETL_MINE
-                        WHERE major_mine_ind = 'f' 
+                        WHERE major_mine_ind = 'f'
                         AND mine_guid in (select mine_guid from ETL_PERMIT)
                     )
                 RETURNING 1

--- a/pipeline/config-dev.groovy
+++ b/pipeline/config-dev.groovy
@@ -275,10 +275,10 @@ environments {
                     replica_max = 1
                 }
                 postgres {
-                    cpu_request = "150m"
-                    cpu_limit = "500m"
-                    memory_request = "512Mi"
-                    memory_limit = "1.5Gi"
+                    cpu_request = "50m"
+                    cpu_limit = "100m"
+                    memory_request = "256Mi"
+                    memory_limit = "512Mi"
                 }
                 redis {
                     cpu_request = "10m"

--- a/pipeline/config-dev.groovy
+++ b/pipeline/config-dev.groovy
@@ -276,7 +276,7 @@ environments {
                 }
                 postgres {
                     cpu_request = "150m"
-                    cpu_limit = "300m"
+                    cpu_limit = "500m"
                     memory_request = "512Mi"
                     memory_limit = "1.5Gi"
                 }

--- a/pipeline/config-dev.groovy
+++ b/pipeline/config-dev.groovy
@@ -275,10 +275,10 @@ environments {
                     replica_max = 1
                 }
                 postgres {
-                    cpu_request = "50m"
-                    cpu_limit = "100m"
-                    memory_request = "256Mi"
-                    memory_limit = "512Mi"
+                    cpu_request = "150m"
+                    cpu_limit = "300m"
+                    memory_request = "512Mi"
+                    memory_limit = "1.5Gi"
                 }
                 redis {
                     cpu_request = "10m"


### PR DESCRIPTION
Only update the record if any of the data has changed and the last person to change that data was the automated migration.

NOTE: I'll revert the postgres increased resources after getting code review so that I can test any changes asked.