### PR TITLE
Fix/increase-flyway-deploy-mem

### DIFF
--- a/openshift/templates/_python36.dc.json
+++ b/openshift/templates/_python36.dc.json
@@ -735,7 +735,7 @@
                 "resources": {
                   "limits": {
                     "cpu": "100m",
-                    "memory": "384Mi"
+                    "memory": "512Mi"
                   },
                   "requests": {
                     "cpu": "50m",


### PR DESCRIPTION
The pre-hook deploy for the backend is running this pod. The pod is slamming up against the prior 384Mi limit before getting oom killed and causing the deploy to dev to fail.