### PR TITLE
MDS-2369: Sort CRR Dropdowns Alphabetically

### DIFF
--- a/services/core-api/app/api/now_applications/resources/now_application_list_resource.py
+++ b/services/core-api/app/api/now_applications/resources/now_application_list_resource.py
@@ -176,7 +176,7 @@ class NOWApplicationListResource(Resource, UserMixin):
         new_now = NOWApplicationIdentity(mine_guid=data['mine_guid'], permit=permit)
         new_now.now_application = NOWApplication(
             notice_of_work_type_code=data['notice_of_work_type_code'],
-            now_application_status_code='SUB',
+            now_application_status_code='REC',
             submitted_date=data['submitted_date'],
             received_date=data['received_date'])
 

--- a/services/core-web/common/utils/helpers.js
+++ b/services/core-web/common/utils/helpers.js
@@ -95,6 +95,11 @@ export const nullableStringSorter = (path) => (a, b) => {
   return aObj.localeCompare(bObj);
 };
 
+export const sortListObjectsByPropertyLocaleCompare = (list, property) =>
+  list.sort(nullableStringSorter(property));
+
+export const sortListObjectsByPropertyDate = (list, property) => list.sort(dateSorter(property));
+
 // Case insensitive filter for a SELECT field by label string
 export const caseInsensitiveLabelFilter = (input, option) =>
   option.props.children.toLowerCase().includes(input.toLowerCase());

--- a/services/core-web/src/components/Forms/reports/AddReportForm.js
+++ b/services/core-web/src/components/Forms/reports/AddReportForm.js
@@ -13,6 +13,7 @@ import {
   resetForm,
   createDropDownList,
   formatComplianceCodeValueOrLabel,
+  sortListObjectsByPropertyLocaleCompare,
 } from "@common/utils/helpers";
 import {
   getDropdownMineReportCategoryOptions,
@@ -84,10 +85,14 @@ export class AddReportForm extends Component {
       );
     }
 
