### PR TITLE
Update metabase to v0.41.5

### DIFF
--- a/openshift4/docker-images/metabase/Dockerfile
+++ b/openshift4/docker-images/metabase/Dockerfile
@@ -8,7 +8,7 @@ ENV LC_CTYPE en_US.UTF-8
 RUN apk add --update bash git wget make gettext ttf-dejavu fontconfig java-cacerts
 
 # add Metabase jar
-RUN wget -q http://downloads.metabase.com/v0.41.4/metabase.jar
+RUN wget -q http://downloads.metabase.com/v0.41.5/metabase.jar
 
 # create the plugins directory, with writable permissions
 RUN chmod -R 777 /app


### PR DESCRIPTION
# Main

- Upgrade metabase to 0.41.5 to address leftover log4j vulnerability

# Other

- N/A

# How to test

- N/A

# Notes

- N/A
