### PR TITLE
MDS-2669: MineSpace and Core CRR Create/Edit/View Issues

### DIFF
--- a/services/core-web/src/components/Forms/reports/ReportHistorySubmissionSummary.js
+++ b/services/core-web/src/components/Forms/reports/ReportHistorySubmissionSummary.js
@@ -1,6 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { Divider } from "antd";
+import { formatDate } from "@common/utils/helpers";
 import FormItemLabel from "@/components/common/FormItemLabel";
 import CommentPanel from "@/components/common/comments/CommentPanel";
 import { UploadedDocumentsTable } from "@/components/common/UploadedDocumentTable";
@@ -16,7 +17,7 @@ const actionBuilder = (visible) => [visible && <span>Comment published to Minesp
 const ReportHistorySubmissionSummary = (props) => (
   <React.Fragment>
     <div className="padding-xxl--bottom">
-      <h4>{props.mineReportSubmission.submission_date}</h4>
+      <h4>{formatDate(props.mineReportSubmission.submission_date)}</h4>
       <Divider style={{ margin: "0" }} />
       <FormItemLabel>Revision Status</FormItemLabel>
       <div>

--- a/services/minespace-web/src/components/Forms/reports/AddReportForm.js
+++ b/services/minespace-web/src/components/Forms/reports/AddReportForm.js
@@ -151,7 +151,7 @@ export class AddReportForm extends Component {
           {this.state.selectedMineReportComplianceArticles.length > 0 ? (
             <List bordered size="small" className="color-primary">
               {this.state.selectedMineReportComplianceArticles.map((opt) => (
-                <List.Item>{formatComplianceCodeValueOrLabel(opt, true)}</List.Item>
+                <List.Item key={opt}>{formatComplianceCodeValueOrLabel(opt, true)}</List.Item>
               ))}
             </List>
           ) : (
@@ -171,6 +171,7 @@ export class AddReportForm extends Component {
           mineGuid={this.props.mineGuid}
           mineReportSubmissions={this.state.mineReportSubmissions}
           updateMineReportSubmissions={this.updateMineReportSubmissions}
+          maxFileListHeight={130}
         />
         <div className="ant-modal-footer">
           <Popconfirm

--- a/services/minespace-web/src/components/Forms/reports/AddReportForm.js
+++ b/services/minespace-web/src/components/Forms/reports/AddReportForm.js
@@ -166,12 +166,10 @@ export class AddReportForm extends Component {
           component={renderConfig.YEAR}
           validate={[required]}
         />
-
         <ReportSubmissions
           mineGuid={this.props.mineGuid}
           mineReportSubmissions={this.state.mineReportSubmissions}
           updateMineReportSubmissions={this.updateMineReportSubmissions}
-          maxFileListHeight={130}
         />
         <div className="ant-modal-footer">
           <Popconfirm

--- a/services/minespace-web/src/components/Forms/reports/EditReportForm.js
+++ b/services/minespace-web/src/components/Forms/reports/EditReportForm.js
@@ -32,7 +32,6 @@ export class EditReportForm extends Component {
           mineGuid={this.props.mineGuid}
           mineReportSubmissions={this.state.mineReportSubmissions}
           updateMineReportSubmissions={this.updateMineReportSubmissions}
-          maxFileListHeight={260}
         />
         <div className="ant-modal-footer">
           <Popconfirm

--- a/services/minespace-web/src/components/Forms/reports/EditReportForm.js
+++ b/services/minespace-web/src/components/Forms/reports/EditReportForm.js
@@ -32,6 +32,7 @@ export class EditReportForm extends Component {
           mineGuid={this.props.mineGuid}
           mineReportSubmissions={this.state.mineReportSubmissions}
           updateMineReportSubmissions={this.updateMineReportSubmissions}
+          maxFileListHeight={260}
         />
         <div className="ant-modal-footer">
           <Popconfirm

--- a/services/minespace-web/src/components/Forms/reports/EditReportForm.js
+++ b/services/minespace-web/src/components/Forms/reports/EditReportForm.js
@@ -1,51 +1,28 @@
-/* eslint-disable */
 import React, { Component } from "react";
-import { connect } from "react-redux";
-import { compose } from "redux";
 import PropTypes from "prop-types";
-import { reduxForm, formValueSelector } from "redux-form";
+import { reduxForm } from "redux-form";
 import { Form, Button, Popconfirm } from "antd";
-import * as FORM from "@/constants/forms";
-import { resetForm } from "@/utils/helpers";
-import {
-  getDropdownMineReportCategoryOptions,
-  getMineReportDefinitionOptions,
-} from "@/selectors/staticContentSelectors";
 import CustomPropTypes from "@/customPropTypes";
+import * as FORM from "@/constants/forms";
 import { ReportSubmissions } from "@/components/Forms/reports/ReportSubmissions";
 
 const propTypes = {
   mineGuid: PropTypes.string.isRequired,
+  mineReport: CustomPropTypes.mineReport.isRequired,
   handleSubmit: PropTypes.func.isRequired,
   closeModal: PropTypes.func.isRequired,
-  mineReportDefinitionOptions: PropTypes.arrayOf(PropTypes.objectOf(PropTypes.any)).isRequired,
-  dropdownMineReportCategoryOptions: PropTypes.arrayOf(
-    PropTypes.objectOf(CustomPropTypes.dropdownListItem)
-  ).isRequired,
-  initialValues: PropTypes.objectOf(PropTypes.any),
-  selectedMineReportCategory: PropTypes.string,
-  selectedMineReportDefinition: PropTypes.string,
-  formMeta: PropTypes.any,
   change: PropTypes.func.isRequired,
-};
-
-const selector = formValueSelector(FORM.ADD_REPORT);
-
-const defaultProps = {
-  initialValues: {},
-  selectedMineReportCategory: null,
-  selectedMineReportDefinition: null,
 };
 
 export class EditReportForm extends Component {
   state = {
-    existingReport: Boolean(!this.props.initialValues.mine_report_definition_guid),
-    mineReportSubmissions: this.props.initialValues.mine_report_submissions,
+    mineReportSubmissions: this.props.mineReport.mine_report_submissions,
   };
 
   updateMineReportSubmissions = (updatedSubmissions) => {
-    this.setState({ mineReportSubmissions: updatedSubmissions });
-    this.props.change("mine_report_submissions", this.state.mineReportSubmissions);
+    this.setState({ mineReportSubmissions: updatedSubmissions }, () =>
+      this.props.change("mine_report_submissions", this.state.mineReportSubmissions)
+    );
   };
 
   render() {
@@ -53,6 +30,7 @@ export class EditReportForm extends Component {
       <Form layout="vertical" onSubmit={this.props.handleSubmit}>
         <ReportSubmissions
           mineGuid={this.props.mineGuid}
+          mineReportSubmissions={this.state.mineReportSubmissions}
           updateMineReportSubmissions={this.updateMineReportSubmissions}
         />
         <div className="ant-modal-footer">
@@ -75,19 +53,8 @@ export class EditReportForm extends Component {
 }
 
 EditReportForm.propTypes = propTypes;
-EditReportForm.defaultProps = defaultProps;
 
-export default compose(
-  connect((state) => ({
-    dropdownMineReportCategoryOptions: getDropdownMineReportCategoryOptions(state),
-    mineReportDefinitionOptions: getMineReportDefinitionOptions(state),
-    selectedMineReportCategory: selector(state, "mine_report_category"),
-    selectedMineReportDefinition: selector(state, "mine_report_definition_guid"),
-    formMeta: state.form[FORM.ADD_REPORT],
-  })),
-  reduxForm({
-    form: FORM.EDIT_REPORT,
-    touchOnBlur: true,
-    onSubmitSuccess: resetForm(FORM.EDIT_REPORT),
-  })
-)(EditReportForm);
+export default reduxForm({
+  form: FORM.EDIT_REPORT,
+  touchOnBlur: true,
+})(EditReportForm);

--- a/services/minespace-web/src/components/Forms/reports/ReportSubmissions.js
+++ b/services/minespace-web/src/components/Forms/reports/ReportSubmissions.js
@@ -1,5 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
+import { Form } from "antd";
 import { Field } from "redux-form";
 import { concat, reject } from "lodash";
 import FileUpload from "@/components/common/FileUpload";
@@ -10,10 +11,12 @@ const propTypes = {
   mineGuid: PropTypes.string.isRequired,
   updateMineReportSubmissions: PropTypes.func.isRequired,
   mineReportSubmissions: PropTypes.arrayOf(PropTypes.objectOf(PropTypes.any)),
+  maxFileListHeight: PropTypes.number,
 };
 
 const defaultProps = {
   mineReportSubmissions: [],
+  maxFileListHeight: undefined,
 };
 
 export const ReportSubmissions = (props) => {
@@ -57,23 +60,31 @@ export const ReportSubmissions = (props) => {
   return (
     <div>
       {uploadedFiles.length > 0 && (
-        <Field
-          id="ReportAttachedFiles"
-          name="ReportAttachedFiles"
-          label="Documents"
-          component={ReportsUploadedFilesList}
-          files={uploadedFiles}
-          onRemoveFile={handleRemoveFile}
-        />
+        <Form.Item
+          label="Uploaded Documents"
+          style={
+            props.maxFileListHeight ? { maxHeight: props.maxFileListHeight, overflowY: "auto" } : {}
+          }
+        >
+          <Field
+            id="ReportAttachedFiles"
+            name="ReportAttachedFiles"
+            maxHeight={260}
+            component={ReportsUploadedFilesList}
+            files={uploadedFiles}
+            onRemoveFile={handleRemoveFile}
+          />
+        </Form.Item>
       )}
-      <Field
-        id="ReportFileUpload"
-        name="ReportFileUpload"
-        label="Upload Files"
-        component={FileUpload}
-        uploadUrl={MINE_REPORT_DOCUMENT(props.mineGuid)}
-        onFileLoad={handleFileLoad}
-      />
+      <Form.Item label="Upload Documents">
+        <Field
+          id="ReportFileUpload"
+          name="ReportFileUpload"
+          component={FileUpload}
+          uploadUrl={MINE_REPORT_DOCUMENT(props.mineGuid)}
+          onFileLoad={handleFileLoad}
+        />
+      </Form.Item>
     </div>
   );
 };

--- a/services/minespace-web/src/components/Forms/reports/ReportSubmissions.js
+++ b/services/minespace-web/src/components/Forms/reports/ReportSubmissions.js
@@ -11,12 +11,10 @@ const propTypes = {
   mineGuid: PropTypes.string.isRequired,
   updateMineReportSubmissions: PropTypes.func.isRequired,
   mineReportSubmissions: PropTypes.arrayOf(PropTypes.objectOf(PropTypes.any)),
-  maxFileListHeight: PropTypes.number,
 };
 
 const defaultProps = {
   mineReportSubmissions: [],
-  maxFileListHeight: undefined,
 };
 
 export const ReportSubmissions = (props) => {
@@ -59,23 +57,6 @@ export const ReportSubmissions = (props) => {
 
   return (
     <div>
-      {uploadedFiles.length > 0 && (
-        <Form.Item
-          label="Uploaded Documents"
-          style={
-            props.maxFileListHeight ? { maxHeight: props.maxFileListHeight, overflowY: "auto" } : {}
-          }
-        >
-          <Field
-            id="ReportAttachedFiles"
-            name="ReportAttachedFiles"
-            maxHeight={260}
-            component={ReportsUploadedFilesList}
-            files={uploadedFiles}
-            onRemoveFile={handleRemoveFile}
-          />
-        </Form.Item>
-      )}
       <Form.Item label="Upload Documents">
         <Field
           id="ReportFileUpload"
@@ -85,6 +66,17 @@ export const ReportSubmissions = (props) => {
           onFileLoad={handleFileLoad}
         />
       </Form.Item>
+      {uploadedFiles.length > 0 && (
+        <Form.Item label="Uploaded Documents">
+          <Field
+            id="ReportAttachedFiles"
+            name="ReportAttachedFiles"
+            component={ReportsUploadedFilesList}
+            files={uploadedFiles}
+            onRemoveFile={handleRemoveFile}
+          />
+        </Form.Item>
+      )}
     </div>
   );
 };

--- a/services/minespace-web/src/components/Forms/reports/ReportsUploadedFilesList.js
+++ b/services/minespace-web/src/components/Forms/reports/ReportsUploadedFilesList.js
@@ -19,12 +19,12 @@ export const ReportsUploadedFilesList = (props) =>
           <Col span={3} className="right">
             <Popconfirm
               placement="top"
-              title={[<h3>Are you sure you want to remove this file?</h3>]}
+              title={<h3>Are you sure you want to remove this file?</h3>}
               okText="Yes"
               cancelText="No"
               onConfirm={() => props.onRemoveFile(file)}
             >
-              <Button type="button">
+              <Button>
                 <Icon type="close" />
               </Button>
             </Popconfirm>

--- a/services/minespace-web/src/components/Forms/reports/ReportsUploadedFilesList.js
+++ b/services/minespace-web/src/components/Forms/reports/ReportsUploadedFilesList.js
@@ -1,41 +1,37 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { Col, Row, Popconfirm, Icon } from "antd";
+import { Col, Row, Popconfirm, Icon, Button } from "antd";
 
 const propTypes = {
   files: PropTypes.arrayOf(PropTypes.any).isRequired,
   onRemoveFile: PropTypes.func.isRequired,
-  editing: PropTypes.bool.isRequired,
 };
 
-export const ReportsUploadedFilesList = (props) => (
-  <div>
-    {props.files.map((file) => (
-      <div className="padding-small margin-small background-bg" key={file.mine_document_guid}>
+export const ReportsUploadedFilesList = (props) =>
+  (props.files &&
+    props.files.length > 0 &&
+    props.files.map((file) => (
+      <div key={file.mine_document_guid} className="padding-small margin-small background-bg">
         <Row className="padding-small">
           <Col span={21}>
             <p className="uploaded-file left">{file.document_name}</p>
           </Col>
-          {props.editing && (
-            <Col span={3} className="right">
-              <Popconfirm
-                placement="top"
-                title={[<h3>Are you sure you want to remove this file?</h3>]}
-                okText="Yes"
-                cancelText="No"
-                onConfirm={() => props.onRemoveFile(file)}
-              >
-                <button type="button">
-                  <Icon type="close" />
-                </button>
-              </Popconfirm>
-            </Col>
-          )}
+          <Col span={3} className="right">
+            <Popconfirm
+              placement="top"
+              title={[<h3>Are you sure you want to remove this file?</h3>]}
+              okText="Yes"
+              cancelText="No"
+              onConfirm={() => props.onRemoveFile(file)}
+            >
+              <Button type="button">
+                <Icon type="close" />
+              </Button>
+            </Popconfirm>
+          </Col>
         </Row>
       </div>
-    ))}
-  </div>
-);
+    ))) || <div>You haven&apos;t added any new documents to this submission yet.</div>;
 
 ReportsUploadedFilesList.propTypes = propTypes;
 

--- a/services/minespace-web/src/components/dashboard/mine/overview/Overview.js
+++ b/services/minespace-web/src/components/dashboard/mine/overview/Overview.js
@@ -123,7 +123,7 @@ export const Overview = (props) => (
               <MinistryContactItem contact={Contacts.CHIEF_INSPECTOR} />
               <MinistryContactItem contact={Contacts.EXEC_LEAD_AUTH} />
               {getMajorMineRegionalContacts(props.mine.mine_region).map((contact) => (
-                <MinistryContactItem contact={contact} />
+                <MinistryContactItem contact={contact} key={contact.title} />
               ))}
             </Card>
           </Col>
@@ -131,7 +131,7 @@ export const Overview = (props) => (
           <Col>
             <Card title="Regional Ministry Contacts">
               {getRegionalMineRegionalContacts(props.mine.mine_region).map((contact) => (
-                <MinistryContactItem contact={contact} />
+                <MinistryContactItem contact={contact} key={contact.title} />
               ))}
             </Card>
           </Col>,

--- a/services/minespace-web/src/components/dashboard/mine/reports/Reports.js
+++ b/services/minespace-web/src/components/dashboard/mine/reports/Reports.js
@@ -65,8 +65,17 @@ export class Reports extends Component {
   };
 
   handleEditReport = (values) => {
+    const payload = {
+      mine_report_submissions: [
+        ...values.mine_report_submissions,
+        {
+          documents:
+            values.mine_report_submissions[values.mine_report_submissions.length - 1].documents,
+        },
+      ],
+    };
     this.props
-      .updateMineReport(this.props.mine.mine_guid, this.state.selectedMineReportGuid, values)
+      .updateMineReport(this.props.mine.mine_guid, this.state.selectedMineReportGuid, payload)
       .then(() => this.props.closeModal())
       .then(() => this.props.fetchMineReports(this.props.mine.mine_guid));
   };
@@ -85,15 +94,15 @@ export class Reports extends Component {
   };
 
   openEditReportModal = (event, report) => {
-    this.setState({ selectedMineReportGuid: report.mine_report_guid });
     event.preventDefault();
+    this.setState({ selectedMineReportGuid: report.mine_report_guid });
     this.props.openModal({
       props: {
-        initialValues: report,
         onSubmit: this.handleEditReport,
         title: `Add Documents to: ${report.report_name}`,
-        mineGuid: this.props.mine.mine_guid,
         width: "40vw",
+        mineGuid: this.props.mine.mine_guid,
+        mineReport: report,
       },
       content: modalConfig.EDIT_REPORT,
     });

--- a/services/minespace-web/src/components/dashboard/mine/reports/ReportsTable.js
+++ b/services/minespace-web/src/components/dashboard/mine/reports/ReportsTable.js
@@ -12,7 +12,6 @@ import AuthorizationWrapper from "@/components/common/wrappers/AuthorizationWrap
 
 const propTypes = {
   mineReports: PropTypes.arrayOf(CustomPropTypes.mineReport).isRequired,
-  // Props are used indirectly. Linting is unable to detect it
   // eslint-disable-next-line react/no-unused-prop-types
   openEditReportModal: PropTypes.func.isRequired,
   isLoaded: PropTypes.bool.isRequired,
@@ -60,27 +59,25 @@ export const ReportsTable = (props) => {
         <div title="Documents" className="cap-col-height">
           {(text &&
             text.length > 0 &&
-            text.filter((sub) => sub.documents && sub.documents.length > 0).length > 0 &&
-            text.map((sub) =>
-              sub.documents.map((doc) => (
-                <div key={doc.mine_document_guid}>
-                  <LinkButton
-                    onClick={() => downloadFileFromDocumentManager(doc)}
-                    title={doc.document_name}
-                  >
-                    {truncateFilename(doc.document_name)}
-                    <br />
-                  </LinkButton>
-                </div>
-              ))
-            )) ||
+            text[text.length - 1].documents &&
+            text[text.length - 1].documents.length > 0 &&
+            text[text.length - 1].documents.map((document) => (
+              <LinkButton
+                key={document.mine_document_guid}
+                onClick={() => downloadFileFromDocumentManager(document)}
+                title={document.document_name}
+              >
+                {truncateFilename(document.document_name)}
+                <br />
+              </LinkButton>
+            ))) ||
             Strings.EMPTY_FIELD}
         </div>
       ),
     },
     {
       title: "",
-      dataIndex: "report",
+      dataIndex: "edit",
       render: (text, record) => {
         return (
           <div title="" align="right">

--- a/services/minespace-web/src/components/modalContent/reports/EditReportModal.js
+++ b/services/minespace-web/src/components/modalContent/reports/EditReportModal.js
@@ -1,28 +1,24 @@
 import React from "react";
 import PropTypes from "prop-types";
+import CustomPropTypes from "@/customPropTypes";
 import EditReportForm from "@/components/Forms/reports/EditReportForm";
 
 const propTypes = {
+  mineGuid: PropTypes.string.isRequired,
+  mineReport: CustomPropTypes.mineReport.isRequired,
   onSubmit: PropTypes.func.isRequired,
   closeModal: PropTypes.func.isRequired,
-  title: PropTypes.string.isRequired,
-  mineGuid: PropTypes.string.isRequired,
-  initialValues: PropTypes.objectOf(PropTypes.any),
 };
-
-const defaultProps = { initialValues: {} };
 
 export const EditReportModal = (props) => (
   <EditReportForm
+    mineGuid={props.mineGuid}
+    mineReport={props.mineReport}
     onSubmit={props.onSubmit}
     closeModal={props.closeModal}
-    title={props.title}
-    mineGuid={props.mineGuid}
-    initialValues={props.initialValues}
   />
 );
 
 EditReportModal.propTypes = propTypes;
-EditReportModal.defaultProps = defaultProps;
 
 export default EditReportModal;


### PR DESCRIPTION
# Main
**MDS-2669**: "Editing a CRR on MineSpace does not show existing documents, and adding new documents overwrites the set (and it only will upload a single document if multiple are provided)": Fixes a variety of issues with CRR on MineSpace:
* Don't allow proponents to delete documents added to a report in the Edit view!
* Fixes an issue where adding documents to an existing CRR in MineSpace did not work. We were improperly packaging the payload sent to the PUT method.
* Fixes an issue with displaying the documents for each CRR record in the MineSpace table

**MDS-2668**: "Uploading CRRs causes the drag & drop box to move, causing users to miss the upload box on subsequent uploads": Now the ~~uploaded files box is capped at 130px in the Add CRR view (see pic below) and 260px (the same as the Filepond upload box height) in the Edit CRR view.~~ positions of the file upload/uploaded files components have been swapped to solve this issue (thanks Ryan for the better idea!):
![image](https://user-images.githubusercontent.com/17113094/75910725-35474f00-5e03-11ea-9fb9-a6ff6e6238db.png)
# Other
* Fixes various "each child must have a key prop" error in Core and MS
* Fixes the styling of the "remove" buttons in the MineSpace "uploaded files" component to use the proper Ant Design styling:
![image](https://user-images.githubusercontent.com/17113094/75910265-6f642100-5e02-11ea-8de6-f0d8831cca82.png)
* Various other small tweaks to tidy/remove redundant code