### PR TITLE
Fix: update docgen api image ver to 2.1.2 to increase max request size

### DIFF
--- a/openshift/templates/docgen/docgen.bc.json
+++ b/openshift/templates/docgen/docgen.bc.json
@@ -44,7 +44,7 @@
             "annotations": null,
             "from": {
               "kind": "DockerImage",
-              "name": "bcgovimages/doc-gen-api:v2.1.1"
+              "name": "bcgovimages/doc-gen-api:v2.1.2"
             },
             "generation": 2,
             "importPolicy": {},


### PR DESCRIPTION
Checked that docker-compose is able to pull the new image. We should check in test before deploying to prod.