### PR TITLE
bug-fix: Incident numbers are stuck in the previous year.

### DIFF
--- a/services/core-api/app/api/incidents/models/mine_incident.py
+++ b/services/core-api/app/api/incidents/models/mine_incident.py
@@ -29,7 +29,7 @@ class MineIncident(SoftDeleteMixin, AuditMixin, Base):
     __tablename__ = 'mine_incident'
 
     mine_incident_id = db.Column(db.Integer, primary_key=True, server_default=FetchedValue())
-    mine_incident_id_year = db.Column(db.Integer, nullable=False, default=getYear())
+    mine_incident_id_year = db.Column(db.Integer, nullable=False)
     mine_incident_guid = db.Column(
         UUID(as_uuid=True), nullable=False, server_default=FetchedValue())
 

--- a/services/core-api/app/api/mines/incidents/resources/mine_incidents.py
+++ b/services/core-api/app/api/mines/incidents/resources/mine_incidents.py
@@ -77,6 +77,9 @@ class MineIncidentListResource(Resource, UserMixin):
             raise NotFound("Mine not found")
         return [i for i in mine.mine_incidents if i.deleted_ind == False]
 
+    def _get_year_incident(self, incident_timestamp):
+        return incident_timestamp.year
+
     @api.expect(MINE_INCIDENT_MODEL)
     @api.doc(description='creates a new incident for the mine')
     @api.marshal_with(MINE_INCIDENT_MODEL, code=201)
@@ -99,6 +102,7 @@ class MineIncidentListResource(Resource, UserMixin):
         reported_timestamp_default = datetime.utcnow(
         ) if not data['reported_timestamp'] and is_minespace_user() else data['reported_timestamp']
 
+        mine_incident_year = self._get_year_incident(data['incident_timestamp'])
         incident = MineIncident.create(
             mine,
             data['incident_timestamp'],
@@ -112,6 +116,7 @@ class MineIncidentListResource(Resource, UserMixin):
             reported_by_name=data['reported_by_name'],
         )
 
+        incident.mine_incident_id_year = mine_incident_year
         incident.reported_by_email = data.get('reported_by_email')
         incident.reported_by_phone_no = data.get('reported_by_phone_no')
         incident.reported_by_phone_ext = data.get('reported_by_phone_ext')


### PR DESCRIPTION
# Main

Incident numbers for 2022 did not update to the 2022- series. 

# Other
- N/A

# How to test
- Go to Mines and select one.
-  Under Oversight, select Incidents & Investigation.
- Click on Record a Mine Incident.
- Fill all required data in Step 1 and click on Next.
- In Step 2,  indicate the Incident Date which the year is taken to create the incident number.
- Click on Save Initial Draft.

![image](https://user-images.githubusercontent.com/10526131/148305029-691fb292-d09f-455d-8ca2-f901acfaeb05.png)


# Notes
https://bcmines.atlassian.net/browse/MDS-4089
