### PR TITLE
Hotfix onRemoveFile from FilePond

### DIFF
--- a/frontend/src/components/Forms/AddPermitForm.js
+++ b/frontend/src/components/Forms/AddPermitForm.js
@@ -76,7 +76,7 @@ export class AddPermitForm extends Component {
     this.props.change("uploadedFiles", this.state.uploadedFiles);
   };
 
-  onRemoveFile = (fileItem) => {
+  onRemoveFile = (err, fileItem) => {
     remove(this.state.uploadedFiles, { document_manager_guid: fileItem.serverId });
     this.props.change("uploadedFiles", this.state.uploadedFiles);
   };

--- a/frontend/src/components/Forms/PermitAmendmentForm.js
+++ b/frontend/src/components/Forms/PermitAmendmentForm.js
@@ -84,7 +84,7 @@ export class PermitAmendmentForm extends Component {
     this.props.change("uploadedFiles", this.state.uploadedFiles);
   };
 
-  onRemoveFile = (fileItem) => {
+  onRemoveFile = (err, fileItem) => {
     remove(this.state.uploadedFiles, { document_manager_guid: fileItem.serverId });
     this.props.change("uploadedFiles", this.state.uploadedFiles);
   };

--- a/frontend/src/components/Forms/variances/AddVarianceForm.js
+++ b/frontend/src/components/Forms/variances/AddVarianceForm.js
@@ -34,7 +34,7 @@ export class AddVarianceForm extends Component {
     }));
   };
 
-  onRemoveFile = (fileItem) => {
+  onRemoveFile = (err, fileItem) => {
     this.setState((prevState) => ({
       uploadedFiles: prevState.uploadedFiles.filter((fileArr) => fileArr[0] !== fileItem.serverId),
     }));

--- a/frontend/src/components/Forms/variances/EditVarianceForm.js
+++ b/frontend/src/components/Forms/variances/EditVarianceForm.js
@@ -61,7 +61,7 @@ export class EditVarianceForm extends Component {
     }));
   };
 
-  onRemoveFile = (fileItem) => {
+  onRemoveFile = (err, fileItem) => {
     this.setState((prevState) => ({
       uploadedFiles: prevState.uploadedFiles.filter((fileArr) => fileArr[0] !== fileItem.serverId),
     }));


### PR DESCRIPTION
The function signature changed in the dependency upgrade to use an error-first pattern. This broke all of our existing `onRemoveFile` functions.