### PR TITLE
Fix/minespace context mine errors

### DIFF
--- a/services/core-api/app/api/parties/party_appt/resources/mine_party_appt_resource.py
+++ b/services/core-api/app/api/parties/party_appt/resources/mine_party_appt_resource.py
@@ -62,7 +62,7 @@ class MinePartyApptResource(Resource, UserMixin):
             permit_guid = request.args.get('permit_guid')
             incl_pmt = request.args.get('include_permittees', 'false').lower() == 'true'
             types = request.args.getlist('types') #list
-            permit = Permit.find_by_permit_guid(permit_guid)
+            permit = Permit.find_by_permit_guid(permit_guid, mine_guid)
             mpas = MinePartyAppointment.find_by(
                 mine_guid=mine_guid,
                 party_guid=party_guid,

--- a/services/core-api/app/api/utils/models_mixins.py
+++ b/services/core-api/app/api/utils/models_mixins.py
@@ -45,7 +45,9 @@ def ensure_constrained(query):
             cls = mzero.class_
 
             # if model includes mine_guid, apply filter on mine_guid.
-            if hasattr(cls, 'mine_guid') and query._user_bound:
+            mapper = inspect(cls)
+
+            if 'mine_guid' in [c.name for c in mapper.columns] and query._user_bound:
                 query = query.enable_assertions(False).filter(
                     cls.mine_guid.in_(user_security.mine_ids))
 


### PR DESCRIPTION
Minespace BCEID login's cause row level auth, which looks for mine_guid as a member of the class. I've changed it to specifically look if it's a column.