### PR TITLE
Commiting only the backend for 2263

### DIFF
--- a/python-backend/app/api/incidents/models/mine_incident.py
+++ b/python-backend/app/api/incidents/models/mine_incident.py
@@ -3,6 +3,8 @@ import uuid, datetime
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import validates
 from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.ext.associationproxy import association_proxy
+
 from sqlalchemy.schema import FetchedValue
 from app.extensions import db
 
@@ -97,6 +99,12 @@ class MineIncident(AuditMixin, Base):
     mine_documents = db.relationship('MineDocument',
                                          lazy='joined',
                                          secondary='mine_incident_document_xref')
+
+    mine_table = db.relationship('Mine', lazy='joined')
+    mine_name = association_proxy('mine_table', 'mine_name')
+    mine_region = association_proxy('mine_table', 'mine_region')
+    major_mine_ind = association_proxy('mine_table', 'major_mine_ind')
+
 
     @hybrid_property
     def mine_incident_report_no(self):

--- a/python-backend/app/api/incidents/namespace/incidents.py
+++ b/python-backend/app/api/incidents/namespace/incidents.py
@@ -4,9 +4,11 @@ from app.api.incidents.resources.mine_incident_status_codes import MineIncidentS
 from app.api.incidents.resources.mine_incident_followup_types import MineIncidentFollowupTypeResource
 from app.api.incidents.resources.mine_incident_determination_types import MineIncidentDeterminationTypeResource
 from app.api.incidents.resources.mine_incident_document_type_codes import MineIncidentDocumentTypeCodeResource
+from app.api.incidents.resources.incidents_resource import IncidentsResource
 
 api = Namespace('incidents', description='Incidents actions/options')
 
+api.add_resource(IncidentsResource, '')
 api.add_resource(MineIncidentFollowupTypeResource, '/followup-types')
 api.add_resource(MineIncidentDeterminationTypeResource, '/determination-types')
 api.add_resource(MineIncidentStatusCodeResource, '/status-codes')

