### PR TITLE
MDS-2777: Fix Null Received Date for CRRs Uploaded by BCeID Users

### DIFF
--- a/migrations/sql/V2020.04.21.12.54__set_received_date_for_bceid_uploaded_crrs.sql
+++ b/migrations/sql/V2020.04.21.12.54__set_received_date_for_bceid_uploaded_crrs.sql
@@ -1,0 +1,9 @@
+UPDATE mine_report mr1
+SET received_date = (
+    SELECT MIN(submission_date)
+    FROM mine_report mr2, mine_report_submission mrs
+    WHERE mr1.mine_report_id = mr2.mine_report_id
+        AND mrs.mine_report_id = mr1.mine_report_id
+    )
+WHERE mr1.created_by_idir ILIKE 'bceid%'
+    AND mr1.received_date IS NULL;


### PR DESCRIPTION
# Main
* Fixes a data quality issue caused by an old bug: Reports that were added by a BCeID user that do not have a received date set have their received date set to the report's earliest submission date.