### PR TITLE
added a not to the document generation if date is changed via new flow

### DIFF
--- a/services/core-api/app/api/now_applications/resources/now_application_progress_resource.py
+++ b/services/core-api/app/api/now_applications/resources/now_application_progress_resource.py
@@ -121,7 +121,7 @@ class NOWApplicationProgressResource(Resource, UserMixin):
                 identity.save()
 
         # only trigger if the technical review is updated via the standard flow and not via the manual editing flow
-        if application_progress_status_code == 'REV' and date_override:
+        if application_progress_status_code == 'REV' and not date_override:
             identity.now_application.add_now_form_to_fap(
                 "This document was automatically created when Technical Review was completed.")
 


### PR DESCRIPTION
# Main
- added a 'not' to an if check to now generate a document on technical review end if dates are edited via the new flow

# Other

- N/A

# How to test

- N/A

# Notes

- N/A
