### PR TITLE
Delete Draft permits that are New Permits.

### DIFF
--- a/services/core-api/app/api/mines/permits/permit/resources/permit.py
+++ b/services/core-api/app/api/mines/permits/permit/resources/permit.py
@@ -21,6 +21,7 @@ from app.api.utils.resources_mixins import UserMixin
 from app.api.mines.response_models import PERMIT_MODEL
 from app.api.mines.mine.resources.mine_type import MineType
 from app.api.mines.mine.models.mine_type_detail import MineTypeDetail
+from app.api.utils.helpers import generate_permit_no_sufix
 
 
 class PermitListResource(Resource, UserMixin):
@@ -148,6 +149,10 @@ class PermitListResource(Resource, UserMixin):
             # Handle the situation where 'P-DRAFT-None' causes a non-unique error
             else:
                 permit_no = permit_prefix + '-DRAFT-' + str(mine.mine_no)
+
+            last_draft_permit = Permit.find_by_permit_no_deleted_in_draft(permit_no)
+            if last_draft_permit:
+                permit_no = generate_permit_no_sufix(last_draft_permit.permit_no, permit_no)
 
         permit = Permit.find_by_permit_no(permit_no)
         if permit:

--- a/services/core-api/app/api/mines/permits/permit/resources/permit.py
+++ b/services/core-api/app/api/mines/permits/permit/resources/permit.py
@@ -21,7 +21,7 @@ from app.api.utils.resources_mixins import UserMixin
 from app.api.mines.response_models import PERMIT_MODEL
 from app.api.mines.mine.resources.mine_type import MineType
 from app.api.mines.mine.models.mine_type_detail import MineTypeDetail
-from app.api.utils.helpers import generate_permit_no_sufix
+from app.api.utils.helpers import generate_draft_permit_no_suffix
 
 
 class PermitListResource(Resource, UserMixin):
@@ -152,7 +152,7 @@ class PermitListResource(Resource, UserMixin):
 
             last_draft_permit = Permit.find_by_permit_no_deleted_in_draft(permit_no)
             if last_draft_permit:
-                permit_no = generate_permit_no_sufix(last_draft_permit.permit_no, permit_no)
+                permit_no = generate_draft_permit_no_suffix(last_draft_permit.permit_no, permit_no)
 
         permit = Permit.find_by_permit_no(permit_no)
         if permit:

--- a/services/core-api/app/api/utils/helpers.py
+++ b/services/core-api/app/api/utils/helpers.py
@@ -8,11 +8,10 @@ def clean_HTML_string(raw_html):
 
 
 """
-Add sufix to permit number adding one to versioning.
+Add two digits suffix to new draft permit numbers modifying the permit_no to the pattern:
+{NOW_type_code}-DRAFT-{NOW_No}-{dd}
 """
-
-
-def generate_permit_no_sufix(permit, separator, filling=2):
+def generate_draft_permit_no_suffix(permit, separator, filling=2):
     result = permit.split(separator + "-")
     version_str = '0' if len(result) < 2 else result[1]
     version = str(int(version_str) + 1).zfill(filling)

--- a/services/core-api/app/api/utils/helpers.py
+++ b/services/core-api/app/api/utils/helpers.py
@@ -1,6 +1,21 @@
 import re
 
+
 def clean_HTML_string(raw_html):
-  cleanr = re.compile('<.*?>')
-  cleantext = re.sub(cleanr, '', raw_html)
-  return cleantext
+    cleanr = re.compile('<.*?>')
+    cleantext = re.sub(cleanr, '', raw_html)
+    return cleantext
+
+
+"""
+Add sufix to permit number adding one to versioning.
+"""
+
+
+def generate_permit_no_sufix(permit, separator, filling=2):
+    result = permit.split(separator + "-")
+    version_str = '0' if len(result) < 2 else result[1]
+    version = str(int(version_str) + 1).zfill(filling)
+    permit_no = separator + "-" + version
+
+    return permit_no

--- a/services/core-web/src/components/noticeOfWork/applications/permitGeneration/NOWPermitGeneration.js
+++ b/services/core-web/src/components/noticeOfWork/applications/permitGeneration/NOWPermitGeneration.js
@@ -516,7 +516,6 @@ export class NOWPermitGeneration extends Component {
             isDraft && (
               <>
                 {" "}
-                {this.props.isAmendment && (
                   <NOWActionWrapper permission={Permission.EDIT_PERMITS} tab="DFT">
                     <Button
                       type="danger"
@@ -525,7 +524,6 @@ export class NOWPermitGeneration extends Component {
                       Delete Draft
                     </Button>
                   </NOWActionWrapper>
-                )}
                 <NOWActionWrapper permission={Permission.EDIT_PERMITS} tab="DFT">
                   <Button type="secondary" onClick={this.props.toggleEditMode}>
                     <img alt="EDIT_OUTLINE" className="padding-small--right" src={EDIT_OUTLINE} />


### PR DESCRIPTION
# Main
Delete a draft permit that is a New Permit  with the format {NOW_type_code}-DRAFT-{NOW_no} as permit_no. If this draft permit is soft deleted, then a new permit has to be created and the permit_no has to include a suffix.  The next draft permits created must contain a suffix with the format {NOW_type_code}-DRAFT-{NOW_No}-{dd} where dd ranges from 01-99.

# Other
The logic of suffix in the permit is added in the permit resource. In addition, the Front End needed to enable the button to delete the permit.

# How to test
Follow the following steps to setup the test case:
1. Browse a Notice Of Work in "Received" status and open it:
![image](https://user-images.githubusercontent.com/10526131/131889765-2411552c-c067-4ec4-add2-2dd9ab04aae3.png)
2.  Go to Draft tab and click on Start Draft Permit:
![image](https://user-images.githubusercontent.com/10526131/131890022-09520d68-0b34-4dde-89fa-bea3496a7566.png)
3.  On the modal window select New Permit as Application Type and Yes for Exploration Permit. Then, click on Proceed. Finally, click on Start Draft Permit:
![image](https://user-images.githubusercontent.com/10526131/131890240-7a7f6bf1-5622-4489-b360-a990ac0dd153.png)
4. Confirm the Permit Number follows the pattern {NOW_type_code}-DRAFT-{NOW_no}:
![image](https://user-images.githubusercontent.com/10526131/131890970-7695be82-9453-4a37-bc61-a6fdda9e7fb9.png)

The following steps test that the draft permit is deleted, and during creation of a new draft permit the suffix is added to avoid issues related to unique constraint for permit_no:
1.  Click on "Delete Draft" button  to delete the draft permit
2.  Create again a Draft Permit by clicking on "Create Draft Permit" button
3.  Confirm the newly created Draft permit is created with the suffix made of two digits:
![image](https://user-images.githubusercontent.com/10526131/131891442-e0c9a3bc-1553-47bf-a86e-77cb55944161.png)
Optionally, you can delete and create more draft permits. It is important to notice that the first created draft permit has the pattern {NOW_type_code}-DRAFT-{NOW_no} and the subsequent created draft permits would have the pattern {NOW_type_code}-DRAFT-{NOW_no}-{dd} starting with 01 in {dd} up to 99.


# Notes
https://bcmines.atlassian.net/browse/MDS-3735
