### PR TITLE
MDS-3202/MDS-3059/MDS-3118: Expose permits and bonds for regional mines on MineSpace & Only show "document generation" form errors on submit & Fix overlapping markers issue on NoW verification map

### DIFF
--- a/services/core-web/src/components/maps/MineHeaderMapLeaflet.js
+++ b/services/core-web/src/components/maps/MineHeaderMapLeaflet.js
@@ -55,12 +55,15 @@ class MineHeaderMapLeaflet extends Component {
   componentDidMount() {
     // Create the base map with layers
     this.createMap();
+
     if (this.props.mine.mine_location.latitude && this.props.mine.mine_location.longitude) {
       this.createPin();
     }
+
     if (this.checkValidityOfCoordinateInput(this.props.additionalPin)) {
       this.createAdditionalPin(this.props.additionalPin);
     }
+
     // Add MinePins to the top of LayerList and add the LayerList widget
     L.control.layers(this.getBaseMaps(), {}, { position: "topright" }).addTo(this.map);
   }
@@ -72,7 +75,7 @@ class MineHeaderMapLeaflet extends Component {
     ) {
       if (this.state.containsAdditionalPin) {
         this.additionalPin.setLatLng(nextProps.additionalPin);
-        this.map.fitBounds(this.layerGroup.getBounds());
+        this.map.fitBounds(this.markerClusterGroup.getBounds());
       } else {
         this.setState({ containsAdditionalPin: false });
         this.createAdditionalPin(nextProps.additionalPin);
@@ -107,7 +110,8 @@ class MineHeaderMapLeaflet extends Component {
       iconUrl: SMALL_PIN,
       iconSize: [60, 60],
     });
-    L.marker(this.latLong, { icon: customIcon }).addTo(this.layerGroup);
+    const marker = L.marker(this.latLong, { icon: customIcon });
+    this.markerClusterGroup.addLayer(marker);
   };
 
   createAdditionalPin = (pin) => {
@@ -115,9 +119,10 @@ class MineHeaderMapLeaflet extends Component {
       iconUrl: SMALL_PIN_SELECTED,
       iconSize: [60, 60],
     });
-    this.additionalPin = L.marker(pin, { icon: customIcon }).addTo(this.layerGroup);
-    // re-size map to include all pins
-    this.map.fitBounds(this.layerGroup.getBounds());
+    this.additionalPin = L.marker(pin, { icon: customIcon });
+    this.markerClusterGroup.addLayer(this.additionalPin);
+    this.map.fitBounds(this.markerClusterGroup.getBounds());
+    this.markerClusterGroup.zoomToShowLayer(this.additionalPin);
     this.setState({ containsAdditionalPin: true });
   };
 
@@ -125,13 +130,19 @@ class MineHeaderMapLeaflet extends Component {
     this.map = L.map("leaflet-map", { attributionControl: false })
       .setView(this.latLong, Strings.DEFAULT_ZOOM)
       .setMaxZoom(12);
-    this.layerGroup = new L.FeatureGroup().addTo(this.map);
     const majorMinePermittedAreas = getMajorMinePermittedAreas();
     this.map.addLayer(majorMinePermittedAreas);
+
+    this.markerClusterGroup = L.markerClusterGroup({
+      animate: false,
+      spiderfyOnMaxZoom: true,
+      showCoverageOnHover: false,
+    });
+    this.map.addLayer(this.markerClusterGroup);
   }
 
   render() {
-    return <div style={{ height: "100%", width: "100%", zIndex: 0 }} id="leaflet-map" />;
+    return <div style={{ height: "100%", width: "100%" }} id="leaflet-map" />;
   }
 }
 

--- a/services/core-web/src/components/mine/NoticeOfWork/MineCard.js
+++ b/services/core-web/src/components/mine/NoticeOfWork/MineCard.js
@@ -48,7 +48,9 @@ export const MineCard = (props) => {
                   ) : (
                     <ul className="mine-list__permits">
                       {props.mine.mine_permit_numbers.map((permit_no) => (
-                        <li key={permit_no}>{permit_no}</li>
+                        <li key={permit_no}>
+                          <p>{permit_no}</p>
+                        </li>
                       ))}
                     </ul>
                   )

