### PR TITLE
Etl/permit numbers with zeros

### DIFF
--- a/migrations/sql/R__stored_procedure_for_bond_etl.sql
+++ b/migrations/sql/R__stored_procedure_for_bond_etl.sql
@@ -122,7 +122,7 @@ declare
 		now()
 	from mms.secsec sec
 	where TRIM(sec.sec_cid) != ''
-	and replace(REPLACE(permit_no,' ',''),'--','-') in (select permit_no from permit)
+	and replace(REPLACE(permit_no,' ',''),'--','-') in (select (select replace(permit_no,'-0','-') from permit)
 	and sec_typ not in ('ALC', '')
 	ON CONFLICT (sec_cid)
 	DO
@@ -252,7 +252,7 @@ declare
 	update ETL_BOND e
 	set core_permit_id = p.permit_id
 	from permit p
-	where p.permit_no = e.permit_no;
+	where (select replace(p.permit_no,'-0','-') = e.permit_no;
 	--initial fetch filtered out missing permit_no's
 
 	---------------------- INSERT BONDS

--- a/migrations/sql/R__stored_procedure_for_bond_etl.sql
+++ b/migrations/sql/R__stored_procedure_for_bond_etl.sql
@@ -122,7 +122,7 @@ declare
 		now()
 	from mms.secsec sec
 	where TRIM(sec.sec_cid) != ''
-	and replace(REPLACE(permit_no,' ',''),'--','-') in (select (select replace(permit_no,'-0','-') from permit)
+	and replace(REPLACE(permit_no,' ',''),'--','-') in (select replace(permit_no,'-0','-') from permit)
 	and sec_typ not in ('ALC', '')
 	ON CONFLICT (sec_cid)
 	DO
@@ -252,7 +252,7 @@ declare
 	update ETL_BOND e
 	set core_permit_id = p.permit_id
 	from permit p
-	where (select replace(p.permit_no,'-0','-') = e.permit_no;
+	where replace(p.permit_no,'-0','-') = e.permit_no;
 	--initial fetch filtered out missing permit_no's
 
 	---------------------- INSERT BONDS


### PR DESCRIPTION
Have ran this on test already for Eva/Ashley. 

Q-4-79 in MMS needs to match Q-4-079 in CORE. 