### PR TITLE
MDS-2779: Fix Compliance Year for "First TSF-Generated" CRRs

### DIFF
--- a/services/core-api/app/api/mines/tailings/resources/tailings.py
+++ b/services/core-api/app/api/mines/tailings/resources/tailings.py
@@ -63,7 +63,7 @@ class MineTailingsStorageFacilityListResource(Resource, UserMixin):
                         mine_guid=mine.mine_guid,
                         due_date=calculated_due_date,
                         received_date=None,
-                        submission_year=calculated_due_date.year,
+                        submission_year=calculated_due_date.year - 1,
                         permit_id=None)
 
             except Exception as e:

--- a/services/core-api/app/api/mines/tailings/resources/tailings.py
+++ b/services/core-api/app/api/mines/tailings/resources/tailings.py
@@ -43,12 +43,14 @@ class MineTailingsStorageFacilityListResource(Resource, UserMixin):
             raise NotFound('Mine not found.')
 
         data = self.parser.parse_args()
+
+        mine_tsf_list = mine.mine_tailings_storage_facilities
+        is_mine_first_tsf = len(mine_tsf_list) == 0
+
         mine_tsf = MineTailingsStorageFacility.create(
             mine, mine_tailings_storage_facility_name=data['mine_tailings_storage_facility_name'])
         mine.mine_tailings_storage_facilities.append(mine_tsf)
 
-        mine_tsf_list = mine.mine_tailings_storage_facilities
-        is_mine_first_tsf = len(mine_tsf_list) == 0
         if is_mine_first_tsf:
             try:
                 tsf_required_reports = MineReportDefinition.find_required_reports_by_category('TSF')
@@ -68,4 +70,4 @@ class MineTailingsStorageFacilityListResource(Resource, UserMixin):
                 raise InternalServerError(str(e) + ", tsf not created")
 
         mine.save()
-        return mine_tsf
+        return mine_tsf, 201

--- a/services/core-api/app/api/mines/tailings/resources/tailings.py
+++ b/services/core-api/app/api/mines/tailings/resources/tailings.py
@@ -17,17 +17,16 @@ from app.api.mines.response_models import MINE_TSF_MODEL
 
 class MineTailingsStorageFacilityListResource(Resource, UserMixin):
     parser = reqparse.RequestParser()
-    parser.add_argument('mine_tailings_storage_facility_name',
-                        type=str,
-                        trim=True,
-                        help='Name of the tailings storage facility.',
-                        required=True)
+    parser.add_argument(
+        'mine_tailings_storage_facility_name',
+        type=str,
+        trim=True,
+        help='Name of the tailings storage facility.',
+        required=True)
 
     @api.doc(description='Gets the tailing storage facilites for the given mine')
-    @api.marshal_with(MINE_TSF_MODEL,
-                      envelope='mine_tailings_storage_facilities',
-                      as_list=True,
-                      code=200)
+    @api.marshal_with(
+        MINE_TSF_MODEL, envelope='mine_tailings_storage_facilities', as_list=True, code=200)
     @requires_role_view_all
     def get(self, mine_guid):
         mine = Mine.find_by_mine_guid(mine_guid)
@@ -36,22 +35,20 @@ class MineTailingsStorageFacilityListResource(Resource, UserMixin):
         return mine.mine_tailings_storage_facilities
 
     @api.doc(description='Creates a new tailing storage facility for the given mine')
-    @api.marshal_with(MINE_TSF_MODEL, code=200)
+    @api.marshal_with(MINE_TSF_MODEL, code=201)
     @requires_role_mine_edit
     def post(self, mine_guid):
         mine = Mine.find_by_mine_guid(mine_guid)
         if not mine:
             raise NotFound('Mine not found.')
 
-        # see if this would be the first TSF
-        mine_tsf_list = mine.mine_tailings_storage_facilities
-        is_mine_first_tsf = len(mine_tsf_list) == 0
-
         data = self.parser.parse_args()
         mine_tsf = MineTailingsStorageFacility.create(
             mine, mine_tailings_storage_facility_name=data['mine_tailings_storage_facility_name'])
         mine.mine_tailings_storage_facilities.append(mine_tsf)
 
