### PR TITLE
Tweak FT's even more

### DIFF
--- a/functional-tests/Dockerfile
+++ b/functional-tests/Dockerfile
@@ -6,9 +6,7 @@ ENV APP_HOME=/opt
 ENV BDD_TEST_HOME=/opt/selenium/bdd-tests
 ENV GRADLE_USER_HOME=/opt/selenium/bdd-tests/gradle_home
 
-USER root
-
-# Copy over the test code and run a gradle build to cache runtime dependencies
+# Copy over the test code
 RUN mkdir $BDD_TEST_HOME/
 COPY . $BDD_TEST_HOME/
 

--- a/functional-tests/Dockerfile
+++ b/functional-tests/Dockerfile
@@ -11,6 +11,7 @@ RUN mkdir $BDD_TEST_HOME/
 COPY . $BDD_TEST_HOME/
 
 # Fix permissions
+USER root
 RUN chmod -R 777 $BDD_TEST_HOME
 
 WORKDIR $HOME

--- a/functional-tests/Dockerfile
+++ b/functional-tests/Dockerfile
@@ -1,10 +1,7 @@
 FROM "__FROM_IMAGE_STREAM_DEFINED_IN_TEMPLATE__"
 
 # Declare environment variables for Gradle and BDD Tests
-ENV HOME=/home/seluser
-ENV APP_HOME=/opt
 ENV BDD_TEST_HOME=/opt/selenium/bdd-tests
-ENV GRADLE_USER_HOME=/opt/selenium/bdd-tests/gradle_home
 
 # Copy over the test code
 RUN mkdir $BDD_TEST_HOME/
@@ -14,4 +11,4 @@ COPY . $BDD_TEST_HOME/
 USER root
 RUN chmod -R 777 $BDD_TEST_HOME
 
-WORKDIR $HOME
+WORKDIR $BDD_TEST_HOME