-    const dropdownMineReportDefinitionOptionsFiltered = createDropDownList(
+    let dropdownMineReportDefinitionOptionsFiltered = createDropDownList(
       mineReportDefinitionOptionsFiltered,
       "report_name",
       "mine_report_definition_guid"
+    );
+    dropdownMineReportDefinitionOptionsFiltered = sortListObjectsByPropertyLocaleCompare(
+      dropdownMineReportDefinitionOptionsFiltered,
+      "label"
     );
 
     this.setState({

--- a/services/core-web/src/components/Forms/reports/ReportFilterForm.js
+++ b/services/core-web/src/components/Forms/reports/ReportFilterForm.js
@@ -9,7 +9,7 @@ import {
   getDropdownMineReportCategoryOptions,
   getMineReportDefinitionOptions,
 } from "@common/selectors/staticContentSelectors";
-import { createDropDownList } from "@common/utils/helpers";
+import { createDropDownList, sortListObjectsByPropertyLocaleCompare } from "@common/utils/helpers";
 import * as FORM from "@/constants/forms";
 import { renderConfig } from "@/components/common/config";
 import CustomPropTypes from "@/customPropTypes";
@@ -57,10 +57,14 @@ export class ReportFilterForm extends Component {
       );
     }
 
-    const dropdownMineReportDefinitionOptionsFiltered = createDropDownList(
+    let dropdownMineReportDefinitionOptionsFiltered = createDropDownList(
       mineReportDefinitionOptionsFiltered,
       "report_name",
       "mine_report_definition_guid"
+    );
+    dropdownMineReportDefinitionOptionsFiltered = sortListObjectsByPropertyLocaleCompare(
+      dropdownMineReportDefinitionOptionsFiltered,
+      "label"
     );
 
     this.setState({

--- a/services/core-web/src/components/Forms/reports/ReportSearchForm.js
+++ b/services/core-web/src/components/Forms/reports/ReportSearchForm.js
@@ -11,6 +11,7 @@ import {
   getDropdownMineReportDefinitionOptions,
   getMineRegionDropdownOptions,
 } from "@common/selectors/staticContentSelectors";
+import { sortListObjectsByPropertyLocaleCompare } from "@common/utils/helpers";
 import * as FORM from "@/constants/forms";
 import { renderConfig } from "@/components/common/config";
 import CustomPropTypes from "@/customPropTypes";
@@ -111,7 +112,10 @@ export class ReportSearchForm extends Component {
                   name="report_name"
                   placeholder="Select Report Name"
                   component={renderConfig.MULTI_SELECT}
-                  data={this.props.dropdownMineReportDefinitionOptions}
+                  data={sortListObjectsByPropertyLocaleCompare(
+                    this.props.dropdownMineReportDefinitionOptions,
+                    "label"
+                  )}
                 />
               </Col>
             </Row>

--- a/services/minespace-web/common/utils/helpers.js
+++ b/services/minespace-web/common/utils/helpers.js
@@ -95,6 +95,11 @@ export const nullableStringSorter = (path) => (a, b) => {
   return aObj.localeCompare(bObj);
 };
 
+export const sortListObjectsByPropertyLocaleCompare = (list, property) =>
+  list.sort(nullableStringSorter(property));
+
+export const sortListObjectsByPropertyDate = (list, property) => list.sort(dateSorter(property));
+
 // Case insensitive filter for a SELECT field by label string
 export const caseInsensitiveLabelFilter = (input, option) =>
   option.props.children.toLowerCase().includes(input.toLowerCase());

--- a/services/minespace-web/src/components/Forms/reports/AddReportForm.js
+++ b/services/minespace-web/src/components/Forms/reports/AddReportForm.js
@@ -10,7 +10,12 @@ import { Form, Button, Popconfirm, List, Typography } from "antd";
 import { renderConfig } from "@/components/common/config";
 import * as FORM from "@/constants/forms";
 import { required, yearNotInFuture } from "@common/utils/Validate";
-import { resetForm, createDropDownList, formatComplianceCodeValueOrLabel } from "@/utils/helpers";
+import {
+  resetForm,
+  createDropDownList,
+  formatComplianceCodeValueOrLabel,
+  sortListObjectsByPropertyLocaleCompare,
+} from "@common/utils/helpers";
 import {
   getDropdownMineReportCategoryOptions,
   getMineReportDefinitionOptions,
@@ -73,10 +78,14 @@ export class AddReportForm extends Component {
       );
     }
 
-    const dropdownMineReportDefinitionOptionsFiltered = createDropDownList(
+    let dropdownMineReportDefinitionOptionsFiltered = createDropDownList(
       mineReportDefinitionOptionsFiltered,
       "report_name",
       "mine_report_definition_guid"
+    );
+    dropdownMineReportDefinitionOptionsFiltered = sortListObjectsByPropertyLocaleCompare(
+      dropdownMineReportDefinitionOptionsFiltered,
+      "label"
     );
 
     this.setState({

--- a/services/minespace-web/src/components/Forms/variances/EditVarianceForm.js
+++ b/services/minespace-web/src/components/Forms/variances/EditVarianceForm.js
@@ -5,7 +5,7 @@ import { remove } from "lodash";
 import { Form, Button, Popconfirm, Typography } from "antd";
 import * as FORM from "@/constants/forms";
 import CustomPropTypes from "@/customPropTypes";
-import { resetForm } from "@/utils/helpers";
+import { resetForm } from "@common/utils/helpers";
 import { VarianceDetails } from "@/components/dashboard/mine/variances/VarianceDetails";
 import VarianceFileUpload from "@/components/Forms/variances/VarianceFileUpload";
 

--- a/services/minespace-web/src/components/dashboard/mine/reports/ReportsTable.js
+++ b/services/minespace-web/src/components/dashboard/mine/reports/ReportsTable.js
@@ -2,10 +2,14 @@ import React from "react";
 import { connect } from "react-redux";
 import { Table, Button } from "antd";
 import PropTypes from "prop-types";
-import { truncateFilename, dateSorter } from "@common/utils/helpers";
+import {
+  truncateFilename,
+  dateSorter,
+  formatComplianceCodeValueOrLabel,
+} from "@common/utils/helpers";
 import { downloadFileFromDocumentManager } from "@common/utils/actionlessNetworkCalls";
 import { getMineReportDefinitionHash } from "@common/selectors/staticContentSelectors";
-import { formatDate, formatComplianceCodeValueOrLabel } from "@/utils/helpers";
+import { formatDate } from "@/utils/helpers";
 import * as Strings from "@/constants/strings";
 import { EDIT_PENCIL } from "@/constants/assets";
 import CustomPropTypes from "@/customPropTypes";

--- a/services/minespace-web/src/utils/helpers.js
+++ b/services/minespace-web/src/utils/helpers.js
@@ -1,45 +1,4 @@
 import moment from "moment";
-import { reset } from "redux-form";
-/**
- * Helper function to clear redux form after submission
- *
- * Usage:
- *  export default (reduxForm({
-    form: formName,
-    onSubmitSuccess: resetForm(formName),
-  })(Component)
-  );
- *
- */
-export const resetForm = (form) => (result, dispatch) => dispatch(reset(form));
-
-// Function to create a reusable reducer (used in src/reducers/rootReducer)
-export const createReducer = (reducer, name) => (state, action) => {
-  if (name !== action.name && state !== undefined) {
-    return state;
-  }
-  return reducer(state, action);
-};
-// Function to create state object using the id as the key (used in src/reducers/<customReducer>)
-export const createItemMap = (array, idField) => {
-  const mapping = {};
-  // NOTE: Implementation chosen for performance
-  // Please do not refactor to use immutable data
-  array.forEach((item) => {
-    mapping[item[idField]] = item;
-  });
-  return mapping;
-};
-
-// Function create id array for redux state. (used in src/reducers/<customReducer>)
-export const createItemIdsArray = (array, idField) => array.map((item) => item[idField]);
-
-export const createDropDownList = (array, labelField, valueField) =>
-  array.map((item) => ({ value: item[valueField], label: item[labelField] }));
-
-// Function to create a hash given an array of values and labels
-export const createLabelHash = (obj) =>
-  obj.reduce((map, { value, label }) => ({ [value]: label, ...map }), {});
 
 // Function to format an API date string to human readable
 export const formatDate = (dateString) =>
@@ -47,13 +6,3 @@ export const formatDate = (dateString) =>
   dateString !== "9999-12-31" &&
   dateString !== "None" &&
   moment(dateString, "YYYY-MM-DD").format("MMM DD YYYY");
-
-export const formatComplianceCodeValueOrLabel = (code, showDescription) => {
-  const { section, sub_section, paragraph, sub_paragraph, description } = code;
-  const formattedSubSection = sub_section ? `.${sub_section}` : "";
-  const formattedParagraph = paragraph ? `.${paragraph}` : "";
-  const formattedSubParagraph = sub_paragraph !== null ? `.${sub_paragraph}` : "";
-  const formattedDescription = showDescription ? ` - ${description}` : "";
-
-  return `${section}${formattedSubSection}${formattedParagraph}${formattedSubParagraph}${formattedDescription}`;
-};


### PR DESCRIPTION
# Main
- Report Name dropdowns are now sorted alphabetically where they are used throughout our apps:
  - Core's Provincial Reports table filter, Core's Mine Reports table filter, Core's Add Report, MineSpace's Add Report
# Other
- Removes some useless helpers from MineSpace's `src/helpers` folder and uses the common helpers instead 