### PR TITLE
NOW fix for Consultation and Referral Package Documents.

### DIFF
--- a/services/core-api/app/api/now_applications/transmogrify_now.py
+++ b/services/core-api/app/api/now_applications/transmogrify_now.py
@@ -21,6 +21,7 @@ vfcbc_status_code_mapping = {
     "Govt. Action Required": "PEV",
     "Referral Complete": "PEV",
     "Referred": "PEV",
+    "No Permit Required": "PEV",
     None: "PEV",
 }
 
@@ -36,11 +37,13 @@ def code_lookup(model, description, code_column_name):
         result = None
     return result
 
+
 def get_boolean_value(field):
     result = field
-    if field is not None: 
+    if field is not None:
         result = field == 'Yes'
     return result
+
 
 def transmogrify_now(now_application_identity, include_contacts=False):
     now_sub = sub_models.Application.find_by_messageid(
@@ -88,7 +91,6 @@ def _transmogrify_now_details(now_app, now_sub, mms_now_sub):
     status = mms_now_sub.status or now_sub.status
     now_app.now_application_status_code = vfcbc_status_code_mapping[status]
 
-
     now_app.application_permit_type_code = type_of_permit_map[now_sub.typeofpermit]
 
     now_app.submitted_date = mms_now_sub.submitteddate or now_sub.submitteddate
@@ -117,7 +119,8 @@ def _transmogrify_now_details(now_app, now_sub, mms_now_sub):
     now_app.proposed_annual_maximum_tonnage = now_sub.maxannualtonnage
     now_app.adjusted_annual_maximum_tonnage = now_sub.maxannualtonnage
     now_app.is_access_gated = get_boolean_value(now_sub.isaccessgated)
-    now_app.has_surface_disturbance_outside_tenure = get_boolean_value(now_sub.hassurfacedisturbanceoutsidetenure)
+    now_app.has_surface_disturbance_outside_tenure = get_boolean_value(
+        now_sub.hassurfacedisturbanceoutsidetenure)
 
     now_app.is_pre_launch = now_sub.is_pre_launch
     now_app.proponent_submitted_permit_number = now_sub.permitnumber
@@ -328,8 +331,7 @@ def _transmogrify_camp_activities(now_app, now_sub, mms_now_sub):
             has_fuel_stored=get_boolean_value(fuellubstoreonsite),
             has_fuel_stored_in_bulk=get_boolean_value(fuellubstoremethodbulk),
             volume_fuel_stored=fuellubstored,
-            has_fuel_stored_in_barrels=get_boolean_value(fuellubstoremethodbarrel)
-        )
+            has_fuel_stored_in_barrels=get_boolean_value(fuellubstoremethodbarrel))
 
         campdisturbedarea = mms_now_sub.campdisturbedarea or now_sub.campdisturbedarea
         camptimbervolume = mms_now_sub.camptimbervolume or now_sub.camptimbervolume
@@ -533,9 +535,9 @@ def _transmogrify_placer_operations(now_app, now_sub, mms_now_sub):
             is_hand_operation=get_boolean_value(placerhandoperations),
             has_stream_diversion=get_boolean_value(placerstreamdiversion) or False,
             proposed_production=proposedproduction,
-            proposed_production_unit_type_code=code_lookup(
-                app_models.UnitType, unit_type_map[proposedproductionunit],
-                'unit_type_code'),
+            proposed_production_unit_type_code=code_lookup(app_models.UnitType,
+                                                           unit_type_map[proposedproductionunit],
+                                                           'unit_type_code'),
             reclamation_unit_type_code='HA',
             reclamation_area=placerreclamationarea)
 
@@ -624,8 +626,7 @@ def _transmogrify_settling_ponds(now_app, now_sub, mms_now_sub):
             sediment_control_structure_description=pondtypeofsediment,
             decant_structure_description=pondtypeconstruction,
             water_discharged_description=pondarea,
-            spillway_design_description=pondspillwaydesign
-)
+            spillway_design_description=pondspillwaydesign)
 
         proposed_settling_pond = now_sub.proposed_settling_pond
 
@@ -860,8 +861,8 @@ def _transmogrify_underground_exploration(now_app, now_sub, mms_now_sub):
     underexpsurftotalwaste = now_sub.underexpsurftotalwaste
     underexpsurftotaloreunits = now_sub.underexpsurftotaloreunits
     underexpsurftotalwasteunits = now_sub.underexpsurftotalwasteunits