--- a/python-backend/app/api/incidents/resources/incidents_resource.py
+++ b/python-backend/app/api/incidents/resources/incidents_resource.py
@@ -1,0 +1,142 @@
+from flask_restplus import Resource
+from flask import request
+from datetime import datetime
+from sqlalchemy_filters import apply_sort, apply_pagination, apply_filters
+from sqlalchemy import desc, cast, NUMERIC, extract
+from app.extensions import api
+from app.api.mines.mine.models.mine import Mine
+from ..models.mine_incident import MineIncident
+from app.api.incidents.models.mine_incident_do_subparagraph import MineIncidentDoSubparagraph
+from ..response_models import PAGINATED_INCIDENT_LIST
+from ...utils.access_decorators import requires_any_of, VIEW_ALL
+from ...utils.resources_mixins import UserMixin, ErrorMixin
+
+PAGE_DEFAULT = 1
+PER_PAGE_DEFAULT = 25
+
+
+class IncidentsResource(Resource, UserMixin, ErrorMixin):
+    @api.doc(
+        description='Get a list of incidents. Order: received_date DESC',
+        params={
+            'page': f'The page number of paginated records to return. Default: {PAGE_DEFAULT}',
+            'per_page': f'The number of records to return per page. Default: {PER_PAGE_DEFAULT}',
+            'search': 'A string to be search in the incident number, mine name, or mine number',
+            'status': 'Comma-separated list of the incident status codes',
+            'determination':  'Comma-separated list of the inspectors determination, a three character code',
+            'codes': 'Comma-separated list of code sub_paragraphs to include in results. Default: All status codes.',
+            'incident_year': 'Return only incidents for this year',
+            'major': 'boolean indicating if variance is from a major or regional mine',
+            'region': 'Comma-separated list of regions the mines associated with the variances are located in',
+            'sort_field': 'The field the returned results will be ordered by',
+            'sort_dir': 'The direction by which the sort field is ordered',
+        })
+
+    @requires_any_of([VIEW_ALL])
+    @api.marshal_with(PAGINATED_INCIDENT_LIST, code=200)
+    def get(self):
+        args = {
+            "page_number": request.args.get('page', PAGE_DEFAULT, type=int),
+            "page_size":request.args.get('per_page', PER_PAGE_DEFAULT, type=int),
+            "status": request.args.get('status', type=str),
+            "determination": request.args.get('determination', type=str),
+            "codes": request.args.get('codes', type=str),
+            'major': request.args.get('major', type=str),
+            'region': request.args.get('region', type=str),
+            'year': request.args.get('incident_year', type=str),
+            'search_terms': request.args.get('search', type=str),
+            'sort_field': request.args.get('sort_field', type=str),
+            'sort_dir': request.args.get('sort_dir', type=str),
+        }
+
+        records, pagination_details = self._apply_filters_and_pagination(args)
+        if not records:
+            raise BadRequest('Unable to fetch variances.')
+        return {
+            'records': records.all(),
+            'current_page': pagination_details.page_number,
+            'total_pages': pagination_details.num_pages,
+            'items_per_page': pagination_details.page_size,
+            'total': pagination_details.total_results,
+        }
+
+    @classmethod
+    def _build_filter(cls, model, field, op, argfield):
+        return {
+            'model': model,
+            'field': field,
+            'op': op,
+            'value': argfield
+        }
+
+    def _apply_filters_and_pagination(self, args):
+        sort_models = {
+            "date": 'MineIncident',
+            # TODO: Mine incident_no is not currently implemented
+            # "incident_no": 'MineIncident',
+            "determination": 'MineIncident',
+            "status": 'MineIncident',
+            "mine_name": 'Mine',
+        }
+
+        sort_field = {
+            "date": 'incident_timestamp',
+            # TODO: Mine incident_no is not currently implemented
+            # "incident_no": 'mine_incident_no',
+            "determination": 'determination_type_code',
+            "status": 'status_code',
+            "mine_name": 'mine_name',
+        }
+
+        query = MineIncident.query.join(Mine)
+        conditions = []
+        if args["status"] is not None:
+            status_values = args["status"].split(',')
+            conditions.append(self._build_filter('MineIncident', 'status_code', 'in',  status_values))
+        if args["determination"] is not None:
+            determination_values = args["determination"].split(',')
+            conditions.append(
+                self._build_filter('MineIncident', 'determination_type_code', 'in', determination_values))
+        if args["codes"] is not None:
+            query = MineIncident.query.join(Mine).outerjoin(MineIncidentDoSubparagraph)
+            code_values = args["codes"].split(',')
+            conditions.append(
+                self._build_filter('MineIncidentDoSubparagraph', 'compliance_article_id', 'in', code_values))
+        if args["year"] is not None:
+            min_datetime = datetime(int(args["year"]), 1, 1)
+            max_datetime = datetime(int(args["year"])+1, 1, 1)
+            conditions.append(
+                self._build_filter('MineIncident', 'incident_timestamp', '>=', min_datetime))
+            conditions.append(
+                self._build_filter('MineIncident', 'incident_timestamp', '<', max_datetime))
+        if args["major"] is not None:
+            conditions.append(
+                self._build_filter('Mine', 'major_mine_ind', '==', args["major"]))
+        if args["search_terms"] is not None:
+            search_conditions = [
+                self._build_filter('Mine', 'mine_name', 'ilike', '%{}%'.format(args["search_terms"])),
+                self._build_filter('Mine', 'mine_no', 'ilike', '%{}%'.format(args["search_terms"])),
+                # TODO: Mine incident_no is not currently implemented
+                # self._build_filter('MineIncident', 'mine_incident_no ', 'ilike','%{}%'.format(args["search_terms"]))
+            ]
+            conditions.append({'or': search_conditions})
+        if args["region"] is not None:
+            region_list = args["region"].split(',')
+            conditions.append(self._build_filter('Mine', 'mine_region', 'in', region_list))
+
+        filtered_query = apply_filters(query, conditions)
+
+        # Apply sorting
+        if args['sort_field'] and args['sort_dir']:
+            # sorting by code section is not applicable since a single incident may have many sections associated.
+            sort_criteria = [{'model': sort_models[args['sort_field']],
+                              'field': sort_field[args['sort_field']],
+                              'direction': args['sort_dir']}]
+            # filtered_query = apply_sort(filtered_query, sort_criteria)
+        else:
+            # default sorting is by descending date.
+            sort_criteria = [
+                {'model': 'MineIncident', 'field': 'incident_timestamp', 'direction': 'desc'}]
+        filtered_query = apply_sort(filtered_query, sort_criteria)
+
+        return apply_pagination(filtered_query, args["page_number"], args["page_size"])

