### PR TITLE
Fix: Increase all build deadlines to allow at least 24 min

### DIFF
--- a/openshift4/templates/backend.bc.yaml
+++ b/openshift4/templates/backend.bc.yaml
@@ -114,7 +114,7 @@ objects:
     spec:
       successfulBuildsHistoryLimit: 5
       failedBuildsHistoryLimit: 5
-      completionDeadlineSeconds: 600
+      completionDeadlineSeconds: 1440
       triggers:
         - type: ImageChange
       runPolicy: SerialLatestOnly

--- a/openshift4/templates/dbbackup.bc.yaml
+++ b/openshift4/templates/dbbackup.bc.yaml
@@ -54,7 +54,7 @@ objects:
     spec:
       successfulBuildsHistoryLimit: 5
       failedBuildsHistoryLimit: 5
-      completionDeadlineSeconds: 600
+      completionDeadlineSeconds: 1440
       triggers:
         - type: ImageChange
       runPolicy: SerialLatestOnly

--- a/openshift4/templates/docman.bc.yaml
+++ b/openshift4/templates/docman.bc.yaml
@@ -112,7 +112,7 @@ objects:
       annotations:
         description: Defines how to build the application
     spec:
-      completionDeadlineSeconds: 600
+      completionDeadlineSeconds: 1440
       triggers:
         - type: ImageChange
       runPolicy: SerialLatestOnly

--- a/openshift4/templates/filesystem-provider.bc.yaml
+++ b/openshift4/templates/filesystem-provider.bc.yaml
@@ -61,7 +61,7 @@ objects:
         to:
           kind: ImageStreamTag
           name: ${NAME}:${TAG}
-      completionDeadlineSeconds: 1200
+      completionDeadlineSeconds: 1440
       resources:
         limits:
           cpu: 2000m

--- a/openshift4/templates/frontend.bc.yaml
+++ b/openshift4/templates/frontend.bc.yaml
@@ -120,7 +120,7 @@ objects:
     spec:
       successfulBuildsHistoryLimit: 5
       failedBuildsHistoryLimit: 5
-      completionDeadlineSeconds: 900
+      completionDeadlineSeconds: 1440
       triggers:
         - type: ImageChange
       runPolicy: SerialLatestOnly

--- a/openshift4/templates/metabase-dbbackup.bc.yaml
+++ b/openshift4/templates/metabase-dbbackup.bc.yaml
@@ -54,7 +54,7 @@ objects:
     spec:
       successfulBuildsHistoryLimit: 5
       failedBuildsHistoryLimit: 5
-      completionDeadlineSeconds: 600
+      completionDeadlineSeconds: 1440
       triggers:
         - type: ImageChange
       runPolicy: SerialLatestOnly

--- a/openshift4/templates/minespace.bc.yaml
+++ b/openshift4/templates/minespace.bc.yaml
@@ -122,7 +122,7 @@ objects:
     spec:
       successfulBuildsHistoryLimit: 5
       failedBuildsHistoryLimit: 5
-      completionDeadlineSeconds: 900
+      completionDeadlineSeconds: 1440
       triggers:
         - type: ImageChange
       runPolicy: SerialLatestOnly

--- a/openshift4/templates/nginx.bc.yaml
+++ b/openshift4/templates/nginx.bc.yaml
@@ -41,7 +41,7 @@ objects:
     spec:
       successfulBuildsHistoryLimit: 5
       failedBuildsHistoryLimit: 5
-      completionDeadlineSeconds: 600
+      completionDeadlineSeconds: 1440
       triggers:
         - type: ImageChange
       runPolicy: SerialLatestOnly

--- a/openshift4/templates/nris.bc.yaml
+++ b/openshift4/templates/nris.bc.yaml
@@ -114,7 +114,7 @@ objects:
       annotations:
         description: Defines how to build the application
     spec:
-      completionDeadlineSeconds: 600
+      completionDeadlineSeconds: 1440
       triggers:
         - type: ImageChange
       runPolicy: SerialLatestOnly

--- a/openshift4/templates/schemaspy.bc.yaml
+++ b/openshift4/templates/schemaspy.bc.yaml
@@ -34,7 +34,7 @@ objects:
       creationTimestamp: null
       name: ${NAME}
     spec:
-      completionDeadlineSeconds: 600
+      completionDeadlineSeconds: 1440
       failedBuildsHistoryLimit: 5
       nodeSelector: null
       output:

--- a/openshift4/templates/tusd.bc.yaml
+++ b/openshift4/templates/tusd.bc.yaml
@@ -83,6 +83,6 @@ objects:
         to:
           kind: ImageStreamTag
           name: ${NAME}:${TAG}
-      completionDeadlineSeconds: 600
+      completionDeadlineSeconds: 1440
       triggers:
         - type: ImageChange


### PR DESCRIPTION
# Main

- Increases all buildconfig manifests completionDeadlineSeconds to be at least 1440 (24 min)

# Other

- N/A

# How to test

- N/A

# Notes

- N/A