-    if (underexptotalore or underexpreclamation or underexpreclamationcost
-            or underexptotalwaste or underexptotaldistarea or underexpsurftotalwaste):
+    if (underexptotalore or underexpreclamation or underexpreclamationcost or underexptotalwaste
+            or underexptotaldistarea or underexpsurftotalwaste):
         now_app.underground_exploration = app_models.UndergroundExploration(
             reclamation_description=underexpreclamation,
             reclamation_cost=underexpreclamationcost,
@@ -885,11 +886,10 @@ def _transmogrify_underground_exploration(now_app, now_sub, mms_now_sub):
             surface_total_ore_amount=underexpsurftotalore,
             surface_total_waste_amount=underexpsurftotalwaste,
             surface_total_ore_unit_type_code=code_lookup(app_models.UnitType,
-                                                   unit_type_map[underexpsurftotaloreunits],
-                                                   'unit_type_code'),
-            surface_total_waste_unit_type_code=code_lookup(app_models.UnitType,
-                                                   unit_type_map[underexpsurftotalwasteunits],
-                                                   'unit_type_code'))
+                                                         unit_type_map[underexpsurftotaloreunits],
+                                                         'unit_type_code'),
+            surface_total_waste_unit_type_code=code_lookup(
+                app_models.UnitType, unit_type_map[underexpsurftotalwasteunits], 'unit_type_code'))
 
         if (len(mms_now_sub.under_exp_new_activity) > 0):
             under_exp_new_activity = mms_now_sub.under_exp_new_activity

