### PR TITLE
Add missing dev infra workflow event trigger

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -6,6 +6,7 @@ on:
       - develop
     paths:
       - openshift4/templates/**.dc.yaml
+      - .github/workflows/deploy-dev.yaml
 
 env:
   TAG: dev


### PR DESCRIPTION
# Main
- Adds a on-push event for if the dev infra workflow file is changed, otherwise infra changes only occur currently if you edit dc templates directly.