### PR TITLE
MDS-3439 - add condition for new incidents to default to blank dates/…

### DIFF
--- a/services/core-web/src/components/mine/Incidents/MineIncidents.js
+++ b/services/core-web/src/components/mine/Incidents/MineIncidents.js
@@ -98,13 +98,19 @@ export class MineIncidents extends Component {
       this.props.fetchMineIncidents(this.props.mineGuid);
     });
 
-  parseIncidentIntoFormData = (existingIncident) => ({
-    ...existingIncident,
-    reported_date: moment(existingIncident.reported_timestamp).format("YYYY-MM-DD"),
-    reported_time: moment(existingIncident.reported_timestamp),
-    incident_date: moment(existingIncident.incident_timestamp).format("YYYY-MM-DD"),
-    incident_time: moment(existingIncident.incident_timestamp),
-  });
+  parseIncidentIntoFormData = (existingIncident, newIncident) => {
+    if (newIncident) {
+      return { ...existingIncident };
+    } 
+      return {
+        ...existingIncident,
+        reported_date: moment(existingIncident.reported_timestamp).format("YYYY-MM-DD"),
+        reported_time: moment(existingIncident.reported_timestamp),
+        incident_date: moment(existingIncident.incident_timestamp).format("YYYY-MM-DD"),
+        incident_time: moment(existingIncident.incident_timestamp),
+      };
+    
+  };
 
   openViewMineIncidentModal = (event, incident) => {
     const mine = this.props.mines[this.props.mineGuid];
@@ -140,7 +146,7 @@ export class MineIncidents extends Component {
         newIncident,
         initialValues: {
           status_code: "PRE",
-          ...this.parseIncidentIntoFormData(existingIncident),
+          ...this.parseIncidentIntoFormData(existingIncident, newIncident),
           dangerous_occurrence_subparagraph_ids: existingIncident.dangerous_occurrence_subparagraph_ids.map(
             String
           ),


### PR DESCRIPTION
# Main

- What did you focus on in this PR?

Changing incident dates/times to be blank by default upon creation, rather than defaulting to today's date.


# Other

- What other side fixes, tweaks did you add on the side?
N/A

# How to test

- Check out branch for these changes (MDS-3439) 
- Create a mine
- Select the mine you just created by clicking on its name under the “Name” field 
- Navigate to the Oversight tab, and select Incidents and Investigations
- Click the Record a Mine Incident button
- Look at the Reported Date and Reported Time fields and they should be blank 
- Create the Incident (make sure you have appropriate permissions, such as the ability to add inspectors if you don’t already have one)
- View the incident details and see that values you selected for Reported Date and Reported Time match what you previously entered.


# Notes

- Any notes/screenshots for this PR?
- N/A
