### PR TITLE
MDS-1789 Task/ Remove 0 lat/lons from ETL process

### DIFF
--- a/migrations/sql/R__stored_procedure_for_mine_information.sql
+++ b/migrations/sql/R__stored_procedure_for_mine_information.sql
@@ -131,7 +131,6 @@ CREATE OR REPLACE FUNCTION transfer_mine_information() RETURNS void AS $$
             old_row         integer;
             new_row         integer;
             update_row      integer;
-            delete_row      integer;
         BEGIN
             RAISE NOTICE '.. Step 2 of 5: Update mine in MDS';
             SELECT count(*) FROM mine into old_row;
@@ -490,6 +489,7 @@ CREATE OR REPLACE FUNCTION transfer_mine_information() RETURNS void AS $$
             old_row         integer;
             new_row         integer;
             update_row      integer;
+            delete_row      integer;
         BEGIN
             RAISE NOTICE '.. Step 4 of 5: Update mine_location in MDS';
             SELECT count(*) FROM mine_location into old_row;

--- a/migrations/sql/R__stored_procedure_for_mine_information.sql
+++ b/migrations/sql/R__stored_procedure_for_mine_information.sql
@@ -382,6 +382,8 @@ CREATE OR REPLACE FUNCTION transfer_mine_information() RETURNS void AS $$
                 WHERE
                     permit_no != ''
                     AND substring(permit_no, 1, 2) NOT IN ('CX', 'MX')
+                    AND (lat_dec <> 0 AND lon_dec <> 0)
+
             )
             INSERT INTO ETL_LOCATION(
                 mine_guid           ,
@@ -422,6 +424,8 @@ CREATE OR REPLACE FUNCTION transfer_mine_information() RETURNS void AS $$
                         SELECT lat_dec
                         FROM mms.mmsnow
                         WHERE mine_no = new.mine_no
+                              AND
+                              (lat_dec <> 0 AND lon_dec <> 0)
                         ORDER BY upd_no DESC
                         LIMIT 1
                     ),
@@ -450,6 +454,8 @@ CREATE OR REPLACE FUNCTION transfer_mine_information() RETURNS void AS $$
                         SELECT lon_dec
                         FROM mms.mmsnow
                         WHERE mine_no = new.mine_no
+                              AND
+                              (lat_dec <> 0 AND lon_dec <> 0)
                         ORDER BY upd_no DESC
                         LIMIT 1
                     ),

--- a/migrations/sql/R__stored_procedure_for_mine_information.sql
+++ b/migrations/sql/R__stored_procedure_for_mine_information.sql
@@ -38,11 +38,11 @@ CREATE OR REPLACE FUNCTION transfer_mine_information() RETURNS void AS $$
             UPDATE ETL_MINE
             SET mine_name      = mms.mmsmin.mine_nm,
                 latitude       = CASE
-                                   WHEN mms_new.lat_dec <> 0 AND mms_new.lon_dec <> 0 THEN mms_new.lat_dec
+                                   WHEN mms.mmsmin.lat_dec <> 0 AND mms.mmsmin.lon_dec <> 0 THEN mms.mmsmin.lat_dec
                                    ELSE NULL
                                  END,
                 longitude      = CASE
-                                   WHEN mms_new.lat_dec <> 0 AND mms_new.lon_dec <> 0 THEN mms_new.lon_dec
+                                   WHEN mms.mmsmin.lat_dec <> 0 AND mms.mmsmin.lon_dec <> 0 THEN mms.mmsmin.lon_dec
                                    ELSE NULL
                                  END,
                 major_mine_ind = (mms.mmsmin.min_lnk = 'Y' AND mms.mmsmin.min_lnk IS NOT NULL),

--- a/migrations/sql/R__stored_procedure_for_mine_information.sql
+++ b/migrations/sql/R__stored_procedure_for_mine_information.sql
@@ -328,6 +328,8 @@ CREATE OR REPLACE FUNCTION transfer_mine_information() RETURNS void AS $$
                         SELECT lon_dec
                         FROM mms.mmsnow
                         WHERE mine_no = ETL_MINE.mine_no
+                              AND
+                              (lat_dec <> 0 AND lon_dec <> 0)
                         ORDER BY upd_no DESC
                         LIMIT 1
                     ),

--- a/migrations/sql/R__stored_procedure_for_mine_information.sql
+++ b/migrations/sql/R__stored_procedure_for_mine_information.sql
@@ -122,6 +122,7 @@ CREATE OR REPLACE FUNCTION transfer_mine_information() RETURNS void AS $$
         END;
 
         -- MDS-1789: Convert all existing 0 lat/lon values in ETL_MINE to NULL
+        -- TODO: Remove after initial run
         UPDATE ETL_MINE
         SET latitude  = NULL,
             longitude = NULL
@@ -501,6 +502,14 @@ CREATE OR REPLACE FUNCTION transfer_mine_information() RETURNS void AS $$
             RAISE NOTICE '....# of mine_location records in MDS: %', old_row;
             RAISE NOTICE '....# of mine_location records updated in MDS: %', update_row;
 
