### PR TITLE
Add index to mine_party_appt to improve mine_summary_view performance

### DIFF
--- a/migrations/sql/R__add_update_indexes.sql
+++ b/migrations/sql/R__add_update_indexes.sql
@@ -24,6 +24,7 @@ CREATE INDEX IF NOT EXISTS mine_party_appt_party_guid_fkey_idx ON mine_party_app
 CREATE INDEX IF NOT EXISTS mine_party_appt_mine_party_appt_type_code_fkey_idx ON mine_party_appt(mine_party_appt_type_code);
 CREATE INDEX IF NOT EXISTS mine_party_appt_mine_guid_permit_id_fkey_idx ON mine_party_appt(mine_guid, permit_id);
 CREATE INDEX IF NOT EXISTS mine_party_appt_mine_tsf_guid_mine_guid_fkey_idx ON mine_party_appt(mine_tailings_storage_facility_guid,mine_guid);
+CREATE INDEX IF NOT EXISTS mine_party_appt_permit_id_mine_party_appt_type_code_end_date_fkey_idx ON mine_party_appt (permit_id, mine_party_appt_type_code, end_date DESC NULLS FIRST);
 
 /* Mine Type */
 DROP INDEX IF EXISTS mine_type_tenure_type_code_idx;

--- a/migrations/sql/R__add_update_indexes.sql
+++ b/migrations/sql/R__add_update_indexes.sql
@@ -24,7 +24,7 @@ CREATE INDEX IF NOT EXISTS mine_party_appt_party_guid_fkey_idx ON mine_party_app
 CREATE INDEX IF NOT EXISTS mine_party_appt_mine_party_appt_type_code_fkey_idx ON mine_party_appt(mine_party_appt_type_code);
 CREATE INDEX IF NOT EXISTS mine_party_appt_mine_guid_permit_id_fkey_idx ON mine_party_appt(mine_guid, permit_id);
 CREATE INDEX IF NOT EXISTS mine_party_appt_mine_tsf_guid_mine_guid_fkey_idx ON mine_party_appt(mine_tailings_storage_facility_guid,mine_guid);
-CREATE INDEX IF NOT EXISTS mine_party_appt_permit_id_mine_party_appt_type_code_end_date_fkey_idx ON mine_party_appt (permit_id, mine_party_appt_type_code, end_date DESC NULLS FIRST);
+CREATE INDEX IF NOT EXISTS mine_party_appt_permit_id_mine_party_appt_type_code_end_date_idx ON mine_party_appt (permit_id, mine_party_appt_type_code, end_date DESC NULLS FIRST);
 
 /* Mine Type */
 DROP INDEX IF EXISTS mine_type_tenure_type_code_idx;


### PR DESCRIPTION
This index has the mine summary view returning in ~1.5 secs as opposed to ~9 secs on my own PC.

Helps with this part of the view which was slowing it down:
```
	LEFT JOIN mine_party_appt mpa ON mpx.permit_id = mpa.permit_id AND mpa.mine_party_appt_id = (SELECT mpa2.mine_party_appt_id FROM mine_party_appt mpa2 WHERE mpx.permit_id = mpa2.permit_id AND mpa2.mine_party_appt_type_code = 'PMT' ORDER BY mpa2.end_date DESC NULLS FIRST LIMIT 1)
```