### PR TITLE
MDS-2807: Update NoW Submissions POST Endpoint

### DIFF
--- a/services/core-api/app/api/now_applications/models/now_application_identity.py
+++ b/services/core-api/app/api/now_applications/models/now_application_identity.py
@@ -64,7 +64,7 @@ class NOWApplicationIdentity(Base, AuditMixin):
     def submission_count_ytd(cls, _mine_guid, _sub_year):
         try:
             return cls.query.filter_by(mine_guid=_mine_guid).filter(
-                cls.now_number.ilike(f'{_sub_year}%')).count()
+                cls.now_number.ilike(f'%-{_sub_year}-%')).count()
         except ValueError:
             return None
 

--- a/services/core-api/app/api/now_applications/models/now_application_identity.py
+++ b/services/core-api/app/api/now_applications/models/now_application_identity.py
@@ -72,4 +72,4 @@ class NOWApplicationIdentity(Base, AuditMixin):
     def create_now_number(cls, mine):
         current_year = datetime.now().strftime("%Y")
         number_of_now = cls.submission_count_ytd(mine.mine_guid, current_year)
-        return f'{current_year}-{mine.mine_no}-{str(number_of_now + 1).zfill(2)}'
+        return f'{mine.mine_no}-{current_year}-{str(number_of_now + 1).zfill(2)}'

--- a/services/core-api/app/api/now_submissions/resources/application_list_resource.py
+++ b/services/core-api/app/api/now_submissions/resources/application_list_resource.py
@@ -111,7 +111,6 @@ class ApplicationListResource(Resource, UserMixin):
     @api.doc(description='Save an application')
     @requires_role_edit_submissions
     @api.expect(APPLICATION)
-    @api.marshal_with(APPLICATION, code=201)
     def post(self):
         current_app.logger.debug('Attempting to load application')
         try:
@@ -139,4 +138,4 @@ class ApplicationListResource(Resource, UserMixin):
             now_number=NOWApplicationIdentity.create_now_number(mine))
         current_app.logger.debug('Attempting to Save')
         application.save()
-        return application, 201
+        return application.now_application_identity.now_number, 201

--- a/services/core-api/tests/now_application_factories.py
+++ b/services/core-api/tests/now_application_factories.py
@@ -444,6 +444,7 @@ class NOWApplicationIdentityFactory(BaseFactory):
     messageid = factory.SelfAttribute('now_submission.messageid')
     mms_cid = factory.Sequence(lambda n: n)
     mine_guid = factory.SelfAttribute('mine.mine_guid')
+    # TODO: Create a value that adheres to the actual structure of a NoW number
     now_number = factory.Sequence(lambda n: n)
 
     now_application = factory.SubFactory('tests.now_application_factories.NOWApplicationFactory')

--- a/services/core-api/tests/now_submissions/resources/test_application_list_resource.py
+++ b/services/core-api/tests/now_submissions/resources/test_application_list_resource.py
@@ -657,9 +657,7 @@ class TestGetApplicationListResource:
         post_data = json.loads(post_resp.data.decode())
 
         assert post_resp.status_code == 201, post_resp.response
-        assert post_data['messageid'] == NOW_APPLICATION_DATA['messageid']
-        assert post_data['application_guid'] is not None
-        assert post_data['mine_guid'] == str(mine.mine_guid)
+        assert post_data is not None
 
     def test_post_now_application_messageid_in_use(self, test_client, db_session, auth_headers):
         """Should return a 400 messageid in use"""


### PR DESCRIPTION
# Main
* Updates the NoW submissions POST endpoint to return the NoW number
E.g., new response is: `"72503195-2020-02"`.
* Changes NoW number structure from 'year-mine_number-now_count' to 'mine_number-year-now_count'

# Notes
Verified working NoW number generation:
![image](https://user-images.githubusercontent.com/17113094/79514156-64ec9800-7ffa-11ea-95d3-2299e804c30c.png)
