### PR TITLE
MDS-3354: Fix Name Issue With Party Organizations

### DIFF
--- a/migrations/sql/V2021.01.28.10.10__remove_first_name_for_party_organizations.sql
+++ b/migrations/sql/V2021.01.28.10.10__remove_first_name_for_party_organizations.sql
@@ -1,0 +1,1 @@
+UPDATE party set first_name = NULL WHERE party_type_code = 'ORG';

--- a/migrations/sql/V2021.01.28.12.36__alter_table_party_drop_column_middle_name.sql
+++ b/migrations/sql/V2021.01.28.12.36__alter_table_party_drop_column_middle_name.sql
@@ -1,0 +1,1 @@
+ALTER TABLE party DROP COLUMN middle_name;

--- a/services/core-api/app/api/parties/party/models/party.py
+++ b/services/core-api/app/api/parties/party/models/party.py
@@ -20,8 +20,6 @@ class Party(SoftDeleteMixin, AuditMixin, Base):
 
     party_guid = db.Column(UUID(as_uuid=True), primary_key=True, server_default=FetchedValue())
     first_name = db.Column(db.String)
-    # TODO: Determine if this column is necessary; it appears to not be used by anything.
-    middle_name = db.Column(db.String)
     party_name = db.Column(db.String, nullable=False)
     phone_no = db.Column(db.String)
     phone_ext = db.Column(db.String)

--- a/services/core-api/app/api/parties/party/models/party.py
+++ b/services/core-api/app/api/parties/party/models/party.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 import re
-from flask import current_app
 
 from sqlalchemy import func, case, and_
 from sqlalchemy.schema import FetchedValue
@@ -145,16 +144,9 @@ class Party(SoftDeleteMixin, AuditMixin, Base):
                party_name,
                phone_no,
                party_type_code,
-               address_type_code=None,
                email=None,
                first_name=None,
                phone_ext=None,
