### PR TITLE
Double unittest timeout in sonar pod

### DIFF
--- a/openshift/templates/sonar.pod.json
+++ b/openshift/templates/sonar.pod.json
@@ -155,7 +155,7 @@
           }
         ],
         "restartPolicy": "Never",
-        "activeDeadlineSeconds": 900,
+        "activeDeadlineSeconds": 1800,
         "dnsPolicy": "ClusterFirst"
       },
       "status": {}


### PR DESCRIPTION
Doubles active deadline for sonar pod as a temporary fix for the blocking timeout issue.