### PR TITLE
Fix file upload crash with WDS

### DIFF
--- a/frontend/src/components/common/FileUpload.js
+++ b/frontend/src/components/common/FileUpload.js
@@ -1,8 +1,7 @@
-import { map } from "lodash";
 import React from "react";
 import PropTypes from "prop-types";
 import "filepond-polyfill";
-import { FilePond, File, registerPlugin } from "react-filepond";
+import { FilePond, registerPlugin } from "react-filepond";
 import "filepond/dist/filepond.min.css";
 import FilePondPluginFileValidateSize from "filepond-plugin-file-validate-size";
 import FilePondPluginFileValidateType from "filepond-plugin-file-validate-type";
@@ -38,10 +37,6 @@ const defaultProps = {
 class FileUpload extends React.Component {
   constructor(props) {
     super(props);
-
-    this.state = {
-      files: [],
-    };
 
     this.server = {
       process: (fieldName, file, metadata, load, error, progress, abort) => {
@@ -92,16 +87,7 @@ class FileUpload extends React.Component {
         allowFileTypeValidation={acceptedFileTypes.length > 0}
         acceptedFileTypes={acceptedFileTypes}
         fileValidateTypeLabelExpectedTypesMap={this.props.acceptedFileTypesMap}
-        onupdatefiles={(fileItems) => {
-          this.setState({
-            files: map(fileItems, "file"),
-          });
-        }}
-      >
-        {this.state.files.map((file) => (
-          <File key={file} src={file} origin="local" />
-        ))}
-      </FilePond>
+      />
     );
   }
 }


### PR DESCRIPTION
It looks like the setup for Filepond changed as we updated to a new
version. The result was that we were rendering `undefined`, which was
crashing WDS. I removed the code causing the problem.

After removing it, everything behaved as-normal. I haven't found any
regressions or missing functionality that this state-based code was
intended to support (at least in the current version of Filepond).