### PR TITLE
Minespace - Fixing Project Summary copy typo

### DIFF
--- a/services/minespace-web/src/components/dashboard/mine/projectSummaries/ProjectSummaries.js
+++ b/services/minespace-web/src/components/dashboard/mine/projectSummaries/ProjectSummaries.js
@@ -99,7 +99,7 @@ export class ProjectSummaries extends Component {
             >
               HSRC
             </a>
-            &nbsp;9.1.1) outside of the permit mine ara of an operating production mineral or coal
+            &nbsp;9.1.1) outside of the permit mine area of an operating production mineral or coal
             mine that does not consist of an expansion to the production mining area, please submit
             a Notice of Work application through{" "}
             <a

--- a/services/minespace-web/src/tests/components/dashboard/mine/projectSummaries/__snapshots__/ProjectSummaries.spec.js.snap
+++ b/services/minespace-web/src/tests/components/dashboard/mine/projectSummaries/__snapshots__/ProjectSummaries.spec.js.snap
@@ -56,7 +56,7 @@ exports[`ProjectSummaries renders properly 1`] = `
       >
         HSRC
       </a>
-       9.1.1) outside of the permit mine ara of an operating production mineral or coal mine that does not consist of an expansion to the production mining area, please submit a Notice of Work application through
+       9.1.1) outside of the permit mine area of an operating production mineral or coal mine that does not consist of an expansion to the production mining area, please submit a Notice of Work application through
        
       <a
         href="https://portal.nrs.gov.bc.ca/web/client/home"


### PR DESCRIPTION
# Main

- Fixing typo of "ara" in the third paragraph of the introductory text on the Project Summary tab

# Other

- N/A

# How to test

- N/A

# Notes

- N/A
