### PR TITLE
MDS-2227 bug/Reduce minimum search character count to 2

### DIFF
--- a/frontend/src/components/search/SearchBar.js
+++ b/frontend/src/components/search/SearchBar.js
@@ -46,7 +46,7 @@ export class SearchBar extends Component {
     const newSearchTerm = e.target.value;
     this.setState({ searchTerm: newSearchTerm });
 
-    if (newSearchTerm.length > 2) {
+    if (newSearchTerm.length > 1) {
       this.fetchSearchResultsThrottled(newSearchTerm);
     }
   };

--- a/frontend/src/components/search/SearchResults.js
+++ b/frontend/src/components/search/SearchResults.js
@@ -87,13 +87,13 @@ const TableForGroup = (
   }[group.type]);
 
 const NoResults = (searchTerms) => {
-  const searchTooShort = !searchTerms.find((term) => term.length > 2);
+  const searchTooShort = !searchTerms.find((term) => term.length > 1);
   return (
     <Row type="flex" justify="center">
       <Col sm={22} md={18} lg={8} className="padding-xxl--top">
         <h2>No Results Found.</h2>
         {searchTooShort && (
-          <p>At least one word in your search needs to be a minimum of three characters.</p>
+          <p>At least one word in your search needs to be a minimum of two characters.</p>
         )}
         <p>Please try another search.</p>
       </Col>

--- a/python-backend/app/api/utils/search.py
+++ b/python-backend/app/api/utils/search.py
@@ -115,10 +115,10 @@ def append_result(search_results, search_term, type, item, id_field, value_field
 def execute_search(app, search_results, search_term, search_terms, type, type_config, limit_results=None):
     with app.app_context():
         for term in search_terms:
-            if len(term) > 2:
+            if len(term) > 1:
                 for column in type_config['columns_to_search']:
 
-                    # Query should return with the calculated column "score", as well as the columns defined in the configuration 
+                    # Query should return with the calculated column "score", as well as the columns defined in the configuration
                     similarity = db.session.query(type_config['model']).with_entities(
                         func.similarity(column, term).label('score'),
                         *type_config['entities_to_return']).filter(column.ilike(f'%{term}%'))
@@ -127,7 +127,7 @@ def execute_search(app, search_results, search_term, search_terms, type, type_co
                         similarity = similarity.filter_by(deleted_ind=False)
 
                     similarity = similarity.order_by(desc(func.similarity(column, term)))
-                    
+
                     if limit_results:
                         similarity = similarity.limit(limit_results)
 


### PR DESCRIPTION
Bug:
There is a record in the system that is 2-characters long. As a result of the 3-character minimum, this record cannot be found using the search bar.

Solution:
Drop the minimum character count per search term to 2.
There may be negative performance implications of this change that could warrant a more thoughtful solution.