### PR TITLE
Fix/Retain correct audit info when creating bond history record

### DIFF
--- a/services/core-api/app/api/securities/models/bond.py
+++ b/services/core-api/app/api/securities/models/bond.py
@@ -54,9 +54,11 @@ class Bond(Base, AuditMixin):
         bond_json = marshal(self, BOND)
         del bond_json['bond_guid']
         del bond_json['documents']
-
         bond_json['payer_name'] = bond_json['payer']['party_name']
-        current_app.logger.info(bond_json)
+        bond_json['update_timestamp'] = str(self.update_timestamp)
+        bond_json['update_user'] = self.update_user
+
+        current_app.logger.debug(bond_json)
         bond_hist = BondHistory._schema().load(bond_json)
         bond_hist.save()
         return bond_hist

--- a/services/core-api/app/api/securities/models/bond_history.py
+++ b/services/core-api/app/api/securities/models/bond_history.py
@@ -33,8 +33,8 @@ class BondHistory(Base):
     project_id = db.Column(db.String)
     closed_date = db.Column(db.DateTime)
     closed_note = db.Column(db.String)
-    update_user = db.Column(db.String, nullable=False, default=User().get_user_username)
-    update_timestamp = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
+    update_user = db.Column(db.String, nullable=False)
+    update_timestamp = db.Column(db.DateTime, nullable=False)
 
     def __repr__(self):
         return '<BondHistory %r>' % self.bond_id

--- a/services/core-api/app/api/securities/models/bond_history.py
+++ b/services/core-api/app/api/securities/models/bond_history.py
@@ -33,13 +33,8 @@ class BondHistory(Base):
     project_id = db.Column(db.String)
     closed_date = db.Column(db.DateTime)
     closed_note = db.Column(db.String)
-    update_user = db.Column(
-        db.String,
-        nullable=False,
-        default=User().get_user_username,
-        onupdate=User().get_user_username)
-    update_timestamp = db.Column(
-        db.DateTime, nullable=False, default=datetime.utcnow, onupdate=datetime.utcnow)
+    update_user = db.Column(db.String, nullable=False, default=User().get_user_username)
+    update_timestamp = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
 
     def __repr__(self):
         return '<BondHistory %r>' % self.bond_id


### PR DESCRIPTION
* Fixes an issue with creating bond history records where the update_user and update_timestamp fields were being populated with current data rather than retaining the original data