### PR TITLE
Grab 'first' login

### DIFF
--- a/tests/functional-tests/src/test/groovy/FrontendMinespace/pages/MinespaceFrontendLogin.groovy
+++ b/tests/functional-tests/src/test/groovy/FrontendMinespace/pages/MinespaceFrontendLogin.groovy
@@ -6,7 +6,6 @@ class MinespaceFrontendLoginPage extends Page {
    
     static url = Const.MINESPACE_URL
     static content = {
-        LoginButton (wait: true) {$("button", text: "Log in")}
+        LoginButton (wait: true) {$("button", 0, text: "Log in")}
     }
 }
-


### PR DESCRIPTION
The current Minespace functional are failing; hypothesis is that the fact that there are two login buttons is causing the issue.

