### PR TITLE
MDS-3925: Add linting workflow for manifests

### DIFF
--- a/.github/workflows/pr_checklist.yaml
+++ b/.github/workflows/pr_checklist.yaml
@@ -11,10 +11,5 @@ jobs:
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
-          msg: |
-            Definition of Done Reminders:
-            - [ ] Did you update associated documentation?
-            - [ ] If you encountered any technical debt during this PR, is there a ticket for it?
-            - [ ] Has the PO or business delegate signed off on these changes?
-            - [ ] If there are API changes, are they backwards compatible for consumers?
-            - [ ] If applicable frontend changes, have you reviewed the user flow with UX?
+          # If block syntax is used, duplicate comment checks will fail
+          msg: "Definition of Done Reminders:\n- [ ] Did you update associated documentation?\n- [ ] If you encountered any technical debt during this PR, is there a ticket for it?\n- [ ] Has the PO or business delegate signed off on these changes?\n- [ ] If there are API changes, are they backwards compatible for consumers?\n- [ ] If applicable frontend changes, have you reviewed the user flow with UX?"

--- a/.github/workflows/pr_checklist.yaml
+++ b/.github/workflows/pr_checklist.yaml
@@ -12,4 +12,4 @@ jobs:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           # If block syntax is used, duplicate comment checks will fail
-          msg: "Definition of Done Reminders:\n- [ ] Did you update associated documentation?\n- [ ] If you encountered any technical debt during this PR, is there a ticket for it?\n- [ ] Has the PO or business delegate signed off on these changes?\n- [ ] If there are API changes, are they backwards compatible for consumers?\n- [ ] If applicable frontend changes, have you reviewed the user flow with UX?"
+          msg: "Definition of Done Reminders: \n- [ ] Did you update associated documentation? \n- [ ] If you encountered any technical debt during this PR, is there a ticket for it? \n- [ ] Has the PO or business delegate signed off on these changes? \n- [ ] If there are API changes, are they backwards compatible for consumers? \n- [ ] If applicable frontend changes, have you reviewed the user flow with UX?"

--- a/.github/workflows/pr_checklist.yaml
+++ b/.github/workflows/pr_checklist.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: unsplash/comment-on-pr@master
+      - uses: unsplash/comment-on-pr@v1.3.0
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:

