### PR TITLE
Remove "Drag and drop to upload" message for empty folders

### DIFF
--- a/services/core-web/src/styles/tools/syncfusion.scss
+++ b/services/core-web/src/styles/tools/syncfusion.scss
@@ -39,3 +39,7 @@ $error-font: $error-color; //#f44336;
 @import "../../../node_modules/@syncfusion/ej2-layouts/styles/material.scss";
 @import "../../../node_modules/@syncfusion/ej2-grids/styles/material.scss";
 @import "../../../node_modules/@syncfusion/ej2-react-filemanager/styles/material.scss";
+
+.e-empty-inner-content {
+  display: none;
+}


### PR DESCRIPTION
* Remove "Drag and drop to upload" message for empty folders
![image](https://user-images.githubusercontent.com/17113094/105067662-c5e74780-5a34-11eb-8a71-0320f0e3863f.png)
