### PR TITLE
Change from todb to appenddb

### DIFF
--- a/microservices/now_etls/NOW_import.py
+++ b/microservices/now_etls/NOW_import.py
@@ -68,7 +68,7 @@ def ETL_MMS_NOW_schema(connection, tables, schema, system_name):
 
                 table_plus_os_guid = join_mine_guids(connection, table_plus_os)
 
-                etl.todb(
+                etl.appenddb(
                     table_plus_os_guid,
                     connection,
                     destination,
@@ -76,7 +76,7 @@ def ETL_MMS_NOW_schema(connection, tables, schema, system_name):
                     commit=False)
             else:
 
-                etl.todb(
+                etl.appenddb(
                     current_table, connection, destination, schema='now_submissions', commit=False)
 
         except Exception as err:


### PR DESCRIPTION
We had tested using 'todb' as part of the troubleshooting when building the NOW MMS ETLs, but the behaviour isn't what we are looking for in this context. 'todb' will automatically truncate before adding the records, while 'appenddb' will not.