### PR TITLE
MDS-2929: Implement Bond Closed Date/Notes (Modify Bond Confiscate/Release Flow)

### DIFF
--- a/migrations/sql/V2020.07.15.08.18__add_bond_closed_date_and_notes.sql
+++ b/migrations/sql/V2020.07.15.08.18__add_bond_closed_date_and_notes.sql
@@ -1,0 +1,8 @@
+ALTER TABLE bond ADD COLUMN IF NOT EXISTS closed_date timestamp;
+ALTER TABLE bond ADD COLUMN IF NOT EXISTS closed_note varchar;
+
+ALTER TABLE bond_history ADD COLUMN IF NOT EXISTS closed_date timestamp;
+ALTER TABLE bond_history ADD COLUMN IF NOT EXISTS closed_note varchar;
+
+UPDATE bond SET closed_date = update_timestamp WHERE bond_status_code in ('REL', 'CON');
+UPDATE bond_history SET closed_date = update_timestamp WHERE bond_status_code in ('REL', 'CON');

--- a/migrations/sql/V2020.07.15.08.18__add_bond_closed_date_and_notes.sql
+++ b/migrations/sql/V2020.07.15.08.18__add_bond_closed_date_and_notes.sql
@@ -4,5 +4,5 @@ ALTER TABLE bond ADD COLUMN IF NOT EXISTS closed_note varchar;
 ALTER TABLE bond_history ADD COLUMN IF NOT EXISTS closed_date timestamp;
 ALTER TABLE bond_history ADD COLUMN IF NOT EXISTS closed_note varchar;
 
-UPDATE bond SET closed_date = update_timestamp WHERE bond_status_code in ('REL', 'CON');
-UPDATE bond_history SET closed_date = update_timestamp WHERE bond_status_code in ('REL', 'CON');
+UPDATE bond SET closed_date = update_timestamp WHERE closed_date IS NULL AND bond_status_code in ('REL', 'CON');
+UPDATE bond_history SET closed_date = update_timestamp WHERE closed_date IS NULL AND bond_status_code in ('REL', 'CON');

--- a/migrations/sql/V2020.07.15.08.18__add_bond_closed_date_and_notes.sql
+++ b/migrations/sql/V2020.07.15.08.18__add_bond_closed_date_and_notes.sql
@@ -5,4 +5,6 @@ ALTER TABLE bond_history ADD COLUMN IF NOT EXISTS closed_date timestamp;
 ALTER TABLE bond_history ADD COLUMN IF NOT EXISTS closed_note varchar;
 
 UPDATE bond SET closed_date = update_timestamp WHERE closed_date IS NULL AND bond_status_code in ('REL', 'CON');
-UPDATE bond_history SET closed_date = update_timestamp WHERE closed_date IS NULL AND bond_status_code in ('REL', 'CON');
+UPDATE bond_history SET closed_date =
+    (SELECT MIN(update_timestamp) FROM bond_history bh2 WHERE bh2.bond_history_id = bond_history.bond_history_id AND bh2.bond_status_code IN ('REL', 'CON'))
+WHERE closed_date IS NULL AND bond_status_code in ('REL', 'CON');

--- a/migrations/sql/V2020.07.15.08.33__update_bond_view_with_closed_date_and_notes.sql
+++ b/migrations/sql/V2020.07.15.08.33__update_bond_view_with_closed_date_and_notes.sql
@@ -1,0 +1,79 @@
+DROP VIEW IF EXISTS bond_view;
+CREATE VIEW bond_view AS
+SELECT
+    *
+FROM
+    (
+    SELECT
+        bond.bond_id,
+        amount,
+        bond.bond_type_code,
+        bond_type.description as "bond_type_description",
+        bond.bond_status_code,
+        bond_status.description as "bond_status_description",
+        issue_date,
+        note,
+        closed_date,
+        closed_note,
+        payer_party_guid,
+        party_name AS "payer_name",
+        institution_city,
+        institution_name,
+        institution_postal_code,
+        institution_province,
+        institution_street,        
+        permit_guid,
+        permit_no,
+        project_id,
+        reference_number,
+        bond.update_timestamp,
+        bond.update_user,
+        'Yes' AS "is_current_record"
+    FROM
+        bond,
+        party,
+        permit,
+        bond_permit_xref,
+        bond_type,
+        bond_status
+    WHERE
+        bond.payer_party_guid = party.party_guid
+        AND permit.permit_id = bond_permit_xref.permit_id
+        AND bond.bond_id = bond_permit_xref.bond_id
+        AND bond.bond_type_code = bond_type.bond_type_code
+        AND bond.bond_status_code = bond_status.bond_status_code        
+    UNION ALL 
+    SELECT
+        bond_id,
+        amount,
+        bond_history.bond_type_code,
+        bond_type.description as "bond_type_description",
+        bond_history.bond_status_code,
+        bond_status.description as "bond_status_description",
+        issue_date,
+        note,
+        closed_date,
+        closed_note,        
+        payer_party_guid,
+        payer_name,
+        institution_city,
+        institution_name,
+        institution_postal_code,
+        institution_province,
+        institution_street,        
+        permit_guid,
+        permit_no,
+        project_id,
+        reference_number,
+        bond_history.update_timestamp,
+        bond_history.update_user,
+        'No' AS "is_current_record"
+    FROM
+        bond_history,
+        bond_type,
+        bond_status
+    WHERE
+        bond_history.bond_type_code = bond_type.bond_type_code
+        AND bond_history.bond_status_code = bond_status.bond_status_code
+    ) AS bond_data
+ORDER BY bond_id, is_current_record DESC;

