### PR TITLE
Bugfix/mds 3611

### DIFF
--- a/services/core-api/app/api/parties/party/resources/party_resource.py
+++ b/services/core-api/app/api/parties/party/resources/party_resource.py
@@ -137,7 +137,7 @@ class PartyResource(Resource, UserMixin):
 
         current_app.logger.info(f'Updating {existing_party} with {data}')
         for key, value in data.items():
-            if key in ['party_type_code']:
+            if key in ['party_type_code', 'signature']:
                 continue     # non-editable fields from put
             setattr(existing_party, key, value)
 
@@ -162,7 +162,7 @@ class PartyResource(Resource, UserMixin):
                 existing_party.party_guid, "INS")
 
             if existing_party.signature != signature:
-                existing_party = signature
+                existing_party.signature = signature
 
             if data.get("set_to_inspector"):
                 start_date = data.inspector_start_date if data.get(

--- a/services/core-api/tests/parties/party/resources/test_party_resource.py
+++ b/services/core-api/tests/parties/party/resources/test_party_resource.py
@@ -257,5 +257,5 @@ def test_set_party_to_inspector_not_by_admin_fail(test_client, db_session, auth_
         headers=auth_headers['core_edit_parties_only_auth_header'])
     put_data = json.loads(put_resp.data.decode())
     assert put_resp.status_code == 200
-    assert put_data['signature'] == test_person_data['signature']
+    assert not put_data['signature']
     assert not put_data['business_role_appts']

--- a/services/core-web/src/components/Forms/parties/EditFullPartyForm.js
+++ b/services/core-web/src/components/Forms/parties/EditFullPartyForm.js
@@ -318,13 +318,13 @@ export class EditFullPartyForm extends Component {
           {isPerson && (
             <>
               <br />
-              <Divider />
-              <Row gutter={16}>
-                <Col span={24}>
-                  <h5>Assign Inspector Role</h5>
-                </Col>
-              </Row>
               <AuthorizationWrapper permission={Permission.ADMIN}>
+                <Divider />
+                <Row gutter={16}>
+                  <Col span={24}>
+                    <h5>Assign Inspector Role</h5>
+                  </Col>
+                </Row>
                 <Row>
                   <p>
                     By setting this checkbox you grant inspector role to this party. Please note

--- a/services/core-web/src/tests/components/Forms/parties/__snapshots__/EditFullPartyForm.spec.js.snap
+++ b/services/core-web/src/tests/components/Forms/parties/__snapshots__/EditFullPartyForm.spec.js.snap
@@ -311,21 +311,21 @@ exports[`EditFullPartyForm renders properly 1`] = `
       />
     </Row>
     <br />
-    <Divider />
-    <Row
-      gutter={16}
-    >
-      <Col
-        span={24}
-      >
-        <h5>
-          Assign Inspector Role
-        </h5>
-      </Col>
-    </Row>
     <Connect(AuthorizationWrapper)
       permission="role_admin"
     >
+      <Divider />
+      <Row
+        gutter={16}
+      >
+        <Col
+          span={24}
+        >
+          <h5>
+            Assign Inspector Role
+          </h5>
+        </Col>
+      </Row>
       <Row>
         <p>
           By setting this checkbox you grant inspector role to this party. Please note that removing this checkbox will not delete party from associated entities.


### PR DESCRIPTION
- do not reset the signature if the inspector was updated by non-admin user
- hid the ASSIGN INSPECTOR label from none admin users