--- a/services/core-web/src/components/modalContent/DownloadDocumentPackageModal.js
+++ b/services/core-web/src/components/modalContent/DownloadDocumentPackageModal.js
@@ -126,6 +126,7 @@ export const DownloadDocumentPackageModal = (props) => {
           <NOWActionWrapper
             permission={Permission.EDIT_PERMITS}
             tab={props.type === "FNC" ? "CON" : props.type}
+            isDisabledReviewButton={true}
           >
             <Button
               type="primary"

--- a/services/core-web/src/components/modalContent/DownloadDocumentPackageModal.js
+++ b/services/core-web/src/components/modalContent/DownloadDocumentPackageModal.js
@@ -126,7 +126,7 @@ export const DownloadDocumentPackageModal = (props) => {
           <NOWActionWrapper
             permission={Permission.EDIT_PERMITS}
             tab={props.type === "FNC" ? "CON" : props.type}
-            isDisabledReviewButton={true}
+            isDisabledReviewButton
           >
             <Button
               type="primary"

--- a/services/core-web/src/components/noticeOfWork/NOWActionWrapper.js
+++ b/services/core-web/src/components/noticeOfWork/NOWActionWrapper.js
@@ -30,6 +30,7 @@ const propTypes = {
   location: PropTypes.shape({
     pathname: PropTypes.string,
   }).isRequired,
+  isDisabledReviewButtons: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -38,6 +39,7 @@ const defaultProps = {
   allowAfterProcess: false,
   noticeOfWork: {},
   progress: {},
+  isDisabledReviewButtons: false,
 };
 
 export class NOWActionWrapper extends Component {
@@ -55,7 +57,11 @@ export class NOWActionWrapper extends Component {
         this.props.noticeOfWork.application_type_code
       ].includes(this.props.tab);
       if (tabShouldIncludeProgress) {
-        this.handleDisableTab(this.props.tab, this.props.progress);
+        this.handleDisableTab(
+          this.props.tab,
+          this.props.progress,
+          this.props.isDisabledReviewButton
+        );
       } else {
         this.setState({ disableTab: false });
       }
@@ -79,18 +85,23 @@ export class NOWActionWrapper extends Component {
       ].includes(nextProps.tab);
 
       if ((tabChanged || progressNoWExists || progressChanged) && tabShouldIncludeProgress) {
-        this.handleDisableTab(nextProps.tab, nextProps.progress);
+        this.handleDisableTab(nextProps.tab, nextProps.progress, nextProps.isDisabledReviewButton);
       }
     }
   };
 
-  handleDisableTab = (tab, progress) => {
+  handleDisableTab = (tab, progress, isDisabledReviewButton) => {
     if (tab) {
+      //application_progress_status_code does not have end_date. Status:In Progress
       if (!isEmpty(progress[tab]) && !progress[tab].end_date) {
         this.setState({ disableTab: false });
-      } else if (isEmpty(progress[tab])) {
+      }
+      //application_progress_status_code does not exist. Status:Not started
+      else if (!isDisabledReviewButton && isEmpty(progress[tab])) {
         this.setState({ disableTab: true });
-      } else if (!isEmpty(progress[tab]) && progress[tab].end_date) {
+      }
+      //application_progress_status_code has end date. Status: Complete
+      else if (!isEmpty(progress[tab]) && progress[tab].end_date) {
         this.setState({ disableTab: true });
       }
     } else {

--- a/services/core-web/src/components/noticeOfWork/NOWActionWrapper.js
+++ b/services/core-web/src/components/noticeOfWork/NOWActionWrapper.js
@@ -30,7 +30,7 @@ const propTypes = {
   location: PropTypes.shape({
     pathname: PropTypes.string,
   }).isRequired,
-  isDisabledReviewButtons: PropTypes.bool,
+  isDisabledReviewButton: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -39,7 +39,7 @@ const defaultProps = {
   allowAfterProcess: false,
   noticeOfWork: {},
   progress: {},
-  isDisabledReviewButtons: false,
+  isDisabledReviewButton: false,
 };
 
 export class NOWActionWrapper extends Component {
@@ -96,6 +96,8 @@ export class NOWActionWrapper extends Component {
       if (!isEmpty(progress[tab]) && !progress[tab].end_date) {
         this.setState({ disableTab: false });
       }
+      //DisabledReviewButton applies for CON/REF to show CON/REF package buttons in not started state.
+      //Otherwise, if not CON/REF tab, do not show buttons.
       //application_progress_status_code does not exist. Status:Not started
       else if (!isDisabledReviewButton && isEmpty(progress[tab])) {
         this.setState({ disableTab: true });

--- a/services/core-web/src/components/noticeOfWork/applications/referals/ReferralConsultationPackage.js
+++ b/services/core-web/src/components/noticeOfWork/applications/referals/ReferralConsultationPackage.js
@@ -27,6 +27,7 @@ import { EDIT_OUTLINE_VIOLET } from "@/constants/assets";
 import { getDropdownNoticeOfWorkApplicationReviewTypeOptions } from "@common/selectors/staticContentSelectors";
 import NOWActionWrapper from "@/components/noticeOfWork/NOWActionWrapper";
 import * as Permission from "@/constants/permissions";
+import { isEmpty, isNil } from "lodash";
 
 /**
  * @constant ReviewNOWApplication renders edit/view for the NoW Application review step
@@ -225,9 +226,16 @@ export class ReferralConsultationPackage extends Component {
 
   render() {
     const label = this.props.type === "REF" ? "Referral Package" : "Consultation Package";
-    const disabled = !this.props.progress[this.props.type];
+    const disabled =
+      !isEmpty(this.props.progress[this.props.type]) &&
+      !isNil(this.props.progress[this.props.type].end_date);
+
     return this.props.isTableHeaderView ? (
-      <NOWActionWrapper permission={Permission.EDIT_PERMITS} tab={this.props.type}>
+      <NOWActionWrapper
+        permission={Permission.EDIT_PERMITS}
+        tab={this.props.type}
+        isDisabledReviewButton={true}
+      >
         <Button ghost type="primary" size="small" onClick={this.openDownloadPackageModal}>
           <img name="remove" src={EDIT_OUTLINE_VIOLET} alt={label} />
         </Button>

--- a/services/core-web/src/components/noticeOfWork/applications/referals/ReferralConsultationPackage.js
+++ b/services/core-web/src/components/noticeOfWork/applications/referals/ReferralConsultationPackage.js
@@ -226,15 +226,16 @@ export class ReferralConsultationPackage extends Component {
 
   render() {
     const label = this.props.type === "REF" ? "Referral Package" : "Consultation Package";
-    const disabled =
-      !isEmpty(this.props.progress[this.props.type]) &&
+    const complete = !isEmpty(this.props.progress[this.props.type]) &&
       !isNil(this.props.progress[this.props.type].end_date);
+
+    const disabled = complete;
 
     return this.props.isTableHeaderView ? (
       <NOWActionWrapper
         permission={Permission.EDIT_PERMITS}
         tab={this.props.type}
-        isDisabledReviewButton={true}
+        isDisabledReviewButton
       >
         <Button ghost type="primary" size="small" onClick={this.openDownloadPackageModal}>
           <img name="remove" src={EDIT_OUTLINE_VIOLET} alt={label} />

--- a/services/core-web/src/tests/components/modalContent/__snapshots__/DownloadDocumentPackageModal.spec.js.snap
+++ b/services/core-web/src/tests/components/modalContent/__snapshots__/DownloadDocumentPackageModal.spec.js.snap
@@ -84,6 +84,7 @@ exports[`DownloadDocumentPackageModal renders properly 1`] = `
         Download Referral Package
       </Button>
       <withRouter(Connect(NOWActionWrapper))
+        isDisabledReviewButton={true}
         permission="role_edit_permits"
       >
         <Button

--- a/services/core-web/src/tests/components/noticeOfWork/applications/referals/ReferralConsultationPackage.spec.js
+++ b/services/core-web/src/tests/components/noticeOfWork/applications/referals/ReferralConsultationPackage.spec.js
@@ -1,0 +1,36 @@
+import React from "react";
+import { shallow } from "enzyme";
+import { ReferralConsultationPackage } from "@/components/noticeOfWork/applications/referals/ReferralConsultationPackage";
+import * as NOW_MOCK from "@/tests/mocks/noticeOfWorkMocks";
+
+const dispatchProps = {};
+const reducerProps = {};
+
+const setupDispatchProps = () => {
+  dispatchProps.openModal = jest.fn();
+  dispatchProps.closeModal = jest.fn();
+  dispatchProps.setNoticeOfWorkApplicationDocumentDownloadState = jest.fn();
+  dispatchProps.updateNoticeOfWorkApplication = jest.fn();
+  dispatchProps.fetchImportedNoticeOfWorkApplication = jest.fn();
+};
+
+const setupReducerProps = () => {
+  reducerProps.noticeOfWork = NOW_MOCK.NOTICE_OF_WORK;
+  reducerProps.importNowSubmissionDocumentsJob = {};
+  reducerProps.progress = 'REV';
+  reducerProps.type = "REF";
+  reducerProps.isTableHeaderView = false;
+  
+};
+
+beforeEach(() => {
+  setupDispatchProps();
+  setupReducerProps();
+});
+
+describe("ReferralConsultationPackage", () => {
+  it("renders properly", () => {
+    const component = shallow(<ReferralConsultationPackage {...dispatchProps} {...reducerProps} />);
+    expect(component).toMatchSnapshot();
+  });
+});

--- a/services/core-web/src/tests/components/noticeOfWork/applications/referals/__snapshots__/ReferralConsultationPackage.spec.js.snap
+++ b/services/core-web/src/tests/components/noticeOfWork/applications/referals/__snapshots__/ReferralConsultationPackage.spec.js.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ReferralConsultationPackage renders properly 1`] = `
+<Button
+  block={false}
+  className="full-mobile"
+  disabled={false}
+  ghost={false}
+  htmlType="button"
+  loading={false}
+  onClick={[Function]}
+  type="secondary"
+>
+  Referral Package
+</Button>
+`;


### PR DESCRIPTION
# Main

- This fix is disabling Referral and Consultation updates when the status is Complete. Otherwise, the user can update them:


# Other

- https://bcmines.atlassian.net/browse/MDS-3866

# How to test

- By selecting a Mine with NOW application:

1. Select Mines in main menu
2. In the Mine Lookup select a mine with Permit (Permits column) :
![image](https://user-images.githubusercontent.com/10526131/131156542-515eb111-eb55-49d6-8ddc-f580e0f063b2.png)
3. In the menu, select Permits & Approvals, then Applications:
![image](https://user-images.githubusercontent.com/10526131/131156735-3bb33dff-31ba-4e71-bf26-92b6d26a7af1.png)
4. Select an Amendment (Click on Open):
![image](https://user-images.githubusercontent.com/10526131/131161357-2f720e85-6b6e-46ba-a6ef-0a3975d94fff.png)
5. Go to Referral and Consultation Tabs to check the status.
    Note: If the Referral status is  "Complete", then the "Referral Package" button is disabled. Other status such as "In Progress", "Not Started", etc. enable the "Referral Package" button. The same logic applies for Consultation. 
Referral Status: Complete disables Referral Package button:
![image](https://user-images.githubusercontent.com/10526131/131162166-0f4e9825-931d-4277-9cd5-80e496bc27d9.png)

Referral Status: In Progress enables Referral Package button:
![image](https://user-images.githubusercontent.com/10526131/131162242-64b5e1ac-77a0-4f30-91dd-6bd1af1e8837.png)

6.  Go to Manage Documents Tab to check "Application Documents" and "Government Documents" sections, This section has the same logic. If the Status of Referral or Consultation is Complete, then the edit pencil is not shown. Other status such as "In Progress", "Not Started", etc. show the edit pencil.
Referral Status: In Progress and Consultation Status: In Progress show edit pencil in each column:
![image](https://user-images.githubusercontent.com/10526131/131162446-c2d7cdba-e3ae-4e02-a29b-22f510a2123e.png)

- By selecting a NOW application:
1. Select Browse in main menu and then select Notice of Work in the submenu:
![image](https://user-images.githubusercontent.com/10526131/131162938-0d0f0e43-9093-4c9d-8881-bdc6c6b5a3e4.png)

2. In the Browse Notice Of Work search look for a Notice Of Work (HALL SHALE QUARRY) and open :
![image](https://user-images.githubusercontent.com/10526131/131163107-8fa2a94f-1ea7-47f4-bdfb-0fa5424432fd.png)

3. Apply the same steps to test the button Referral Package and Consultation Package in relation to its status as well as the edit pencil in Manage Documents for both columns (Referral Package and Consultation Package).



# Misc

- Changes in core-api. No Database changes are required.