### PR TITLE
Removing limit of mines returned.

### DIFF
--- a/services/core-api/app/api/mines/mine/models/mine.py
+++ b/services/core-api/app/api/mines/mine/models/mine.py
@@ -226,7 +226,6 @@ class Mine(SoftDeleteMixin, AuditMixin, Base):
 
     @classmethod
     def find_by_mine_name(cls, term=None, major=None):
-        MINE_LIST_RESULT_LIMIT = 50
         if term:
             name_filter = Mine.mine_name.ilike('%{}%'.format(term))
             mines_q = Mine.query.filter(name_filter).filter_by(deleted_ind=False)
@@ -235,7 +234,7 @@ class Mine(SoftDeleteMixin, AuditMixin, Base):
 
         if major is not None:
             mines_q = mines_q.filter_by(major_mine_ind=major)
-        return mines_q.limit(MINE_LIST_RESULT_LIMIT).all()
+        return mines_q.all()
 
     @classmethod
     def find_by_name_no_permit(cls, term=None, major=None):

--- a/services/core-api/app/api/mines/mine/models/mine.py
+++ b/services/core-api/app/api/mines/mine/models/mine.py
@@ -15,6 +15,7 @@ from app.api.mines.permits.permit.models.mine_permit_xref import MinePermitXref
 from app.api.users.minespace.models.minespace_user_mine import MinespaceUserMine
 from app.api.mines.work_information.models.mine_work_information import MineWorkInformation
 from app.api.constants import *
+from app.api.utils.access_decorators import is_minespace_user
 
 # NOTE: Be careful about relationships defined in the mine model. lazy='joined' will cause the relationship
 # to be joined and loaded immediately, so that data will load even when it may not be needed. Setting
@@ -226,6 +227,7 @@ class Mine(SoftDeleteMixin, AuditMixin, Base):
 
     @classmethod
     def find_by_mine_name(cls, term=None, major=None):
+        MINE_LIST_RESULT_LIMIT = None if is_minespace_user() else 50
         if term:
             name_filter = Mine.mine_name.ilike('%{}%'.format(term))
             mines_q = Mine.query.filter(name_filter).filter_by(deleted_ind=False)
@@ -234,7 +236,11 @@ class Mine(SoftDeleteMixin, AuditMixin, Base):
 
         if major is not None:
             mines_q = mines_q.filter_by(major_mine_ind=major)
-        return mines_q.all()
+
+        response = mines_q.limit(
+            MINE_LIST_RESULT_LIMIT).all() if MINE_LIST_RESULT_LIMIT else mines_q.all()
+
+        return response
 
     @classmethod
     def find_by_name_no_permit(cls, term=None, major=None):


### PR DESCRIPTION
# Main
- Minespace list every mine that a proponent has access on the "My Mines" page.

# Other
- N/A

# How to test
- Adding mines to proponent.

1. Get the maximum number of mines associated to a proponent:
```
select user_id, count(user_id)
from minespace_user_mds_mine_access
group by user_id
order by 1 desc
```

2. Delete data for your user in minespace_user_mds_mine_access. I am using mining@bceid which is user_id= 253
```
delete 
from minespace_user_mds_mine_access
where user_id= 253

```
3. Insert new records considering as a base the records with the maximum number of mines found in step 1:
```
select 'INSERT INTO minespace_user_mds_mine_access values (253, '''||mine_guid||''')'
from minespace_user_mds_mine_access
where user_id=237 // the user_id with the maximum number of mines from step 1.
```
4. Ensure you commit the changes in database if you did not auto-commit.

- **Validation**: 
Get the same number of mines in the first query and in minespace UI:
![image](https://user-images.githubusercontent.com/10526131/137810042-b22cabb7-02a3-4c25-9c2a-92925c3bd04e.png)

Get the 50 mines limit in core UI:
![image](https://user-images.githubusercontent.com/10526131/142259588-393382d7-773b-44a7-964c-6fd338c28285.png)


# Notes
https://bcmines.atlassian.net/browse/MDS-3721
