### PR TITLE
Updated the now_submission tables to include the new fields

### DIFF
--- a/migrations/sql/V2021.12.14.15.52__update_now_submission_data.sql
+++ b/migrations/sql/V2021.12.14.15.52__update_now_submission_data.sql
@@ -1,9 +1,9 @@
 ALTER TABLE now_submissions.application
 ADD COLUMN IF NOT EXISTS maxannualcubicmeters   numeric,
 ADD COLUMN IF NOT EXISTS proposedstartmonth     varchar(100),
-ADD COLUMN IF NOT EXISTS proposedstartday       varchar(300),
-ADD COLUMN IF NOT EXISTS proposedendmonth       varchar(300),
-ADD COLUMN IF NOT EXISTS proposedendday         varchar(300),
+ADD COLUMN IF NOT EXISTS proposedstartday       varchar(100),
+ADD COLUMN IF NOT EXISTS proposedendmonth       varchar(100),
+ADD COLUMN IF NOT EXISTS proposedendday         varchar(100),
 ADD COLUMN IF NOT EXISTS minepurpose            varchar(100);
 
 

--- a/migrations/sql/V2021.12.14.15.52__update_now_submission_data.sql
+++ b/migrations/sql/V2021.12.14.15.52__update_now_submission_data.sql
@@ -1,0 +1,42 @@
+ALTER TABLE now_submissions.application
+ADD COLUMN IF NOT EXISTS maxannualcubicmeters   numeric,
+ADD COLUMN IF NOT EXISTS proposedstartmonth     varchar(100),
+ADD COLUMN IF NOT EXISTS proposedstartday       varchar(300),
+ADD COLUMN IF NOT EXISTS proposedendmonth       varchar(300),
+ADD COLUMN IF NOT EXISTS proposedendday         varchar(300),
+ADD COLUMN IF NOT EXISTS minepurpose            varchar(100);
+
+
+ALTER TABLE now_submissions.exp_access_activity
+ADD COLUMN IF NOT EXISTS lengthinmeters numeric,
+ADD COLUMN IF NOT EXISTS width          numeric;
+
+ALTER TABLE now_submissions.camps
+ADD COLUMN IF NOT EXISTS length numeric,
+ADD COLUMN IF NOT EXISTS width  numeric;
+
+
+ALTER TABLE now_submissions.buildings
+ADD COLUMN IF NOT EXISTS length numeric,
+ADD COLUMN IF NOT EXISTS width  numeric;
+
+ALTER TABLE now_submissions.stagingareas
+ADD COLUMN IF NOT EXISTS length numeric,
+ADD COLUMN IF NOT EXISTS width  numeric;
+
+ALTER TABLE now_submissions.exp_surface_drill_activity
+ADD COLUMN IF NOT EXISTS length numeric,
+ADD COLUMN IF NOT EXISTS width  numeric;
+
+ALTER TABLE now_submissions.surface_bulk_sample_activity
+ADD COLUMN IF NOT EXISTS length numeric,
+ADD COLUMN IF NOT EXISTS width  numeric;
+
+ALTER TABLE now_submissions.under_exp_surface_activity
+ADD COLUMN IF NOT EXISTS length numeric,
+ADD COLUMN IF NOT EXISTS width  numeric;
+
+
+ALTER TABLE now_submissions.sand_grv_qry_activity
+ADD COLUMN IF NOT EXISTS length numeric,
+ADD COLUMN IF NOT EXISTS width  numeric;

--- a/services/core-api/app/api/now_submissions/models/application.py
+++ b/services/core-api/app/api/now_submissions/models/application.py
@@ -128,6 +128,7 @@ class Application(Base):
     latitude = db.Column(db.Numeric(9, 7))
     longitude = db.Column(db.Numeric(11, 7))
     nameofproperty = db.Column(db.String)
+    minepurpose = db.Column(db.String)
     tenurenumbers = db.Column(db.String)
     crowngrantlotnumbers = db.Column(db.String)
     sitedirections = db.Column(db.String)
@@ -135,8 +136,14 @@ class Application(Base):
     firstaidcertlevel = db.Column(db.String)
     descexplorationprogram = db.Column(db.String)
     describeexplosivetosite = db.Column(db.String)
+
     proposedstartdate = db.Column(db.DateTime)
     proposedenddate = db.Column(db.DateTime)
+    proposedstartmonth = db.Column(db.String)
+    proposedstartday = db.Column(db.String)
+    proposedendmonth = db.Column(db.String)
+    proposedendday = db.Column(db.String)
+
     landcommunitywatershed = db.Column(db.String)
     landprivate = db.Column(db.String)
     landlegaldesc = db.Column(db.String)
@@ -305,7 +312,9 @@ class Application(Base):
     hasproposedcrossings = db.Column(db.String)
     proposedcrossingschanges = db.Column(db.String)
     cleanoutdisposalplan = db.Column(db.String)
