### PR TITLE
Leaflet map performance improvement

### DIFF
--- a/frontend/src/components/maps/MineMapLeaflet.js
+++ b/frontend/src/components/maps/MineMapLeaflet.js
@@ -183,6 +183,8 @@ class MineMapLeaflet extends Component {
       center: [this.props.lat, this.props.long],
       zoom: this.props.zoom,
       worldCopyJump: true,
+      zoomAnimationThreshold: 8,
+      minZoom: 4,
     });
 
     // Add Topographic BaseMap by default
@@ -334,7 +336,7 @@ class MineMapLeaflet extends Component {
           // Stop checking
           clearInterval(resetZoomCheckID);
         }
-      }, 10);
+      }, 5);
     });
   }
 

--- a/frontend/src/components/maps/MineMapLeaflet.js
+++ b/frontend/src/components/maps/MineMapLeaflet.js
@@ -246,7 +246,6 @@ class MineMapLeaflet extends Component {
     this.props.minesBasicInfo.map(this.createPin);
     this.map.addLayer(this.markerClusterGroup);
     this.addLatLongCircle();
-    this.map.setView([this.props.lat, this.props.long], this.props.zoom, true);
   };
 
   addWidgets = async () => {
@@ -288,13 +287,6 @@ class MineMapLeaflet extends Component {
     L.control
       .groupedLayers(this.getLayerGroupFromList(baseMapsArray), groupedOverlays)
       .addTo(this.map);
-
-    // Esri WebMap resets the zoom level, zoom back to props coordinates after they're done loading
-    setTimeout(() => {
-      if (this.map.getZoom() !== this.props.zoom) {
-        this.map.setView([this.props.lat, this.props.long], this.props.zoom, true);
-      }
-    }, 200);
   };
 
   /* eslint-disable */
@@ -333,7 +325,16 @@ class MineMapLeaflet extends Component {
     this.webMap.on("load", () => {
       // Add the WebMap layers and the Layer control widget
       this.addWebMapLayers();
-      this.map.setView([this.props.lat, this.props.long], this.props.zoom, true);
+
+      // Esri WebMap resets the zoom level, zoom back to props coordinates after they're done loading
+      const resetZoomCheckID = setInterval(() => {
+        if (this.map.getZoom() !== this.props.zoom) {
+          this.map.setView([this.props.lat, this.props.long], this.props.zoom, true);
+
+          // Stop checking
+          clearInterval(resetZoomCheckID);
+        }
+      }, 10);
     });
   }
 

--- a/frontend/src/components/maps/MineMapLeaflet.js
+++ b/frontend/src/components/maps/MineMapLeaflet.js
@@ -195,10 +195,6 @@ class MineMapLeaflet extends Component {
 
     // Load external leaflet libraries for WebMap and Widgets
     this.asyncScriptStatusCheck();
-
-    // Esri webmaps centers map to base map center after loading
-    // Change the mapview back to location passed down in props
-    this.map.setView([this.props.lat, this.props.long], this.props.zoom, true);
   }
 
   asyncScriptStatusCheck = () => {
@@ -291,10 +287,6 @@ class MineMapLeaflet extends Component {
     L.control
       .groupedLayers(this.getLayerGroupFromList(baseMapsArray), groupedOverlays)
       .addTo(this.map);
-
-    // Esri webmaps centers map to base map center after loading
-    // Change the mapview back to location passed down in props
-    this.map.setView([this.props.lat, this.props.long], this.props.zoom, true);
   };
 
   /* eslint-disable */
@@ -329,8 +321,14 @@ class MineMapLeaflet extends Component {
     // Fetch the WebMap
     this.webMap = window.L.esri.webMap("803130a9bebb4035b3ac671aafab12d7", { map: this.map });
 
+    // Esri webmaps centers map to base map center after loading
+    // Change the mapview back to location passed down in props
+    this.map.on("zoom", () => {
+      this.map.setView([this.props.lat, this.props.long], this.props.zoom, true);
+    });
+
     // Once the WebMap is loaded, add the rest of Layers and tools
-    this.webMap.on("load", async () => {
+    this.webMap.on("load", () => {
       // Add the WebMap layers and the Layer control widget
       this.addWebMapLayers();
     });

--- a/frontend/src/components/maps/MineMapLeaflet.js
+++ b/frontend/src/components/maps/MineMapLeaflet.js
@@ -242,7 +242,7 @@ class MineMapLeaflet extends Component {
     }
   };
 
-  addMinePinClusters = async () => {
+  addMinePinClusters = () => {
     // Add Clustered MinePins
     this.markerClusterGroup = L.markerClusterGroup({ animate: false });
     this.props.minesBasicInfo.map(this.createPin);
@@ -250,7 +250,7 @@ class MineMapLeaflet extends Component {
     this.addLatLongCircle();
   };
 
-  addWidgets = async () => {
+  addWidgets = () => {
     // Add Mouse coordinate widget
     L.control.mouseCoordinate({ utm: true, position: "topright" }).addTo(this.map);
 

--- a/frontend/src/components/maps/MineMapLeaflet.js
+++ b/frontend/src/components/maps/MineMapLeaflet.js
@@ -195,6 +195,10 @@ class MineMapLeaflet extends Component {
 
     // Load external leaflet libraries for WebMap and Widgets
     this.asyncScriptStatusCheck();
+
+    // Esri webmaps centers map to base map center after loading
+    // Change the mapview back to location passed down in props
+    this.map.setView([this.props.lat, this.props.long], this.props.zoom, true);
   }
 
   asyncScriptStatusCheck = () => {


### PR DESCRIPTION
Loading clusters and Web map was too much work on the main thread. Causing browser slowing down and even page crashes. Couldn't catch it with happy PROD data or locally seeded one.
Needed TEST data for it to really push the limits 😅 

Anyways, I moved the order of loading map components around for no-jitter loading experience.

Basically load the lightweight leaflet map first and add the clusters while the external widget and esri webmap layer libraries are being downloaded by react-async-script-loader. 

Once the libraries are downloaded, asynchronously add the widgets, layers and other controls to the map.