+        mine_tsf_list = mine.mine_tailings_storage_facilities
+        is_mine_first_tsf = len(mine_tsf_list) == 0
         if is_mine_first_tsf:
             try:
                 tsf_required_reports = MineReportDefinition.find_required_reports_by_category('TSF')
@@ -65,10 +62,10 @@ class MineTailingsStorageFacilityListResource(Resource, UserMixin):
                         received_date=None,
                         submission_year=calculated_due_date.year - 1,
                         permit_id=None)
-
             except Exception as e:
                 db.session.rollback()
                 current_app.logger.error(str(e))
                 raise InternalServerError(str(e) + ", tsf not created")
+
         mine.save()
         return mine_tsf

--- a/services/core-api/tests/mines/tailings/resources/test_mine_tailings_resource.py
+++ b/services/core-api/tests/mines/tailings/resources/test_mine_tailings_resource.py
@@ -1,6 +1,8 @@
 import json
+from app.extensions import db
 from app.api.mines.tailings.models.tailings import MineTailingsStorageFacility
 from app.api.mines.reports.models.mine_report_definition import MineReportDefinition
+from app.api.mines.reports.models.mine_report import MineReport
 from tests.factories import MineFactory, MineTailingsStorageFacilityFactory
 
 
@@ -22,7 +24,7 @@ def test_post_mine_tailings_storage_facility_by_mine_guid(test_client, db_sessio
         f'/mines/{mine.mine_guid}/tailings',
         data={'mine_tailings_storage_facility_name': 'a name'},
         headers=auth_headers['full_auth_header'])
-    assert post_resp.status_code == 200
+    assert post_resp.status_code == 201
     assert len(mine.mine_tailings_storage_facilities) == org_mine_tsf_list_len + 1
 
 
@@ -35,7 +37,7 @@ def test_post_first_mine_tailings_storage_facility_by_mine_guid(test_client, db_
         f'/mines/{mine.mine_guid}/tailings',
         data={'mine_tailings_storage_facility_name': 'a name'},
         headers=auth_headers['full_auth_header'])
-    assert post_resp.status_code == 200
+    assert post_resp.status_code == 201
     assert len(mine.mine_tailings_storage_facilities) == 1
 
 
@@ -48,6 +50,6 @@ def test_post_first_mine_tailings_storage_facility_by_mine_guid_creates_tsf_requ
         f'/mines/{mine.mine_guid}/tailings',
         data={'mine_tailings_storage_facility_name': 'a name'},
         headers=auth_headers['full_auth_header'])
-    assert post_resp.status_code == 200
+    assert post_resp.status_code == 201
     tsf_required_reports = MineReportDefinition.find_required_reports_by_category('TSF')
     assert len(mine.mine_reports) == len(tsf_required_reports)

--- a/services/core-api/tests/mines/tailings/resources/test_mine_tailings_resource.py
+++ b/services/core-api/tests/mines/tailings/resources/test_mine_tailings_resource.py
@@ -1,14 +1,14 @@
 import json
 from app.api.mines.tailings.models.tailings import MineTailingsStorageFacility
+from app.api.mines.reports.models.mine_report_definition import MineReportDefinition
 from tests.factories import MineFactory, MineTailingsStorageFacilityFactory
 
 
-# GET
 def test_get_mine_tailings_storage_facility_by_mine_guid(test_client, db_session, auth_headers):
     tsf = MineTailingsStorageFacilityFactory()
 
-    get_resp = test_client.get(f'/mines/{tsf.mine_guid}/tailings',
-                               headers=auth_headers['full_auth_header'])
+    get_resp = test_client.get(
+        f'/mines/{tsf.mine_guid}/tailings', headers=auth_headers['full_auth_header'])
     get_data = json.loads(get_resp.data.decode())
     assert get_resp.status_code == 200, get_resp.response
     assert len(get_data['mine_tailings_storage_facilities']) == 1
