### PR TITLE
Add cronjob manifest for gis refresh

### DIFF
--- a/openshift4/templates/cronjob.gis_export.yaml
+++ b/openshift4/templates/cronjob.gis_export.yaml
@@ -24,7 +24,7 @@ spec:
                 - '-c'
                 - >-
                   psql -d $DB_NAME -h $DB_HOST -c "REFRESH MATERIALIZED VIEW
-                  CONCURRENTLY $VIEW"
+                  $VIEW"
               env:
                 - name: DB_USER
                   valueFrom:
@@ -63,6 +63,7 @@ spec:
               imagePullPolicy: Always
           restartPolicy: OnFailure
           terminationGracePeriodSeconds: 30
+          activeDeadlineSeconds: 1200
           dnsPolicy: ClusterFirst
           securityContext: {}
           schedulerName: default-scheduler

--- a/openshift4/templates/cronjob.gis_export.yaml
+++ b/openshift4/templates/cronjob.gis_export.yaml
@@ -1,0 +1,70 @@
+kind: CronJob
+apiVersion: batch/v1beta1
+metadata:
+  name: cj-refresh-gis-export
+spec:
+  schedule: 30 02 * * *
+  concurrencyPolicy: Replace
+  suspend: false
+  jobTemplate:
+    metadata:
+      creationTimestamp: null
+    spec:
+      parallelism: 1
+      completions: 1
+      template:
+        metadata:
+          creationTimestamp: null
+        spec:
+          containers:
+            - name: refresh
+              image: image-registry.apps.silver.devops.gov.bc.ca/openshift/postgresql
+              args:
+                - /bin/sh
+                - '-c'
+                - >-
+                  psql -d $DB_NAME -h $DB_HOST -c "REFRESH MATERIALIZED VIEW
+                  CONCURRENTLY $VIEW"
+              env:
+                - name: DB_USER
+                  valueFrom:
+                    secretKeyRef:
+                      name: postgresql
+                      key: database-admin-user
+                - name: PGPASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: postgresql
+                      key: database-admin-password
+                - name: DB_HOST
+                  valueFrom:
+                    secretKeyRef:
+                      name: refresh-gis
+                      key: database-host
+                - name: DB_NAME
+                  valueFrom:
+                    secretKeyRef:
+                      name: postgresql
+                      key: database-name
+                - name: VIEW
+                  valueFrom:
+                    secretKeyRef:
+                      name: refresh-gis
+                      key: view-name
+                  resources:
+                    limits:
+                      cpu: 512m
+                      memory: 1Gi
+                    requests:
+                      cpu: 128m
+                      memory: 256Mi
+              terminationMessagePath: /dev/termination-log
+              terminationMessagePolicy: File
+              imagePullPolicy: Always
+          restartPolicy: OnFailure
+          terminationGracePeriodSeconds: 30
+          dnsPolicy: ClusterFirst
+          securityContext: {}
+          schedulerName: default-scheduler
+  successfulJobsHistoryLimit: 5
+  failedJobsHistoryLimit: 5


### PR DESCRIPTION
# Main

- Adds manifest for cronjob definition that generates a generic psql client pod that executes a arbitrary psql command
- sql command for this manifest is to refresh the gis export materialized view nightly

# Other

- N/A

# How to test

- N/A

# Notes

- N/A
