### PR TITLE
Fixed broken date sorting on the front end

### DIFF
--- a/frontend/src/components/mine/Compliance/ComplianceOrdersTable.js
+++ b/frontend/src/components/mine/Compliance/ComplianceOrdersTable.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { Table } from "antd";
-
+import moment from "moment";
 import { RED_CLOCK } from "@/constants/assets";
 import { formatDate } from "@/utils/helpers";
 import { COLOR } from "@/constants/styles";
@@ -91,7 +91,7 @@ const columns = [
         {formatDate(record.due_date) || "-"}
       </div>
     ),
-    sorter: (a, b) => (a.due_date > b.due_date ? -1 : 1),
+    sorter: (a, b) => (moment(a.due_date) > moment(b.due_date) ? -1 : 1),
     defaultSortOrder: "descend",
   },
 ];

--- a/frontend/src/components/mine/Incidents/MineIncidentTable.js
+++ b/frontend/src/components/mine/Incidents/MineIncidentTable.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { Table, Button } from "antd";
-
+import moment from "moment";
 import _ from "lodash";
 
 import { BRAND_PENCIL } from "@/constants/assets";
@@ -43,7 +43,7 @@ const columns = (props) => [
   {
     title: "Incident Time",
     dataIndex: "incident_timestamp",
-    sorter: (a, b) => new Date(a.incident_timestamp) > new Date(b.incident_timestamp),
+    sorter: (a, b) => moment(a.incident_timestamp) > moment(b.incident_timestamp),
   },
   {
     title: "Reported By",

--- a/frontend/src/components/mine/Variances/MineVarianceTable.js
+++ b/frontend/src/components/mine/Variances/MineVarianceTable.js
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import { Table, Button, Icon } from "antd";
 import { connect } from "react-redux";
 import { Link } from "react-router-dom";
+import moment from "moment";
 import CustomPropTypes from "@/customPropTypes";
 import AuthorizationWrapper from "@/components/common/wrappers/AuthorizationWrapper";
 import {
@@ -144,7 +145,8 @@ export class MineVarianceTable extends Component {
           </div>
         ),
         sorter:
-          !this.props.isDashboardView && ((a, b) => (a.received_date > b.received_date ? -1 : 1)),
+          !this.props.isDashboardView &&
+          ((a, b) => (moment(a.received_date) > moment(b.received_date) ? -1 : 1)),
         defaultSortOrder: "ascend",
       },
       {
@@ -178,7 +180,7 @@ export class MineVarianceTable extends Component {
             {text}
           </div>
         ),
-        sorter: (a, b) => (a.issue_date > b.issue_date ? -1 : 1),
+        sorter: (a, b) => (moment(a.issue_date) > moment(b.issue_date) ? -1 : 1),
       },
       {
         title: "Expiry Date",
@@ -193,7 +195,7 @@ export class MineVarianceTable extends Component {
             {text}
           </div>
         ),
-        sorter: (a, b) => ((a.expiry_date || 0) > (b.expiry_date || 0) ? -1 : 1),
+        sorter: (a, b) => (moment(a.expiry_date || 0) > moment(b.expiry_date || 0) ? -1 : 1),
         defaultSortOrder: "ascend",
       },
       {


### PR DESCRIPTION
This fixes the date sorting in the Variance, Incident, and Compliance tables.
The compliance sorting must be tested on Test since that tab is not populated locally.
This is a purely frontend solution since none of these tables seem to be paginated.  
The strategy was to use moment on every date based sort function in the front end.