### PR TITLE
MDS-2934: Document Generation Does Not Successfully Upload File

### DIFF
--- a/services/core-api/app/api/document_generation/resources/now_document.py
+++ b/services/core-api/app/api/document_generation/resources/now_document.py
@@ -6,6 +6,7 @@ from app.extensions import api, cache
 
 from app.api.utils.resources_mixins import UserMixin
 from app.api.constants import NOW_DOCUMENT_DOWNLOAD_TOKEN
+from app.config import Config
 
 from app.api.mines.documents.models.mine_document import MineDocument
 from app.api.now_applications.models.now_application_identity import NOWApplicationIdentity
@@ -77,6 +78,7 @@ class NoticeOfWorkDocumentResource(Resource, UserMixin):
 
         # Return the generated document
         file_gen_resp = Response(
-            stream_with_context(docgen_resp.iter_content(chunk_size=2048)),
+            stream_with_context(
+                docgen_resp.iter_content(chunk_size=Config.DOCUMENT_UPLOAD_CHUNK_SIZE_BYTES)),
             headers=dict(docgen_resp.headers))
         return file_gen_resp

--- a/services/core-api/app/api/services/document_manager_service.py
+++ b/services/core-api/app/api/services/document_manager_service.py
@@ -48,7 +48,9 @@ class DocumentManagerService():
         }
 
         my_client = client.TusClient(cls.document_manager_url, headers=data)
-        uploader = my_client.uploader(file_stream=io.BytesIO(file_content), chunk_size=2048)
+        uploader = my_client.uploader(
+            file_stream=io.BytesIO(file_content),
+            chunk_size=Config.DOCUMENT_UPLOAD_CHUNK_SIZE_BYTES)
         uploader.upload()
         document_manager_guid = uploader.url.rsplit('/', 1)[-1]
         return document_manager_guid

--- a/services/core-api/app/api/services/nris_download_service.py
+++ b/services/core-api/app/api/services/nris_download_service.py
@@ -4,6 +4,7 @@ from flask import Response, stream_with_context, request, current_app
 from requests.auth import HTTPBasicAuth
 from app.extensions import cache
 from app.api.constants import NRIS_REMOTE_TOKEN, TIMEOUT_60_MINUTES
+from app.config import Config
 
 
 def _change_default_cipher():