--- a/python-backend/app/api/incidents/response_models.py
+++ b/python-backend/app/api/incidents/response_models.py
@@ -1,6 +1,12 @@
 from app.extensions import api
 from flask_restplus import fields
 
+
+class DateTime(fields.Raw):
+    def format(self, value):
+        return value.strftime("%Y-%m-%d %H:%M") if value else None
+
+
 MINE_INCIDENT_DETERMINATION_TYPE_MODEL = api.model(
     'Mine Incident Determination Type', {
         'mine_incident_determination_type_code': fields.String,
@@ -24,3 +30,69 @@ MINE_INCIDENT_DOCUMENT_TYPE_CODE_MODEL = api.model(
         'mine_incident_document_type_code': fields.String,
         'description': fields.String
     })
+
+
+MINE_INCIDENT_DOCUMENT_MODEL = api.model(
+    'Mine Incident Document', {
+        'mine_document_guid': fields.String,
+        'document_manager_guid': fields.String,
+        'document_name': fields.String,
+        'mine_incident_document_type_code': fields.String
+
+    }
+)
+
+MINE_INCIDENT_RECOMMENDATION_MODEL = api.model(
+    'Mine Incident Recommendation', {
+        'recommendation': fields.String,
+        'mine_incident_recommendation_guid': fields.String
+    }
+)
+
+MINE_INCIDENT_MODEL = api.model(
+    'Mine Incident', {
+        'mine_incident_guid': fields.String,
+        'mine_incident_report_no': fields.String,
+        'mine_incident_id_year': fields.Integer,
+        'mine_guid': fields.String,
+        'mine_name': fields.String,
+        'mine_region': fields.String,
+        'major_mine_ind':fields.Boolean,
+        'incident_timestamp': DateTime,
+        'incident_description': fields.String,
+        'reported_timestamp': DateTime,
+        'reported_by_name': fields.String,
+        'reported_by_email': fields.String,
+        'reported_by_phone_no': fields.String,
+        'reported_by_phone_ext': fields.String,
+        'emergency_services_called': fields.Boolean,
+        'number_of_injuries': fields.Integer,
+        'number_of_fatalities': fields.Integer,
+        'reported_to_inspector_party_guid': fields.String,
+        'responsible_inspector_party_guid': fields.String,
+        'determination_type_code': fields.String,
+        'status_code': fields.String,
+        'followup_investigation_type_code': fields.String,
+        'followup_inspection': fields.Boolean,
+        'followup_inspection_date': fields.Date,
+        'determination_inspector_party_guid': fields.String,
+        'mms_inspector_initials': fields.String(attribute='mms_insp_cd'),
+        'dangerous_occurrence_subparagraph_ids': fields.List(fields.Integer),
+        'proponent_incident_no': fields.String,
+        'mine_incident_no': fields.String,
+        'documents': fields.List(fields.Nested(MINE_INCIDENT_DOCUMENT_MODEL)),
+        'recommendations': fields.List(fields.Nested(
+            MINE_INCIDENT_RECOMMENDATION_MODEL))
+    })
+
+PAGINATED_LIST = api.model(
+    'List', {
+        'current_page': fields.Integer,
+        'total_pages': fields.Integer,
+        'items_per_page': fields.Integer,
+        'total': fields.Integer,
+    })
+
+PAGINATED_INCIDENT_LIST = api.inherit('VarianceList', PAGINATED_LIST, {
+    'records': fields.List(fields.Nested(MINE_INCIDENT_MODEL)),
+})

--- a/python-backend/tests/incidents/resources/test_incidents_resource.py
+++ b/python-backend/tests/incidents/resources/test_incidents_resource.py
@@ -1,0 +1,204 @@
+import json
+from datetime import datetime
+import time
+import random
+
+from tests.status_code_gen import *
+from tests.factories import MineIncidentFactory, MineFactory
+
+class TestGetIncidents:
+    """GET /incidents"""
+    # get all incidents
+    # filter by each of the following fields: "status" "determination" "codes" "year" "major" "search_terms" "region"
+    # sort by each field: "date",  "incident_no", "determination", "status", "mine_name"
+    def test_get_incidents(self, test_client, db_session, auth_headers):
+        """Should return all records and a 200 response code"""
+        batch_size = 20
+        MineIncidentFactory.create_batch(size=batch_size)
+        get_resp = test_client.get('/incidents?per_page=25', headers=auth_headers['full_auth_header'])
+        get_data = json.loads(get_resp.data.decode())
+        assert get_resp.status_code == 200
+        assert len(get_data['records']) == batch_size
+
+    def test_get_incidents_status_filter(self, test_client, db_session, auth_headers):
+        """Should respect incidents status query param"""
+        batch_size = 20
+        status_pre="PRE";
+        MineIncidentFactory.create_batch(size=batch_size, status_code=status_pre)
+        status_fin = "FIN"
+        MineIncidentFactory.create_batch(size=batch_size, status_code=status_fin)
+        get_resp = test_client.get(f"/incidents?status={status_pre}", headers=auth_headers['full_auth_header'])
+        get_data = json.loads(get_resp.data.decode())
+        assert get_resp.status_code == 200
+        assert len(get_data['records']) == batch_size
+        assert all(map(lambda v: v['status_code'] == status_pre, get_data['records']))
+
+    def test_get_incidents_determination_filter(self, test_client, db_session, auth_headers):
+        """Should respect incidents determination query param"""
+        batch_size = 10
+        MineIncidentFactory.create_batch(size=batch_size, determination_type_code="PEN")
+        MineIncidentFactory.create_batch(size=batch_size, determination_type_code="DO")
+        MineIncidentFactory.create_batch(size=batch_size, determination_type_code="NDO")
+        get_resp = test_client.get(f"/incidents?determination=DO%2CNDO", headers=auth_headers['full_auth_header'])
+        get_data = json.loads(get_resp.data.decode())
+        assert get_resp.status_code == 200
+        assert len(get_data['records']) == 2*batch_size
+        assert all(map(lambda v: v['determination_type_code'] in ["DO","NDO"], get_data['records']))
+
+    def test_get_incidents_codes_filter(self, test_client, db_session, auth_headers):
+        """Should respect incidents codes query param"""
+        code1 = SampleDangerousOccurrenceSubparagraphs(1)
+        code2 = SampleDangerousOccurrenceSubparagraphs(2)
+        code3 = SampleDangerousOccurrenceSubparagraphs(1)
+        batch_size = 5
+        MineIncidentFactory.create_batch(size=batch_size, determination_type_code= 'DO', dangerous_occurrence_subparagraphs=code1)
+        MineIncidentFactory.create_batch(size=batch_size, determination_type_code= 'DO', dangerous_occurrence_subparagraphs=code2)
+        MineIncidentFactory.create_batch(size=batch_size, determination_type_code= 'DO', dangerous_occurrence_subparagraphs=code3)
+
+        get_resp = test_client.get(f"/incidents?codes={code2[0].compliance_article_id}%2C{code2[1].compliance_article_id}",
+                                   headers=auth_headers['full_auth_header'])
+        get_data = json.loads(get_resp.data.decode())
+        assert get_resp.status_code == 200
+        # The intersection of two lists
+        assert all(map(lambda v: set(v['dangerous_occurrence_subparagraph_ids'])
+                                 & set([code2[0].compliance_article_id, code2[1].compliance_article_id]),
+                       get_data['records']))
+
+
+    def test_get_incidents_year_filter(self, test_client, db_session, auth_headers):
+        """Should respect incidents year query param"""
+        batch_size = 10
+        MineIncidentFactory.create_batch(size=batch_size)
+        random_time_past = random.uniform(-time.time(), time.time())
+        random_date_time = datetime.fromtimestamp(random_time_past)
+        MineIncidentFactory(incident_timestamp=random_date_time)
+        incident_year = str(random_date_time.year)
+        get_resp = test_client.get( f"/incidents?incident_year={incident_year}", headers=auth_headers['full_auth_header'])
+        get_data = json.loads(get_resp.data.decode())
+        assert get_resp.status_code == 200
+        assert len(get_data['records']) == 1
+        assert all(map(lambda v: v['incident_timestamp'][0:4] == incident_year, get_data['records']))
+
+    def test_get_incidents_major_filter(self, test_client, db_session, auth_headers):
+        """Should respect incidents codes major mine indicator param"""
+        batch_size = 10
+        small_batch_size = 5
+        major_mine = MineFactory.create_batch(size=small_batch_size, major_mine_ind=True)
+        MineFactory.create_batch(size=batch_size, major_mine_ind=False)
+
+        get_resp = test_client.get( f"/incidents?major=t", headers=auth_headers['full_auth_header'])
+        get_data = json.loads(get_resp.data.decode())
+        assert get_resp.status_code == 200
+        assert len(get_data['records']) == small_batch_size
+        assert all(map(
+            lambda v: v['mine_name'] in [ mine.mine_name for mine in major_mine],
+            get_data['records']))
+
+
+    def test_get_incidents_search_filter(self, test_client, db_session, auth_headers):
+        """Should respect incidents search query param"""
+        MineFactory(mine_no='12345')
+        MineFactory(mine_no="678910", mine_name='steve')
+        MineFactory(mine_name="7891011")
+        get_resp = test_client.get(f'/incidents?search=78910', headers=auth_headers['full_auth_header'])
+        get_data = json.loads(get_resp.data.decode())
+        assert get_resp.status_code == 200
+        assert len(get_data['records']) == 2
+        assert all(map(
+            lambda v: v['mine_name'] in ["7891011","steve"] , get_data['records']))
+
+    def test_get_incidents_region_filter(self, test_client, db_session, auth_headers):
+        """Should respect incidents region query param"""
+        region_code = "NW"
+        mine_with_region_nw = MineFactory(mine_region='NW')
+        mine_with_region_sw = MineFactory(mine_region="SW")
+        batch_size = 3
+        MineIncidentFactory.create_batch(size=batch_size)
+        MineIncidentFactory(mine=mine_with_region_nw)
+        MineIncidentFactory(mine=mine_with_region_sw)
+        get_resp = test_client.get(f'/incidents?region={region_code}', headers=auth_headers['full_auth_header'])
+        get_data = json.loads(get_resp.data.decode())
+        assert get_resp.status_code == 200
+        assert all(map(
+            lambda v: v['mine_name'] == mine_with_region_nw.mine_name,
+            get_data['records']))
+
+    def test_get_incidents_date_sort(self, test_client, db_session, auth_headers):
+        """Should respect incidents date sort"""
+        sort_field = "date"
+        sort_dir = "desc"
+        batch_size = 20
+        MineIncidentFactory.create_batch(size=batch_size)
+        get_resp = test_client.get(f'/incidents?sort_field={sort_field}&sort_dir={sort_dir}', headers=auth_headers['full_auth_header'])
+        get_data = json.loads(get_resp.data.decode())
+        assert get_resp.status_code == 200
+        assert len(get_data['records']) == batch_size
+        assert all(get_data['records'][i]['incident_timestamp'] >= get_data['records'][i+1]['incident_timestamp']
+                   for i in range(len(get_data['records'])-1))
+
+    # TODO: When this incident_no is implemented a test on sorting by it will be needed
+    # def test_get_incidents_incident_no_sort(self, test_client, db_session, auth_headers):
+    #     """Should respect incidents incident_no sort"""
+
+    def test_get_incidents_determination_sort(self, test_client, db_session, auth_headers):
+        """Should respect incidents determination sort"""
+        sort_field = "determination"
+        sort_dir = "asc"
+        batch_size = 20
+        MineIncidentFactory.create_batch(size=batch_size)
+        get_resp = test_client.get(f'/incidents?sort_field={sort_field}&sort_dir={sort_dir}',
+                                   headers=auth_headers['full_auth_header'])
+        get_data = json.loads(get_resp.data.decode())
+        assert get_resp.status_code == 200
+        assert len(get_data['records']) == batch_size
+        assert all(get_data['records'][i]['determination_type_code'] <= get_data['records'][i + 1]['determination_type_code']
+                   for i in range(len(get_data['records']) - 1))
+
+    def test_get_incidents_status_sort(self, test_client, db_session, auth_headers):
+        """Should respect incidents status sort"""
+        sort_field = "status"
+        sort_dir = "desc"
+        batch_size = 20
+        MineIncidentFactory.create_batch(size=batch_size)
+        get_resp = test_client.get(f'/incidents?sort_field={sort_field}&sort_dir={sort_dir}',
+                                   headers=auth_headers['full_auth_header'])
+        get_data = json.loads(get_resp.data.decode())
+        assert get_resp.status_code == 200
+        assert len(get_data['records']) == batch_size
+        assert all(
+            get_data['records'][i]['status_code'] >= get_data['records'][i + 1]['status_code']
+            for i in range(len(get_data['records']) - 1))
+
+    def test_get_incidents_mine_name_sort(self, test_client, db_session, auth_headers):
+        """Should respect incidents mine_name sort"""
+        sort_field = "mine_name"
+        sort_dir = "desc"
+        batch_size = 20
+        MineIncidentFactory.create_batch(size=batch_size)
+        get_resp = test_client.get(f'/incidents?sort_field={sort_field}&sort_dir={sort_dir}',
+                                   headers=auth_headers['full_auth_header'])
+        get_data = json.loads(get_resp.data.decode())
+        assert get_resp.status_code == 200
+        assert len(get_data['records']) == batch_size
+        assert all(
+            get_data['records'][i]['mine_name'] >= get_data['records'][i + 1]['mine_name']
+            for i in range(len(get_data['records']) - 1))
+
+    def test_get_incidents_sort_and_filter_multiple_fields(self, test_client, db_session, auth_headers):
+        """Should respect incidents sort and filter by multiple fields"""
+        batch_size = 20
+        status_pre="PRE";
+        MineIncidentFactory.create_batch(size=batch_size, status_code=status_pre)
+        status_fin = "FIN"
+        MineIncidentFactory.create_batch(size=batch_size, status_code=status_fin)
+        sort_field = "mine_name"
+        sort_dir = "desc"
+        get_resp = test_client.get(f'/incidents?sort_field={sort_field}&sort_dir={sort_dir}&status={status_pre}',
+                                   headers=auth_headers['full_auth_header'])
+        get_data = json.loads(get_resp.data.decode())
+        assert get_resp.status_code == 200
+        assert len(get_data['records']) == batch_size
+        assert all(map(lambda v: v['status_code'] == status_pre, get_data['records']))
+        assert all(
+            get_data['records'][i]['mine_name'] >= get_data['records'][i + 1]['mine_name']
+            for i in range(len(get_data['records']) - 1))

--- a/python-backend/tests/mines/incidents/test_incident_document_resource.py
+++ b/python-backend/tests/mines/incidents/test_incident_document_resource.py
@@ -3,7 +3,7 @@ import json
 import uuid
 
 from tests.status_code_gen import RandomIncidentDocumentType
-from tests.factories import (MineIncidentFactory, MineFactory, MineDocumentFactory,
+from tests.factories import ( MineIncidentFactory, MineFactory, MineDocumentFactory,
                              VarianceDocumentFactory)
 
 

--- a/python-backend/tests/mines/incidents/test_incident_document_resource.py
+++ b/python-backend/tests/mines/incidents/test_incident_document_resource.py
@@ -3,7 +3,7 @@ import json
 import uuid
 
 from tests.status_code_gen import RandomIncidentDocumentType
-from tests.factories import ( MineIncidentFactory, MineFactory, MineDocumentFactory,
+from tests.factories import (MineIncidentFactory, MineFactory, MineDocumentFactory,
                              VarianceDocumentFactory)
 
 


### PR DESCRIPTION
This is the complete and tested new enpoint for the mine incidents dashboard page.
There is currently some ambiguity about incident_no vs incident_id, etc, so it's sorting and filtering has not been implemented.