### PR TITLE
MDS-4015 - Add Mines Certification Registry Link to Core home Page

### DIFF
--- a/services/core-web/src/components/dashboard/HomePage.js
+++ b/services/core-web/src/components/dashboard/HomePage.js
@@ -151,6 +151,15 @@ export class HomePage extends Component {
                     EPIC (EAO)
                   </a>
                 </li>
+                <li>
+                  <a
+                    href="https://mines.qp.gov.bc.ca/mines/app"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Mines Certification Registry
+                  </a>
+                </li>
               </ul>
             </div>
           </Col>


### PR DESCRIPTION
# Main

- Add Mines Certification Registry link to "External Links" on Core homepage

# Other

- N/A

# How to test

- Visit CORE homepage and find new link at the bottom of the list

# Notes

- N/A