+            -- MDS-1789: Convert all existing 0 lat/lon values in ETL_LOCATION to NULL
+            -- TODO: Remove after initial run
+            UPDATE ETL_LOCATION
+            SET latitude  = NULL,
+                longitude = NULL
+            WHERE
+                latitude = 0 OR longitude = 0;
+
             RAISE NOTICE '.. Insert new ETL_LOCATION records into mine_location';
             WITH new_record AS (
                 SELECT *
@@ -542,6 +551,14 @@ CREATE OR REPLACE FUNCTION transfer_mine_information() RETURNS void AS $$
             RAISE NOTICE '....# of new mine_location records loaded into MDS: %.', (new_row-old_row);
             RAISE NOTICE '....Total mine records with location info in the MDS: %.', new_row;
         END;
+
+        -- MDS-1789: Convert all existing 0 lat/lon values in mine_location to NULL
+        -- TODO: Remove after initial run
+        UPDATE ETL_LOCATION
+        SET latitude  = NULL,
+            longitude = NULL
+        WHERE
+            latitude = 0 OR longitude = 0;
 
         DECLARE
             old_row    integer;

--- a/migrations/sql/R__stored_procedure_for_mine_information.sql
+++ b/migrations/sql/R__stored_procedure_for_mine_information.sql
@@ -127,14 +127,6 @@ CREATE OR REPLACE FUNCTION transfer_mine_information() RETURNS void AS $$
             RAISE NOTICE '....Total mine records in ETL_MINE: %.', new_row;
         END;
 
-        -- MDS-1789: Convert all existing 0 lat/lon values in ETL_MINE to NULL
-        -- TODO: Remove after initial run
-        UPDATE ETL_MINE
-        SET latitude  = NULL,
-            longitude = NULL
-        WHERE
-            latitude = 0 OR longitude = 0;
-
         DECLARE
             old_row         integer;
             new_row         integer;
@@ -511,14 +503,6 @@ CREATE OR REPLACE FUNCTION transfer_mine_information() RETURNS void AS $$
             RAISE NOTICE '....# of mine_location records in MDS: %', old_row;
             RAISE NOTICE '....# of mine_location records updated in MDS: %', update_row;
 
-            -- MDS-1789: Convert all existing 0 lat/lon values in ETL_LOCATION to NULL
-            -- TODO: Remove after initial run
-            UPDATE ETL_LOCATION
-            SET latitude  = NULL,
-                longitude = NULL
-            WHERE
-                latitude = 0 OR longitude = 0;
-
             RAISE NOTICE '.. Insert new ETL_LOCATION records into mine_location';
             WITH new_record AS (
                 SELECT *
@@ -560,14 +544,6 @@ CREATE OR REPLACE FUNCTION transfer_mine_information() RETURNS void AS $$
             RAISE NOTICE '....# of new mine_location records loaded into MDS: %.', (new_row-old_row);
             RAISE NOTICE '....Total mine records with location info in the MDS: %.', new_row;
         END;
-
-        -- MDS-1789: Convert all existing 0 lat/lon values in mine_location to NULL
-        -- TODO: Remove after initial run
-        UPDATE ETL_LOCATION
-        SET latitude  = NULL,
-            longitude = NULL
-        WHERE
-            latitude = 0 OR longitude = 0;
 
         DECLARE
             old_row    integer;

--- a/migrations/sql/R__stored_procedure_for_mine_information.sql
+++ b/migrations/sql/R__stored_procedure_for_mine_information.sql
@@ -37,14 +37,8 @@ CREATE OR REPLACE FUNCTION transfer_mine_information() RETURNS void AS $$
             RAISE NOTICE '.. Update existing records with latest MMS data';
             UPDATE ETL_MINE
             SET mine_name      = mms.mmsmin.mine_nm,
-                latitude       = CASE
-                                   WHEN mms.mmsmin.lat_dec <> 0 AND mms.mmsmin.lon_dec <> 0 THEN mms.mmsmin.lat_dec
-                                   ELSE NULL
-                                 END,
-                longitude      = CASE
-                                   WHEN mms.mmsmin.lat_dec <> 0 AND mms.mmsmin.lon_dec <> 0 THEN mms.mmsmin.lon_dec
-                                   ELSE NULL
-                                 END,
+                latitude       = mms.mmsmin.lat_dec,
+                longitude      = mms.mmsmin.lon_dec,
                 major_mine_ind = (mms.mmsmin.min_lnk = 'Y' AND mms.mmsmin.min_lnk IS NOT NULL),
                 mine_region    = CASE mms.mmsmin.reg_cd
                                     WHEN '1' THEN 'SW'
@@ -110,14 +104,8 @@ CREATE OR REPLACE FUNCTION transfer_mine_information() RETURNS void AS $$
                     WHEN mms_new.mine_typ = ANY('{Q,CM,SG}'::text[]) THEN 'BCL'
                     ELSE NULL
                 END,
-                CASE
-                    WHEN mms_new.lat_dec <> 0 AND mms_new.lon_dec <> 0 THEN mms_new.lat_dec
-                    ELSE NULL
-                END,
-                CASE
-                    WHEN mms_new.lat_dec <> 0 AND mms_new.lon_dec <> 0 THEN mms_new.lon_dec
-                    ELSE NULL
-                END,
+                mms_new.lat_dec    ,
+                mms_new.lon_dec    ,
                 (mms_new.min_lnk = 'Y' AND mms_new.min_lnk IS NOT NULL),
             CASE WHEN lower(mms_new.mine_nm) LIKE '%delete%' OR lower(mms_new.mine_nm) LIKE '%deleted%' OR lower(mms_new.mine_nm) LIKE '%reuse%' THEN TRUE ELSE FALSE END
             FROM mms_new
@@ -145,10 +133,7 @@ CREATE OR REPLACE FUNCTION transfer_mine_information() RETURNS void AS $$
                 update_user      = 'mms_migration'        ,
                 update_timestamp = now()
             FROM ETL_MINE
-            WHERE ETL_MINE.mine_guid = mine.mine_guid
-            AND (ETL_MINE.mine_name != mine.mine_name
-                OR ETL_MINE.mine_region != mine.mine_region
-                OR ETL_MINE.major_mine_ind != mine.major_mine_ind);
+            WHERE ETL_MINE.mine_guid = mine.mine_guid;
             SELECT count(*) FROM mine, ETL_MINE WHERE ETL_MINE.mine_guid = mine.mine_guid INTO update_row;
             RAISE NOTICE '....# of mine records in MDS: %', old_row;
             RAISE NOTICE '....# of mine records updated in MDS: %', update_row;
@@ -247,8 +232,8 @@ CREATE OR REPLACE FUNCTION transfer_mine_information() RETURNS void AS $$
             FROM mms.mmsnow, mms.mmspmt
             WHERE
                 mms.mmsnow.cid = mms.mmspmt.cid
-                AND lat_dec <> 0
-                AND lon_dec <> 0;
+                AND lat_dec IS NOT NULL
+                AND lon_dec IS NOT NULL;
 
             -- Update existing ETL_LOCATION records
             WITH pmt_now_preferred AS (
@@ -263,7 +248,6 @@ CREATE OR REPLACE FUNCTION transfer_mine_information() RETURNS void AS $$
                 WHERE
                     permit_no != ''
                     AND substring(permit_no, 1, 2) NOT IN ('CX', 'MX')
-                    AND (lat_dec <> 0 AND lon_dec <> 0)
             )
             UPDATE ETL_LOCATION
             SET mine_guid = ETL_MINE.mine_guid,
@@ -298,8 +282,6 @@ CREATE OR REPLACE FUNCTION transfer_mine_information() RETURNS void AS $$
                         SELECT lat_dec
                         FROM mms.mmsnow
                         WHERE mine_no = ETL_MINE.mine_no
-                              AND
-                              (lat_dec <> 0 AND lon_dec <> 0)
                         ORDER BY upd_no DESC
                         LIMIT 1
                     ),
@@ -500,9 +482,6 @@ CREATE OR REPLACE FUNCTION transfer_mine_information() RETURNS void AS $$
                     ON ETL_LOCATION.mine_guid = ETL_MINE.mine_guid
                 WHERE
                     ETL_LOCATION.mine_guid = mine_location.mine_guid
-                AND (ETL_LOCATION.latitude != mine_location.latitude
-                    OR ETL_LOCATION.longitude != mine_location.longitude
-                    OR ETL_LOCATION.mine_location_description != mine_location.mine_location_description)
                 RETURNING 1
             )
             SELECT count(*) FROM updated_rows INTO update_row;