@@ -18,11 +18,11 @@ def test_post_mine_tailings_storage_facility_by_mine_guid(test_client, db_sessio
     mine = MineFactory()
     org_mine_tsf_list_len = len(mine.mine_tailings_storage_facilities)
 
-    post_resp = test_client.post(f'/mines/{mine.mine_guid}/tailings',
-                                 data={'mine_tailings_storage_facility_name': 'a name'},
-                                 headers=auth_headers['full_auth_header'])
-    post_data = json.loads(post_resp.data.decode())
-    assert post_resp.status_code == 200
+    post_resp = test_client.post(
+        f'/mines/{mine.mine_guid}/tailings',
+        data={'mine_tailings_storage_facility_name': 'a name'},
+        headers=auth_headers['full_auth_header'])
+    assert post_resp.status_code == 201
     assert len(mine.mine_tailings_storage_facilities) == org_mine_tsf_list_len + 1
 
 
@@ -30,10 +30,24 @@ def test_post_first_mine_tailings_storage_facility_by_mine_guid(test_client, db_
                                                                 auth_headers):
     mine = MineFactory(minimal=True)
     assert len(mine.mine_tailings_storage_facilities) == 0
-    
-    post_resp = test_client.post(f'/mines/{mine.mine_guid}/tailings',
-                                 data={'mine_tailings_storage_facility_name': 'a name'},
-                                 headers=auth_headers['full_auth_header'])
-    assert post_resp.status_code == 200
-    post_data = json.loads(post_resp.data.decode())
+
+    post_resp = test_client.post(
+        f'/mines/{mine.mine_guid}/tailings',
+        data={'mine_tailings_storage_facility_name': 'a name'},
+        headers=auth_headers['full_auth_header'])
+    assert post_resp.status_code == 201
     assert len(mine.mine_tailings_storage_facilities) == 1
+
+
+def test_post_first_mine_tailings_storage_facility_by_mine_guid_creates_tsf_required_reports(
+    test_client, db_session, auth_headers):
+    mine = MineFactory(minimal=True)
+    assert len(mine.mine_tailings_storage_facilities) == 0
+
+    post_resp = test_client.post(
+        f'/mines/{mine.mine_guid}/tailings',
+        data={'mine_tailings_storage_facility_name': 'a name'},
+        headers=auth_headers['full_auth_header'])
+    assert post_resp.status_code == 201
+    tsf_required_reports = MineReportDefinition.find_required_reports_by_category('TSF')
+    assert len(mine.mine_reports) == len(tsf_required_reports)

--- a/services/core-api/tests/mines/tailings/resources/test_mine_tailings_resource.py
+++ b/services/core-api/tests/mines/tailings/resources/test_mine_tailings_resource.py
@@ -22,7 +22,7 @@ def test_post_mine_tailings_storage_facility_by_mine_guid(test_client, db_sessio
         f'/mines/{mine.mine_guid}/tailings',
         data={'mine_tailings_storage_facility_name': 'a name'},
         headers=auth_headers['full_auth_header'])
-    assert post_resp.status_code == 201
+    assert post_resp.status_code == 200
     assert len(mine.mine_tailings_storage_facilities) == org_mine_tsf_list_len + 1
 
 
@@ -35,7 +35,7 @@ def test_post_first_mine_tailings_storage_facility_by_mine_guid(test_client, db_
         f'/mines/{mine.mine_guid}/tailings',
         data={'mine_tailings_storage_facility_name': 'a name'},
         headers=auth_headers['full_auth_header'])
-    assert post_resp.status_code == 201
+    assert post_resp.status_code == 200
     assert len(mine.mine_tailings_storage_facilities) == 1
 
 
@@ -48,6 +48,6 @@ def test_post_first_mine_tailings_storage_facility_by_mine_guid_creates_tsf_requ
         f'/mines/{mine.mine_guid}/tailings',
         data={'mine_tailings_storage_facility_name': 'a name'},
         headers=auth_headers['full_auth_header'])
-    assert post_resp.status_code == 201
+    assert post_resp.status_code == 200
     tsf_required_reports = MineReportDefinition.find_required_reports_by_category('TSF')
     assert len(mine.mine_reports) == len(tsf_required_reports)


### PR DESCRIPTION
# Main
* Fixes the compliance year for reports that are added the first time a TSF is created for a mine (reduces the year by one from the report due date) and writes tests to ensure generating the CRRs work