### PR TITLE
Fix/Can't save empty string preamble date

### DIFF
--- a/services/core-api/app/api/mines/permits/permit_amendment/resources/permit_amendment.py
+++ b/services/core-api/app/api/mines/permits/permit_amendment/resources/permit_amendment.py
@@ -330,7 +330,7 @@ class PermitAmendmentResource(Resource, UserMixin):
                     continue
                 doc.preamble_title = values.get('preamble_title')
                 doc.preamble_author = values.get('preamble_author')
-                doc.preamble_date = values.get('preamble_date')
+                doc.preamble_date = values.get('preamble_date') or None
                 doc.save()
 
         # Update file metadata for the requested final application package files.
@@ -343,7 +343,7 @@ class PermitAmendmentResource(Resource, UserMixin):
                     continue
                 doc.preamble_title = values.get('preamble_title')
                 doc.preamble_author = values.get('preamble_author')
-                doc.preamble_date = values.get('preamble_date')
+                doc.preamble_date = values.get('preamble_date') or None
                 doc.save()
 
         # Update file metadata for the previous amendment files.
@@ -358,7 +358,7 @@ class PermitAmendmentResource(Resource, UserMixin):
                     continue
                 doc.preamble_title = values.get('preamble_title')
                 doc.preamble_author = values.get('preamble_author')
-                doc.preamble_date = values.get('preamble_date')
+                doc.preamble_date = values.get('preamble_date') or None
                 doc.save()
 
         permit_amendment.save()


### PR DESCRIPTION
* Fixes an issue where sending over an empty preamble date was sending over an empty string, and the backend could not parse this correctly as null

![image](https://user-images.githubusercontent.com/17113094/109733539-20b3a900-7b74-11eb-8349-a8faa684ac16.png)
