### PR TITLE
MDS-4102: Update the AuthWrapper in Minespace to consider an unauthenticated state

### DIFF
--- a/services/minespace-web/src/components/common/wrappers/AuthorizationWrapper.js
+++ b/services/minespace-web/src/components/common/wrappers/AuthorizationWrapper.js
@@ -57,7 +57,7 @@ export const AuthorizationWrapper = (props) => {
   const checkDev = props.inDevelopment && detectDevelopmentEnvironment();
   const checkTest = props.inTesting && !detectProdEnvironment();
   // do not show any actions if the user is not a proponents, unless in the development
-  if (!props.isProponent && !detectDevelopmentEnvironment()) {
+  if (!props.isProponent && !detectDevelopmentEnvironment() && !checkTest) {
     return <span />;
   }
   if (props.inDevelopment === undefined && props.inTesting === undefined) {


### PR DESCRIPTION
# Main
In test an an unauthenticated user render "Log in with Verifiable Credentials"  wrapped by the AuthorizationWrapper.

# Other

# How to test
In test, the button "Log in with Verifiable Credentials" is rendered as in Dev environment:
![image](https://user-images.githubusercontent.com/10526131/149601595-42730db0-3992-4a66-a280-3fcca8681796.png)



# Notes
https://bcmines.atlassian.net/browse/MDS-4102