--- a/pipeline/config-dev.groovy
+++ b/pipeline/config-dev.groovy
@@ -275,10 +275,10 @@ environments {
                     replica_max = 1
                 }
                 postgres {
-                    cpu_request = "50m"
-                    cpu_limit = "100m"
-                    memory_request = "256Mi"
-                    memory_limit = "512Mi"
+                    cpu_request = "150m"
+                    cpu_limit = "400m"
+                    memory_request = "512Mi"
+                    memory_limit = "1Gi"
                 }
                 redis {
                     cpu_request = "10m"

--- a/pipeline/config-dev.groovy
+++ b/pipeline/config-dev.groovy
@@ -275,10 +275,10 @@ environments {
                     replica_max = 1
                 }
                 postgres {
-                    cpu_request = "150m"
-                    cpu_limit = "400m"
-                    memory_request = "512Mi"
-                    memory_limit = "1Gi"
+                    cpu_request = "50m"
+                    cpu_limit = "100m"
+                    memory_request = "256Mi"
+                    memory_limit = "512Mi"
                 }
                 redis {
                     cpu_request = "10m"


### PR DESCRIPTION
Changes defaults from 0 to `NULL` when:
- Updating mine records in ETL_MINE
- Inserting new mine records into ETL_MINE
- Updating ETL_LOCATION from multiple sources
- Inserting into ETL_LOCATION from multiple sources

Keep in mind:
- ETL_MINE is the final fallback for lat/lon data when inserting into ETL_LOCATION
- ETL_LOCATION is used to populate `mine.latitude` and `mine.longitude`, so the final value that is upserted into ETL_LOCATION is the one that will reach CORE