### PR TITLE
MDS-3218: Do not allow deletion of permit or permit amendments

### DIFF
--- a/services/core-api/app/api/mines/permits/permit/models/permit.py
+++ b/services/core-api/app/api/mines/permits/permit/models/permit.py
@@ -116,9 +116,8 @@ class Permit(SoftDeleteMixin, AuditMixin, Base):
         if self.bonds:
             raise Exception('Unable to delete permit with attached bonds.')
 
-        if self.permit_amendments and any(
-                amendment.is_linked_now_application_imported_to_core == True
-                for amendment in self.permit_amendments):
+        if self.permit_amendments and any(amendment.now_application_guid is not None
+                                          for amendment in self.permit_amendments):
             raise Exception(
                 'Unable to delete permit with linked NOW application in Core to one of its permit amendments.'
             )

--- a/services/core-api/app/api/mines/permits/permit_amendment/models/permit_amendment.py
+++ b/services/core-api/app/api/mines/permits/permit_amendment/models/permit_amendment.py
@@ -74,13 +74,6 @@ class PermitAmendment(SoftDeleteMixin, AuditMixin, Base):
     now_application_identity = db.relationship(
         'NOWApplicationIdentity', lazy='selectin', uselist=False)
 
-    @hybrid_property
-    def is_linked_now_application_imported_to_core(self):
-        if self.now_application_guid is None:
-            return False
-
-        return self.now_application_identity and self.now_application_identity.now_application is not None
-
     def __repr__(self):
         return '<PermitAmendment %r, %r>' % (self.mine_guid, self.permit_id)
 
@@ -90,7 +83,7 @@ class PermitAmendment(SoftDeleteMixin, AuditMixin, Base):
                 "Deletion of permit amendment of type 'Original Permit' is not allowed, please, consider deleting the permit itself."
             )
 
-        if self.is_linked_now_application_imported_to_core:
+        if self.now_application_guid:
             raise Exception(
                 'The permit amendment with linked NOW application in Core cannot be deleted.')
 

--- a/services/core-api/app/api/mines/permits/permit_amendment/models/permit_amendment.py
+++ b/services/core-api/app/api/mines/permits/permit_amendment/models/permit_amendment.py
@@ -5,6 +5,7 @@ import uuid
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import validates
 from sqlalchemy.ext.associationproxy import association_proxy
+from sqlalchemy.ext.hybrid import hybrid_property
 
 from sqlalchemy.schema import FetchedValue
 from app.extensions import db
@@ -70,6 +71,16 @@ class PermitAmendment(SoftDeleteMixin, AuditMixin, Base):
         "and_(PermitAmendment.mine_guid==foreign(MinePermitXref.mine_guid), PermitAmendment.permit_id==foreign(MinePermitXref.permit_id))"
     )
 
+    now_application_identity = db.relationship(
+        'NOWApplicationIdentity', lazy='selectin', uselist=False)
+
+    @hybrid_property
+    def is_linked_now_application_imported_to_core(self):
+        if self.now_application_guid is None:
+            return False
+
+        return self.now_application_identity and self.now_application_identity.now_application is not None
+
     def __repr__(self):
         return '<PermitAmendment %r, %r>' % (self.mine_guid, self.permit_id)
 
@@ -78,6 +89,10 @@ class PermitAmendment(SoftDeleteMixin, AuditMixin, Base):
             raise Exception(
                 "Deletion of permit amendment of type 'Original Permit' is not allowed, please, consider deleting the permit itself."
             )
+
+        if self.is_linked_now_application_imported_to_core:
+            raise Exception(
+                'The permit amendment with linked NOW application in Core cannot be deleted.')
 
         permit_amendment_documents = PermitAmendmentDocument.query.filter_by(
             permit_amendment_id=self.permit_amendment_id, deleted_ind=False).all()

--- a/services/core-api/app/api/mines/response_models.py
+++ b/services/core-api/app/api/mines/response_models.py
@@ -117,7 +117,8 @@ PERMIT_AMENDMENT_MODEL = api.model(
         'now_application_guid': fields.String,
         'related_documents': fields.List(fields.Nested(PERMIT_AMENDMENT_DOCUMENT_MODEL)),
         'permit_conditions_last_updated_by': fields.String,
-        'permit_conditions_last_updated_date': fields.DateTime
+        'permit_conditions_last_updated_date': fields.DateTime,
+        'is_linked_now_application_imported_to_core': fields.Boolean
     })
 
 BOND_MODEL = api.model('Bond_guid', {'bond_guid': fields.String})

--- a/services/core-api/app/api/mines/response_models.py
+++ b/services/core-api/app/api/mines/response_models.py
@@ -118,7 +118,6 @@ PERMIT_AMENDMENT_MODEL = api.model(
         'related_documents': fields.List(fields.Nested(PERMIT_AMENDMENT_DOCUMENT_MODEL)),
         'permit_conditions_last_updated_by': fields.String,
         'permit_conditions_last_updated_date': fields.DateTime,
-        'is_linked_now_application_imported_to_core': fields.Boolean
     })
 
 BOND_MODEL = api.model('Bond_guid', {'bond_guid': fields.String})

--- a/services/core-web/src/components/mine/Permit/MinePermitTable.js
+++ b/services/core-web/src/components/mine/Permit/MinePermitTable.js
@@ -14,6 +14,7 @@ import CustomPropTypes from "@/customPropTypes";
 import { EDIT_OUTLINE, EDIT_OUTLINE_VIOLET, EDIT, CARAT, TRASHCAN } from "@/constants/assets";
 import LinkButton from "@/components/common/LinkButton";
 import CoreTable from "@/components/common/CoreTable";
