### PR TITLE
bug/MDS-2653 escape file names. 

### DIFF
--- a/services/core-api/app/api/compliance/resources/compliance_document_resource.py
+++ b/services/core-api/app/api/compliance/resources/compliance_document_resource.py
@@ -6,25 +6,26 @@ from werkzeug.exceptions import NotFound, InternalServerError, BadRequest
 from app.api.constants import TIMEOUT_5_MINUTES
 from app.extensions import api, cache
 from app.api.utils.access_decorators import requires_role_view_all
-from app.api.utils.resources_mixins import UserMixin 
+from app.api.utils.resources_mixins import UserMixin
 
 from app.api.services.nris_download_service import NRISDownloadService
 
 DOWNLOAD_TOKEN_MODEL = api.model('DownloadToken', {'token_guid': fields.String})
 
+
 def DOWNLOAD_TOKEN(token_guid):
     return f'compliance-document:download-token:{token_guid}'
 
 
-class ComplianceDocumentTokenResource(Resource, UserMixin ):
-    @api.doc(description='Issues a one-time token for access to a document without auth headers.',
+class ComplianceDocumentTokenResource(Resource, UserMixin):
+    @api.doc(
+        description='Issues a one-time token for access to a document without auth headers.',
         params={'file_name': 'The file name for the download being requested.'})
     @api.marshal_with(DOWNLOAD_TOKEN_MODEL, code=200)
     @requires_role_view_all
     def get(self, inspection_id, attachment_id):
         documenturl = f'https://api.nrs.gov.bc.ca/nrisws-api/v1/attachments/{inspection_id}/attachment/{attachment_id}'
-        filename = request.args.get('file_name', '')
-
+        filename = request.args['file_name']
         token_guid = uuid.uuid4()
         cache.set(
             DOWNLOAD_TOKEN(token_guid), {
@@ -35,7 +36,7 @@ class ComplianceDocumentTokenResource(Resource, UserMixin ):
         return {'token_guid': token_guid}
 
 
-class ComplianceDocumentResource(Resource, UserMixin ):
+class ComplianceDocumentResource(Resource, UserMixin):
     @api.doc(
         description='Fetch an compliance document by id',
         params={'token': 'A one-time token issued for downloading the file.'})

--- a/services/core-api/app/api/services/nris_download_service.py
+++ b/services/core-api/app/api/services/nris_download_service.py
@@ -1,10 +1,10 @@
-import requests
-import urllib3
-import json
+import requests, urllib3, json
+from urllib.parse import quote
 from flask import Response, stream_with_context, request, current_app
 from requests.auth import HTTPBasicAuth
 from app.extensions import cache
 from app.api.constants import NRIS_REMOTE_TOKEN, TIMEOUT_60_MINUTES
+
 
 def _change_default_cipher():
     requests.packages.urllib3.disable_warnings()
@@ -15,11 +15,12 @@ def _change_default_cipher():
         # no pyopenssl support used / needed / available
         pass
 
+
 def _get_NRIS_token():
     result = cache.get(NRIS_REMOTE_TOKEN)
 
     if result is None:
-        
+
         _change_default_cipher()
 
         params = {
@@ -34,7 +35,8 @@ def _get_NRIS_token():
             resp = requests.get(
                 url=url,
                 params=params,
-                auth=(current_app.config['NRIS_REMOTE_CLIENT_ID'], current_app.config['NRIS_REMOTE_CLIENT_SECRET']))
+                auth=(current_app.config['NRIS_REMOTE_CLIENT_ID'],
+                      current_app.config['NRIS_REMOTE_CLIENT_SECRET']))
             try:
                 resp.raise_for_status()
             except:
@@ -44,6 +46,7 @@ def _get_NRIS_token():
             cache.set(NRIS_REMOTE_TOKEN, result, timeout=TIMEOUT_60_MINUTES)
 
     return result
+
 
 class NRISDownloadService():
     def download(file_url, file_name):
@@ -59,5 +62,5 @@ class NRISDownloadService():
 
         file_download_resp.headers['Content-Type'] = file_download_req.headers['Content-Type']
         file_download_resp.headers[
-            'Content-Disposition'] = f'attachment; filename="{file_name}"'
+            'Content-Disposition'] = f'attachment; filename="{quote(file_name)}"'
         return file_download_resp

--- a/services/core-api/app/api/services/nros_download_service.py
+++ b/services/core-api/app/api/services/nros_download_service.py
@@ -1,5 +1,5 @@
-import requests
-import json
+import requests, json
+from urllib.parse import quote
 from flask import Response, stream_with_context, request, current_app
 from requests.auth import HTTPBasicAuth
 from app.extensions import cache
@@ -32,5 +32,5 @@ class NROSDownloadService():
 
         file_download_resp.headers['Content-Type'] = file_download_req.headers['Content-Type']
         file_download_resp.headers[
-            'Content-Disposition'] = f'attachment; filename="{file_info_body["filename"]}"'
+            'Content-Disposition'] = f'attachment; filename="{quote(file_info_body["filename"])}"'
         return file_download_resp

--- a/services/core-api/app/api/services/vfcbc_download_service.py
+++ b/services/core-api/app/api/services/vfcbc_download_service.py
@@ -1,6 +1,6 @@
 import requests
 from flask import Response, stream_with_context, request, current_app
-from urllib.parse import urlparse
+from urllib.parse import urlparse, quote
 from app.extensions import cache
 from app.api.constants import VFCBC_COOKIES, TIMEOUT_60_MINUTES
 
@@ -59,6 +59,7 @@ class VFCBCDownloadService():
             stream_with_context(file_download_req.iter_content(chunk_size=2048)))
 
         file_download_resp.headers['Content-Type'] = file_download_req.headers['Content-Type']