--- a/services/core-api/app/api/securities/models/bond.py
+++ b/services/core-api/app/api/securities/models/bond.py
@@ -44,6 +44,8 @@ class Bond(Base, AuditMixin):
     payer = db.relationship('Party', lazy='joined')
     permit = db.relationship('Permit', uselist=False, lazy='joined', secondary='bond_permit_xref')
     documents = db.relationship('BondDocument', lazy='select')
+    closed_date = db.Column(db.DateTime)
+    closed_note = db.Column(db.String)
 
     def __repr__(self):
         return '<Bond %r>' % self.bond_guid

--- a/services/core-api/app/api/securities/models/bond_history.py
+++ b/services/core-api/app/api/securities/models/bond_history.py
@@ -31,6 +31,8 @@ class BondHistory(Base):
     institution_postal_code = db.Column(db.String)
     note = db.Column(db.String)
     project_id = db.Column(db.String)
+    closed_date = db.Column(db.DateTime)
+    closed_note = db.Column(db.String)
     update_user = db.Column(
         db.String,
         nullable=False,

--- a/services/core-api/app/api/securities/response_models.py
+++ b/services/core-api/app/api/securities/response_models.py
@@ -42,6 +42,8 @@ BOND = api.model(
         'institution_province': fields.String,
         'institution_postal_code': fields.String,
         'note': fields.String,
+        'closed_date': fields.DateTime,
+        'closed_note': fields.String,
         'payer': fields.Nested(BOND_PARTY),
         'project_id': fields.String,
         'permit_guid': fields.String(attribute='permit.permit_guid'),

--- a/services/core-web/common/utils/Validate.js
+++ b/services/core-web/common/utils/Validate.js
@@ -116,6 +116,18 @@ export const validateStartDate = memoize((previousStartDate) => (value) =>
 export const dateNotInFuture = (value) =>
   value && new Date(value) >= new Date() ? "Date cannot be in the future" : undefined;
 
+export const dateNotBeforeOther = memoize((other) => (value) =>
+  value && other && new Date(value) <= new Date(other)
+    ? `Date cannot be on or before ${other}`
+    : undefined
+);
+
+export const dateNotAfterOther = memoize((other) => (value) =>
+  value && other && new Date(value) >= new Date(other)
+    ? `Date cannot be on or after ${other}`
+    : undefined
+);
+
 export const yearNotInFuture = (value) =>
   value && value > new Date().getFullYear() ? "Year cannot be in the future" : undefined;
 

--- a/services/core-web/src/components/Forms/Securities/BondForm.js
+++ b/services/core-web/src/components/Forms/Securities/BondForm.js
@@ -29,12 +29,14 @@ const propTypes = {
   closeModal: PropTypes.func.isRequired,
   title: PropTypes.string.isRequired,
   submitting: PropTypes.bool.isRequired,
+  pristine: PropTypes.bool.isRequired,
   bond: CustomPropTypes.bond.isRequired,
   mineGuid: PropTypes.string.isRequired,
   provinceOptions: PropTypes.arrayOf(CustomPropTypes.dropdownListItem).isRequired,
   bondTypeDropDownOptions: PropTypes.arrayOf(CustomPropTypes.dropdownListItem).isRequired,
   bondDocumentTypeDropDownOptions: PropTypes.arrayOf(CustomPropTypes.dropdownListItem).isRequired,
   bondDocumentTypeOptionsHash: PropTypes.objectOf(PropTypes.string).isRequired,
+  bondStatusOptionsHash: PropTypes.objectOf(PropTypes.string).isRequired,
   initialPartyValue: PropTypes.objectOf(PropTypes.string),
   editBond: PropTypes.bool,
 };
@@ -94,6 +96,12 @@ export class BondForm extends Component {
       []
     );
 
+    const isBondClosed =
+      this.props.bond.bond_status_code === "REL" || this.props.bond.bond_status_code === "CON";
+    const bondStatusDescription = this.props.bondStatusOptionsHash[
+      this.props.bond.bond_status_code
+    ];
+
     return (
       <Form
         layout="vertical"
@@ -145,6 +153,7 @@ export class BondForm extends Component {
                 component={RenderSelect}
                 data={this.props.bondTypeDropDownOptions}
                 validate={[required]}
+                disabled={this.props.bond.bond_status_code === "CON"}
               />
             </Form.Item>
           </Col>
@@ -193,6 +202,40 @@ export class BondForm extends Component {
             </Form.Item>
           </Col>
         </Row>
+        <Row>
+          <Col md={24}>
+            <Form.Item>
+              <Field id="note" name="note" label="Notes" component={RenderAutoSizeField} />
+            </Form.Item>
+          </Col>
+        </Row>
+        {this.props.editBond && isBondClosed && (
+          <Row gutter={16}>
+            <Col md={12} sm={24}>
+              <Form.Item>
+                <Field
+                  id="closed_date"
+                  name="closed_date"
+                  label={`${bondStatusDescription} Date*`}
+                  showTime
+                  component={RenderDate}
+                  validate={[required, dateNotInFuture]}
+                />
+              </Form.Item>
+            </Col>
+            <Col md={12} sm={24}>
+              <Form.Item>
+                <Field
+                  id="closed_note"
+                  name="closed_note"
+                  label={`${bondStatusDescription} Notes`}
+                  component={RenderAutoSizeField}
+                  validate={[maxLength(4000)]}
+                />
+              </Form.Item>
+            </Col>
+          </Row>
+        )}
         <Row gutter={16}>
           <Col md={12} xs={24}>
             <h5>Institution</h5>
@@ -256,13 +299,6 @@ export class BondForm extends Component {
                 validate={[maxLength(6), postalCode]}
                 normalize={upperCase}
               />
-            </Form.Item>
-          </Col>
-        </Row>
-        <Row>
-          <Col md={24}>
-            <Form.Item>
-              <Field id="note" name="note" label="Notes" component={RenderAutoSizeField} />
             </Form.Item>
           </Col>
         </Row>
@@ -330,7 +366,7 @@ export class BondForm extends Component {
             className="full-mobile"
             type="primary"
             htmlType="submit"
-            disabled={this.props.submitting}
+            disabled={this.props.submitting || this.props.pristine}
           >
             {this.props.title}
           </Button>

--- a/services/core-web/src/components/Forms/Securities/BondForm.js
+++ b/services/core-web/src/components/Forms/Securities/BondForm.js
@@ -9,6 +9,8 @@ import {
   maxLength,
   dateNotInFuture,
   currency,
+  dateNotBeforeOther,
+  dateNotAfterOther,
 } from "@common/utils/Validate";
 import { resetForm, upperCase, currencyMask } from "@common/utils/helpers";
 import { BOND_DOCUMENTS } from "@common/constants/API";
@@ -180,7 +182,11 @@ export class BondForm extends Component {
                 label="Issue Date*"
                 showTime
                 component={RenderDate}
-                validate={[required, dateNotInFuture]}
+                validate={[
+                  required,
+                  dateNotInFuture,
+                  dateNotAfterOther(this.props.bond.closed_date),
+                ]}
               />
             </Form.Item>
           </Col>
@@ -219,7 +225,11 @@ export class BondForm extends Component {
                   label={`${bondStatusDescription} Date*`}
                   showTime
                   component={RenderDate}
-                  validate={[required, dateNotInFuture]}
+                  validate={[
+                    required,
+                    dateNotInFuture,
+                    dateNotBeforeOther(this.props.bond.issue_date),
+                  ]}
                 />
               </Form.Item>
             </Col>

--- a/services/core-web/src/components/Forms/Securities/CloseBondForm.js
+++ b/services/core-web/src/components/Forms/Securities/CloseBondForm.js
@@ -13,14 +13,13 @@ const propTypes = {
   closeModal: PropTypes.func.isRequired,
   title: PropTypes.string.isRequired,
   bondStatusCode: PropTypes.string.isRequired,
+  bondStatusOptionsHash: PropTypes.objectOf(PropTypes.string).isRequired,
   submitting: PropTypes.bool.isRequired,
   pristine: PropTypes.bool.isRequired,
 };
 
 export const CloseBondForm = (props) => {
-  const closeType =
-    (props.bondStatusCode === "REL" && "Release") ||
-    (props.bondStatusCode === "CON" && "Confiscate");
+  const bondStatusDescription = props.bondStatusOptionsHash[props.bondStatusCode];
   return (
     <Form layout="vertical" onSubmit={props.handleSubmit}>
       <Row>
@@ -29,7 +28,7 @@ export const CloseBondForm = (props) => {
             <Field
               id="closed_date"
               name="closed_date"
-              label={`${closeType}d Date*`}
+              label={`${bondStatusDescription} Date*`}
               showTime
               component={RenderDate}
               validate={[required, dateNotInFuture]}
@@ -43,7 +42,7 @@ export const CloseBondForm = (props) => {
             <Field
               id="closed_note"
               name="closed_note"
-              label={`${closeType} Notes`}
+              label={`${bondStatusDescription} Notes`}
               component={RenderAutoSizeField}
               validate={[maxLength(4000)]}
             />

--- a/services/core-web/src/components/Forms/Securities/CloseBondForm.js
+++ b/services/core-web/src/components/Forms/Securities/CloseBondForm.js
@@ -2,16 +2,18 @@ import React from "react";
 import PropTypes from "prop-types";
 import { Field, reduxForm } from "redux-form";
 import { Form, Button, Col, Row, Popconfirm } from "antd";
-import { required, dateNotInFuture, maxLength } from "@common/utils/Validate";
+import { required, dateNotInFuture, maxLength, dateNotBeforeOther } from "@common/utils/Validate";
 import { resetForm } from "@common/utils/helpers";
 import * as FORM from "@/constants/forms";
 import RenderAutoSizeField from "@/components/common/RenderAutoSizeField";
 import RenderDate from "@/components/common/RenderDate";
+import CustomPropTypes from "@/customPropTypes";
 
 const propTypes = {
   handleSubmit: PropTypes.func.isRequired,
   closeModal: PropTypes.func.isRequired,
   title: PropTypes.string.isRequired,
+  bond: CustomPropTypes.bond.isRequired,
   bondStatusCode: PropTypes.string.isRequired,
   bondStatusOptionsHash: PropTypes.objectOf(PropTypes.string).isRequired,
   submitting: PropTypes.bool.isRequired,
@@ -19,6 +21,7 @@ const propTypes = {
 };
 
 export const CloseBondForm = (props) => {
+  console.log(props.bond);
   const bondStatusDescription = props.bondStatusOptionsHash[props.bondStatusCode];
   return (
     <Form layout="vertical" onSubmit={props.handleSubmit}>
@@ -31,7 +34,7 @@ export const CloseBondForm = (props) => {
               label={`${bondStatusDescription} Date*`}
               showTime
               component={RenderDate}
-              validate={[required, dateNotInFuture]}
+              validate={[required, dateNotInFuture, dateNotBeforeOther(props.bond.issue_date)]}
             />
           </Form.Item>
         </Col>

--- a/services/core-web/src/components/Forms/Securities/CloseBondForm.js
+++ b/services/core-web/src/components/Forms/Securities/CloseBondForm.js
@@ -1,0 +1,84 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Field, reduxForm } from "redux-form";
+import { Form, Button, Col, Row, Popconfirm } from "antd";
+import { required, dateNotInFuture, maxLength } from "@common/utils/Validate";
+import { resetForm } from "@common/utils/helpers";
+import * as FORM from "@/constants/forms";
+import RenderAutoSizeField from "@/components/common/RenderAutoSizeField";
+import RenderDate from "@/components/common/RenderDate";
+
+const propTypes = {
+  handleSubmit: PropTypes.func.isRequired,
+  closeModal: PropTypes.func.isRequired,
+  title: PropTypes.string.isRequired,
+  bondStatusCode: PropTypes.string.isRequired,
+  submitting: PropTypes.bool.isRequired,
+  pristine: PropTypes.bool.isRequired,
+};
+
+export const CloseBondForm = (props) => {
+  const closeType =
+    (props.bondStatusCode === "REL" && "Release") ||
+    (props.bondStatusCode === "CON" && "Confiscate");
+  return (
+    <Form layout="vertical" onSubmit={props.handleSubmit}>
+      <Row>
+        <Col>
+          <Form.Item>
+            <Field
+              id="closed_date"
+              name="closed_date"
+              label={`${closeType}d Date*`}
+              showTime
+              component={RenderDate}
+              validate={[required, dateNotInFuture]}
+            />
+          </Form.Item>
+        </Col>
+      </Row>
+      <Row>
+        <Col>
+          <Form.Item>
+            <Field
+              id="closed_note"
+              name="closed_note"
+              label={`${closeType} Notes`}
+              component={RenderAutoSizeField}
+              validate={[maxLength(4000)]}
+            />
+          </Form.Item>
+        </Col>
+      </Row>
+      <div className="right center-mobile">
+        <Popconfirm
+          placement="topRight"
+          title="Are you sure you want to cancel?"
+          onConfirm={props.closeModal}
+          okText="Yes"
+          cancelText="No"
+        >
+          <Button className="full-mobile" type="secondary">
+            Cancel
+          </Button>
+        </Popconfirm>
+        <Button
+          className="full-mobile"
+          type="primary"
+          htmlType="submit"
+          disabled={props.submitting || props.pristine}
+        >
+          {props.title}
+        </Button>
+      </div>
+    </Form>
+  );
+};
+
+CloseBondForm.propTypes = propTypes;
+
+export default reduxForm({
+  form: FORM.CLOSE_BOND,
+  touchOnBlur: false,
+  onSubmitSuccess: resetForm(FORM.CLOSE_BOND),
+})(CloseBondForm);

--- a/services/core-web/src/components/mine/Securities/MineBondTable.js
+++ b/services/core-web/src/components/mine/Securities/MineBondTable.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Menu, Dropdown, Button, Icon, Tooltip, Table, Popconfirm } from "antd";
+import { Menu, Dropdown, Button, Icon, Tooltip, Table } from "antd";
 import PropTypes from "prop-types";
 import * as Strings from "@common/constants/strings";
 import { formatDate, dateSorter, formatMoney } from "@common/utils/helpers";
@@ -34,7 +34,7 @@ const propTypes = {
   // eslint-disable-next-line react/no-unused-prop-types
   openAddBondModal: PropTypes.func.isRequired,
   // eslint-disable-next-line react/no-unused-prop-types
-  releaseOrConfiscateBond: PropTypes.func.isRequired,
+  openCloseBondModal: PropTypes.func.isRequired,
   // eslint-disable-next-line react/no-unused-prop-types
   onExpand: PropTypes.func.isRequired,
   // eslint-disable-next-line react/no-unused-prop-types
@@ -173,47 +173,36 @@ export const MineBondTable = (props) => {
         const menu = (
           <Menu>
             {record.bond_status_code === "ACT" && (
-              <span>
-                <div className="custom-menu-item">
-                  <Popconfirm
-                    placement="leftTop"
-                    title={`Are you sure you want to release Bond ${record.bond_id}?`}
-                    onConfirm={() => props.releaseOrConfiscateBond("REL", record.bond_guid, record)}
-                    okText="Release"
-                    cancelText="Cancel"
+              <>
+                <Menu.Item key="release" className="custom-menu-item">
+                  <button
+                    type="button"
+                    onClick={(event) => props.openCloseBondModal(event, record, "REL")}
                   >
-                    <button type="button" className="full">
-                      Release Bond
-                    </button>
-                  </Popconfirm>
-                </div>
-                <div className="custom-menu-item">
-                  <Popconfirm
-                    placement="leftTop"
-                    title="Are you sure you want to confiscate this bond? Doing so will convert the bond type to cash."
-                    onConfirm={() => props.releaseOrConfiscateBond("CON", record.bond_guid, record)}
-                    okText="Confiscate"
-                    cancelText="Cancel"
+                    Release Bond
+                  </button>
+                </Menu.Item>
+                <Menu.Item key="confiscate" className="custom-menu-item">
+                  <button
+                    type="button"
+                    onClick={(event) => props.openCloseBondModal(event, record, "CON")}
                   >
-                    <button type="button" className="full">
-                      Confiscate Bond
-                    </button>
-                  </Popconfirm>
-                </div>
+                    Confiscate Bond
+                  </button>
+                </Menu.Item>
                 {props.permits.length > 1 && (
-                  <div className="custom-menu-item">
+                  <Menu.Item key="transfer" className="custom-menu-item">
                     <button
                       type="button"
-                      className="full"
                       onClick={(event) => props.openTransferBondModal(event, record)}
                     >
                       Transfer Bond
                     </button>
-                  </div>
+                  </Menu.Item>
                 )}
-              </span>
+              </>
             )}
-            <Menu.Item key="2">
+            <Menu.Item key="edit" className="custom-menu-item">
               <button
                 type="button"
                 className="full"

--- a/services/core-web/src/components/mine/Securities/MineSecurityInfo.js
+++ b/services/core-web/src/components/mine/Securities/MineSecurityInfo.js
@@ -180,6 +180,25 @@ export class MineSecurityInfo extends Component {
     });
   };
 
+  openCloseBondModal = (event, bond, bondStatusCode) => {
+    event.preventDefault();
+    this.props.openModal({
+      props: {
+        title:
+          (bondStatusCode === "REL" && "Release Bond") ||
+          (bondStatusCode === "CON" && "Confiscate Bond"),
+        onSubmit: this.closeBond,
+        editBond: true,
+        bond,
+        bondStatusCode,
+        permitGuid: bond.permit_guid,
+        mineGuid: this.props.mineGuid,
+      },
+      width: "50vw",
+      content: modalConfig.CLOSE_BOND_MODAL,
+    });
+  };
+
   editBond = (values, bondGuid) => {
     const payload = values;
     // payload expects the basic bond object without the following:
@@ -196,12 +215,13 @@ export class MineSecurityInfo extends Component {
     });
   };
 
-  releaseOrConfiscateBond = (code, bondGuid, bond) => {
-    // if bond is confiscated, convert to bond type to Cash
+  closeBond = (bondStatusCode, values, bond) => {
     const payload = {
       ...bond,
-      bond_status_code: code,
-      bond_type_code: code === "CON" ? "CAS" : bond.bond_type_code,
+      bond_status_code: bondStatusCode,
+      bond_type_code: bondStatusCode === "CON" ? "CAS" : bond.bond_type_code,
+      closed_date: values.closed_date,
+      closed_note: values.closed_note,
     };
     this.editBond(payload, bond.bond_guid);
   };
@@ -331,12 +351,12 @@ export class MineSecurityInfo extends Component {
                 onExpand={this.onExpand}
                 openAddBondModal={this.openAddBondModal}
                 bonds={this.props.bonds}
-                releaseOrConfiscateBond={this.releaseOrConfiscateBond}
                 bondStatusOptionsHash={this.props.bondStatusOptionsHash}
                 bondTypeOptionsHash={this.props.bondTypeOptionsHash}
                 openViewBondModal={this.openViewBondModal}
                 openEditBondModal={this.openEditBondModal}
                 openTransferBondModal={this.openTransferBondModal}
+                openCloseBondModal={this.openCloseBondModal}
                 recordsByPermit={this.recordsByPermit}
                 activeBondCount={this.activeBondCount}
                 getSum={this.getSum}

--- a/services/core-web/src/components/mine/Securities/MineSecurityInfo.js
+++ b/services/core-web/src/components/mine/Securities/MineSecurityInfo.js
@@ -191,6 +191,7 @@ export class MineSecurityInfo extends Component {
         editBond: true,
         bond,
         bondStatusCode,
+        bondStatusOptionsHash: this.props.bondStatusOptionsHash,
         permitGuid: bond.permit_guid,
         mineGuid: this.props.mineGuid,
       },

--- a/services/core-web/src/components/modalContent/AddBondModal.js
+++ b/services/core-web/src/components/modalContent/AddBondModal.js
@@ -7,6 +7,7 @@ import {
   getBondTypeDropDownOptions,
   getBondDocumentTypeDropDownOptions,
   getBondDocumentTypeOptionsHash,
+  getBondStatusOptionsHash,
 } from "@common/selectors/staticContentSelectors";
 import BondForm from "@/components/Forms/Securities/BondForm";
 import CustomPropTypes from "@/customPropTypes";
@@ -19,6 +20,7 @@ const propTypes = {
   provinceOptions: PropTypes.arrayOf(CustomPropTypes.dropdownListItem).isRequired,
   bondDocumentTypeDropDownOptions: PropTypes.arrayOf(CustomPropTypes.dropdownListItem).isRequired,
   bondDocumentTypeOptionsHash: PropTypes.objectOf(PropTypes.string).isRequired,
+  bondStatusOptionsHash: PropTypes.objectOf(PropTypes.string).isRequired,
   permitGuid: PropTypes.string.isRequired,
   mineGuid: PropTypes.string.isRequired,
   bond: CustomPropTypes.bond,
@@ -65,6 +67,7 @@ export const AddBondModal = (props) => {
         bondTypeDropDownOptions={props.bondTypeDropDownOptions}
         bondDocumentTypeDropDownOptions={props.bondDocumentTypeDropDownOptions}
         bondDocumentTypeOptionsHash={props.bondDocumentTypeOptionsHash}
+        bondStatusOptionsHash={props.bondStatusOptionsHash}
         initialValues={props.bond}
         bond={props.bond}
         mineGuid={props.mineGuid}
@@ -82,6 +85,7 @@ const mapStateToProps = (state) => ({
   bondTypeDropDownOptions: getBondTypeDropDownOptions(state),
   bondDocumentTypeDropDownOptions: getBondDocumentTypeDropDownOptions(state),
   bondDocumentTypeOptionsHash: getBondDocumentTypeOptionsHash(state),
+  bondStatusOptionsHash: getBondStatusOptionsHash(state),
 });
 
 export default connect(mapStateToProps)(AddBondModal);

--- a/services/core-web/src/components/modalContent/CloseBondModal.js
+++ b/services/core-web/src/components/modalContent/CloseBondModal.js
@@ -1,0 +1,46 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Alert } from "antd";
+import CloseBondForm from "@/components/Forms/Securities/CloseBondForm";
+import CustomPropTypes from "@/customPropTypes";
+
+const propTypes = {
+  onSubmit: PropTypes.func.isRequired,
+  closeModal: PropTypes.func.isRequired,
+  title: PropTypes.string.isRequired,
+  bond: CustomPropTypes.bond.isRequired,
+  bondStatusCode: PropTypes.string.isRequired,
+};
+
+export const CloseBondModal = (props) => {
+  const handleCloseBond = (values) => props.onSubmit(props.bondStatusCode, values, props.bond);
+  const alertMessage =
+    (props.bondStatusCode === "REL" && "Release Bond") ||
+    (props.bondStatusCode === "CON" && "Confiscate Bond");
+  const alertDescription =
+    (props.bondStatusCode === "REL" && "Are you sure you want to release this bond?") ||
+    (props.bondStatusCode === "CON" &&
+      "Are you sure you want to confiscate this bond? Doing so will convert the bond type to cash.");
+  return (
+    <div>
+      <Alert
+        message={alertMessage}
+        description={alertDescription}
+        type="info"
+        showIcon
+        style={{ textAlign: "left" }}
+      />
+      <br />
+      <CloseBondForm
+        onSubmit={handleCloseBond}
+        closeModal={props.closeModal}
+        title={props.title}
+        bondStatusCode={props.bondStatusCode}
+      />
+    </div>
+  );
+};
+
+CloseBondModal.propTypes = propTypes;
+
+export default CloseBondModal;

--- a/services/core-web/src/components/modalContent/CloseBondModal.js
+++ b/services/core-web/src/components/modalContent/CloseBondModal.js
@@ -36,6 +36,7 @@ export const CloseBondModal = (props) => {
         onSubmit={handleCloseBond}
         closeModal={props.closeModal}
         title={props.title}
+        bond={props.bond}
         bondStatusCode={props.bondStatusCode}
         bondStatusOptionsHash={props.bondStatusOptionsHash}
       />

--- a/services/core-web/src/components/modalContent/CloseBondModal.js
+++ b/services/core-web/src/components/modalContent/CloseBondModal.js
@@ -9,6 +9,7 @@ const propTypes = {
   closeModal: PropTypes.func.isRequired,
   title: PropTypes.string.isRequired,
   bond: CustomPropTypes.bond.isRequired,
+  bondStatusOptionsHash: PropTypes.objectOf(PropTypes.string).isRequired,
   bondStatusCode: PropTypes.string.isRequired,
 };
 
@@ -36,6 +37,7 @@ export const CloseBondModal = (props) => {
         closeModal={props.closeModal}
         title={props.title}
         bondStatusCode={props.bondStatusCode}
+        bondStatusOptionsHash={props.bondStatusOptionsHash}
       />
     </div>
   );

--- a/services/core-web/src/components/modalContent/ViewBondModal.js
+++ b/services/core-web/src/components/modalContent/ViewBondModal.js
@@ -44,6 +44,10 @@ export const ViewBondModal = (props) => {
     []
   );
 
+  const isBondClosed =
+    props.bond.bond_status_code === "REL" || props.bond.bond_status_code === "CON";
+  const bondStatusDescription = props.bondStatusOptionsHash[props.bond.bond_status_code];
+
   return (
     <div>
       <div className="inline-flex between block-tablet">
@@ -53,7 +57,7 @@ export const ViewBondModal = (props) => {
         </div>
         <div className="flex-tablet">
           <p className="field-title">Status</p>
-          <p>{props.bondStatusOptionsHash[props.bond.bond_status_code] || Strings.EMPTY_FIELD}</p>
+          <p>{bondStatusDescription || Strings.EMPTY_FIELD}</p>
         </div>
       </div>
       <br />
@@ -90,6 +94,18 @@ export const ViewBondModal = (props) => {
           <p className="field-title">Notes</p>
           <p>{props.bond.note || Strings.EMPTY_FIELD}</p>
         </div>
+        {isBondClosed && (
+          <>
+            <div className="inline-flex padding-small">
+              <p className="field-title">{`${bondStatusDescription} Date`}</p>
+              <p>{formatDate(props.bond.closed_date) || Strings.EMPTY_FIELD}</p>
+            </div>
+            <div className="inline-flex padding-small">
+              <p className="field-title">{`${bondStatusDescription} Notes`}</p>
+              <p>{props.bond.closed_note || Strings.EMPTY_FIELD}</p>
+            </div>
+          </>
+        )}
       </div>
       <br />
       <div className="between block-tablet">

--- a/services/core-web/src/components/modalContent/config.js
+++ b/services/core-web/src/components/modalContent/config.js
@@ -26,6 +26,7 @@ import AddBondModal from "./AddBondModal";
 import ViewBondModal from "./ViewBondModal";
 import AddReclamationInvoiceModal from "./AddReclamationInvoiceModal";
 import TransferBondModal from "./TransferBondModal";
+import CloseBondModal from "./CloseBondModal";
 
 export const modalConfig = {
   MINE_RECORD: MineRecordModal,
@@ -55,6 +56,7 @@ export const modalConfig = {
   ADD_BOND_MODAL: AddBondModal,
   VIEW_BOND_MODAL: ViewBondModal,
   TRANSFER_BOND_MODAL: TransferBondModal,
+  CLOSE_BOND_MODAL: CloseBondModal,
   ADD_RECLAMATION_INVOICE_MODAL: AddReclamationInvoiceModal,
 };
 

--- a/services/core-web/src/constants/forms.js
+++ b/services/core-web/src/constants/forms.js
@@ -45,6 +45,7 @@ export const MAJOR_MINE_PERMIT_APPLICATION_CREATE = "MAJOR_MINE_PERMIT_APPLICATI
 // Securities
 export const ADD_BOND = "ADD_BOND";
 export const TRANSFER_BOND = "TRANSFER_BOND";
+export const CLOSE_BOND = "CLOSE_BOND";
 export const ADD_RECLAMATION_INVOICE = "ADD_RECLAMATION_INVOICE";
 
 // Permit Generation

--- a/services/core-web/src/customPropTypes/securities.js
+++ b/services/core-web/src/customPropTypes/securities.js
@@ -22,6 +22,8 @@ export const bond = PropTypes.shape({
   institution_province: PropTypes.string,
   institution_postal_code: PropTypes.string,
   note: PropTypes.string,
+  closed_date: PropTypes.string,
+  closed_note: PropTypes.string,
   payer,
   permit_guid: PropTypes.string,
   documents: PropTypes.arrayOf(mineDocument),

--- a/services/core-web/src/tests/components/Forms/Securities/BondForm.spec.js
+++ b/services/core-web/src/tests/components/Forms/Securities/BondForm.spec.js
@@ -17,6 +17,8 @@ const setupProps = () => {
   props.submitting = false;
   props.provinceOptions = MOCK.DROPDOWN_PROVINCE_OPTIONS;
   props.bondTypeOptions = [];
+  props.bondStatusOptionsHash = MOCK.BULK_STATIC_CONTENT_RESPONSE.bondStatusOptions;
+  // eslint-disable-next-line prefer-destructuring
   props.bond = MOCK.BONDS.records[0];
 };
 

--- a/services/core-web/src/tests/components/Forms/Securities/BondForm.spec.js
+++ b/services/core-web/src/tests/components/Forms/Securities/BondForm.spec.js
@@ -18,8 +18,7 @@ const setupProps = () => {
   props.provinceOptions = MOCK.DROPDOWN_PROVINCE_OPTIONS;
   props.bondTypeOptions = [];
   props.bondStatusOptionsHash = MOCK.BULK_STATIC_CONTENT_RESPONSE.bondStatusOptions;
-  // eslint-disable-next-line prefer-destructuring
-  props.bond = MOCK.BONDS.records[0];
+  [props.bond] = MOCK.BONDS.records;
 };
 
 beforeEach(() => {

--- a/services/core-web/src/tests/components/Forms/Securities/__snapshots__/BondForm.spec.js.snap
+++ b/services/core-web/src/tests/components/Forms/Securities/__snapshots__/BondForm.spec.js.snap
@@ -102,6 +102,7 @@ exports[`BondForm renders properly 1`] = `
             Array [
               [Function],
               [Function],
+              [Function],
             ]
           }
         />

--- a/services/core-web/src/tests/components/Forms/Securities/__snapshots__/BondForm.spec.js.snap
+++ b/services/core-web/src/tests/components/Forms/Securities/__snapshots__/BondForm.spec.js.snap
@@ -47,6 +47,7 @@ exports[`BondForm renders properly 1`] = `
       >
         <Field
           component={[Function]}
+          disabled={false}
           id="bond_type_code"
           label="Bond Type*"
           name="bond_type_code"
@@ -137,6 +138,24 @@ exports[`BondForm renders properly 1`] = `
           id="project_id"
           label="Project ID"
           name="project_id"
+        />
+      </FormItem>
+    </Col>
+  </Row>
+  <Row
+    gutter={0}
+  >
+    <Col
+      md={24}
+    >
+      <FormItem
+        hasFeedback={false}
+      >
+        <Field
+          component={[Function]}
+          id="note"
+          label="Notes"
+          name="note"
         />
       </FormItem>
     </Col>
@@ -268,24 +287,6 @@ exports[`BondForm renders properly 1`] = `
     </Col>
   </Row>
   <Row
-    gutter={0}
-  >
-    <Col
-      md={24}
-    >
-      <FormItem
-        hasFeedback={false}
-      >
-        <Field
-          component={[Function]}
-          id="note"
-          label="Notes"
-          name="note"
-        />
-      </FormItem>
-    </Col>
-  </Row>
-  <Row
     gutter={16}
   >
     <Col
@@ -404,7 +405,6 @@ exports[`BondForm renders properly 1`] = `
     <Button
       block={false}
       className="full-mobile"
-      disabled={false}
       ghost={false}
       htmlType="submit"
       loading={false}

--- a/services/core-web/src/tests/components/mine/Securities/__snapshots__/MineSecurityInfo.spec.js.snap
+++ b/services/core-web/src/tests/components/mine/Securities/__snapshots__/MineSecurityInfo.spec.js.snap
@@ -148,6 +148,7 @@ exports[`MineSecurityInfo renders properly 1`] = `
           isLoaded={false}
           onExpand={[Function]}
           openAddBondModal={[Function]}
+          openCloseBondModal={[Function]}
           openEditBondModal={[Function]}
           openTransferBondModal={[Function]}
           openViewBondModal={[Function]}
@@ -184,7 +185,6 @@ exports[`MineSecurityInfo renders properly 1`] = `
             ]
           }
           recordsByPermit={[Function]}
-          releaseOrConfiscateBond={[Function]}
         />
       </div>
     </TabPane>

--- a/services/minespace-web/common/utils/Validate.js
+++ b/services/minespace-web/common/utils/Validate.js
@@ -116,6 +116,18 @@ export const validateStartDate = memoize((previousStartDate) => (value) =>
 export const dateNotInFuture = (value) =>
   value && new Date(value) >= new Date() ? "Date cannot be in the future" : undefined;
 
+export const dateNotBeforeOther = memoize((other) => (value) =>
+  value && other && new Date(value) <= new Date(other)
+    ? `Date cannot be on or before ${other}`
+    : undefined
+);
+
+export const dateNotAfterOther = memoize((other) => (value) =>
+  value && other && new Date(value) >= new Date(other)
+    ? `Date cannot be on or after ${other}`
+    : undefined
+);
+
 export const yearNotInFuture = (value) =>
   value && value > new Date().getFullYear() ? "Year cannot be in the future" : undefined;
 


### PR DESCRIPTION
# Main
* Modifies the bond release/confiscation flow by allowing users to set the release/confiscation date as well as provide release/confiscation notes. **Note**: Adding release/confiscation documents is supported in the Edit Bond modal after the bond has been closed. This was decided because it would add a lot more scope if we allowed the user to select/upload multiple release/confiscation document types in the modal.
* Adds the columns `closed_date` and `closed_note` to the tables `bond` and `bond_history` and updates the `bond_view` to account for these new columns. **Note**: Securities reporting will be addressed in another ticket to account for these new columns.
* Updates the View Bond Modal by displaying the closed date/notes if the bond is closed.
* Updates the Edit Bond Modal by allowing the editing of the closed date/notes if the bond is closed. **Note**: If the bond is confiscated, the bond type cannot be edited, as changing the bond type to cash when the bond was confiscated was an enforced business rule.

**Note**: The language for the closed date/notes changes dynamically depending on whether the bond was released or confiscated.
**Note**: Existing bond and bond history entries, if they are released or confiscated, have their closed date set to the update timestamp.

## Screenshots
![image](https://user-images.githubusercontent.com/17113094/87580195-f5835480-c68b-11ea-9df8-f0ebcc054b70.png)
![image](https://user-images.githubusercontent.com/17113094/87580218-016f1680-c68c-11ea-96c6-ec231729b8a8.png)
![image](https://user-images.githubusercontent.com/17113094/87580384-48f5a280-c68c-11ea-979e-1183821b0bf4.png)
![image](https://user-images.githubusercontent.com/17113094/87580429-5f036300-c68c-11ea-94d3-55fd1469187d.png)

# Other
* Moves the Notes field in the Edit Bond Modal up to the other general information area rather than the Institution area
