### PR TITLE
MDS-3529: Contacts - Person/Company toggle misbehaving

### DIFF
--- a/services/core-web/src/components/Forms/parties/AddFullPartyForm.js
+++ b/services/core-web/src/components/Forms/parties/AddFullPartyForm.js
@@ -30,7 +30,12 @@ export const AddFullPartyForm = (props) => (
       <Row gutter={48}>
         <Col md={12} sm={24} className="border--right--layout">
           <div className="center margin-large">
-            <Radio.Group defaultValue size="large" onChange={props.togglePartyChange}>
+            <Radio.Group
+              defaultValue
+              value={props.isPerson}
+              size="large"
+              onChange={props.togglePartyChange}
+            >
               <Radio.Button value>Person</Radio.Button>
               <Radio.Button value={false}>Organization</Radio.Button>
             </Radio.Group>

--- a/services/core-web/src/tests/components/Forms/parties/__snapshots__/AddFullPartyForm.spec.js.snap
+++ b/services/core-web/src/tests/components/Forms/parties/__snapshots__/AddFullPartyForm.spec.js.snap
@@ -23,6 +23,7 @@ exports[`AddFullPartyForm renders properly 1`] = `
             defaultValue={true}
             onChange={[MockFunction]}
             size="large"
+            value={false}
           >
             <ForwardRef(RadioButton)
               value={true}


### PR DESCRIPTION
# Main

- N/A

# Other

- N/A

# How to test

- Contact Lookup -> Add New Contact -> When selecting Organization type and clicking next followed by going back to the previous screen the Person/Org tab will now be set correctly

# Notes

- N/A
