### PR TITLE
MDS-3960: Backup process update

### DIFF
--- a/openshift4/templates/metabase-dbbackup.bc.yaml
+++ b/openshift4/templates/metabase-dbbackup.bc.yaml
@@ -1,0 +1,77 @@
+kind: Template
+apiVersion: v1
+metadata:
+  name: mds-metabase-dbbackup-bc
+  creationTimestamp: null
+parameters:
+  - name: NAME
+    displayName: Name
+    description: The name assigned to all of the resources defined in this template.
+    required: true
+    value: metabase-dbbackup
+  - name: TAG
+    displayName: Output Image Tag
+    description: The tag given to the built image.
+    value: dev
+objects:
+  - kind: ImageStream
+    apiVersion: v1
+    metadata:
+      name: rhscl-postgres-10-rhel7
+      creationTimestamp: null
+      annotations:
+        description: Postgres10 Base Image
+      labels:
+        shared: "true"
+    spec:
+      lookupPolicy:
+        local: false
+      tags:
+        - name: latest
+          annotations: null
+          from:
+            kind: DockerImage
+            name: registry.access.redhat.com/rhscl/postgresql-10-rhel7:latest
+          importPolicy: {}
+          referencePolicy:
+            type: Local
+  - kind: ImageStream
+    apiVersion: v1
+    metadata:
+      name: ${NAME}
+      labels:
+        shared: "true"
+    spec:
+      lookupPolicy:
+        local: false
+      tags: []
+  - kind: BuildConfig
+    apiVersion: v1
+    metadata:
+      name: ${NAME}
+      labels:
+        app: ${NAME}
+    spec:
+      successfulBuildsHistoryLimit: 5
+      failedBuildsHistoryLimit: 5
+      completionDeadlineSeconds: 600
+      triggers:
+        - type: ImageChange
+      runPolicy: SerialLatestOnly
+      source:
+        type: Git
+        git:
+          uri: https://github.com/BCDevOps/backup-container.git
+          ref: master
+        contextDir: /docker
+      strategy:
+        type: Docker
+        dockerStrategy:
+          from:
+            kind: ImageStreamTag
+            name: rhscl-postgres-10-rhel7:latest
+          dockerfilePath: Dockerfile
+      output:
+        to:
+          kind: ImageStreamTag
+          name: ${NAME}:${TAG}

--- a/openshift4/templates/metabase-dbbackup.dc.yaml
+++ b/openshift4/templates/metabase-dbbackup.dc.yaml
@@ -12,7 +12,7 @@ parameters:
   - name: DATABASE_SERVICE_NAME
     displayName: Database Service Name
     description: The name of the database service.
-    value: postgresql
+    value: metabase-postgres
   - name: WEBHOOK_SECRET_NAME
     value: template.rocket-chat-integrations
   - name: ENVIRONMENT_NAME
@@ -72,7 +72,7 @@ objects:
       name: mds-metabase-db-backup-config
     data:
       backup.conf: |
-        ${DATABASE_SERVICE_NAME}/mds
+        ${DATABASE_SERVICE_NAME}/metabase
         0 2 * * * default ./backup.sh -s
   - kind: DeploymentConfig
     apiVersion: v1
@@ -138,15 +138,12 @@ objects:
                 - name: MONTHLY_BACKUPS
                   value: "1"
                 - name: DATABASE_USER
-                  valueFrom:
-                    secretKeyRef:
-                      name: ${DATABASE_SERVICE_NAME}
-                      key: database-admin-user
+                  value: "postgres"
                 - name: DATABASE_PASSWORD
                   valueFrom:
                     secretKeyRef:
-                      name: ${DATABASE_SERVICE_NAME}
-                      key: database-admin-password
+                      name: template.metabase-key
+                      key: postgres-admin-password
                 - name: WEBHOOK_URL
                   valueFrom:
                     secretKeyRef:

--- a/openshift4/templates/metabase-dbbackup.dc.yaml
+++ b/openshift4/templates/metabase-dbbackup.dc.yaml
@@ -1,0 +1,175 @@
+kind: Template
+apiVersion: v1
+metadata:
+  name: mds-metabase-dbbackup-dc
+parameters:
+  - name: NAME
+    displayName: Name
+    description: The name assigned to all of the resources defined in this template.
+    value: metabase-dbbackup
+  - name: TAG
+    required: true
+  - name: DATABASE_SERVICE_NAME
+    displayName: Database Service Name
+    description: The name of the database service.
+    value: postgresql
+  - name: WEBHOOK_SECRET_NAME
+    value: template.rocket-chat-integrations
+  - name: ENVIRONMENT_NAME
+    displayName: Environment Name (Environment Id)
+    description: The name or Id of the environment.  This variable is used by the webhook integration to identify the environment in which the backup notifications originate.
+    required: false
+  - name: ENVIRONMENT_FRIENDLY_NAME
+    value: Mines Digital Services Metabase
+  - name: VERIFICATION_VOLUME_SIZE
+    displayName: Verification Volume Size
+    description: The size of the persistent volume , e.g. 512Mi, 1Gi, 2Gi.
+    value: 1Gi
+  - name: BACKUP_VOLUME_SIZE
+    displayName: Backup Volume Size
+    description: The size of the persistent volume , e.g. 512Mi, 1Gi, 2Gi.
+    value: 5Gi
+  - name: CPU_REQUEST
+    value: "0"
+  - name: CPU_LIMIT
+    value: "0"
+  - name: MEMORY_REQUEST
+    value: "0"
+  - name: MEMORY_LIMIT
+    value: "0"
+  - name: IMAGE_NAMESPACE
+    value: 4c2ba9-tools
+  - name: APPNAME
+    displayName: AppName
+    description: Application name for grouping pods in Openshift
+    value: Core
+objects:
+  - kind: PersistentVolumeClaim
+    apiVersion: v1
+    metadata:
+      name: mds-metabase-db-backup-verification
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: ${VERIFICATION_VOLUME_SIZE}
+  - kind: PersistentVolumeClaim
+    apiVersion: v1
+    metadata:
+      name: mds-metabase-db-backup-data
+    spec:
+      accessModes:
+        - ReadWriteMany
+      resources:
+        requests:
+          storage: ${BACKUP_VOLUME_SIZE}
+      storageClassName: netapp-file-backup
+      volumeMode: Filesystem
+  - kind: ConfigMap
+    apiVersion: v1
+    metadata:
+      name: mds-metabase-db-backup-config
+    data:
+      backup.conf: |
+        ${DATABASE_SERVICE_NAME}/mds
+        0 2 * * * default ./backup.sh -s
+  - kind: DeploymentConfig
+    apiVersion: v1
+    metadata:
+      name: ${NAME}
+      annotations:
+        description: Defines how to deploy the ${NAME} server
+      labels:
+        app.kubernetes.io/part-of: ${APPNAME}
+        app.openshift.io/runtime: postgresql
+    spec:
+      strategy:
+        type: Recreate
+        recreateParams:
+          maxSurge: 50%
+          maxUnavailable: 0
+          timeoutSeconds: 1200
+      triggers:
+        - type: ConfigChange
+        - type: ImageChange
+          imageChangeParams:
+            automatic: true
+            containerNames:
+              - backup
+            from:
+              kind: ImageStreamTag
+              name: ${NAME}:${TAG}
+              namespace: ${IMAGE_NAMESPACE}
+      replicas: 1
+      selector:
+        name: ${NAME}
+      template:
+        metadata:
+          name: ${NAME}
+          labels:
+            name: ${NAME}
+        spec:
+          volumes:
+            - name: mds-metabase-db-backup-data
+              persistentVolumeClaim:
+                claimName: mds-metabase-db-backup-data
+            - name: mds-metabase-db-backup-verification
+              persistentVolumeClaim:
+                claimName: mds-metabase-db-backup-verification
+            - name: mds-metabase-db-backup-config-volume
+              configMap:
+                name: mds-metabase-db-backup-config
+                items:
+                  - key: backup.conf
+                    path: backup.conf
+          containers:
+            - name: backup
+              image: " "
+              env:
+                - name: BACKUP_STRATEGY
+                  value: rolling
+                - name: BACKUP_DIR
+                  value: /backups/
+                - name: DAILY_BACKUPS
+                  value: "5"
+                - name: WEEKLY_BACKUPS
+                  value: "1"
+                - name: MONTHLY_BACKUPS
+                  value: "1"
+                - name: DATABASE_USER
+                  valueFrom:
+                    secretKeyRef:
+                      name: ${DATABASE_SERVICE_NAME}
+                      key: database-admin-user
+                - name: DATABASE_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: ${DATABASE_SERVICE_NAME}
+                      key: database-admin-password
+                - name: WEBHOOK_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: ${WEBHOOK_SECRET_NAME}
+                      key: chatops-db-backup
+                - name: DATABASE_SERVER_TIMEOUT
+                  value: "600"
+                - name: ENVIRONMENT_NAME
+                  value: ${ENVIRONMENT_NAME}
+                - name: ENVIRONMENT_FRIENDLY_NAME
+                  value: ${ENVIRONMENT_FRIENDLY_NAME}
+              resources:
+                requests:
+                  cpu: ${CPU_REQUEST}
+                  memory: ${MEMORY_REQUEST}
+                limits:
+                  cpu: ${CPU_LIMIT}
+                  memory: ${MEMORY_LIMIT}
+              volumeMounts:
+                - name: mds-metabase-db-backup-data
+                  mountPath: /backups/
+                - name: mds-metabase-db-backup-verification
+                  mountPath: /var/lib/pgsql/data
+                - name: mds-metabase-db-backup-config-volume
+                  mountPath: /backup.conf
+                  subPath: backup.conf


### PR DESCRIPTION
# Main

- Separates out metabase backups to separate service and volume for improved redundancy

# Other

- N/A

# How to test

- `oc -n <redacted>-dev process -p TAG=dev -f metabase-dbbackup.dc.yaml | oc -n <redacted>-dev apply -f -` in dev namespace
- terminal into pod
- `./backup.sh -s` should produce a backup in `backups/`

# Notes

- This has already been deployed manually to dev/test/prod