-               suite_no=None,
-               address_line_1=None,
-               address_line_2=None,
-               city=None,
-               sub_division_code=None,
-               post_code=None,
                add_to_session=True):
         party = cls(
             party_name=party_name,

--- a/services/core-api/app/api/parties/party/models/party.py
+++ b/services/core-api/app/api/parties/party/models/party.py
@@ -1,55 +1,61 @@
 from datetime import datetime
 import re
-import uuid
+from flask import current_app
 
-from sqlalchemy import func
+from sqlalchemy import func, case
 from sqlalchemy.schema import FetchedValue
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import validates
-from app.extensions import db
 from werkzeug.exceptions import BadRequest
 
+from app.extensions import db
 from app.api.utils.models_mixins import SoftDeleteMixin, AuditMixin, Base
 from app.api.parties.party.models.address import Address
+
+MAX_NAME_LENGTH = 100
 
 
 class Party(SoftDeleteMixin, AuditMixin, Base):
     __tablename__ = 'party'
+
     party_guid = db.Column(UUID(as_uuid=True), primary_key=True, server_default=FetchedValue())
-    first_name = db.Column(db.String, nullable=True)
-    middle_name = db.Column(db.String, nullable=True)
+    first_name = db.Column(db.String)
+    # TODO: Determine if this column is necessary; it appears to not be used by anything.
+    middle_name = db.Column(db.String)
     party_name = db.Column(db.String, nullable=False)
-    phone_no = db.Column(db.String, nullable=False)
-    phone_ext = db.Column(db.String, nullable=True)
-    email = db.Column(db.String, nullable=True)
+    phone_no = db.Column(db.String)
+    phone_ext = db.Column(db.String)
+    email = db.Column(db.String)
     party_type_code = db.Column(db.String, db.ForeignKey('party_type_code.party_type_code'))
+    address = db.relationship('Address', lazy='joined')
+    job_title = db.Column(db.String)
+    postnominal_letters = db.Column(db.String)
+    idir_username = db.Column(db.String)
+    signature = db.Column(db.String)
 
     mine_party_appt = db.relationship('MinePartyAppointment', lazy='joined')
-    address = db.relationship('Address', lazy='joined')
-    job_title = db.Column(db.String, nullable=True)
-    postnominal_letters = db.Column(db.String, nullable=True)
-    idir_username = db.Column(db.String, nullable=True)
-    signature = db.Column(db.String, nullable=True)
+
     now_party_appt = db.relationship(
         'NOWPartyAppointment',
         lazy='selectin',
         primaryjoin=
-        "and_(NOWPartyAppointment.party_guid == Party.party_guid, NOWPartyAppointment.deleted_ind==False)"
+        'and_(NOWPartyAppointment.party_guid == Party.party_guid, NOWPartyAppointment.deleted_ind==False)'
     )
 
     business_role_appts = db.relationship(
         'PartyBusinessRoleAppointment',
         lazy='dynamic',
         primaryjoin=
-        "and_(Party.party_guid == PartyBusinessRoleAppointment.party_guid, PartyBusinessRoleAppointment.deleted_ind==False)",
+        'and_(Party.party_guid == PartyBusinessRoleAppointment.party_guid, PartyBusinessRoleAppointment.deleted_ind==False)',
     )
+
     party_orgbook_entity = db.relationship(
         'PartyOrgBookEntity', backref='party_orgbook_entity', uselist=False, lazy='select')
 
     @hybrid_property
     def name(self):
-        return self.first_name + ' ' + self.party_name if self.first_name else self.party_name
+        return f'{self.first_name} {self.party_name}' if self.first_name and self.party_type_code == 'PER' else self.party_name
 
     @hybrid_property
     def phone(self):
@@ -71,7 +77,11 @@ class Party(SoftDeleteMixin, AuditMixin, Base):
 
     @name.expression
     def name(cls):
-        return func.concat(cls.first_name, ' ', cls.party_name)
+        return case([
+            (cls.first_name != None
+             and cls.party_type_code == 'PER', f'{cls.first_name} {cls.party_name}'),
+        ],
+                    else_=cls.party_name)
 
     def __repr__(self):
         return '<Party %r>' % self.party_guid
@@ -91,6 +101,7 @@ class Party(SoftDeleteMixin, AuditMixin, Base):
             'postnominal_letters': self.postnominal_letters,
             'idir_username': self.idir_username
         }
