### PR TITLE
MDS-2088 feature/ Hide HUK option unless on a historical record

### DIFF
--- a/frontend/src/components/Forms/incidents/AddIncidentFollowUpForm.js
+++ b/frontend/src/components/Forms/incidents/AddIncidentFollowUpForm.js
@@ -48,7 +48,7 @@ const renderRecommendations = ({ fields }) => [
 ];
 
 export class AddIncidentFollowUpForm extends Component {
-  isHistoricalVariance =
+  isHistoricalIncident =
     this.props.initialValues.followup_investigation_type_code ===
     Strings.INCIDENT_FOLLOWUP_ACTIONS.unknown;
 
@@ -61,7 +61,7 @@ export class AddIncidentFollowUpForm extends Component {
   filteredFollowupActions = () =>
     this.props.followupActionOptions.filter(
       ({ value }) =>
-        this.isHistoricalVariance || value !== Strings.INCIDENT_FOLLOWUP_ACTIONS.unknown
+        this.isHistoricalIncident || value !== Strings.INCIDENT_FOLLOWUP_ACTIONS.unknown
     );
 
   render() {

--- a/frontend/src/components/Forms/incidents/AddIncidentFollowUpForm.js
+++ b/frontend/src/components/Forms/incidents/AddIncidentFollowUpForm.js
@@ -27,6 +27,7 @@ const propTypes = {
   uploadedFiles: PropTypes.arrayOf(PropTypes.objectOf(PropTypes.any)).isRequired,
   onFileLoad: PropTypes.func.isRequired,
   onRemoveFile: PropTypes.func.isRequired,
+  initialValues: PropTypes.objectOf(PropTypes.any).isRequired,
 };
 
 const renderRecommendations = ({ fields }) => [
@@ -47,11 +48,21 @@ const renderRecommendations = ({ fields }) => [
 ];
 
 export class AddIncidentFollowUpForm extends Component {
+  isHistoricalVariance =
+    this.props.initialValues.followup_investigation_type_code ===
+    Strings.INCIDENT_FOLLOWUP_ACTIONS.unknown;
+
   uncommonBehaviourWarning = () =>
     this.props.determinationTypeCode === Strings.INCIDENT_DETERMINATION_TYPES.pending &&
     this.props.hasFollowUp
       ? "Warning: It's uncommon for an inspection to occur if a determination has not been made"
       : undefined;
+
+  filteredFollowupActions = () =>
+    this.props.followupActionOptions.filter(
+      ({ value }) =>
+        this.isHistoricalVariance || value !== Strings.INCIDENT_FOLLOWUP_ACTIONS.unknown
+    );
 
   render() {
     return (
@@ -93,7 +104,7 @@ export class AddIncidentFollowUpForm extends Component {
                   label="Was it escalated to EMPR investigation?*"
                   placeholder="Please choose one"
                   component={renderConfig.SELECT}
-                  data={this.props.followupActionOptions}
+                  data={this.filteredFollowupActions()}
                   validate={[required]}
                 />
               </Form.Item>

--- a/frontend/src/tests/components/Forms/incidents/AddIncidentFollowUpForm.spec.js
+++ b/frontend/src/tests/components/Forms/incidents/AddIncidentFollowUpForm.spec.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { shallow } from "enzyme";
 import { AddIncidentFollowUpForm } from "@/components/Forms/incidents/AddIncidentFollowUpForm";
+import { FOLLOWUP_ACTIONS } from "@/tests/mocks/dataMocks";
 
 const dispatchProps = {};
 const props = {};
@@ -12,6 +13,7 @@ const setupDispatchProps = () => {
 const setupProps = () => {
   props.initialValues = {};
   props.uploadedFiles = [];
+  props.followupActionOptions = FOLLOWUP_ACTIONS;
 };
 
 beforeEach(() => {

--- a/frontend/src/tests/components/Forms/incidents/__snapshots__/AddIncidentFollowUpForm.spec.js.snap
+++ b/frontend/src/tests/components/Forms/incidents/__snapshots__/AddIncidentFollowUpForm.spec.js.snap
@@ -35,6 +35,14 @@ exports[`AddIncidentFollowUpForm renders properly 1`] = `
         >
           <Field
             component={[Function]}
+            data={
+              Array [
+                Object {
+                  "description": "No Action",
+                  "mine_incident_followup_type_code": "NOA",
+                },
+              ]
+            }
             id="followup_investigation_type_code"
             label="Was it escalated to EMPR investigation?*"
             name="followup_investigation_type_code"


### PR DESCRIPTION
The historical - unknown option needs to be hidden when creating new Incidents and when editing existing incidents that are not using the historical - unknown option.

Updated behaviour:
- Create new: HUK option is not available
- Update existing HUK: all options are available
- Update existing non-HUK: HUK option is not available