+
     maxannualtonnage = db.Column(db.Numeric(14, 0))
+    maxannualcubicmeters = db.Column(db.Numeric)
     proposedproduction = db.Column(db.Numeric(14, 0))
     isaccessgated = db.Column(db.String)
     hassurfacedisturbanceoutsidetenure = db.Column(db.String)

--- a/services/core-api/app/api/now_submissions/models/buildings.py
+++ b/services/core-api/app/api/now_submissions/models/buildings.py
@@ -13,6 +13,8 @@ class Buildings(Base):
     structure = db.Column(db.String)
     disturbedarea = db.Column(db.Numeric)
     timbervolume = db.Column(db.Numeric)
+    width = db.Column(db.Numeric)
+    length = db.Column(db.Numeric)
 
     def __repr__(self):
         return '<Buildings %r>' % self.id

--- a/services/core-api/app/api/now_submissions/models/camps.py
+++ b/services/core-api/app/api/now_submissions/models/camps.py
@@ -18,6 +18,8 @@ class Camps(Base):
     quantityofwater = db.Column(db.Numeric)
     disturbedarea = db.Column(db.Numeric)
     timbervolume = db.Column(db.Numeric)
+    width = db.Column(db.Numeric)
+    length = db.Column(db.Numeric)
 
     def __repr__(self):
         return '<Camps %r>' % self.id

--- a/services/core-api/app/api/now_submissions/models/exp_access_activity.py
+++ b/services/core-api/app/api/now_submissions/models/exp_access_activity.py
@@ -10,6 +10,8 @@ class ExpAccessActivity(Base):
     messageid = db.Column(db.Integer, db.ForeignKey('now_submissions.application.messageid'))
     type = db.Column(db.String)
     length = db.Column(db.Numeric(14, 2))
+    lengthinmeters = db.Column(db.Numeric)
+    width = db.Column(db.Numeric)
     disturbedarea = db.Column(db.Numeric(14, 2))
     timbervolume = db.Column(db.Numeric(14, 2))
     numberofsites = db.Column(db.Numeric)

--- a/services/core-api/app/api/now_submissions/models/exp_surface_drill_activity.py
+++ b/services/core-api/app/api/now_submissions/models/exp_surface_drill_activity.py
@@ -12,6 +12,8 @@ class ExpSurfaceDrillActivity(Base):
     numberofsites = db.Column(db.Integer)
     disturbedarea = db.Column(db.Numeric(14, 2))
     timbervolume = db.Column(db.Numeric(14, 2))
+    width = db.Column(db.Numeric)
+    length = db.Column(db.Numeric)
 
     def __repr__(self):
         return '<ExpSurfaceDrillActivity %r>' % self.id

--- a/services/core-api/app/api/now_submissions/models/sand_grv_qry_activity.py
+++ b/services/core-api/app/api/now_submissions/models/sand_grv_qry_activity.py
@@ -11,6 +11,8 @@ class SandGrvQryActivity(Base):
     type = db.Column(db.String)
     disturbedarea = db.Column(db.Numeric(14, 2))
     timbervolume = db.Column(db.Numeric(14, 2))
+    width = db.Column(db.Numeric)
+    length = db.Column(db.Numeric)
 
     def __repr__(self):
         return '<SandGrvQryActivity %r>' % self.id

--- a/services/core-api/app/api/now_submissions/models/staging_areas.py
+++ b/services/core-api/app/api/now_submissions/models/staging_areas.py
@@ -11,6 +11,8 @@ class StagingAreas(Base):
     name = db.Column(db.String)
     disturbedarea = db.Column(db.Numeric)
     timbervolume = db.Column(db.Numeric)
+    width = db.Column(db.Numeric)
+    length = db.Column(db.Numeric)
 
     def __repr__(self):
         return '<StagingAreas %r>' % self.id

--- a/services/core-api/app/api/now_submissions/models/surface_bulk_sample_activity.py
+++ b/services/core-api/app/api/now_submissions/models/surface_bulk_sample_activity.py
@@ -12,6 +12,8 @@ class SurfaceBulkSampleActivity(Base):
     disturbedarea = db.Column(db.Numeric(14, 2))
     timbervolume = db.Column(db.Numeric(14, 2))
     quantity = db.Column(db.Integer)
+    width = db.Column(db.Numeric)
+    length = db.Column(db.Numeric)
 
     def __repr__(self):
         return '<SurfaceBulkSampleActivity %r>' % self.id

--- a/services/core-api/app/api/now_submissions/models/under_exp_surface_activity.py
+++ b/services/core-api/app/api/now_submissions/models/under_exp_surface_activity.py
@@ -12,6 +12,8 @@ class UnderExpSurfaceActivity(Base):
     quantity = db.Column(db.Integer)
     disturbedarea = db.Column(db.Numeric(14, 2))
     timbervolume = db.Column(db.Numeric(14, 2))