@@ -58,7 +59,8 @@ class NRISDownloadService():
             f'{file_url}', stream=True, headers={"Authorization": f"Bearer {_nris_token}"})
 
         file_download_resp = Response(
-            stream_with_context(file_download_req.iter_content(chunk_size=2048)))
+            stream_with_context(
+                file_download_req.iter_content(chunk_size=Config.DOCUMENT_UPLOAD_CHUNK_SIZE_BYTES)))
 
         file_download_resp.headers['Content-Type'] = file_download_req.headers['Content-Type']
         file_download_resp.headers[

--- a/services/core-api/app/api/services/nros_download_service.py
+++ b/services/core-api/app/api/services/nros_download_service.py
@@ -4,6 +4,7 @@ from flask import Response, stream_with_context, request, current_app
 from requests.auth import HTTPBasicAuth
 from app.extensions import cache
 from app.api.constants import NROS_TOKEN, TIMEOUT_60_MINUTES
+from app.config import Config
 
 
 class NROSDownloadService():
@@ -28,7 +29,8 @@ class NROSDownloadService():
             f'{file_url}/content', stream=True, headers={"Authorization": f"Bearer {_nros_token}"})
 
         file_download_resp = Response(
-            stream_with_context(file_download_req.iter_content(chunk_size=2048)))
+            stream_with_context(
+                file_download_req.iter_content(chunk_size=Config.DOCUMENT_UPLOAD_CHUNK_SIZE_BYTES)))
 
         file_download_resp.headers['Content-Type'] = file_download_req.headers['Content-Type']
         file_download_resp.headers[

--- a/services/core-api/app/api/services/vfcbc_download_service.py
+++ b/services/core-api/app/api/services/vfcbc_download_service.py
@@ -3,6 +3,7 @@ from flask import Response, stream_with_context, request, current_app
 from urllib.parse import urlparse, quote
 from app.extensions import cache
 from app.api.constants import VFCBC_COOKIES, TIMEOUT_60_MINUTES
+from app.config import Config
 
 
 def vfcbc_login(download_session):
@@ -56,7 +57,8 @@ class VFCBCDownloadService():
         file_download_req = download_session.get(file_url, stream=True)
 
         file_download_resp = Response(
-            stream_with_context(file_download_req.iter_content(chunk_size=2048)))
+            stream_with_context(
+                file_download_req.iter_content(chunk_size=Config.DOCUMENT_UPLOAD_CHUNK_SIZE_BYTES)))
 
         file_download_resp.headers['Content-Type'] = file_download_req.headers['Content-Type']
         file_download_resp.headers[

--- a/services/core-api/app/config.py
+++ b/services/core-api/app/config.py
@@ -72,6 +72,8 @@ class Config(object):
     DOCUMENT_MANAGER_URL = os.environ.get('DOCUMENT_MANAGER_URL',
                                           'http://document_manager_backend:5001')
     DOCUMENT_GENERATOR_URL = os.environ.get('DOCUMENT_GENERATOR_URL', 'http://docgen-api:3030')
+    DOCUMENT_UPLOAD_CHUNK_SIZE_BYTES = int(
+        os.environ.get('DOCUMENT_UPLOAD_CHUNK_SIZE_BYTES', '1048576'))
     NRIS_TOKEN_URL = os.environ.get('NRIS_TOKEN_URL', None)
     NRIS_API_URL = os.environ.get('NRIS_API_URL', 'http://nris_backend:5500')
 

--- a/services/document-manager/backend/app/config.py
+++ b/services/document-manager/backend/app/config.py
@@ -46,7 +46,7 @@ class Config(object):
     CACHE_REDIS_URL = 'redis://:{0}@{1}:{2}'.format(CACHE_REDIS_PASS, CACHE_REDIS_HOST,
                                                     CACHE_REDIS_PORT)
 
-    DOCUMENT_MANAGER_URL = os.environ.get('DOCUMENT_MANAGER_URL', 'http://localhost:5001')
+    DOCUMENT_MANAGER_URL = os.environ.get('DOCUMENT_MANAGER_URL', 'http://document_manager_backend:5001')
     UPLOADED_DOCUMENT_DEST = os.environ.get('UPLOADED_DOCUMENT_DEST', '/app/document_uploads')
 
     MAX_CONTENT_LENGTH = 750 * 1024 * 1024

--- a/services/document-manager/backend/app/config.py
+++ b/services/document-manager/backend/app/config.py
@@ -46,8 +46,7 @@ class Config(object):
     CACHE_REDIS_URL = 'redis://:{0}@{1}:{2}'.format(CACHE_REDIS_PASS, CACHE_REDIS_HOST,
                                                     CACHE_REDIS_PORT)
 
-    DOCUMENT_MANAGER_URL = os.environ.get('DOCUMENT_MANAGER_URL',
-                                          'http://document_manager_backend:5001')
+    DOCUMENT_MANAGER_URL = os.environ.get('DOCUMENT_MANAGER_URL', 'http://localhost:5001')
     UPLOADED_DOCUMENT_DEST = os.environ.get('UPLOADED_DOCUMENT_DEST', '/app/document_uploads')
 
     MAX_CONTENT_LENGTH = 750 * 1024 * 1024
@@ -56,7 +55,7 @@ class Config(object):
     TUSD_URL = os.environ.get('TUSD_URL', 'http://tusd:1080/files/')
 
     # Document hosting settings
-    OBJECT_STORE_ENABLED = os.environ.get('OBJECT_STORE_ENABLED', False)
+    OBJECT_STORE_ENABLED = bool(int(os.environ.get('OBJECT_STORE_ENABLED', '0')))
     OBJECT_STORE_HOST = os.environ.get('OBJECT_STORE_HOST', '')
     OBJECT_STORE_ACCESS_KEY_ID = os.environ.get('OBJECT_STORE_ACCESS_KEY_ID', '')
     OBJECT_STORE_ACCESS_KEY = os.environ.get('OBJECT_STORE_ACCESS_KEY', '')

--- a/services/document-manager/backend/app/docman/resources/document.py
+++ b/services/document-manager/backend/app/docman/resources/document.py
@@ -234,7 +234,7 @@ class DocumentResource(Resource):
     @requires_any_of(DOCUMENT_UPLOAD_ROLES)
     def head(self, document_guid):
         file_path = cache.get(FILE_UPLOAD_PATH(document_guid))
-        if file_path is None or not os.path.lexists(file_path):
+        if file_path is None:
             raise NotFound('File does not exist')
 
         response = make_response('', 200)


### PR DESCRIPTION
# Main
* Fixes an issue where document generation (i.e., generating a NoW document) did not successfully upload the generated file

# Other
* Creates and uses a "document upload chunk size" constant to be used where files are streamed. The previous size was small and decreased performance (2 KB). The size has been increased to match the front end's upload chunk size of 1 MB.
* Fixes an issue where the OBJECT_STORE_ENABLED env variable would not be parsed correctly

**Note**: We verified that regular file upload still works locally for both when the object store was enabled/disabled.