### PR TITLE
Make default params for appname not required

### DIFF
--- a/openshift4/templates/backend.dc.yaml
+++ b/openshift4/templates/backend.dc.yaml
@@ -72,7 +72,6 @@ parameters:
     displayName: AppName
     description: Application name for grouping pods in Openshift
     value: Core
-    required: true
 objects:
   - kind: DeploymentConfig
     apiVersion: v1

--- a/openshift4/templates/dbbackup.dc.yaml
+++ b/openshift4/templates/dbbackup.dc.yaml
@@ -43,7 +43,6 @@ parameters:
     displayName: AppName
     description: Application name for grouping pods in Openshift
     value: Core
-    required: true
 objects:
   - kind: PersistentVolumeClaim
     apiVersion: v1
@@ -83,7 +82,7 @@ objects:
         description: Defines how to deploy the ${NAME} server
       labels:
         app.kubernetes.io/part-of: ${APPNAME}
-        app.openshift.io/runtime: postgresql      
+        app.openshift.io/runtime: postgresql
     spec:
       strategy:
         type: Recreate

--- a/openshift4/templates/docgen.dc.yaml
+++ b/openshift4/templates/docgen.dc.yaml
@@ -40,7 +40,6 @@ parameters:
     displayName: AppName
     description: Application name for grouping pods in Openshift
     value: Core
-    required: true
 objects:
   - kind: Service
     apiVersion: v1
@@ -49,7 +48,7 @@ objects:
       annotations:
         description: Exposes and load balances the application pods
       labels:
-        app.kubernetes.io/part-of: ${APPNAME}      
+        app.kubernetes.io/part-of: ${APPNAME}
     spec:
       ports:
         - name: web
@@ -67,7 +66,7 @@ objects:
       labels:
         component: ${NAME}
         app.kubernetes.io/part-of: ${APPNAME}
-        app.openshift.io/runtime: nodejs        
+        app.openshift.io/runtime: nodejs
     spec:
       strategy:
         type: Rolling

--- a/openshift4/templates/docman.dc.yaml
+++ b/openshift4/templates/docman.dc.yaml
@@ -85,7 +85,6 @@ parameters:
     displayName: AppName
     description: Application name for grouping pods in Openshift
     value: Core
-    required: true
 objects:
   - apiVersion: v1
     kind: PersistentVolumeClaim
@@ -104,7 +103,7 @@ objects:
       creationTimestamp: null
       labels:
         app.kubernetes.io/part-of: ${APPNAME}
-        app.openshift.io/runtime: nodejs      
+        app.openshift.io/runtime: nodejs
       annotations:
         description: Defines how to deploy the application server
     spec:
@@ -298,7 +297,7 @@ objects:
       creationTimestamp: null
       labels:
         app.kubernetes.io/part-of: ${APPNAME}
-        app.openshift.io/runtime: nodejs      
+        app.openshift.io/runtime: nodejs
       annotations:
         description: Defines how to deploy the celery task worker
     spec:

--- a/openshift4/templates/fider.dc.yaml
+++ b/openshift4/templates/fider.dc.yaml
@@ -16,7 +16,6 @@ parameters:
     displayName: AppName
     description: Application name for grouping pods in Openshift
     value: Fider
-    required: true
 objects:
   - apiVersion: apps.openshift.io/v1
     kind: DeploymentConfig
@@ -25,8 +24,8 @@ objects:
         app: fider
       name: fider-postgresql
     labels:
-        app.kubernetes.io/part-of: ${APPNAME}
-        app.openshift.io/runtime: postgresql    
+      app.kubernetes.io/part-of: ${APPNAME}
+      app.openshift.io/runtime: postgresql
     spec:
       replicas: 1
       revisionHistoryLimit: 10
@@ -135,7 +134,7 @@ objects:
       labels:
         app: fider
         app.kubernetes.io/part-of: ${APPNAME}
-        app.openshift.io/runtime: nodejs        
+        app.openshift.io/runtime: nodejs
       name: fider-postgresql
     spec:
       ports:
@@ -156,7 +155,7 @@ objects:
       labels:
         app: fider
         app.kubernetes.io/part-of: ${APPNAME}
-        app.openshift.io/runtime: nodejs        
+        app.openshift.io/runtime: nodejs
       name: fider
     spec:
       ports:
@@ -197,7 +196,7 @@ objects:
       labels:
         app: fider
         app.kubernetes.io/part-of: ${APPNAME}
-        app.openshift.io/runtime: nodejs        
+        app.openshift.io/runtime: nodejs
       name: fider-app
     spec:
       replicas: 1

--- a/openshift4/templates/filesystem-provider.dc.yaml
+++ b/openshift4/templates/filesystem-provider.dc.yaml
@@ -7,7 +7,6 @@ parameters:
     displayName: AppName
     description: Application name for grouping pods in Openshift
     value: Core
-    required: true
 objects:
   - kind: Service
     apiVersion: v1

--- a/openshift4/templates/frontend.dc.yaml
+++ b/openshift4/templates/frontend.dc.yaml
@@ -78,7 +78,6 @@ parameters:
     displayName: AppName
     description: Application name for grouping pods in Openshift
     value: Core
-    required: true
 objects:
   - kind: Service
     apiVersion: v1
@@ -105,7 +104,7 @@ objects:
       labels:
         component: ${NAME}
         app.kubernetes.io/part-of: ${APPNAME}
-        app.openshift.io/runtime: nodejs              
+        app.openshift.io/runtime: nodejs
     spec:
       strategy:
         type: Rolling

--- a/openshift4/templates/metabase-postgres.dc.yaml
+++ b/openshift4/templates/metabase-postgres.dc.yaml
@@ -28,7 +28,6 @@ parameters:
     displayName: AppName
     description: Application name for grouping pods in Openshift
     value: Metabase
