### PR TITLE
Remove configchange triggers from all buildconfigs 

### DIFF
--- a/openshift4/templates/backend.bc.yaml
+++ b/openshift4/templates/backend.bc.yaml
@@ -77,8 +77,6 @@ objects:
       completionDeadlineSeconds: 1440
       triggers:
         - type: ImageChange
-          imageChange: {}
-        - type: ConfigChange
       runPolicy: SerialLatestOnly
       source:
         contextDir: openshift/docker-images/python-36
@@ -119,7 +117,6 @@ objects:
       completionDeadlineSeconds: 600
       triggers:
         - type: ImageChange
-        - type: ConfigChange
       runPolicy: SerialLatestOnly
       source:
         type: Git

--- a/openshift4/templates/dbbackup.bc.yaml
+++ b/openshift4/templates/dbbackup.bc.yaml
@@ -57,7 +57,6 @@ objects:
       completionDeadlineSeconds: 600
       triggers:
         - type: ImageChange
-        - type: ConfigChange
       runPolicy: SerialLatestOnly
       source:
         type: Git

--- a/openshift4/templates/docman.bc.yaml
+++ b/openshift4/templates/docman.bc.yaml
@@ -77,8 +77,6 @@ objects:
       completionDeadlineSeconds: 1440
       triggers:
         - type: ImageChange
-          imageChange: {}
-        - type: ConfigChange
       runPolicy: SerialLatestOnly
       source:
         type: Git
@@ -117,7 +115,6 @@ objects:
       completionDeadlineSeconds: 600
       triggers:
         - type: ImageChange
-        - type: ConfigChange
       runPolicy: SerialLatestOnly
       source:
         type: Git

--- a/openshift4/templates/filesystem-provider.bc.yaml
+++ b/openshift4/templates/filesystem-provider.bc.yaml
@@ -40,7 +40,6 @@ objects:
         app: ${NAME}
     spec:
       triggers:
-        - type: ConfigChange
         - type: ImageChange
       runPolicy: Serial
       source:
@@ -78,7 +77,6 @@ objects:
         app: ${NAME}-base
     spec:
       triggers:
-        - type: ConfigChange
         - type: ImageChange
       runPolicy: Serial
       source:

--- a/openshift4/templates/flyway.bc.yaml
+++ b/openshift4/templates/flyway.bc.yaml
@@ -61,8 +61,6 @@ objects:
       completionDeadlineSeconds: 1440
       triggers:
         - type: ImageChange
-          imageChange: {}
-        - type: ConfigChange
       runPolicy: SerialLatestOnly
       source:
         contextDir: ${SOURCE_CONTEXT_DIR}

--- a/openshift4/templates/frontend.bc.yaml
+++ b/openshift4/templates/frontend.bc.yaml
@@ -83,8 +83,6 @@ objects:
       successfulBuildsHistoryLimit: 5
       failedBuildsHistoryLimit: 5
       completionDeadlineSeconds: 1440
-      triggers:
-        - type: ConfigChange
       runPolicy: SerialLatestOnly
       source:
         contextDir: ${DOCKER_IMAGE_DIRECTORY}
@@ -125,7 +123,6 @@ objects:
       completionDeadlineSeconds: 900
       triggers:
         - type: ImageChange
-        - type: ConfigChange
       runPolicy: SerialLatestOnly
       source:
         type: Git

--- a/openshift4/templates/metabase.bc.yaml
+++ b/openshift4/templates/metabase.bc.yaml
@@ -82,5 +82,4 @@ objects:
           name: ${NAME}:${TAG}
       completionDeadlineSeconds: 1440
       triggers:
-        - type: ConfigChange
         - type: ImageChange

--- a/openshift4/templates/minespace.bc.yaml
+++ b/openshift4/templates/minespace.bc.yaml
@@ -85,8 +85,6 @@ objects:
       completionDeadlineSeconds: 1440
       triggers:
         - type: ImageChange
-          imageChange: {}
-        - type: ConfigChange
       runPolicy: SerialLatestOnly
       source:
         contextDir: ${DOCKER_IMAGE_DIRECTORY}
@@ -127,7 +125,6 @@ objects:
       completionDeadlineSeconds: 900
       triggers:
         - type: ImageChange
-        - type: ConfigChange
       runPolicy: SerialLatestOnly
       source:
         type: Git

--- a/openshift4/templates/nginx.bc.yaml
+++ b/openshift4/templates/nginx.bc.yaml
@@ -44,7 +44,6 @@ objects:
       completionDeadlineSeconds: 600
       triggers:
         - type: ImageChange
-        - type: ConfigChange
       runPolicy: SerialLatestOnly
       source:
         type: Git

--- a/openshift4/templates/nris.bc.yaml
+++ b/openshift4/templates/nris.bc.yaml
@@ -79,8 +79,6 @@ objects:
       failedBuildsHistoryLimit: 3
       triggers:
         - type: ImageChange
-          imageChange: {}
-        - type: ConfigChange
       runPolicy: SerialLatestOnly
       source:
         contextDir: openshift/docker-images/python-36-oracle
@@ -119,7 +117,6 @@ objects:
       completionDeadlineSeconds: 600
       triggers:
         - type: ImageChange
-        - type: ConfigChange
       runPolicy: SerialLatestOnly
       source:
         type: Git

--- a/openshift4/templates/postgresql.bc.yaml
+++ b/openshift4/templates/postgresql.bc.yaml
@@ -63,8 +63,6 @@ objects:
       completionDeadlineSeconds: 3600
       triggers:
         - type: ImageChange
-          imageChange: {}
-        - type: ConfigChange
       runPolicy: SerialLatestOnly
       source:
         secrets:

--- a/openshift4/templates/tusd.bc.yaml
+++ b/openshift4/templates/tusd.bc.yaml
@@ -85,5 +85,4 @@ objects:
           name: ${NAME}:${TAG}
       completionDeadlineSeconds: 600
       triggers:
-        - type: ConfigChange
         - type: ImageChange


### PR DESCRIPTION
This prevents double builds from occurring in the pipeline and requires us to explicitly request that a build occur.