### PR TITLE
Create Document Manager command for getting list of unrecorded files

### DIFF
--- a/services/document-manager/backend/app/commands.py
+++ b/services/document-manager/backend/app/commands.py
@@ -24,3 +24,9 @@ def register_commands(app):
     def missing_files(path):
         from app.services.transfer_files import get_missing_files
         print(get_missing_files(path))
+
+    @app.cli.command()
+    @click.argument('path')
+    def unregistered_files(path):
+        from app.services.transfer_files import get_unregistered_files
+        print(get_unregistered_files(path))

--- a/services/document-manager/backend/app/services/transfer_files.py
+++ b/services/document-manager/backend/app/services/transfer_files.py
@@ -95,3 +95,26 @@ def get_missing_files(path):
         if (not os.path.isfile(doc.full_storage_path)):
             missing.append(doc.full_storage_path if path else doc.document_id)
     return missing
+
+
+def get_unregistered_files(path):
+
+    # Validate the path
+    if (not os.path.isdir(path)):
+        raise Exception('Path does not exist')
+    if (not os.path.isabs(path)):
+        raise Exception('Path is not absolute')
+
+    # Get all files under the path
+    files = []
+    for dirpath, dirnames, filenames in os.walk(path):
+        for filename in filenames:
+            files.append(os.path.join(dirpath, filename))
+
+    # Get all files that aren't associated with a Document record
+    unregistered = []
+    for file in files:
+        doc = Document.query.filter_by(full_storage_path=file).first()
+        if (not doc):
+            unregistered.append(file)
+    return unregistered


### PR DESCRIPTION
* Adds a Document Manager command for getting a list of unrecorded files (files that exist in the filesystem but don't have a record in the Document table)

Example usage:
`flask unregistered-files /app/document_uploads/`