### PR TITLE
NRIS ETL fix and raise exception on ETL failure

### DIFF
--- a/microservices/nris_api/backend/app/nris/cli_jobs/nris_jobs.py
+++ b/microservices/nris_api/backend/app/nris/cli_jobs/nris_jobs.py
@@ -21,6 +21,10 @@ def run_nris_etl():
         current_app.logger.info('NRIS ETL Completed!')
 
     except cx_Oracle.DatabaseError as e:
-        current_app.logger.error("Error establishing connection to NRIS database: " + str(e))
+        current_app.logger.error(
+            "Error establishing connection to NRIS database: " + str(e))
+        raise
     except Exception as e:
-        current_app.logger.error("Unexpected error with NRIS XML import: " + str(e))
+        current_app.logger.error(
+            "Unexpected error with NRIS XML import: " + str(e))
+        raise

--- a/microservices/nris_api/backend/app/nris/etl/nris_etl.py
+++ b/microservices/nris_api/backend/app/nris/etl/nris_etl.py
@@ -7,6 +7,7 @@ from app.extensions import db
 
 from app.nris.models.inspection import Inspection
 from app.nris.models.inspection_status import InspectionStatus
+from app.nris.modesl.inspection_substatus import InspectionSubstatus
 from app.nris.models.location import Location
 from app.nris.models.inspected_location import InspectedLocation
 from app.nris.models.order_request_detail import OrderRequestDetail
@@ -518,9 +519,9 @@ def _find_or_save_inspection_substatus(inspection_substatus):
     if inspection_substatus is not None:
         for substatus in substatuses:
             if substatus.inspection_substatus_code == inspection_substatus.text:
-                type_found = True
+                substatus_found = True
                 inspec_substatus = substatus
-    if not type_found:
+    if not substatus_found:
         inspec_substatus = InspectionSubstatus(
             inspection_substatus_code=inspection_substatus.text)
         db.session.add(inspec_substatus)

--- a/microservices/nris_api/backend/app/nris/etl/nris_etl.py
+++ b/microservices/nris_api/backend/app/nris/etl/nris_etl.py
@@ -7,7 +7,7 @@ from app.extensions import db
 
 from app.nris.models.inspection import Inspection
 from app.nris.models.inspection_status import InspectionStatus
-from app.nris.modesl.inspection_substatus import InspectionSubstatus
+from app.nris.models.inspection_substatus import InspectionSubstatus
 from app.nris.models.location import Location
 from app.nris.models.inspected_location import InspectedLocation
 from app.nris.models.order_request_detail import OrderRequestDetail


### PR DESCRIPTION
Currently the NRIS job will show a successful status on our job scheduler even if it fails. Raising exception will cause job to error out and reflect status accurately on scheduler.