### PR TITLE
Fix link to Architecture diagram

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -123,7 +123,7 @@ psql --dbname=mds --username=mds --host=localhost --password --port=5432
 
 ## Architecture Diagrams
 
-![High Level Architecture](docs\MDS_Arch.png)
+![High Level Architecture](./docs/MDS_Arch.png)
 
 ## Authentication Workflow
 


### PR DESCRIPTION
From `USAGE.md`, the link to the PNG was stale; updated to (relative) link to the updated location.