### PR TITLE
Add remaining liability when closing a permit

### DIFF
--- a/migrations/sql/V2021.01.04.17.52__add_remaining_liability.sql
+++ b/migrations/sql/V2021.01.04.17.52__add_remaining_liability.sql
@@ -1,0 +1,1 @@
+ALTER TABLE permit ADD COLUMN IF NOT EXISTS remaining_liability numeric;

--- a/services/core-api/app/api/mines/permits/permit/models/permit.py
+++ b/services/core-api/app/api/mines/permits/permit/models/permit.py
@@ -52,6 +52,7 @@ class Permit(SoftDeleteMixin, AuditMixin, Base):
 
     permit_no_sequence = db.Column(db.Integer)
     is_exploration = db.Column(db.Boolean)
+    remaining_liability = db.Column(db.Numeric(16, 2))
 
     bonds = db.relationship(
         'Bond', lazy='select', secondary='bond_permit_xref', order_by='desc(Bond.issue_date)')
@@ -97,7 +98,7 @@ class Permit(SoftDeleteMixin, AuditMixin, Base):
 
     @hybrid_property
     def assessed_liability_total(self):
-        return sum([
+        return self.remaining_liability if self.remaining_liability is not None else sum([
             pa.security_adjustment for pa in self._all_permit_amendments if pa.security_adjustment
         ])
 

--- a/services/core-api/app/api/mines/permits/permit/resources/permit.py
+++ b/services/core-api/app/api/mines/permits/permit/resources/permit.py
@@ -65,6 +65,7 @@ class PermitListResource(Resource, UserMixin):
         help='Whether the permit is an exploration permit or not.')
     parser.add_argument('description', type=str, location='json', help='Permit description')
     parser.add_argument('uploadedFiles', type=list, location='json', store_missing=False)
+    parser.add_argument('remaining_liability', type=str, location='json', store_missing=True)
 
     @api.doc(params={'mine_guid': 'mine_guid to filter on'})
     @requires_role_view_all
@@ -217,6 +218,7 @@ class PermitResource(Resource, UserMixin):
     parser.add_argument(
         'description', type=str, location='json', help='Permit description', store_missing=False)
     parser.add_argument('uploadedFiles', type=list, location='json', store_missing=False)
+    parser.add_argument('remaining_liability', type=str, location='json', store_missing=True)
 
     @api.doc(params={'permit_guid': 'Permit guid.'})
     @requires_role_view_all
@@ -242,6 +244,10 @@ class PermitResource(Resource, UserMixin):
             if key in ['permit_no', 'mine_guid', 'uploadedFiles']:
                 continue     # non-editable fields from put
             setattr(permit, key, value)
+
+        # TODO: Confirm desired behavior
+        if data.get('permit_status_code') != 'C':
+            permit.remaining_liability = None
 
         permit.save()
         return permit

--- a/services/core-api/app/api/mines/response_models.py
+++ b/services/core-api/app/api/mines/response_models.py
@@ -154,6 +154,7 @@ PERMIT_MODEL = api.model(
         'current_permittee': fields.String,
         'project_id': fields.String,
         'permit_amendments': fields.List(fields.Nested(PERMIT_AMENDMENT_MODEL)),
+        'remaining_liability': fields.Fixed(description='Currency', decimals=2),
         'assessed_liability_total': fields.Float,
         'confiscated_bond_total': fields.Float,
         'active_bond_total': fields.Float,

--- a/services/core-web/src/components/Forms/EditPermitForm.js
+++ b/services/core-web/src/components/Forms/EditPermitForm.js
@@ -2,15 +2,16 @@ import React from "react";
 import { connect } from "react-redux";
 import { compose } from "redux";
 import PropTypes from "prop-types";
-import { Field, reduxForm } from "redux-form";
+import { Field, reduxForm, formValueSelector } from "redux-form";
 import { Form } from "@ant-design/compatible";
 import "@ant-design/compatible/assets/index.css";
 import { Button, Col, Row, Popconfirm } from "antd";
-import { required, validateSelectOptions } from "@common/utils/Validate";
-import { resetForm } from "@common/utils/helpers";
+import { required, validateSelectOptions, number } from "@common/utils/Validate";
+import { resetForm, currencyMask } from "@common/utils/helpers";
 import { getDropdownPermitStatusOptions } from "@common/selectors/staticContentSelectors";
 import * as FORM from "@/constants/forms";
 import RenderSelect from "@/components/common/RenderSelect";
+import { renderConfig } from "@/components/common/config";
 import CustomPropTypes from "@/customPropTypes";
 
 const propTypes = {
@@ -19,7 +20,10 @@ const propTypes = {
   permitStatusOptions: PropTypes.arrayOf(CustomPropTypes.dropdownListItem).isRequired,
   title: PropTypes.string.isRequired,
   submitting: PropTypes.bool.isRequired,
+  permitStatusCode: PropTypes.string.isRequired,
 };
+
+const selector = formValueSelector(FORM.EDIT_PERMIT);
 
 export const EditPermitForm = (props) => (
   <Form layout="vertical" onSubmit={props.handleSubmit}>
@@ -36,6 +40,18 @@ export const EditPermitForm = (props) => (
             validate={[required, validateSelectOptions(props.permitStatusOptions)]}
           />
         </Form.Item>
+        {props.permitStatusCode === "C" && (
+          <Form.Item>
+            <Field
+              id="remaining_liability"
+              name="remaining_liability"
+              label="Remaining liability*"
+              component={renderConfig.FIELD}
+              {...currencyMask}
+              validate={[number, required]}
+            />
+          </Form.Item>
+        )}
       </Col>
     </Row>
     <div className="right center-mobile">
@@ -63,6 +79,7 @@ EditPermitForm.propTypes = propTypes;
 export default compose(
   connect((state) => ({
     permitStatusOptions: getDropdownPermitStatusOptions(state),
+    permitStatusCode: selector(state, "permit_status_code"),
   })),
   reduxForm({
     form: FORM.EDIT_PERMIT,

--- a/services/core-web/src/components/modalContent/EditPermitModal.js
+++ b/services/core-web/src/components/modalContent/EditPermitModal.js
@@ -5,9 +5,18 @@ import EditPermitForm from "@/components/Forms/EditPermitForm";
 const propTypes = {
   onSubmit: PropTypes.func.isRequired,
   title: PropTypes.string.isRequired,
+  initialValues: PropTypes.objectOf(PropTypes.any).isRequired,
 };
 
-export const EditPermitModal = (props) => <EditPermitForm {...props} />;
+export const EditPermitModal = (props) => (
+  <EditPermitForm
+    {...props}
+    initialValues={{
+      ...props.initialValues,
+      remaining_liability: props.initialValues.remaining_liability || 0,
+    }}
+  />
+);
 
 EditPermitModal.propTypes = propTypes;
 


### PR DESCRIPTION
Adds the ability to set a remaining liability when closing a permit, and displays this value as the total assessed liability after closing:

![image](https://user-images.githubusercontent.com/7525580/103664163-f496f580-4f3f-11eb-954c-a7a6f5eb8aa2.png)

![image](https://user-images.githubusercontent.com/7525580/103664192-fcef3080-4f3f-11eb-934c-628f10447ebd.png)

![image](https://user-images.githubusercontent.com/7525580/103664217-04163e80-4f40-11eb-8010-4c6d9fd28f06.png)