-    required: true
 objects:
   - apiVersion: v1
     kind: Service
@@ -38,7 +37,7 @@ objects:
       name: ${NAME}
       lables:
         app.kubernetes.io/part-of: ${APPNAME}
-        app.openshift.io/runtime: postgresql 
+        app.openshift.io/runtime: postgresql
     spec:
       ports:
         - name: postgresql

--- a/openshift4/templates/metabase.dc.yaml
+++ b/openshift4/templates/metabase.dc.yaml
@@ -31,7 +31,6 @@ parameters:
     displayName: AppName
     description: Application name for grouping pods in Openshift
     value: Metabase
-    required: true
 objects:
   - kind: Service
     apiVersion: v1
@@ -41,7 +40,7 @@ objects:
         description: Exposes and load balances the application pods
       labels:
         app.kubernetes.io/part-of: ${APPNAME}
-        app.openshift.io/runtime: nodejs        
+        app.openshift.io/runtime: nodejs
     spec:
       ports:
         - name: 3000-tcp

--- a/openshift4/templates/minespace.dc.yaml
+++ b/openshift4/templates/minespace.dc.yaml
@@ -81,7 +81,6 @@ parameters:
     displayName: AppName
     description: Application name for grouping pods in Openshift
     value: Stand-Alone
-    required: true
 objects:
   - kind: Service
     apiVersion: v1
@@ -91,7 +90,7 @@ objects:
         description: Exposes and load balances the application pods
       Labels:
         app.kubernetes.io/part-of: ${APPNAME}
-        app.openshift.io/runtime: nodejs      
+        app.openshift.io/runtime: nodejs
     spec:
       ports:
         - name: web

--- a/openshift4/templates/nginx.dc.yaml
+++ b/openshift4/templates/nginx.dc.yaml
@@ -54,7 +54,6 @@ parameters:
     displayName: AppName
     description: Application name for grouping pods in Openshift
     value: Stand-Alone
-    required: true
 objects:
   - apiVersion: v1
     kind: PersistentVolumeClaim

--- a/openshift4/templates/nris-etl.dc.yaml
+++ b/openshift4/templates/nris-etl.dc.yaml
@@ -48,7 +48,6 @@ parameters:
     displayName: AppName
     description: Application name for grouping pods in Openshift
     value: Core
-    required: true
 objects:
   - kind: CronJob
     apiVersion: batch/v1beta1

--- a/openshift4/templates/nris.dc.yaml
+++ b/openshift4/templates/nris.dc.yaml
@@ -56,7 +56,6 @@ parameters:
     displayName: AppName
     description: Application name for grouping pods in Openshift
     value: Core
-    required: true
 objects:
   - kind: DeploymentConfig
     apiVersion: v1
@@ -65,7 +64,7 @@ objects:
       creationTimestamp: null
       labels:
         app.kubernetes.io/part-of: ${APPNAME}
-        app.openshift.io/runtime: nodejs      
+        app.openshift.io/runtime: nodejs
       annotations:
         description: Defines how to deploy the application server
     spec:

--- a/openshift4/templates/postgresql.dc.yaml
+++ b/openshift4/templates/postgresql.dc.yaml
@@ -37,7 +37,6 @@ parameters:
     displayName: AppName
     description: Application name for grouping pods in Openshift
     value: Core
-    required: true
 objects:
   - apiVersion: v1
     kind: Secret
@@ -53,7 +52,7 @@ objects:
         template.openshift.io/expose-uri: postgres://{.spec.clusterIP}:{.spec.ports[?(.name=="postgresql")].port}
       name: ${NAME}
       lables:
-        app.kubernetes.io/part-of: ${APPNAME}      
+        app.kubernetes.io/part-of: ${APPNAME}
     spec:
       ports:
         - name: postgresql
@@ -72,7 +71,7 @@ objects:
     metadata:
       name: ${NAME}-reporting
       labels:
-        app.kubernetes.io/part-of: ${APPNAME}      
+        app.kubernetes.io/part-of: ${APPNAME}
     spec:
       ports:
         - name: postgresql-reporting
@@ -103,7 +102,7 @@ objects:
       name: ${NAME}
       labels:
         app.kubernetes.io/part-of: ${APPNAME}
-        app.openshift.io/runtime: postgresql        
+        app.openshift.io/runtime: postgresql
     spec:
       replicas: 1
       selector:
@@ -247,7 +246,7 @@ objects:
       name: ${NAME}-reporting
       lables:
         app.kubernetes.io/part-of: ${APPNAME}
-        app.openshift.io/runtime: postgresql      
+        app.openshift.io/runtime: postgresql
     spec:
       replicas: 1
       selector:

--- a/openshift4/templates/redis.dc.yaml
+++ b/openshift4/templates/redis.dc.yaml
@@ -19,7 +19,6 @@ parameters:
     displayName: AppName
     description: Application name for grouping pods in Openshift
     value: Core
-    required: true
 objects:
   - kind: Service
     apiVersion: v1

--- a/openshift4/templates/tusd.dc.yaml
+++ b/openshift4/templates/tusd.dc.yaml
@@ -27,7 +27,6 @@ parameters:
     displayName: AppName
     description: Application name for grouping pods in Openshift
     value: Core
-    required: true
 objects:
   - kind: Service
     apiVersion: v1
@@ -36,7 +35,7 @@ objects:
       annotations:
         description: Exposes and load balances the application pods
       labels:
-        app.kubernetes.io/part-of: ${APPNAME}      
+        app.kubernetes.io/part-of: ${APPNAME}
     spec:
       ports:
         - name: 1080-tcp


### PR DESCRIPTION
# Main
- makes appname params in dc templates not required so pipeline doesn't need to pass parameters in