### PR TITLE
Remove restriction to show button for incidents **DO NOT MERGE UNTIL JAN 19th**

### DIFF
--- a/services/minespace-web/src/components/dashboard/mine/incidents/Incidents.js
+++ b/services/minespace-web/src/components/dashboard/mine/incidents/Incidents.js
@@ -15,7 +15,6 @@ import {
 import { getIncidents, getIncidentPageData } from "@common/selectors/incidentSelectors";
 import { modalConfig } from "@/components/modalContent/config";
 import CustomPropTypes from "@/customPropTypes";
-import { AuthorizationWrapper } from "@/components/common/wrappers/AuthorizationWrapper";
 import * as FORM from "@/constants/forms";
 
 import IncidentsTable from "@/components/dashboard/mine/incidents/IncidentsTable";
@@ -89,16 +88,14 @@ export class Incidents extends Component {
     return (
       <Row>
         <Col span={24}>
-          <AuthorizationWrapper inTesting>
-            <Button
-              style={{ display: "inline", float: "right" }}
-              type="primary"
-              onClick={(event) => this.openCreateIncidentModal(event)}
-            >
-              <PlusCircleFilled />
-              Record a mine incident
-            </Button>
-          </AuthorizationWrapper>
+          <Button
+            style={{ display: "inline", float: "right" }}
+            type="primary"
+            onClick={(event) => this.openCreateIncidentModal(event)}
+          >
+            <PlusCircleFilled />
+            Record a mine incident
+          </Button>
           <Typography.Title level={4}>Incidents</Typography.Title>
           <Typography.Paragraph>
             This table shows your mine&apos;s history of&nbsp;

--- a/services/minespace-web/src/tests/components/dashboard/mine/incidents/__snapshots__/Incidents.spec.js.snap
+++ b/services/minespace-web/src/tests/components/dashboard/mine/incidents/__snapshots__/Incidents.spec.js.snap
@@ -5,27 +5,23 @@ exports[`MineIncidents renders properly 1`] = `
   <Col
     span={24}
   >
-    <AuthorizationWrapper
-      inTesting={true}
-    >
-      <Button
-        block={false}
-        ghost={false}
-        htmlType="button"
-        loading={false}
-        onClick={[Function]}
-        style={
-          Object {
-            "display": "inline",
-            "float": "right",
-          }
+    <Button
+      block={false}
+      ghost={false}
+      htmlType="button"
+      loading={false}
+      onClick={[Function]}
+      style={
+        Object {
+          "display": "inline",
+          "float": "right",
         }
-        type="primary"
-      >
-        <ForwardRef(PlusCircleFilled) />
-        Record a mine incident
-      </Button>
-    </AuthorizationWrapper>
+      }
+      type="primary"
+    >
+      <ForwardRef(PlusCircleFilled) />
+      Record a mine incident
+    </Button>
     <Title
       level={4}
     >


### PR DESCRIPTION
# Main

- In minespace-web, enable button "Record a mine incident" under Incidents tab: 
![image](https://user-images.githubusercontent.com/10526131/149572945-d94bef09-dfa2-40da-8f1c-6748b0cf2d09.png)


# Other
- Needs to be merge on January 19th and deploy during the morning in Prod 

# How to test

- N/A

# Notes
https://bcmines.atlassian.net/browse/MDS-4087
