### PR TITLE
should not be testing this field. it's generated by the backend.

### DIFF
--- a/services/core-api/tests/mines/incidents/test_mine_incident_list_resource.py
+++ b/services/core-api/tests/mines/incidents/test_mine_incident_list_resource.py
@@ -6,7 +6,6 @@ from tests.factories import MineIncidentFactory, MineFactory
 
 class TestGetMineIncidents:
     """GET /mines/{mine_guid}/incidents"""
-
     def test_get_incidents_for_a_mine(self, test_client, db_session, auth_headers):
         """Should return the correct number of records and a 200 staus code"""
 
@@ -21,7 +20,6 @@ class TestGetMineIncidents:
         assert get_resp.status_code == 200
         assert len(get_data['records']) == batch_size
 
-
     def test_get_incidents_non_existent_mine_guid(self, test_client, db_session, auth_headers):
         """Should return a 404 when the provided mine guid does not exist"""
 
@@ -29,21 +27,20 @@ class TestGetMineIncidents:
         fake_guid = uuid.uuid4()
         MineIncidentFactory.create_batch(size=batch_size)
 
-        get_resp = test_client.get(f'/mines/{fake_guid}/incidents', headers=auth_headers['full_auth_header'])
+        get_resp = test_client.get(
+            f'/mines/{fake_guid}/incidents', headers=auth_headers['full_auth_header'])
         get_data = json.loads(get_resp.data.decode())
         assert get_resp.status_code == 404
 
 
 class TestPostMineIncident:
     """POST /mines/{mine_guid}/incidents"""
-
     def test_post_mine_incident(self, test_client, db_session, auth_headers):
         """Should return the new mine incident record"""
 
         mine = MineFactory()
         incident = MineIncidentFactory(mine=mine)
         test_incident_data = {
-            'mine_incident_id_year': incident.mine_incident_id_year,
             'incident_timestamp': '2019-01-01 00:00',
             'reported_timestamp': '2019-01-01 00:00',
             'incident_description': incident.incident_description,
@@ -54,7 +51,6 @@ class TestPostMineIncident:
             headers=auth_headers['full_auth_header'])
         post_data = json.loads(post_resp.data.decode())
         assert post_resp.status_code == 201, post_resp.response
-        assert post_data['mine_incident_id_year'] == test_incident_data['mine_incident_id_year']
         assert post_data['incident_timestamp'] == test_incident_data['incident_timestamp']
         assert post_data['incident_description'] == test_incident_data['incident_description']
         assert post_data['reported_timestamp'] == str(test_incident_data['reported_timestamp'])


### PR DESCRIPTION
don't test this field. I would like to see this column destroyed and either properly save the id or just show the integer id and use the other dates as dates. 