### PR TITLE
Changing missed PVC access mode change

### DIFF
--- a/openshift/templates/postgresql.dc.json
+++ b/openshift/templates/postgresql.dc.json
@@ -152,7 +152,7 @@
         "name": "${NAME}${SUFFIX}"
       },
       "spec": {
-        "accessModes": ["ReadWriteMany"],
+        "accessModes": ["ReadWriteOnce"],
         "resources": {
           "requests": {
             "storage": "${VOLUME_CAPACITY}"


### PR DESCRIPTION
This is a followup to the PVC migration PR. There was a missed PVC access mode change in the postgres template file.