+    width = db.Column(db.Numeric)
+    length = db.Column(db.Numeric)
 
     def __repr__(self):
         return '<UnderExpSurfaceActivity %r>' % self.id

--- a/services/core-api/app/api/now_submissions/response_models.py
+++ b/services/core-api/app/api/now_submissions/response_models.py
@@ -104,12 +104,16 @@ SURFACE_BULK_SAMPLE_ACTIVITY = api.model(
         'quantity': fields.Integer,
         'disturbedarea': fields.Arbitrary,
         'timbervolume': fields.Arbitrary,
+        'length': fields.Integer,
+        'width': fields.Integer,
     })
 
 SAND_GRAVEL_QUARRY_ACTIVITY = api.model('SAND_GRAVEL_QUARRY_ACTIVITY', {
     'type': fields.String,
     'disturbedarea': fields.Arbitrary,
     'timbervolume': fields.Arbitrary,
+    'length': fields.Integer,
+    'width': fields.Integer,
 })
 
 UNDER_EXP_NEW_ACTIVITY = api.model(
@@ -148,6 +152,8 @@ EXP_ACCESS_ACTIVITY = api.model(
     'EXP_ACCESS_ACTIVITY', {
         'type': fields.String,
         'length': fields.Arbitrary,
+        'lengthinmeters': fields.Integer,
+        'width': fields.Integer,
         'disturbedarea': fields.Arbitrary,
         'timbervolume': fields.Arbitrary,
         'numberofsites': fields.Arbitrary,
@@ -159,6 +165,8 @@ EXP_SURFACE_DRILL_ACTIVITY = api.model(
         'numberofsites': fields.Arbitrary,
         'disturbedarea': fields.Arbitrary,
         'timbervolume': fields.Arbitrary,
+        'length': fields.Integer,
+        'width': fields.Integer,
     })
 
 MECH_TRENCHING_ACTIVITY = api.model(
@@ -200,6 +208,8 @@ CAMP_ACTIVITY = api.model(
         'quantityofwater': fields.Integer,
         'disturbedarea': fields.Arbitrary,
         'timbervolume': fields.Arbitrary,
+        'length': fields.Integer,
+        'width': fields.Integer,
     })
 
 BUILDING_ACTIVITY = api.model(
@@ -209,12 +219,16 @@ BUILDING_ACTIVITY = api.model(
         'structure': fields.String,
         'disturbedarea': fields.Arbitrary,
         'timbervolume': fields.Arbitrary,
+        'length': fields.Integer,
+        'width': fields.Integer,
     })
 
 STAGING_AREA_ACTIVITY = api.model('STAGING_AREA_ACTIVITY', {
     'name': fields.String,
     'disturbedarea': fields.Arbitrary,
     'timbervolume': fields.Arbitrary,
+    'length': fields.Integer,
+    'width': fields.Integer,
 })
 
 APPLICATION = api.model(
@@ -238,6 +252,7 @@ APPLICATION = api.model(
         'typeofpermit': fields.String,
         'typeofapplication': fields.String,
         'minenumber': fields.String,
+        'minepurpose': fields.String,
         'latitude': fields.Fixed(decimals=7),
         'longitude': fields.Fixed(decimals=7),
         'nameofproperty': fields.String,
@@ -250,6 +265,10 @@ APPLICATION = api.model(
         'describeexplosivetosite': fields.String,
         'proposedstartdate': fields.DateTime,
         'proposedenddate': fields.DateTime,
+        'proposedstartmonth': fields.String,
+        'proposedstartday': fields.String,
+        'proposedendmonth': fields.String,
+        'proposedendday': fields.String,
         'yearroundseasonal': fields.String,
         'landcommunitywatershed': fields.String,
         'landprivate': fields.String,
@@ -389,6 +408,7 @@ APPLICATION = api.model(
         'proposedcrossingschanges': fields.String,
         'cleanoutdisposalplan': fields.String,
         'maxannualtonnage': fields.Arbitrary,
+        'maxannualcubicmeters': fields.Arbitrary,
         'proposedproduction': fields.Arbitrary,
         'isaccessgated': fields.String,
         'permitnumber': fields.String,


### PR DESCRIPTION
# Main

-  Updated the following now_submission tables:
- application
- exp_access_activity
- camps
- buildings
- stagingareas
- exp_surface_drill_activity
- surface_bulk_sample_activity
- sand_grv_qry_activity


# Other

- Mapping to the core now_application tables will happen in a follow up PR - This PR is to ensure we get the data when vFCBC pushes their updated to prod.

# How to test

- Submit a now_submission to the local API with the new fields and ensure it populates in the db.

# Notes
 N/A
