### PR TITLE
Git hooks for minespace and core-web.

### DIFF
--- a/services/core-web/package.json
+++ b/services/core-web/package.json
@@ -211,7 +211,7 @@
   "husky": {
     "hooks": {
       "pre-commit": "lint-staged",
-      "pre-push": "lint-prepush"
+      "pre-push": "lint-prepush && cd ../minespace-web && lint-prepush"
     }
   },
   "lint-staged": {
@@ -219,7 +219,15 @@
       "npm run format:write",
       "git add"
     ],
+    "../minespace-web/**/*.{js,css,json,md}": [
+      "npm run format:write",
+      "git add"
+    ],
     "*.js": [
+      "eslint --fix",
+      "git add"
+    ],
+    "../minespace-web/**/*.js": [
       "eslint --fix",
       "git add"
     ]

--- a/services/minespace-web/package.json
+++ b/services/minespace-web/package.json
@@ -174,7 +174,7 @@
   "husky": {
     "hooks": {
       "pre-commit": "lint-staged",
-      "pre-push": "lint-prepush"
+      "pre-push": "lint-prepush && cd ../core-web && lint-prepush"
     }
   },
   "lint-staged": {
@@ -182,7 +182,15 @@
       "npm run format:write",
       "git add"
     ],
+    "../core-web/**/*.{js,css,json,md}": [
+      "npm run format:write",
+      "git add"
+    ],
     "*.js": [
+      "eslint --fix",
+      "git add"
+    ],
+    "../core-web/**/*.js": [
       "eslint --fix",
       "git add"
     ]


### PR DESCRIPTION
# Main

Currently, Git hooks for linting that run after every commit, only run on the FE that had their package.json last updated by “npm ci”. This change fixes the mentioned behaviour to take both minespace-web and core-web during 

# Other
Pending snapshots tests during pre-push hook. See comments in the ticket https://bcmines.atlassian.net/browse/MDS-4044


# How to test
1.- On minespace, run npm ci
2.- Generate a lint error in core-web
3.- Commit the change and catch the linting error
4.- Generate a lint error in minespace
5.- Commit the change and keep catching the linting error

# Notes
https://bcmines.atlassian.net/browse/MDS-4044