--- a/functional-tests/build.gradle
+++ b/functional-tests/build.gradle
@@ -22,7 +22,7 @@ ext {
 
     ext {
         groovyVersion = '2.4.15'
-        gebVersion = '2.3.1'
+        gebVersion = '3.0.1'
         seleniumVersion = '3.141.0'
         chromeDriverVersion = '75.0.3770.8'
         geckoDriverVersion = '0.24.0'

--- a/functional-tests/gradle.properties
+++ b/functional-tests/gradle.properties
@@ -1,6 +1,5 @@
-org.gradle.daemon=false
+org.gradle.daemon=true
 org.gradle.parallel=true
 org.gradle.workers.max=4
-android.enableBuildCache=true
 org.gradle.caching=true
 org.gradle.configureondemand=true

--- a/functional-tests/run_tests.sh
+++ b/functional-tests/run_tests.sh
@@ -3,11 +3,6 @@ set -exv -o pipefail
 
 # NOTE: FIREFOX HEADLESS IS THE ONLY BROWSER WHERE THE UPLOAD DOWNLOAD TEST CAN BE COMPLETED
 
-# Config needed for firefoxest
-# For more info: https://github.com/BCDevOps/BDDStack/wiki/Running-firefoxHeadlessTest-in-CentOS
-Xvfb :1 -screen 0 1920x1080x24 &
-export DISPLAY=:1
-
 ### Run both Core and MineSpace tests
-./gradlew firefoxHeadlessTest -DfirefoxHeadlessTest.single=CustomJUnitSpecRunner
 ./gradlew firefoxHeadlessTest -DfirefoxHeadlessTest.single=CustomJUnitPublicSpecRunner
+./gradlew firefoxHeadlessTest -DfirefoxHeadlessTest.single=CustomJUnitSpecRunner

--- a/functional-tests/src/test/groovy/FrontendCore/spec/Tailings.groovy
+++ b/functional-tests/src/test/groovy/FrontendCore/spec/Tailings.groovy
@@ -31,7 +31,7 @@ class Tailings extends GebReportingSpec {
 
     def "Scenario: User adds TSF to a mine"(){
         when: "User clicks the 'Add a TSF' button on the summary page and adds a TSF"
-        createTSFDropdown.click()
+        waitFor() { createTSFDropdown.click() }
         createTSFDropdownButton.click()
         tailingsTab.addTailingsForm.addTailings(Const.TSF_NAME)
 

--- a/functional-tests/src/test/groovy/FrontendCore/spec/Tailings.groovy
+++ b/functional-tests/src/test/groovy/FrontendCore/spec/Tailings.groovy
@@ -31,7 +31,7 @@ class Tailings extends GebReportingSpec {
 
     def "Scenario: User adds TSF to a mine"(){
         when: "User clicks the 'Add a TSF' button on the summary page and adds a TSF"
-        waitFor() { createTSFDropdown.click() }
+        createTSFDropdown.click()
         createTSFDropdownButton.click()
         tailingsTab.addTailingsForm.addTailings(Const.TSF_NAME)
 
@@ -73,7 +73,7 @@ class Tailings extends GebReportingSpec {
 
         and: "User opens a file in the folder specified in GebConfig"
         waitFor() { tailingsTab.downloadLink[0].click() }
-        print(Const.DOWNLOAD_PATH+'/'+Const.TEST_FILE_NAME)
+
         def file = new File(Const.DOWNLOAD_PATH+'/'+Const.TEST_FILE_NAME)
         // allow time for the file to be created in the DOWNLOAD_PATH
         waitFor(){ file.exists() && file.length() }

--- a/functional-tests/src/test/groovy/FrontendCore/spec/Tenure.groovy
+++ b/functional-tests/src/test/groovy/FrontendCore/spec/Tenure.groovy
@@ -20,7 +20,7 @@ class  Tenure extends GebReportingSpec {
     def "Scenario: User can add tenure number"(){
         when: "User open the update tenure form and add a new tenure number"
         tenureTab.addTenure(Const.TENURE)
-        waitFor {toastMessage!= null }
+        waitFor { toastMessage!= null }
 
         and: "see successful message"
         toastMessage == "Successfully updated: ${Const.MINE_NAME}"

--- a/functional-tests/src/test/resources/GebConfig.groovy
+++ b/functional-tests/src/test/resources/GebConfig.groovy
@@ -90,19 +90,22 @@ environments {
 			profile.setPreference("browser.download.manager.showAlertOnComplete", false);
 			profile.setPreference("browser.download.manager.closeWhenDone", false);
 			profile.setPreference("browser.download.panel.shown", false);
+            options.setProfile(profile);
 
 			//To find the settings that need to be modified, visit the about:config firefox url
 			options.addPreference("browser.download.forbid_open_with", true);
 			//In order to allow auto saving of files the user must specify the specific MIME types in a comma separated
 			//string. (Cannot set all to true)
-			options.addPreference("browser.helperApps.neverAsk.saveToDisk", "application/vnd.oasis.opendocument.text")
-			options.setProfile(profile);
+			options.addPreference("browser.helperApps.neverAsk.saveToDisk", "application/vnd.oasis.opendocument.text");
 			options.addPreference("browser.download.dir", Const.DOWNLOAD_PATH);
 			options.addPreference("browser.download.useDownloadDir", true);
-			options.addArguments("--width=1920")
-			options.addArguments("--height=1080")
-			options.addArguments("--headless")
-			new FirefoxDriver(options);
+			options.addArguments("--width=1920");
+			options.addArguments("--height=1080");
+			options.addArguments("--headless");
+
+            FirefoxDriver firefoxDriver = new FirefoxDriver(options);
+            firefoxDriver.manage().window().maximize();
+            firefoxDriver;
 
 		}
 	}

--- a/openshift/bddstack.bc.json
+++ b/openshift/bddstack.bc.json
@@ -133,12 +133,12 @@
         },
         "resources": {
           "limits": {
-            "cpu": "500m",
-            "memory": "2Gi"
+            "cpu": "200m",
+            "memory": "1Gi"
           },
           "requests": {
-            "cpu": "250m",
-            "memory": "1Gi"
+            "cpu": "100m",
+            "memory": "512Mi"
           }
         },
         "nodeSelector": null

--- a/openshift/bddstack.bc.json
+++ b/openshift/bddstack.bc.json
@@ -133,12 +133,12 @@
         },
         "resources": {
           "limits": {
-            "cpu": "500m",
-            "memory": "1Gi"
+            "cpu": "200m",
+            "memory": "2Gi"
           },
           "requests": {
-            "cpu": "250m",
-            "memory": "512Mi"
+            "cpu": "100m",
+            "memory": "1Gi"
           }
         },
         "nodeSelector": null

--- a/openshift/bddstack.bc.json
+++ b/openshift/bddstack.bc.json
@@ -133,11 +133,11 @@
         },
         "resources": {
           "limits": {
-            "cpu": "200m",
+            "cpu": "500m",
             "memory": "1Gi"
           },
           "requests": {
-            "cpu": "100m",
+            "cpu": "250m",
             "memory": "512Mi"
           }
         },

--- a/openshift/bddstack.pod.json
+++ b/openshift/bddstack.pod.json
@@ -104,6 +104,10 @@
                 "value": "false"
               },
               {
+                "name": "GRADLE_USER_HOME",
+                "value": "/opt/selenium/bdd-tests/gradle_home"
+              },
+              {
                 "name": "DB_HOST",
                 "value": "${DB_CONFIG_NAME}"
               },

--- a/openshift/bddstack.pod.json
+++ b/openshift/bddstack.pod.json
@@ -100,6 +100,10 @@
                 "value": "24"
               },
               {
+                "name": "START_XVFB",
+                "value": "false"
+              },
+              {
                 "name": "DB_HOST",
                 "value": "${DB_CONFIG_NAME}"
               },


### PR DESCRIPTION
- Turned off XVFB as it's not needed anymore
- Updated geb version
- Cleaned up dockerfile
- Enabled gradle daemon for faster builds
- Switched order that the tests run in.  i.e. Build and Run Minespace first! So the gradle daemon can intialize with a small overhead and then quickly run through Core tests
- Reduced build resources as needed
- Added a maximize option to the firefox driver (I dont know why but it makes them more stable)


~Ran tests 10 times in a row, one random failure, 9 blazing successes~ 10/10 ✅ 

Out of the 40-50ish tests, I ran! The TSF test failed twice :( Which I wasn't sure why but the rest of the runs worked great.