+
         if self.party_type_code == 'PER':
             context.update({
                 'first_name': self.first_name,
@@ -100,15 +111,12 @@ class Party(SoftDeleteMixin, AuditMixin, Base):
             context.update({
                 'mine_party_appt': [item.json() for item in self.mine_party_appt],
             })
+
         return context
 
     @classmethod
-    def find_by_party_guid(cls, _id):
-        try:
-            uuid.UUID(_id)
-        except ValueError:
-            raise BadRequest('Invalid Party guid')
-        return cls.query.filter_by(party_guid=_id, deleted_ind=False).first()
+    def find_by_party_guid(cls, party_guid):
+        return cls.query.filter_by(party_guid=party_guid, deleted_ind=False).one_or_none()
 
     @classmethod
     def find_by_name(cls, party_name, first_name=None):
@@ -133,33 +141,27 @@ class Party(SoftDeleteMixin, AuditMixin, Base):
                 cls.deleted_ind == False).limit(query_limit)
 
     @classmethod
-    def create(
-            cls,
-                                                 # Required fields
-            party_name,
-            phone_no,
-            party_type_code,
-                                                 # Optional fields
-            address_type_code=None,
-                                                 # Nullable fields
-            email=None,
-            first_name=None,
-            phone_ext=None,
-            suite_no=None,
-            address_line_1=None,
-            address_line_2=None,
-            city=None,
-            sub_division_code=None,
-            post_code=None,
-            add_to_session=True):
+    def create(cls,
+               party_name,
+               phone_no,
+               party_type_code,
+               address_type_code=None,
+               email=None,
+               first_name=None,
+               phone_ext=None,
+               suite_no=None,
+               address_line_1=None,
+               address_line_2=None,
+               city=None,
+               sub_division_code=None,
+               post_code=None,
+               add_to_session=True):
         party = cls(
-                                                 # Required fields
             party_name=party_name,
             phone_no=phone_no,
             party_type_code=party_type_code,
-                                                 # Optional fields
             email=email,
-            first_name=first_name,
+            first_name=first_name if party_type_code == 'PER' else None,
             phone_ext=phone_ext)
         if add_to_session:
             party.save(commit=False)
@@ -176,17 +178,19 @@ class Party(SoftDeleteMixin, AuditMixin, Base):
     @validates('first_name')
     def validate_first_name(self, key, first_name):
         if self.party_type_code == 'PER' and not first_name:
-            raise AssertionError('Person first name is not provided.')
-        if first_name and len(first_name) > 100:
-            raise AssertionError('Person first name must not exceed 100 characters.')
+            raise AssertionError('First name is not provided.')
+        if self.party_type_code == 'ORG' and first_name:
+            raise AssertionError('Organizations cannot have a first name.')
+        if first_name and len(first_name) > MAX_NAME_LENGTH:
+            raise AssertionError(f'First name must not exceed {MAX_NAME_LENGTH} characters.')
         return first_name
 
     @validates('party_name')
     def validate_party_name(self, key, party_name):
         if not party_name:
             raise AssertionError('Party name is not provided.')
-        if len(party_name) > 100:
-            raise AssertionError('Party name must not exceed 100 characters.')
+        if len(party_name) > MAX_NAME_LENGTH:
+            raise AssertionError(f'Party name must not exceed {MAX_NAME_LENGTH} characters.')
         return party_name
 
     @validates('phone_no')

--- a/services/core-api/tests/parties/party/models/test_party_model.py
+++ b/services/core-api/tests/parties/party/models/test_party_model.py
@@ -1,6 +1,6 @@
 import pytest
 
-from app.api.parties.party.models.party import Party
+from app.api.parties.party.models.party import Party, MAX_NAME_LENGTH
 from tests.factories import PartyFactory
 
 
@@ -31,11 +31,11 @@ def test_party_model_validate_first_name():
     with pytest.raises(AssertionError) as e:
         Party(
             party_name='test_fail_party_name',
-            first_name='e' * 101,
+            first_name='e' * (MAX_NAME_LENGTH + 1),
             party_type_code='PER',
             phone_no='123-123-1234',
             phone_ext='1234')
-    assert 'Person first name must not exceed 100 characters.' in str(e.value)
+    assert f'First name must not exceed {MAX_NAME_LENGTH} characters.' in str(e.value)
 
 
 def test_party_model_validate_party_name_not_provided():
@@ -49,15 +49,15 @@ def test_party_model_validate_party_name_not_provided():
     assert 'Party name is not provided.' in str(e.value)
 
 
-def test_party_model_validate_party_name_exceeds_100_chars():
+def test_party_model_validate_party_name_exceeds_char_limit():
     with pytest.raises(AssertionError) as e:
         Party(
-            party_name='p' * 101,
+            party_name='p' * (MAX_NAME_LENGTH + 1),
             first_name='test_first_name_fail',
             party_type_code='PER',
             phone_no='123-123-1234',
             phone_ext='1234')
-    assert 'Party name must not exceed 100 characters.' in str(e.value)
+    assert f'Party name must not exceed {MAX_NAME_LENGTH} characters.' in str(e.value)
 
 
 def test_party_model_validate_phone_no_not_provided():


### PR DESCRIPTION
# Main
* Fixes an issue where parties of type "organization" could be created with a "first name" field, causing data quality issues
* Sets `first_name` to null for all existing parties that are an organization
# Other
* Fixes an issue where a party's "name" hybrid property and expression was not being correctly calculated