### PR TITLE
Allow 13 minutes for schemaspy deploy

### DIFF
--- a/openshift/templates/tools/schemaspy.dc.json
+++ b/openshift/templates/tools/schemaspy.dc.json
@@ -145,23 +145,25 @@
                   }
                 ],
                 "livenessProbe": {
-                  "failureThreshold": 3,
-                  "initialDelaySeconds": 25,
+                  "failureThreshold": 60,
+                  "initialDelaySeconds": 180,
                   "periodSeconds": 10,
                   "successThreshold": 1,
-                  "tcpSocket": {
-                    "port": 8080
-                  },
-                  "timeoutSeconds": 1
-                },
-                "readinessProbe": {
-                  "failureThreshold": 3,
                   "httpGet": {
                     "path": "/",
                     "port": 8080,
                     "scheme": "HTTP"
                   },
-                  "initialDelaySeconds": 25,
+                  "timeoutSeconds": 1
+                },
+                "readinessProbe": {
+                  "failureThreshold": 60,
+                  "httpGet": {
+                    "path": "/",
+                    "port": 8080,
+                    "scheme": "HTTP"
+                  },
+                  "initialDelaySeconds": 180,
                   "periodSeconds": 10,
                   "successThreshold": 1,
                   "timeoutSeconds": 1


### PR DESCRIPTION
Increase liveness check timeout to 3+10 minutes for schemaspy. It takes a while to go through all the schemas. The checks start at 3 minutes though, so it wont stall the pipeline for the whole 13 minutes.