### PR TITLE
MDS-1175: Feature/mds Show PDF Preview

### DIFF
--- a/frontend/src/components/common/DocumentTable.js
+++ b/frontend/src/components/common/DocumentTable.js
@@ -23,7 +23,7 @@ export class DocumentTable extends Component {
   transformRowData = (documents) =>
     documents.map((document) => ({
       key: document.mine_document_guid,
-      guid: document.document_manager_guid,
+      document_manager_guid: document.document_manager_guid,
       name: document.document_name,
       category: document.variance_document_category_code
         ? this.props.documentCategoryOptionsHash[document.variance_document_category_code]
@@ -38,10 +38,7 @@ export class DocumentTable extends Component {
         dataIndex: "name",
         render: (text, record) => (
           <div title="File name">
-            <LinkButton
-              key={record.key}
-              onClick={() => downloadFileFromDocumentManager(record.guid)}
-            >
+            <LinkButton key={record.key} onClick={() => downloadFileFromDocumentManager(record)}>
               {text}
             </LinkButton>
           </div>

--- a/frontend/src/components/mine/Incidents/MineIncidentTable.js
+++ b/frontend/src/components/mine/Incidents/MineIncidentTable.js
@@ -27,7 +27,7 @@ const renderDownloadLinks = (files, mine_incident_document_type_code) =>
       <div key={file.mine_document_guid}>
         <LinkButton
           key={file.mine_document_guid}
-          onClick={() => downloadFileFromDocumentManager(file.document_manager_guid)}
+          onClick={() => downloadFileFromDocumentManager(file)}
         >
           {file.document_name}
         </LinkButton>

--- a/frontend/src/components/mine/Permit/MinePermitTable.js
+++ b/frontend/src/components/mine/Permit/MinePermitTable.js
@@ -41,10 +41,7 @@ const defaultProps = {
 };
 
 const renderDocumentLink = (file, text) => (
-  <LinkButton
-    key={file.mine_document_guid}
-    onClick={() => downloadFileFromDocumentManager(file.document_manager_guid)}
-  >
+  <LinkButton key={file.mine_document_guid} onClick={() => downloadFileFromDocumentManager(file)}>
     {text}
   </LinkButton>
 );

--- a/frontend/src/components/mine/Tailings/MineTailingsTable.js
+++ b/frontend/src/components/mine/Tailings/MineTailingsTable.js
@@ -102,7 +102,7 @@ const columns = [
             <div key={file.mine_document_guid}>
               <LinkButton
                 key={file.mine_document_guid}
-                onClick={() => downloadFileFromDocumentManager(file.document_manager_guid)}
+                onClick={() => downloadFileFromDocumentManager(file)}
               >
                 {file.document_name}
               </LinkButton>

--- a/frontend/src/components/mine/Variances/MineVarianceTable.js
+++ b/frontend/src/components/mine/Variances/MineVarianceTable.js
@@ -14,9 +14,10 @@ import * as Permission from "@/constants/permissions";
 import { RED_CLOCK, EDIT_OUTLINE } from "@/constants/assets";
 import NullScreen from "@/components/common/NullScreen";
 import { formatDate } from "@/utils/helpers";
-import { getDownloadLink } from "@/utils/actionlessNetworkCalls";
+import downloadFileFromDocumentManager from "@/utils/actionlessNetworkCalls";
 import * as Strings from "@/constants/strings";
 import { COLOR } from "@/constants/styles";
+import LinkButton from "@/components/common/LinkButton";
 import * as router from "@/constants/routes";
 
 const { errorRed } = COLOR;
@@ -52,28 +53,6 @@ const errorStyle = (isOverdue) => (isOverdue ? { color: errorRed } : {});
 const hideColumn = (condition) => (condition ? "column-hide" : "");
 
 export class MineVarianceTable extends Component {
-  state = {
-    downloadLinks: {},
-  };
-
-  prepareDownloadLinks = () => {
-    this.props.variances.forEach(({ documents }) => documents.forEach(this.prepareDownloadLink));
-  };
-
-  prepareDownloadLink = async (file) => {
-    if (this.state.downloadLinks[file.document_manager_guid]) {
-      return;
-    }
-
-    const url = await getDownloadLink(file.document_manager_guid);
-    this.setState(({ downloadLinks }) => ({
-      downloadLinks: {
-        [file.document_manager_guid]: url,
-        ...downloadLinks,
-      },
-    }));
-  };
-
   handleOpenModal = (event, isEditable, variance) => {
     event.preventDefault();
     if (isEditable) {
@@ -107,7 +86,6 @@ export class MineVarianceTable extends Component {
     }));
 
   render() {
-    this.prepareDownloadLinks();
     const columns = [
       {
         title: "",
@@ -240,14 +218,12 @@ export class MineVarianceTable extends Component {
             {record.documents.length > 0
               ? record.documents.map((file) => (
                   <div key={file.mine_document_guid}>
-                    <a
+                    <LinkButton
                       key={file.mine_document_guid}
-                      href={this.state.downloadLinks[file.document_manager_guid]}
-                      target="_blank"
-                      rel="noopener noreferrer"
+                      onClick={() => downloadFileFromDocumentManager(file.document_manager_guid)}
                     >
                       {file.document_name}
-                    </a>
+                    </LinkButton>
                   </div>
                 ))
               : Strings.EMPTY_FIELD}

--- a/frontend/src/components/mine/Variances/MineVarianceTable.js
+++ b/frontend/src/components/mine/Variances/MineVarianceTable.js
@@ -220,7 +220,7 @@ export class MineVarianceTable extends Component {
                   <div key={file.mine_document_guid}>
                     <LinkButton
                       key={file.mine_document_guid}
-                      onClick={() => downloadFileFromDocumentManager(file.document_manager_guid)}
+                      onClick={() => downloadFileFromDocumentManager(file)}
                     >
                       {file.document_name}
                     </LinkButton>

--- a/frontend/src/components/mine/Variances/MineVarianceTable.js
+++ b/frontend/src/components/mine/Variances/MineVarianceTable.js
@@ -17,7 +17,6 @@ import { formatDate } from "@/utils/helpers";
 import { getDownloadLink } from "@/utils/actionlessNetworkCalls";
 import * as Strings from "@/constants/strings";
 import { COLOR } from "@/constants/styles";
-import LinkButton from "@/components/common/LinkButton";
 import * as router from "@/constants/routes";
 
 const { errorRed } = COLOR;
@@ -57,13 +56,22 @@ export class MineVarianceTable extends Component {
     downloadLinks: {},
   };
 
+  prepareDownloadLinks = () => {
+    this.props.variances.forEach(({ documents }) => documents.forEach(this.prepareDownloadLink));
+  };
+
   prepareDownloadLink = async (file) => {
+    if (this.state.downloadLinks[file.document_manager_guid]) {
+      return;
+    }
+
     const url = await getDownloadLink(file.document_manager_guid);
-    this.setState({
+    this.setState(({ downloadLinks }) => ({
       downloadLinks: {
         [file.document_manager_guid]: url,
+        ...downloadLinks,
       },
-    });
+    }));
   };
 
   handleOpenModal = (event, isEditable, variance) => {
@@ -99,6 +107,7 @@ export class MineVarianceTable extends Component {
     }));
 
   render() {
+    this.prepareDownloadLinks();
     const columns = [
       {
         title: "",
@@ -231,21 +240,14 @@ export class MineVarianceTable extends Component {
             {record.documents.length > 0
               ? record.documents.map((file) => (
                   <div key={file.mine_document_guid}>
-                    <LinkButton
+                    <a
                       key={file.mine_document_guid}
-                      onClick={() => this.prepareDownloadLink(file)}
+                      href={this.state.downloadLinks[file.document_manager_guid]}
+                      target="_blank"
+                      rel="noopener noreferrer"
                     >
                       {file.document_name}
-                    </LinkButton>
-                    {this.state.downloadLinks[file.document_manager_guid] && (
-                      <a
-                        href={this.state.downloadLinks[file.document_manager_guid]}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                      >
-                        Open in Preview
-                      </a>
-                    )}
+                    </a>
                   </div>
                 ))
               : Strings.EMPTY_FIELD}

--- a/frontend/src/components/mine/Variances/MineVarianceTable.js
+++ b/frontend/src/components/mine/Variances/MineVarianceTable.js
@@ -14,7 +14,7 @@ import * as Permission from "@/constants/permissions";
 import { RED_CLOCK, EDIT_OUTLINE } from "@/constants/assets";
 import NullScreen from "@/components/common/NullScreen";
 import { formatDate } from "@/utils/helpers";
-import downloadFileFromDocumentManager from "@/utils/actionlessNetworkCalls";
+import { getDownloadLink } from "@/utils/actionlessNetworkCalls";
 import * as Strings from "@/constants/strings";
 import { COLOR } from "@/constants/styles";
 import LinkButton from "@/components/common/LinkButton";
@@ -53,6 +53,19 @@ const errorStyle = (isOverdue) => (isOverdue ? { color: errorRed } : {});
 const hideColumn = (condition) => (condition ? "column-hide" : "");
 
 export class MineVarianceTable extends Component {
+  state = {
+    downloadLinks: {},
+  };
+
+  prepareDownloadLink = async (file) => {
+    const url = await getDownloadLink(file.document_manager_guid);
+    this.setState({
+      downloadLinks: {
+        [file.document_manager_guid]: url,
+      },
+    });
+  };
+
   handleOpenModal = (event, isEditable, variance) => {
     event.preventDefault();
     if (isEditable) {
@@ -220,10 +233,19 @@ export class MineVarianceTable extends Component {
                   <div key={file.mine_document_guid}>
                     <LinkButton
                       key={file.mine_document_guid}
-                      onClick={() => downloadFileFromDocumentManager(file.document_manager_guid)}
+                      onClick={() => this.prepareDownloadLink(file)}
                     >
                       {file.document_name}
                     </LinkButton>
+                    {this.state.downloadLinks[file.document_manager_guid] && (
+                      <a
+                        href={this.state.downloadLinks[file.document_manager_guid]}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Open in Preview
+                      </a>
+                    )}
                   </div>
                 ))
               : Strings.EMPTY_FIELD}

--- a/frontend/src/components/search/DocumentResultsTable.js
+++ b/frontend/src/components/search/DocumentResultsTable.js
@@ -28,9 +28,7 @@ export const DocumentResultsTable = (props) => {
           <Col span={24}>
             <LinkButton
               key={record.mine_document_guid || record.permit_amendment_document_guid}
-              onClick={() =>
-                downloadFileFromDocumentManager(record.document_manager_guid, record.document_name)
-              }
+              onClick={() => downloadFileFromDocumentManager(record)}
             >
               <Highlight search={props.highlightRegex}>{record.document_name}</Highlight>
             </LinkButton>

--- a/frontend/src/utils/actionlessNetworkCalls.js
+++ b/frontend/src/utils/actionlessNetworkCalls.js
@@ -3,6 +3,22 @@ import { createRequestHeader } from "@/utils/RequestHeaders";
 import { ENVIRONMENT } from "@/constants/environment";
 import { DOCUMENT_MANAGER_FILE_GET_URL, DOCUMENT_MANAGER_TOKEN_GET_URL } from "@/constants/API";
 
+const getDownloadLink = async (docManagerGuid) => {
+  if (!docManagerGuid) {
+    throw new Error("Must provide docManagerGuid");
+  }
+
+  return CustomAxios()
+    .get(
+      `${ENVIRONMENT.apiUrl + DOCUMENT_MANAGER_TOKEN_GET_URL(docManagerGuid)}`,
+      createRequestHeader()
+    )
+    .then((response) => {
+      const token = { token: response.data.token_guid };
+      return `${ENVIRONMENT.apiUrl + DOCUMENT_MANAGER_FILE_GET_URL(token)}`;
+    });
+};
+
 const downloadFileFromDocumentManager = (docManagerGuid) => {
   if (!docManagerGuid) {
     throw new Error("Must provide docManagerGuid");
@@ -21,3 +37,5 @@ const downloadFileFromDocumentManager = (docManagerGuid) => {
 };
 
 export default downloadFileFromDocumentManager;
+
+export { getDownloadLink };

--- a/frontend/src/utils/actionlessNetworkCalls.js
+++ b/frontend/src/utils/actionlessNetworkCalls.js
@@ -3,22 +3,6 @@ import { createRequestHeader } from "@/utils/RequestHeaders";
 import { ENVIRONMENT } from "@/constants/environment";
 import { DOCUMENT_MANAGER_FILE_GET_URL, DOCUMENT_MANAGER_TOKEN_GET_URL } from "@/constants/API";
 
-const getDownloadLink = async (docManagerGuid) => {
-  if (!docManagerGuid) {
-    throw new Error("Must provide docManagerGuid");
-  }
-
-  return CustomAxios()
-    .get(
-      `${ENVIRONMENT.apiUrl + DOCUMENT_MANAGER_TOKEN_GET_URL(docManagerGuid)}`,
-      createRequestHeader()
-    )
-    .then((response) => {
-      const token = { token: response.data.token_guid };
-      return `${ENVIRONMENT.apiUrl + DOCUMENT_MANAGER_FILE_GET_URL(token)}`;
-    });
-};
-
 const downloadFileFromDocumentManager = (docManagerGuid) => {
   if (!docManagerGuid) {
     throw new Error("Must provide docManagerGuid");
@@ -32,10 +16,8 @@ const downloadFileFromDocumentManager = (docManagerGuid) => {
     )
     .then((response) => {
       const token = { token: response.data.token_guid };
-      window.location = `${ENVIRONMENT.apiUrl + DOCUMENT_MANAGER_FILE_GET_URL(token)}`;
+      window.open(`${ENVIRONMENT.apiUrl + DOCUMENT_MANAGER_FILE_GET_URL(token)}`, "_blank");
     });
 };
 
 export default downloadFileFromDocumentManager;
-
-export { getDownloadLink };

--- a/frontend/src/utils/actionlessNetworkCalls.js
+++ b/frontend/src/utils/actionlessNetworkCalls.js
@@ -3,20 +3,24 @@ import { createRequestHeader } from "@/utils/RequestHeaders";
 import { ENVIRONMENT } from "@/constants/environment";
 import { DOCUMENT_MANAGER_FILE_GET_URL, DOCUMENT_MANAGER_TOKEN_GET_URL } from "@/constants/API";
 
-const downloadFileFromDocumentManager = (docManagerGuid) => {
-  if (!docManagerGuid) {
+const downloadFileFromDocumentManager = ({ document_manager_guid, document_name = "" }) => {
+  if (!document_manager_guid) {
     throw new Error("Must provide docManagerGuid");
   }
 
   // TODO: Update url when Document Manager moves to its own microservice.
   CustomAxios()
     .get(
-      `${ENVIRONMENT.apiUrl + DOCUMENT_MANAGER_TOKEN_GET_URL(docManagerGuid)}`,
+      `${ENVIRONMENT.apiUrl + DOCUMENT_MANAGER_TOKEN_GET_URL(document_manager_guid)}`,
       createRequestHeader()
     )
     .then((response) => {
       const token = { token: response.data.token_guid };
-      window.open(`${ENVIRONMENT.apiUrl + DOCUMENT_MANAGER_FILE_GET_URL(token)}`, "_blank");
+      if (document_name.toLowerCase().includes("pdf")) {
+        window.open(`${ENVIRONMENT.apiUrl + DOCUMENT_MANAGER_FILE_GET_URL(token)}`, "_blank");
+      } else {
+        window.location = `${ENVIRONMENT.apiUrl + DOCUMENT_MANAGER_FILE_GET_URL(token)}`;
+      }
     });
 };
 

--- a/frontend/src/utils/actionlessNetworkCalls.js
+++ b/frontend/src/utils/actionlessNetworkCalls.js
@@ -16,7 +16,7 @@ const downloadFileFromDocumentManager = ({ document_manager_guid, document_name 
     )
     .then((response) => {
       const token = { token: response.data.token_guid };
-      if (document_name.toLowerCase().includes("pdf")) {
+      if (document_name.toLowerCase().includes(".pdf")) {
         window.open(`${ENVIRONMENT.apiUrl + DOCUMENT_MANAGER_FILE_GET_URL(token)}`, "_blank");
       } else {
         window.location = `${ENVIRONMENT.apiUrl + DOCUMENT_MANAGER_FILE_GET_URL(token)}`;

--- a/python-backend/app/api/document_manager/resources/document_manager.py
+++ b/python-backend/app/api/document_manager/resources/document_manager.py
@@ -171,9 +171,11 @@ class DocumentManagerResource(Resource):
         if not doc:
             raise NotFound('Could not find the document corresponding to the token')
 
+        not_pdf = '.pdf' not in doc.file_display_name.lower()
         return send_file(
             filename_or_fp=doc.full_storage_path,
-            attachment_filename=doc.file_display_name)
+            attachment_filename=doc.file_display_name,
+            as_attachment=not_pdf)
 
     def options(self, document_guid):
         response = make_response('', 200)

--- a/python-backend/app/api/document_manager/resources/document_manager.py
+++ b/python-backend/app/api/document_manager/resources/document_manager.py
@@ -173,8 +173,7 @@ class DocumentManagerResource(Resource):
 
         return send_file(
             filename_or_fp=doc.full_storage_path,
-            attachment_filename=doc.file_display_name,
-            as_attachment=True)
+            attachment_filename=doc.file_display_name)
 
     def options(self, document_guid):
         response = make_response('', 200)


### PR DESCRIPTION
Tested on MacOS in
- Google Chrome
- Safari
- Firefox

**Feature**
Open PDF as a preview in a new tab, with the option to download. Non-PDF files are downloaded (or prompted, in the case of Firefox defaults or user-adjusted browser preferences).

**Caveat**
All browsers tested detected this new tab as a popup and blocked it on first click. The browser shows a notification that allows the users to "allow popups from this domain." We should include this as an example in our training material. Once the popups have been allowed, the tab will open with the preview, and all future previews open without the popup blocker warning.