--- a/services/core-web/src/components/mine/NoticeOfWork/MineCard.js
+++ b/services/core-web/src/components/mine/NoticeOfWork/MineCard.js
@@ -42,13 +42,19 @@ export const MineCard = (props) => {
               </div>
               <div className="inline-flex padding-small">
                 <p className="field-title">Permit Number</p>
-                <ul className="mine-list__permits">
-                  {props.mine.mine_permit_numbers && props.mine.mine_permit_numbers.length > 0
-                    ? props.mine.mine_permit_numbers.map((permit_no) => (
+                {props.mine?.mine_permit_numbers?.length > 0 ? (
+                  props.mine.mine_permit_numbers.length === 1 ? (
+                    <p>{props.mine.mine_permit_numbers[0]}</p>
+                  ) : (
+                    <ul className="mine-list__permits">
+                      {props.mine.mine_permit_numbers.map((permit_no) => (
                         <li key={permit_no}>{permit_no}</li>
-                      ))
-                    : Strings.EMPTY_FIELD}
-                </ul>
+                      ))}
+                    </ul>
+                  )
+                ) : (
+                  <p>{Strings.EMPTY_FIELD}</p>
+                )}
               </div>
             </Col>
             <Col md={12} sm={24}>

--- a/services/core-web/src/components/modalContent/GenerateDocumentModal.js
+++ b/services/core-web/src/components/modalContent/GenerateDocumentModal.js
@@ -2,16 +2,17 @@ import React from "react";
 import PropTypes from "prop-types";
 import { Alert } from "antd";
 import { connect } from "react-redux";
-import { getFormSyncErrors } from "redux-form";
+import { getFormSyncErrors, hasSubmitFailed } from "redux-form";
 import GenerateDocumentForm from "@/components/Forms/GenerateDocumentForm";
 import * as FORM from "@/constants/forms";
 
 const propTypes = {
   documentType: PropTypes.objectOf(PropTypes.any).isRequired,
   onSubmit: PropTypes.func.isRequired,
-  title: PropTypes.string,
-  documentFormErrors: PropTypes.arrayOf(PropTypes.objectOf(PropTypes.string)).isRequired,
+  formSyncErrors: PropTypes.arrayOf(PropTypes.objectOf(PropTypes.string)).isRequired,
   signature: PropTypes.string.isRequired,
+  submitFailed: PropTypes.bool.isRequired,
+  title: PropTypes.string,
 };
 
 const defaultProps = {
@@ -19,8 +20,8 @@ const defaultProps = {
 };
 
 export const GenerateDocumentModal = (props) => {
-  const errorsLength = Object.keys(props.documentFormErrors).length;
-  const showErrors = errorsLength > 0;
+  const errorsLength = Object.keys(props.formSyncErrors).length;
+  const showErrors = props.submitFailed && errorsLength > 0;
   return (
     <div>
       {!props.signature && (
@@ -30,7 +31,6 @@ export const GenerateDocumentModal = (props) => {
             description="The signature for the Issuing Inspector has not been provided."
             type="error"
             showIcon
-            style={{ textAlign: "left" }}
           />
           <br />
         </>
@@ -55,7 +55,8 @@ GenerateDocumentModal.propTypes = propTypes;
 GenerateDocumentModal.defaultProps = defaultProps;
 
 const mapStateToProps = (state) => ({
-  documentFormErrors: getFormSyncErrors(FORM.GENERATE_DOCUMENT)(state),
+  formSyncErrors: getFormSyncErrors(FORM.GENERATE_DOCUMENT)(state),
+  submitFailed: hasSubmitFailed(FORM.GENERATE_DOCUMENT)(state),
 });
 
 export default connect(mapStateToProps)(GenerateDocumentModal);

--- a/services/minespace-web/src/components/dashboard/mine/MineDashboard.js
+++ b/services/minespace-web/src/components/dashboard/mine/MineDashboard.js
@@ -8,7 +8,6 @@ import { fetchPartyRelationships } from "@common/actionCreators/partiesActionCre
 import { getStaticContentLoadingIsComplete } from "@common/selectors/staticContentSelectors";
 import * as staticContent from "@common/actionCreators/staticContentActionCreator";
 import { getMines } from "@common/selectors/mineSelectors";
-import { isProponent } from "@/selectors/authenticationSelectors";
 import CustomPropTypes from "@/customPropTypes";
 import Loading from "@/components/common/Loading";
 import Overview from "@/components/dashboard/mine/overview/Overview";
@@ -36,7 +35,6 @@ const propTypes = {
   }).isRequired,
   history: PropTypes.shape({ push: PropTypes.func }).isRequired,
   staticContentLoadingIsComplete: PropTypes.bool.isRequired,
-  isProponent: PropTypes.bool.isRequired,
   dispatch: PropTypes.func.isRequired,
 };
 
@@ -124,11 +122,9 @@ export class MineDashboard extends Component {
                   <TabPane tab="Overview" key={initialTab}>
                     <Overview mine={mine} match={this.props.match} />
                   </TabPane>
-                  {mine.major_mine_ind && (
-                    <TabPane tab="Permits" key="permits">
-                      <Permits mine={mine} match={this.props.match} />
-                    </TabPane>
-                  )}
+                  <TabPane tab="Permits" key="permits">
+                    <Permits mine={mine} match={this.props.match} />
+                  </TabPane>
                   <TabPane tab="Inspections" key="inspections">
                     <Inspections mine={mine} match={this.props.match} />
                   </TabPane>
@@ -141,12 +137,9 @@ export class MineDashboard extends Component {
                   <TabPane tab="Reports" key="reports">
                     <Reports mine={mine} match={this.props.match} />
                   </TabPane>
-                  {/* Hide bonds from proponents for the time being */}
-                  {this.props.isProponent === false && (
-                    <TabPane tab="Bonds" key="bonds">
-                      <Bonds mine={mine} match={this.props.match} />
-                    </TabPane>
-                  )}
+                  <TabPane tab="Bonds" key="bonds">
+                    <Bonds mine={mine} match={this.props.match} />
+                  </TabPane>
                 </Tabs>
               </Col>
             </Row>
@@ -158,7 +151,6 @@ export class MineDashboard extends Component {
 }
 
 const mapStateToProps = (state) => ({
-  isProponent: isProponent(state),
   mines: getMines(state),
   staticContentLoadingIsComplete: getStaticContentLoadingIsComplete(state),
 });


### PR DESCRIPTION
# Main
## MDS-3202
* Bonds are now visible to proponents on MineSpace
* Permits are now visible to regional mines on MineSpace
## MDS-3059
* Fixes an issue on the "document generation" form where the "X remaining issues" message was being displayed when the user hadn't submitted the form yet
## MDS-3118
* Fixes the issue on the NoW verification map, where identical or very close mine and NoW longitude and latitudes would make the pins difficult to see
* Fixes an issue (caused by z-index) where users could not control the zoom level on the NoW verification map

![image](https://user-images.githubusercontent.com/17113094/101409754-2c544400-3893-11eb-9baf-dceaf0a9c86e.png)

## Other
* Improves the styling of single and multiple permit numbers on the mine card
![image](https://user-images.githubusercontent.com/17113094/101409718-2199af00-3893-11eb-9f1e-bdbdff63a86e.png)