### PR TITLE
MDS-3167: Update "Total Confiscated" Column On Bond Table

### DIFF
--- a/services/core-web/src/components/mine/Securities/MineBondTable.js
+++ b/services/core-web/src/components/mine/Securities/MineBondTable.js
@@ -40,6 +40,7 @@ const propTypes = {
   // eslint-disable-next-line react/no-unused-prop-types
   recordsByPermit: PropTypes.func.isRequired,
   activeBondCount: PropTypes.func.isRequired,
+  getBalance: PropTypes.func.isRequired,
 };
 
 export const MineBondTable = (props) => {
@@ -84,19 +85,17 @@ export const MineBondTable = (props) => {
     {
       title: (
         <div>
-          Total Confiscated
-          <CoreTooltip title="Total Confiscated: This is the total value of bonds that have been confiscated for the permit. This amount is also shown below as Cash On Hand for the permit" />
+          Confiscated Cash On Hand
+          <CoreTooltip title="Confiscated Cash On Hand: This is the current amount of money available from the confiscated bonds. If this amount is negative, it means invoices have exceeded the confiscated bonds." />
         </div>
       ),
-      dataIndex: "amount_confiscated",
-      key: "amount_confiscated",
+      dataIndex: "balance",
+      key: "balance",
       render: (text) => (
-        <div title="Total Confiscated">{formatMoney(text) || Strings.EMPTY_FIELD}</div>
+        <div title="Confiscated Cash On Hand">{formatMoney(text) || Strings.EMPTY_FIELD}</div>
       ),
     },
     {
-      title: "",
-      dataIndex: "addEditButton",
       key: "addEditButton",
       align: "right",
       render: (text, record) => {
@@ -158,8 +157,6 @@ export const MineBondTable = (props) => {
       defaultSortOrder: "descend",
     },
     {
-      title: "",
-      dataIndex: "addEditButton",
       key: "addEditButton",
       align: "right",
       render: (text, record) => {
@@ -275,7 +272,7 @@ export const MineBondTable = (props) => {
       return {
         key: permit.permit_guid,
         total_bonds: props.activeBondCount(permit),
-        amount_confiscated: permit.confiscated_bond_total,
+        balance: props.getBalance(permit),
         amount_held: permit.active_bond_total,
         total_assessed: permit.assessed_liability_total,
         ...permit,

--- a/services/core-web/src/components/mine/Securities/MineReclamationInvoiceTable.js
+++ b/services/core-web/src/components/mine/Securities/MineReclamationInvoiceTable.js
@@ -75,8 +75,6 @@ export const MineReclamationInvoiceTable = (props) => {
       render: (text) => <div title="Balance">{formatMoney(text) || Strings.EMPTY_FIELD}</div>,
     },
     {
-      title: "",
-      dataIndex: "addEditButton",
       key: "addEditButton",
       align: "right",
       render: (text, record) => {
@@ -140,8 +138,6 @@ export const MineReclamationInvoiceTable = (props) => {
       ),
     },
     {
-      title: "",
-      dataIndex: "addEditButton",
       key: "addEditButton",
       align: "right",
       render: (text, record) => {

--- a/services/core-web/src/components/mine/Securities/MineSecurityInfo.js
+++ b/services/core-web/src/components/mine/Securities/MineSecurityInfo.js
@@ -362,6 +362,7 @@ export class MineSecurityInfo extends Component {
                 openCloseBondModal={this.openCloseBondModal}
                 recordsByPermit={this.recordsByPermit}
                 activeBondCount={this.activeBondCount}
+                getBalance={this.getBalance}
               />
             </div>
           </Tabs.TabPane>

--- a/services/core-web/src/tests/components/mine/Securities/__snapshots__/MineBondTable.spec.js.snap
+++ b/services/core-web/src/tests/components/mine/Securities/__snapshots__/MineBondTable.spec.js.snap
@@ -40,22 +40,20 @@ exports[`MineBondTable renders properly 1`] = `
         "title": "Total Held",
       },
       Object {
-        "dataIndex": "amount_confiscated",
-        "key": "amount_confiscated",
+        "dataIndex": "balance",
+        "key": "balance",
         "render": [Function],
         "title": <div>
-          Total Confiscated
+          Confiscated Cash On Hand
           <CoreTooltip
-            title="Total Confiscated: This is the total value of bonds that have been confiscated for the permit. This amount is also shown below as Cash On Hand for the permit"
+            title="Confiscated Cash On Hand: This is the current amount of money available from the confiscated bonds. If this amount is negative, it means invoices have exceeded the confiscated bonds."
           />
         </div>,
       },
       Object {
         "align": "right",
-        "dataIndex": "addEditButton",
         "key": "addEditButton",
         "render": [Function],
-        "title": "",
       },
     ]
   }

--- a/services/core-web/src/tests/components/mine/Securities/__snapshots__/MineReclamationInvoiceTable.spec.js.snap
+++ b/services/core-web/src/tests/components/mine/Securities/__snapshots__/MineReclamationInvoiceTable.spec.js.snap
@@ -41,10 +41,8 @@ exports[`MineReclamationInvoiceTable renders properly 1`] = `
       },
       Object {
         "align": "right",
-        "dataIndex": "addEditButton",
         "key": "addEditButton",
         "render": [Function],
-        "title": "",
       },
     ]
   }

--- a/services/core-web/src/tests/components/mine/Securities/__snapshots__/MineSecurityInfo.spec.js.snap
+++ b/services/core-web/src/tests/components/mine/Securities/__snapshots__/MineSecurityInfo.spec.js.snap
@@ -141,6 +141,7 @@ exports[`MineSecurityInfo renders properly 1`] = `
             ]
           }
           expandedRowKeys={Array []}
+          getBalance={[Function]}
           isLoaded={false}
           onExpand={[Function]}
           openAddBondModal={[Function]}


### PR DESCRIPTION
# Main
* Changes the "Total Confiscated" column to be a "Confiscated Cash on Hand" column in the Securities tab. This is being calculated the same way as "Balance" in the Reclamation Invoices tab.

![image](https://user-images.githubusercontent.com/17113094/100266484-c072f280-2f06-11eb-82a0-039bbf430286.png)
