### PR TITLE
remove sorting

### DIFF
--- a/frontend/src/components/mine/Variances/MineVarianceTable.js
+++ b/frontend/src/components/mine/Variances/MineVarianceTable.js
@@ -143,7 +143,8 @@ export class MineVarianceTable extends Component {
             {text}
           </div>
         ),
-        sorter: (a, b) => (a.received_date > b.received_date ? -1 : 1),
+        sorter:
+          !this.props.isDashboardView && ((a, b) => (a.received_date > b.received_date ? -1 : 1)),
         defaultSortOrder: "ascend",
       },
       {
@@ -162,7 +163,7 @@ export class MineVarianceTable extends Component {
             {text}
           </div>
         ),
-        sorter: (a, b) => (a.status > b.status ? -1 : 1),
+        sorter: !this.props.isDashboardView && ((a, b) => (a.status > b.status ? -1 : 1)),
       },
       {
         title: "Issue Date",


### PR DESCRIPTION
removed sorting when viewing variances from the `my dashboard` view as sorting is being handled by the API on this table and the API isn't set up to handle sorting at this time.