### PR TITLE
Fix/adjust ocp4 quotas

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -55,33 +55,33 @@ jobs:
           -p TAG=${{env.INITIAL_TAG}} \
           | oc -n ${{secrets.NS_TOOLS}} apply -f -
 
-  build-bases:
-    name: build-bases
-    needs: template
-    runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        include:
-          - name: frontend
-          - name: backend
-          - name: docman
-          - name: nris
-          - name: minespace
-    steps:
-      - name: Install oc
-        uses: redhat-actions/oc-installer@v1
-        with:
-          oc_version: "4.6"
-      - name: oc login
-        run: |
-          oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
-      - name: build
-        run: |
-          oc start-build ${{ matrix.name }}-base -n ${{secrets.NS_TOOLS}} --wait
+  # build-bases:
+  #   name: build-bases
+  #   needs: template
+  #   runs-on: ubuntu-20.04
+  #   strategy:
+  #     matrix:
+  #       include:
+  #         - name: frontend
+  #         - name: backend
+  #         - name: docman
+  #         - name: nris
+  #         - name: minespace
+  #   steps:
+  #     - name: Install oc
+  #       uses: redhat-actions/oc-installer@v1
+  #       with:
+  #         oc_version: "4.6"
+  #     - name: oc login
+  #       run: |
+  #         oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
+  #     - name: build
+  #       run: |
+  #         oc start-build ${{ matrix.name }}-base -n ${{secrets.NS_TOOLS}} --wait
 
   build:
     name: build
-    needs: build-bases
+    needs: template
     runs-on: ubuntu-20.04
     strategy:
       matrix:

--- a/openshift4/templates/backend.dc.yaml
+++ b/openshift4/templates/backend.dc.yaml
@@ -48,7 +48,7 @@ parameters:
   - name: CPU_REQUEST
     value: 150m
   - name: MEMORY_REQUEST
-    value: 768Mi
+    value: 512Mi
   - name: UWSGI_PROCESSES
     value: "2"
   - name: UWSGI_THREADS

--- a/openshift4/templates/docman.dc.yaml
+++ b/openshift4/templates/docman.dc.yaml
@@ -49,9 +49,9 @@ parameters:
   - name: MEMORY_LIMIT
     value: 1.5Gi
   - name: CPU_REQUEST
-    value: 225m
+    value: 128m
   - name: MEMORY_REQUEST
-    value: 1152Mi
+    value: 512Mi
   - name: UWSGI_PROCESSES
     value: "4"
   - name: UWSGI_THREADS
@@ -67,7 +67,7 @@ parameters:
   - name: WORKER_CPU_LIMIT
     value: 225m
   - name: WORKER_MEMORY_REQUEST
-    value: 1152Mi
+    value: 900Mi
   - name: WORKER_REPLICA_MIN
     value: "1"
   - name: WORKER_REPLICA_MAX


### PR DESCRIPTION
Adjusts docman and backend dc's to use less memory based on ocp3 metrics and needs.

Also disables base image builds to save time as those base images should not change unless a security fix / update is manually needed.