-        file_download_resp.headers['Content-Disposition'] = f'attachment; filename="{file_name}"'
+        file_download_resp.headers[
+            'Content-Disposition'] = f'attachment; filename="{quote(file_name)}"'
 
         return file_download_resp

--- a/services/core-web/common/constants/API.js
+++ b/services/core-web/common/constants/API.js
@@ -180,6 +180,8 @@ export const MINE_PARTY_APPOINTMENT_DOCUMENTS = (mineGuid, minePartyAppointmentG
   `/mines/${mineGuid}/party-appts/${minePartyAppointmentGuid}/documents`;
 
 export const NRIS_DOCUMENT_TOKEN_GET_URL = (externalId, inspectionId, file_name) =>
-  `/compliance/inspection/${inspectionId}/document/${externalId}/token?file_name=${file_name}`;
+  `/compliance/inspection/${inspectionId}/document/${externalId}/token?${queryString.stringify({
+    file_name,
+  })}`;
 export const NRIS_DOCUMENT_FILE_GET_URL = (externalId, inspectionId, token) =>
   `/compliance/inspection/${inspectionId}/document/${externalId}?${queryString.stringify(token)}`;

--- a/services/minespace-web/common/constants/API.js
+++ b/services/minespace-web/common/constants/API.js
@@ -180,6 +180,8 @@ export const MINE_PARTY_APPOINTMENT_DOCUMENTS = (mineGuid, minePartyAppointmentG
   `/mines/${mineGuid}/party-appts/${minePartyAppointmentGuid}/documents`;
 
 export const NRIS_DOCUMENT_TOKEN_GET_URL = (externalId, inspectionId, file_name) =>
-  `/compliance/inspection/${inspectionId}/document/${externalId}/token?file_name=${file_name}`;
+  `/compliance/inspection/${inspectionId}/document/${externalId}/token?${queryString.stringify({
+    file_name,
+  })}`;
 export const NRIS_DOCUMENT_FILE_GET_URL = (externalId, inspectionId, token) =>
   `/compliance/inspection/${inspectionId}/document/${externalId}?${queryString.stringify(token)}`;


### PR DESCRIPTION
be sure to use querystring.jsonify() to properly escape query string params, axios doesn't do it perfectly. 

Backend uses to ensure safe responses. 
https://docs.python.org/3/library/urllib.parse.html#urllib.parse.quote