### PR TITLE
Add file type option to generated NoW documents.

### DIFF
--- a/services/core-api/app/api/services/document_generator_service.py
+++ b/services/core-api/app/api/services/document_generator_service.py
@@ -19,6 +19,9 @@ class DocumentGeneratorService():
     @classmethod
     def generate_document(cls, document_template, template_data):
 
+        file_type = template_data.get('file_type')
+        file_type = file_type.lower() if file_type else 'pdf'
+
         # Get the template file
         fileobj = None
         dynamic_template = document_template.get_dynamic_template(template_data)
@@ -38,8 +41,8 @@ class DocumentGeneratorService():
         document_name_start_extra = f'{document_name_start_extra} ' if document_name_start_extra else ''
         date_string = datetime.date.today().strftime("%Y-%m-%d")
         draft_string = ' DRAFT' if template_data.get('is_draft') == True else ''
-        document_name = f'{document_name_start_extra}{document_template.template_name_no_extension}{draft_string} {date_string}.pdf'
-        data = {'data': template_data, 'options': {'reportName': document_name, 'convertTo': 'pdf'}}
+        document_name = f'{document_name_start_extra}{document_template.template_name_no_extension}{draft_string} {date_string}.{file_type}'
+        data = {'data': template_data, 'options': {'reportName': document_name, 'convertTo': file_type}}
 
         # Send the document generation request and return the response
         resp = requests.post(

--- a/services/core-web/src/components/Forms/GenerateDocumentForm.js
+++ b/services/core-web/src/components/Forms/GenerateDocumentForm.js
@@ -1,26 +1,41 @@
-import React from "react";
+import React, { useState } from "react";
 import PropTypes from "prop-types";
-import { reduxForm } from "redux-form";
+import { reduxForm, Field } from "redux-form";
 import { Form } from "@ant-design/compatible";
 import "@ant-design/compatible/assets/index.css";
-import { Button, Col, Row, Popconfirm } from "antd";
+import { Button, Col, Row, Popconfirm, Alert } from "antd";
 import { resetForm } from "@common/utils/helpers";
 import * as FORM from "@/constants/forms";
 import { getGenerateDocumentFormField } from "@/components/common/GenerateDocumentFormField";
+import RenderSelect from "@/components/common/RenderSelect";
 
 const propTypes = {
+  initialValues: PropTypes.objectOf(PropTypes.any).isRequired,
   documentType: PropTypes.objectOf(PropTypes.any).isRequired,
   handleSubmit: PropTypes.func.isRequired,
   closeModal: PropTypes.func.isRequired,
   submitting: PropTypes.bool.isRequired,
   additionalTitle: PropTypes.string,
   disabled: PropTypes.bool,
+  allowDocx: PropTypes.bool,
 };
 
 const defaultProps = {
   additionalTitle: "",
   disabled: false,
+  allowDocx: false,
 };
+
+const fileTypes = [
+  {
+    label: ".PDF",
+    value: "PDF",
+  },
+  {
+    label: ".DOCX",
+    value: "DOCX",
+  },
+];
 
 const createFields = (fields) => (
   <div>
@@ -38,36 +53,70 @@ const createFields = (fields) => (
   </div>
 );
 
-export const GenerateDocumentForm = (props) => (
-  <Form layout="vertical" onSubmit={props.handleSubmit}>
-    <Row gutter={16}>
-      <Col span={24}>{createFields(props.documentType.document_template.form_spec)}</Col>
-    </Row>
-    <div className="right center-mobile">
-      <Popconfirm
-        placement="topRight"
-        title="Are you sure you want to cancel?"
-        onConfirm={props.closeModal}
-        okText="Yes"
-        cancelText="No"
-        disabled={props.submitting}
-      >
-        <Button className="full-mobile" type="secondary" disabled={props.submitting}>
-          Cancel
+export const GenerateDocumentForm = (props) => {
+  const [fileType, setFileType] = useState("PDF");
+
+  return (
+    <Form layout="vertical" onSubmit={props.handleSubmit}>
+      {props.allowDocx && (
+        <div>
+          <Row key="fileType">
+            <Col span={24}>
+              <>
+                <Form.Item>
+                  <Field
+                    id="file_type"
+                    name="file_type"
+                    label="Select the file type for this document"
+                    data={fileTypes}
+                    component={RenderSelect}
+                    onChange={(value) => setFileType(value)}
+                  />
+                </Form.Item>
+                {fileType === "DOCX" && (
+                  <>
+                    <Alert
+                      description="If you plan to edit this document, please ensure that you do not change any vital information that would contradict BC government legislation pertaining to privacy, or financial information."
+                      type="warning"
+                      showIcon
+                    />
+                    <br />
+                  </>
+                )}
+              </>
+            </Col>
+          </Row>
+        </div>
+      )}
+      <Row gutter={16}>
+        <Col span={24}>{createFields(props.documentType.document_template.form_spec)}</Col>
+      </Row>
+      <div className="right center-mobile">
+        <Popconfirm
+          placement="topRight"
+          title="Are you sure you want to cancel?"
+          onConfirm={props.closeModal}
+          okText="Yes"
+          cancelText="No"
+          disabled={props.submitting}
+        >
+          <Button className="full-mobile" type="secondary" disabled={props.submitting}>
+            Cancel
+          </Button>
+        </Popconfirm>
+        <Button
+          className="full-mobile"
+          type="primary"
+          htmlType="submit"
+          loading={props.submitting}
+          disabled={props.disabled}
+        >
+          Generate {props.documentType.description} {props.additionalTitle}
         </Button>
-      </Popconfirm>
-      <Button
-        className="full-mobile"
-        type="primary"
-        htmlType="submit"
-        loading={props.submitting}
-        disabled={props.disabled}
-      >
-        Generate {props.documentType.description} {props.additionalTitle}
-      </Button>
-    </div>
-  </Form>
-);
+      </div>
+    </Form>
+  );
+};
 
 GenerateDocumentForm.propTypes = propTypes;
 GenerateDocumentForm.defaultProps = defaultProps;

--- a/services/core-web/src/components/Forms/GenerateDocumentForm.js
+++ b/services/core-web/src/components/Forms/GenerateDocumentForm.js
@@ -76,7 +76,7 @@ export const GenerateDocumentForm = (props) => {
                 {fileType === "DOCX" && (
                   <>
                     <Alert
-                      description="If you plan to edit this document, please ensure that you do not change any vital information that would contradict BC government legislation pertaining to privacy, or financial information."
+                      description="If you plan to edit this document, please ensure that you do not change any vital information that would contradict BC government legislation pertaining to privacy or financial information."
                       type="warning"
                       showIcon
                     />

--- a/services/core-web/src/components/modalContent/GenerateDocumentModal.js
+++ b/services/core-web/src/components/modalContent/GenerateDocumentModal.js
@@ -7,16 +7,19 @@ import GenerateDocumentForm from "@/components/Forms/GenerateDocumentForm";
 import * as FORM from "@/constants/forms";
 
 const propTypes = {
+  initialValues: PropTypes.objectOf(PropTypes.any).isRequired,
   documentType: PropTypes.objectOf(PropTypes.any).isRequired,
   onSubmit: PropTypes.func.isRequired,
   formSyncErrors: PropTypes.arrayOf(PropTypes.objectOf(PropTypes.string)).isRequired,
   signature: PropTypes.string.isRequired,
   submitFailed: PropTypes.bool.isRequired,
   title: PropTypes.string,
+  allowDocx: PropTypes.bool,
 };
 
 const defaultProps = {
   title: "Generate Document",
+  allowDocx: false,
 };
 
 export const GenerateDocumentModal = (props) => {
@@ -35,7 +38,11 @@ export const GenerateDocumentModal = (props) => {
           <br />
         </>
       )}
-      <GenerateDocumentForm {...props} disabled={!props.signature} />
+      <GenerateDocumentForm
+        {...props}
+        initialValues={{ ...props.initialValues, file_type: "PDF" }}
+        disabled={!props.signature}
+      />
       {showErrors && (
         <div className="error center">
           <Alert

--- a/services/core-web/src/components/modalContent/UpdateStatusGenerateLetterModal.js
+++ b/services/core-web/src/components/modalContent/UpdateStatusGenerateLetterModal.js
@@ -73,11 +73,13 @@ export class UpdateStatusGenerateLetterModal extends Component {
         content: (
           <GenerateDocumentForm
             {...this.props}
+            initialValues={{ ...this.props.initialValues, file_type: "PDF" }}
             showActions={false}
             additionalTitle="and Process"
             onSubmit={this.handleGenerate}
             submitting={this.state.submitting}
             disabled={!this.props.signature}
+            allowDocx
           />
         ),
       },

--- a/services/core-web/src/components/noticeOfWork/applications/administrative/AdministrativeTab.js
+++ b/services/core-web/src/components/noticeOfWork/applications/administrative/AdministrativeTab.js
@@ -89,6 +89,7 @@ export class AdministrativeTab extends Component {
             onSubmit: (values) => this.handleGenerateDocumentFormSubmit(documentType, values),
             title: `Generate ${documentType.description}`,
             signature,
+            allowDocx: true,
           },
           width: "75vw",
           content: modalConfig.GENERATE_DOCUMENT,


### PR DESCRIPTION
This PR adds an option to choose between PDF or DOCX generated documents when generating NoW documents. If DOCX is selected, a warning is displayed to users.

![image](https://user-images.githubusercontent.com/7525580/119581363-40bfc680-bd77-11eb-922b-7e2e22705e49.png)

![image](https://user-images.githubusercontent.com/7525580/119581397-51703c80-bd77-11eb-8cfa-2a90f6716fa3.png)
