### PR TITLE
Fix: Adjust metabase rollouts

### DIFF
--- a/openshift4/docker-images/metabase/Dockerfile
+++ b/openshift4/docker-images/metabase/Dockerfile
@@ -17,4 +17,4 @@ RUN chmod -R 777 /app
 EXPOSE 3000
 
 # run it
-CMD ["java", "-jar", "metabase.jar"]
+CMD ["java", "-Xmx1G", "-jar", "metabase.jar"]

--- a/openshift4/templates/metabase.dc.yaml
+++ b/openshift4/templates/metabase.dc.yaml
@@ -10,7 +10,7 @@ parameters:
   - name: CPU_REQUEST
     value: 30m
   - name: MEMORY_REQUEST
-    value: 750Mi
+    value: 1500Mi
   - name: ENVIRONMENT_NAME
     value: dev
   - name: NAME
@@ -31,6 +31,9 @@ parameters:
     displayName: AppName
     description: Application name for grouping pods in Openshift
     value: Metabase
+  - name: BASE_PATH
+    required: false
+    value: /api
 objects:
   - kind: Service
     apiVersion: v1
@@ -135,6 +138,22 @@ objects:
                 limits:
                   cpu: ${CPU_LIMIT}
                   memory: ${MEMORY_LIMIT}
+              livenessProbe:
+                httpGet:
+                  path: ${BASE_PATH}/health
+                  port: 3000
+                  scheme: HTTP
+                initialDelaySeconds: 160
+                timeoutSeconds: 15
+                periodSeconds: 30
+              readinessProbe:
+                httpGet:
+                  path: ${BASE_PATH}/health
+                  port: 3000
+                  scheme: HTTP
+                initialDelaySeconds: 160
+                timeoutSeconds: 15
+                periodSeconds: 30
               terminationMessagePath: /dev/termination-log
               imagePullPolicy: IfNotPresent
               capabilities: {}

--- a/openshift4/templates/metabase.dc.yaml
+++ b/openshift4/templates/metabase.dc.yaml
@@ -4,11 +4,11 @@ metadata:
   name: mds-metabase-dc
 parameters:
   - name: CPU_LIMIT
-    value: 90m
+    value: 240m
   - name: MEMORY_LIMIT
     value: 2250Mi
   - name: CPU_REQUEST
-    value: 30m
+    value: 80m
   - name: MEMORY_REQUEST
     value: 1500Mi
   - name: ENVIRONMENT_NAME

--- a/openshift4/templates/metabase.dc.yaml
+++ b/openshift4/templates/metabase.dc.yaml
@@ -143,17 +143,17 @@ objects:
                   path: ${BASE_PATH}/health
                   port: 3000
                   scheme: HTTP
-                initialDelaySeconds: 160
+                initialDelaySeconds: 240
                 timeoutSeconds: 15
-                periodSeconds: 30
+                periodSeconds: 60
               readinessProbe:
                 httpGet:
                   path: ${BASE_PATH}/health
                   port: 3000
                   scheme: HTTP
-                initialDelaySeconds: 160
+                initialDelaySeconds: 240
                 timeoutSeconds: 15
-                periodSeconds: 30
+                periodSeconds: 60
               terminationMessagePath: /dev/termination-log
               imagePullPolicy: IfNotPresent
               capabilities: {}


### PR DESCRIPTION
# Main

- Adjust dockerfile for metabase that defines the heapsize of JVM (doubled)
- Add API healthchecks so rollouts don't surge 100% all at once and properly rolls out and doesn't cause an outage

# Other

- N/A

# How to test

- N/A

# Notes

- N/A