+import { isEmpty } from "lodash";
 
 /**
  * @class  MinePermitTable - displays a table of permits and permit amendments
@@ -56,8 +57,7 @@ const renderDeleteButtonForPermitAmendments = (record) => {
     return;
   }
 
-  const isLinkedToNowApplication =
-    record.amendmentEdit.amendment.is_linked_now_application_imported_to_core;
+  const isLinkedToNowApplication = !isEmpty(record.amendmentEdit.amendment.now_application_guid);
 
   // eslint-disable-next-line consistent-return
   return (
@@ -226,7 +226,7 @@ const columns = [
 
       const isLinkedToNowApplication =
         record.permit.permit_amendments.filter(
-          (amendment) => amendment.is_linked_now_application_imported_to_core === true
+          (amendment) => !isEmpty(amendment.now_application_guid)
         ).length > 0;
 
       const isAnyBondsAssociatedTo = record.permit.bonds && record.permit.bonds.length > 0;

--- a/services/core-web/src/components/mine/Permit/MinePermitTable.js
+++ b/services/core-web/src/components/mine/Permit/MinePermitTable.js
@@ -240,18 +240,18 @@ const columns = [
       } else {
         if (isLinkedToNowApplication) {
           title +=
-            "You cannot delete permit which has permit amendments associated to a NOW application which is imported to Core. ";
+            "You cannot delete a permit that has permit amendments associated with a NOW application imported to Core.\n";
         }
 
         if (isAnyBondsAssociatedTo) {
-          title += "You cannot delete a permit that has associated bond records. ";
+          title += "You cannot delete a permit that has associated bond records.";
         }
       }
 
       const deletePermitPopUp = (
         <Popconfirm
           placement="topLeft"
-          title={title}
+          title={<div style={{ whiteSpace: "pre-wrap" }}>{title}</div>}
           onConfirm={
             isDeletionAllowed
               ? () => record.handleDeletePermit(record.permit.permit_guid)

--- a/services/core-web/src/components/mine/Permit/MinePermitTable.js
+++ b/services/core-web/src/components/mine/Permit/MinePermitTable.js
@@ -66,7 +66,7 @@ const renderDeleteButtonForPermitAmendments = (record) => {
         placement="topLeft"
         title={
           isLinkedToNowApplication
-            ? "You cannot delete permit amendment with associated NOW application imported to Core."
+            ? "You cannot delete permit amendment with associated NoW application imported to CORE."
             : "Are you sure you want to delete this amendment and all related documents?"
         }
         okText={isLinkedToNowApplication ? "Ok" : "Delete"}
@@ -233,25 +233,35 @@ const columns = [
 
       const isDeletionAllowed = !isAnyBondsAssociatedTo && !isLinkedToNowApplication;
 
-      let title = "";
-      if (isDeletionAllowed) {
-        title =
-          "Are you sure you want to delete this permit and all related permit amendments and permit documents?";
-      } else {
+      const issues = [];
+
+      if (!isDeletionAllowed) {
         if (isLinkedToNowApplication) {
-          title +=
-            "You cannot delete a permit that has permit amendments associated with a NOW application imported to Core.\n";
+          issues.push("Permit has amendments associated with a NoW application imported to CORE.");
         }
 
         if (isAnyBondsAssociatedTo) {
-          title += "You cannot delete a permit that has associated bond records.";
+          issues.push("Permit has associated bond records.");
         }
       }
 
       const deletePermitPopUp = (
         <Popconfirm
           placement="topLeft"
-          title={<div style={{ whiteSpace: "pre-wrap" }}>{title}</div>}
+          title={
+            issues && issues.length > 0 ? (
+              <div style={{ whiteSpace: "pre-wrap" }}>
+                <p>You cannot delete this permit due to following issues:</p>
+                <ul>
+                  {issues.map((issue) => (
+                    <li>{issue}</li>
+                  ))}
+                </ul>
+              </div>
+            ) : (
+              "Are you sure you want to delete this permit and all related permit amendments and permit documents?"
+            )
+          }
           onConfirm={
             isDeletionAllowed
               ? () => record.handleDeletePermit(record.permit.permit_guid)

--- a/services/core-web/src/components/noticeOfWork/applications/NOWDocuments.js
+++ b/services/core-web/src/components/noticeOfWork/applications/NOWDocuments.js
@@ -201,15 +201,17 @@ export const NOWDocuments = (props) => {
         return (
           /* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */
           <div disabled onClick={(event) => event.stopPropagation()}>
-            <Tooltip
-              title="You cannot remove a document that is a part of the Final Application Package."
-              placement="right"
-              mouseEnterDelay={0.3}
-            >
-              <Button ghost type="primary" disabled size="small">
-                <img className="lessOpacity" name="remove" src={TRASHCAN} alt="Remove document" />
-              </Button>
-            </Tooltip>
+            <NOWActionWrapper permission={Permission.EDIT_PERMITS}>
+              <Tooltip
+                title="You cannot remove a document that is a part of the Final Application Package."
+                placement="right"
+                mouseEnterDelay={0.3}
+              >
+                <Button ghost type="primary" disabled size="small">
+                  <img className="lessOpacity" name="remove" src={TRASHCAN} alt="Remove document" />
+                </Button>
+              </Tooltip>
+            </NOWActionWrapper>
           </div>
         );
       },


### PR DESCRIPTION
- Restricted deletion of permit and permit amendments with imported to Core NOW applications
- Fixed issue with permit deletion with original permit amendment 

![NOW_1](https://user-images.githubusercontent.com/61513701/100489366-abde5800-30c8-11eb-8305-1a37a2834f82.gif)
![image](https://user-images.githubusercontent.com/61513701/100657037-82107580-3302-11eb-9932-4a067f70243c.png)
