### PR TITLE
Fix: Update app path for new build

### DIFF
--- a/openshift4/templates/docman.dc.yaml
+++ b/openshift4/templates/docman.dc.yaml
@@ -30,7 +30,7 @@ parameters:
     value: /document-manager
   - name: UPLOADED_DOCUMENT_DEST
     required: false
-    value: /opt/app-root/src/document_uploads
+    value: /app/document_uploads
   - name: DOCMAN_API_URL
     required: true
   - name: OBJECT_STORE_ENABLED
@@ -117,7 +117,7 @@ objects:
               command:
                 - bash
                 - -c
-                - cd /opt/app-root/src && flask db upgrade
+                - cd /app && flask db upgrade
           maxSurge: 50%
           maxUnavailable: 1
           timeoutSeconds: 1200
@@ -284,7 +284,7 @@ objects:
               terminationMessagePath: /dev/termination-log
               terminationMessagePolicy: File
               volumeMounts:
-                - mountPath: /opt/app-root/src/document_uploads
+                - mountPath: /app/document_uploads
                   name: mds-document-storage-data
               imagePullPolicy: Always
           restartPolicy: Always
@@ -498,7 +498,7 @@ objects:
               terminationMessagePath: /dev/termination-log
               terminationMessagePolicy: File
               volumeMounts:
-                - mountPath: /opt/app-root/src/document_uploads
+                - mountPath: /app/document_uploads
                   name: mds-document-storage-data
               imagePullPolicy: Always
           restartPolicy: Always


### PR DESCRIPTION
# Main

- Corrects prehook script path and makes volume mounts path consistent (they still functioned but were confusing)
- Issue was not caught in original PR due to prehook command not raising an error

# Other

- N/A

# How to test

- N/A

# Notes

- N/A
