### PR TITLE
MDS-3886 Allow Draft Permit Issue Date to be in the future/or not required

### DIFF
--- a/services/core-api/app/api/mines/permits/permit_amendment/models/permit_amendment.py
+++ b/services/core-api/app/api/mines/permits/permit_amendment/models/permit_amendment.py
@@ -259,7 +259,7 @@ class PermitAmendment(SoftDeleteMixin, AuditMixin, Base):
             if issue_date.isoformat() == '9999-12-31':
                 raise AssertionError(
                     'Permit amendment issue date should be set to null if not known.')
-            if issue_date > datetime.today():
+            if self.permit_amendment_status_code != 'DFT' and issue_date > datetime.today():
                 raise AssertionError('Permit amendment issue date cannot be set to the future.')
         return issue_date
 

--- a/services/core-web/src/components/Forms/permits/GeneratePermitForm.js
+++ b/services/core-web/src/components/Forms/permits/GeneratePermitForm.js
@@ -6,11 +6,7 @@ import { Field, reduxForm, getFormValues } from "redux-form";
 import { Form } from "@ant-design/compatible";
 import "@ant-design/compatible/assets/index.css";
 import { Col, Row, Descriptions } from "antd";
-import {
-  required,
-  dateNotAfterOther,
-  dateNotBeforeOther,
-} from "@common/utils/Validate";
+import { required, dateNotAfterOther, dateNotBeforeOther } from "@common/utils/Validate";
 import { resetForm, formatDate } from "@common/utils/helpers";
 import * as FORM from "@/constants/forms";
 import CustomPropTypes from "@/customPropTypes";
@@ -218,9 +214,7 @@ export const GeneratePermitForm = (props) => {
                 name="issue_date"
                 label="Issue Date*"
                 component={renderConfig.DATE}
-                validate={[
-                  dateNotAfterOther(props.formValues.auth_end_date),
-                ]}
+                validate={[dateNotAfterOther(props.formValues.auth_end_date)]}
                 disabled={props.isViewMode}
               />
             </Col>
@@ -230,7 +224,7 @@ export const GeneratePermitForm = (props) => {
                 name="auth_end_date"
                 label="Authorization End Date*"
                 component={renderConfig.DATE}
-                validate={[required, dateNotBeforeOther(props.formValues.issue_date)]}
+                validate={[dateNotBeforeOther(props.formValues.issue_date)]}
                 disabled={props.isViewMode}
               />
             </Col>

--- a/services/core-web/src/components/Forms/permits/GeneratePermitForm.js
+++ b/services/core-web/src/components/Forms/permits/GeneratePermitForm.js
@@ -9,7 +9,6 @@ import { Col, Row, Descriptions } from "antd";
 import {
   required,
   dateNotAfterOther,
-  dateNotInFuture,
   dateNotBeforeOther,
 } from "@common/utils/Validate";
 import { resetForm, formatDate } from "@common/utils/helpers";
@@ -220,8 +219,6 @@ export const GeneratePermitForm = (props) => {
                 label="Issue Date*"
                 component={renderConfig.DATE}
                 validate={[
-                  required,
-                  dateNotInFuture,
                   dateNotAfterOther(props.formValues.auth_end_date),
                 ]}
                 disabled={props.isViewMode}


### PR DESCRIPTION
# Main

- Only issue date in Draft permits are allowed to be in the future and the date is not required.
- Issue date in issued permits is not allowed.

# Other
- N/A

# How to test
## Set date in the future
- Set a date in the future in a Draft permit and save:
![image](https://user-images.githubusercontent.com/10526131/137004980-90c33e19-2bf5-4093-bb3b-7e9bc32386fc.png)

- Confirm is successfully updated:
![image](https://user-images.githubusercontent.com/10526131/137005131-1d43bbc9-3983-4e6e-90d3-e2d63feecb04.png)

- Solve all the issues in Process tab.

- Click on issue a Permit:
![image](https://user-images.githubusercontent.com/10526131/137005657-d9a83a32-cab5-48b7-a03a-7708f56ffa3e.png)

-  Confirm issue date cannot be set in the future:
![image](https://user-images.githubusercontent.com/10526131/137005975-7fb05159-bfd9-4cbb-8775-ad208ae39896.png)

- Have to be unable to proceed to issue the permit when clicking Issue Permit button.

## Issue date is not set:

- Under Draft, fill with blank as issue date and set authorization end date. Then save:
![image](https://user-images.githubusercontent.com/10526131/137007390-f4f03f00-d940-443a-901d-d2d24dae3876.png)

- Confirm is successfully updated:
![image](https://user-images.githubusercontent.com/10526131/137005131-1d43bbc9-3983-4e6e-90d3-e2d63feecb04.png)

- Solve all the issues in Process tab.

- Click on issue a Permit:
![image](https://user-images.githubusercontent.com/10526131/137005657-d9a83a32-cab5-48b7-a03a-7708f56ffa3e.png)

-  Confirm issue date cannot be empty:
![image](https://user-images.githubusercontent.com/10526131/137007937-4793bdb7-0b59-4ec7-befc-d7eecc90c0c9.png)

- Have to be unable to proceed to issue the permit when clicking Issue Permit button.



# Notes
https://bcmines.atlassian.net/browse/MDS-3886

