### PR TITLE
ETL can convert into this bond type.

### DIFF
--- a/migrations/sql/V2020.09.14.09.37__new_bond_type.sql
+++ b/migrations/sql/V2020.09.14.09.37__new_bond_type.sql
@@ -1,0 +1,11 @@
+INSERT INTO BOND_TYPE 
+(
+    bond_type_code,
+    description,
+    active_ind,
+    create_user,
+    update_user
+)
+VALUES
+    ('PFB', 'Performance Bond', true, 'system-mds', 'system-mds')
+ON CONFLICT DO NOTHING;


### PR DESCRIPTION
This bond type was never added. Only showed up now because it's only used on Major Mines in MMS.