--- a/.github/workflows/tests-lint-manifests.yaml
+++ b/.github/workflows/tests-lint-manifests.yaml
@@ -1,0 +1,114 @@
+name: Lint manifests
+
+on:
+  pull_request:
+    paths:
+      - openshift4/templates/**.yaml
+  push: # REMOVE AFTER TESTING
+
+env:
+  INITIAL_TAG: latest
+  TAG: dev
+  SOURCE_REPOSITORY_URL: https://github.com/bcgov/mds.git
+  SOURCE_REPOSITORY_REF: develop
+
+jobs:
+  tests-lint-deploy-manifests:
+    name: tests-lint-deploy-manifests
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        include:
+          - config: frontend
+          - config: backend
+          - config: dbbackup
+          - config: docgen
+          - config: postgresql
+          - config: nginx
+          - config: redis
+          - config: tusd
+          - config: metabase
+          - config: metabase-postgres
+          - config: docman
+          - config: filesystem-provider
+          - config: nris
+          - config: nris-etl
+          - config: minespace
+          - config: fider
+          - config: schemaspy
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Install oc
+        uses: redhat-actions/oc-installer@v1
+        with:
+          oc_version: "4.6"
+      - name: oc login
+        run: |
+          oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
+      - name:
+        run: |
+          oc -n ${{secrets.NS_DEV}} process -f openshift4/templates/${{ matrix.config }}.dc.yaml --ignore-unknown-parameters=true \
+          -p TAG=${{env.TAG}} \
+          -p JWT_OIDC_WELL_KNOWN_CONFIG=https://test.oidc.gov.bc.ca/auth/realms/mds/.well-known/openid-configuration \
+          -p JWT_OIDC_AUDIENCE=mines-application-dev \
+          -p JWT_OIDC_AUTHORITY=https://test.oidc.gov.bc.ca/auth/realms/mds \
+          -p DOCMAN_API_URL=https://mds-dev.apps.silver.devops.gov.bc.ca/document-manager \
+          -p CORE_API_URL=https://mds-dev.apps.silver.devops.gov.bc.ca/api \
+          -p URL=https://mds-dev.apps.silver.devops.gov.bc.ca/ \
+          -p ENVIRONMENT_NAME=dev \
+          -p NODE_ENV=development \
+          -p CORE_DOMAIN=${{env.CORE_DOMAIN}} \
+          -p MINESPACE_DOMAIN=${{env.MINESPACE_DOMAIN}} \
+          -p KEYCLOAK_URL=https://test.oidc.gov.bc.ca/auth \
+          -p KEYCLOAK_CLIENT_ID=mines-application-dev \
+          -p KEYCLOAK_RESOURCE=mines-application-dev \
+          -p MS_KEYCLOAK_CLIENT_ID=minespace-dev \
+          -p SITEMINDER_URL=https://logontest7.gov.bc.ca \
+          -p MATOMO_URL=https://matomo-4c2ba9-test.apps.silver.devops.gov.bc.ca/ \
+          -p OBJECT_STORE_ENABLED=1 \
+          | oc -n ${{secrets.NS_DEV}} apply -f - \
+          --dry-run=server \
+          --validate=true
+
+  tests-lint-build-manifests:
+    name: tests-lint-build-manifests
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        include:
+          # - name: nginx
+          # - name: postgresql
+          - name: frontend
+          # - name: backend
+          # - name: flyway
+          # - name: tusd
+          # - name: docgen
+          # - name: dbbackup
+          # - name: metabase
+          # - name: metabase-postgres
+          # - name: docman
+          # - name: filesystem-provider
+          # - name: nris
+          # - name: minespace
+          # - name: fider
+          # - name: schemaspy
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Install oc
+        uses: redhat-actions/oc-installer@v1
+        with:
+          oc_version: "4.6"
+      - name: oc login
+        run: |
+          oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
+      - name: Template build config
+        run: |
+          oc -n ${{secrets.NS_TOOLS}} process -f openshift4/templates/${{ matrix.name }}.bc.yaml --ignore-unknown-parameters=true \
+          -p SOURCE_REPOSITORY_URL=${{env.SOURCE_REPOSITORY_URL}} \
+          -p SOURCE_REPOSITORY_REF=${{env.SOURCE_REPOSITORY_REF}} \
+          -p TAG=${{env.INITIAL_TAG}} \
+          | oc -n ${{secrets.NS_TOOLS}} apply -f - \
+          --dry-run=server \
+          --validate=true

--- a/.github/workflows/tests-lint-manifests.yaml
+++ b/.github/workflows/tests-lint-manifests.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
     paths:
       - openshift4/templates/**.yaml
-  push: # REMOVE AFTER TESTING
+      - .github/workflows/tests-lint-manifests.yaml
 
 env:
   INITIAL_TAG: latest
@@ -70,7 +70,7 @@ jobs:
           -p MATOMO_URL=https://matomo-4c2ba9-test.apps.silver.devops.gov.bc.ca/ \
           -p OBJECT_STORE_ENABLED=1 \
           | oc -n ${{secrets.NS_DEV}} apply -f - \
-          --dry-run=server \
+          --dry-run=client \
           --validate=true
 
   tests-lint-build-manifests:
@@ -79,22 +79,21 @@ jobs:
     strategy:
       matrix:
         include:
-          # - name: nginx
-          # - name: postgresql
+          - name: nginx
           - name: frontend
-          # - name: backend
-          # - name: flyway
-          # - name: tusd
-          # - name: docgen
-          # - name: dbbackup
-          # - name: metabase
-          # - name: metabase-postgres
-          # - name: docman
-          # - name: filesystem-provider
-          # - name: nris
-          # - name: minespace
-          # - name: fider
-          # - name: schemaspy
+          - name: backend
+          - name: flyway
+          - name: tusd
+          - name: docgen
+          - name: dbbackup
+          - name: metabase
+          - name: metabase-postgres
+          - name: docman
+          - name: filesystem-provider
+          - name: nris
+          - name: minespace
+          - name: fider
+          - name: schemaspy
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
@@ -112,5 +111,5 @@ jobs:
           -p SOURCE_REPOSITORY_REF=${{env.SOURCE_REPOSITORY_REF}} \
           -p TAG=${{env.INITIAL_TAG}} \
           | oc -n ${{secrets.NS_TOOLS}} apply -f - \
-          --dry-run=server \
+          --dry-run=client \
           --validate=true

--- a/.github/workflows/tests-lint-manifests.yaml
+++ b/.github/workflows/tests-lint-manifests.yaml
@@ -11,6 +11,8 @@ env:
   TAG: dev
   SOURCE_REPOSITORY_URL: https://github.com/bcgov/mds.git
   SOURCE_REPOSITORY_REF: develop
+  CORE_DOMAIN: mds-dev.apps.silver.devops.gov.bc.ca
+  MINESPACE_DOMAIN: minespace-dev.apps.silver.devops.gov.bc.ca
 
 jobs:
   tests-lint-deploy-manifests:

--- a/openshift4/templates/backend.dc.yaml
+++ b/openshift4/templates/backend.dc.yaml
@@ -42,11 +42,11 @@ parameters:
   - name: CACHE_REDIS_HOST
     value: redis
   - name: CPU_LIMIT
-    value: 200m
+    value: 600m
   - name: MEMORY_LIMIT
-    value: 1Gi
+    value: 2Gi
   - name: CPU_REQUEST
-    value: 150m
+    value: 200m
   - name: MEMORY_REQUEST
     value: 512Mi
   - name: UWSGI_PROCESSES
@@ -56,7 +56,7 @@ parameters:
   - name: REPLICA_MIN
     value: "3"
   - name: REPLICA_MAX
-    value: "4"
+    value: "5"
   - name: ENVIRONMENT_NAME
     displayName: Environment Name (Environment Id)
     description: The name or Id of the environment.  This variable is used by the webhook integration to identify the environment in which the backup notifications originate.
@@ -337,17 +337,17 @@ objects:
                   path: ${BASE_PATH}/health
                   port: 5000
                   scheme: HTTP
-                initialDelaySeconds: 30
+                initialDelaySeconds: 60
                 timeoutSeconds: 15
-                periodSeconds: 20
+                periodSeconds: 30
               readinessProbe:
                 httpGet:
                   path: ${BASE_PATH}/health
                   port: 5000
                   scheme: HTTP
-                initialDelaySeconds: 30
+                initialDelaySeconds: 60
                 timeoutSeconds: 15
-                periodSeconds: 15
+                periodSeconds: 30
               terminationMessagePath: /dev/termination-log
               terminationMessagePolicy: File
               imagePullPolicy: IfNotPresent
@@ -422,10 +422,10 @@ objects:
                   value: "300"
               resources:
                 limits:
-                  cpu: 100m
-                  memory: 384Mi
+                  cpu: 300m
+                  memory: 512Mi
                 requests:
-                  cpu: 50m
+                  cpu: 100m
                   memory: 128Mi
           restartPolicy: Always
           volumeMounts:
@@ -453,7 +453,7 @@ objects:
       maxReplicas: ${{REPLICA_MAX}}
       minReplicas: ${{REPLICA_MIN}}
       scaleTargetRef:
-        apiVersion: v1
+        apiVersion: apps.openshift.io/v1
         kind: DeploymentConfig
         name: ${NAME}
       targetCPUUtilizationPercentage: 95

--- a/openshift4/templates/docgen.dc.yaml
+++ b/openshift4/templates/docgen.dc.yaml
@@ -145,7 +145,7 @@ objects:
       maxReplicas: ${{REPLICA_MAX}}
       minReplicas: ${{REPLICA_MIN}}
       scaleTargetRef:
-        apiVersion: v1
+        apiVersion: apps.openshift.io/v1
         kind: DeploymentConfig
         name: ${NAME}
       targetCPUUtilizationPercentage: 95

--- a/openshift4/templates/docman.dc.yaml
+++ b/openshift4/templates/docman.dc.yaml
@@ -514,7 +514,7 @@ objects:
       maxReplicas: ${{REPLICA_MAX}}
       minReplicas: ${{REPLICA_MIN}}
       scaleTargetRef:
-        apiVersion: v1
+        apiVersion: apps.openshift.io/v1
         kind: DeploymentConfig
         name: ${NAME}
       targetCPUUtilizationPercentage: 95

--- a/openshift4/templates/frontend.dc.yaml
+++ b/openshift4/templates/frontend.dc.yaml
@@ -61,7 +61,7 @@ parameters:
   - name: CORE_DOMAIN
     required: true
   - name: CPU_LIMIT
-    value: 250m
+    value: 300m
   - name: MEMORY_LIMIT
     value: 512Mi
   - name: CPU_REQUEST
@@ -71,7 +71,7 @@ parameters:
   - name: REPLICA_MIN
     value: "3"
   - name: REPLICA_MAX
-    value: "4"
+    value: "5"
   - name: IMAGE_NAMESPACE
     value: 4c2ba9-tools
   - name: APPNAME
@@ -199,7 +199,7 @@ objects:
       maxReplicas: ${{REPLICA_MAX}}
       minReplicas: ${{REPLICA_MIN}}
       scaleTargetRef:
-        apiVersion: v1
+        apiVersion: apps.openshift.io/v1
         kind: DeploymentConfig
         name: ${NAME}
       targetCPUUtilizationPercentage: 95

--- a/openshift4/templates/minespace.dc.yaml
+++ b/openshift4/templates/minespace.dc.yaml
@@ -197,7 +197,7 @@ objects:
       maxReplicas: ${{REPLICA_MAX}}
       minReplicas: ${{REPLICA_MIN}}
       scaleTargetRef:
-        apiVersion: v1
+        apiVersion: apps.openshift.io/v1
         kind: DeploymentConfig
         name: ${NAME}
       targetCPUUtilizationPercentage: 95

--- a/openshift4/templates/nginx.dc.yaml
+++ b/openshift4/templates/nginx.dc.yaml
@@ -168,7 +168,7 @@ objects:
       maxReplicas: ${{REPLICA_MAX}}
       minReplicas: ${{REPLICA_MIN}}
       scaleTargetRef:
-        apiVersion: v1
+        apiVersion: apps.openshift.io/v1
         kind: DeploymentConfig
         name: ${NAME}
       targetCPUUtilizationPercentage: 95

--- a/openshift4/templates/nris.dc.yaml
+++ b/openshift4/templates/nris.dc.yaml
@@ -30,7 +30,7 @@ parameters:
     required: false
     value: template.nris-odb-credentials
   - name: CPU_LIMIT
-    value: 200m
+    value: 300m
   - name: MEMORY_LIMIT
     value: 1Gi
   - name: CPU_REQUEST
@@ -42,9 +42,9 @@ parameters:
   - name: UWSGI_THREADS
     value: "4"
   - name: REPLICA_MIN
-    value: "2"
+    value: "3"
   - name: REPLICA_MAX
-    value: "2"
+    value: "4"
   - name: REDIS_CONFIG_NAME
     required: false
     value: template.redis-secret

--- a/openshift4/templates/nris.dc.yaml
+++ b/openshift4/templates/nris.dc.yaml
@@ -235,7 +235,7 @@ objects:
       maxReplicas: ${{REPLICA_MAX}}
       minReplicas: ${{REPLICA_MIN}}
       scaleTargetRef:
-        apiVersion: v1
+        apiVersion: apps.openshift.io/v1
         kind: DeploymentConfig
         name: ${NAME}
       targetCPUUtilizationPercentage: 95

--- a/openshift4/templates/schemaspy.dc.yaml
+++ b/openshift4/templates/schemaspy.dc.yaml
@@ -149,7 +149,7 @@ objects:
       maxReplicas: ${{REPLICA_MAX}}
       minReplicas: ${{REPLICA_MIN}}
       scaleTargetRef:
-        apiVersion: v1
+        apiVersion: apps.openshift.io/v1
         kind: DeploymentConfig
         name: ${NAME}
       targetCPUUtilizationPercentage: 95


### PR DESCRIPTION
# Main

- Adds workflow to check kubernetes manifests during PRs

# Other

- Increases select quotas to better handle spiking demand for key services (namely FE, BE)
- Adjusts backend readiness & liveness probes to be more forgiving during deploy. Should lead to a smoother prod deploy.
- As per the PS request: update legacy scalingTargetRef blocks on all HPAs to specify the API endpoint of DCs as this is required syntax in new OCP versions.
- Fixes pr checklist spam. Had to collapse comment to single line and include extra whitepace at the end of every line??!?!??

# How to test

- N/A

# Notes

- N/A
