### PR TITLE
MDS-4118: Change verbiage in mine incident follow up.

### DIFF
--- a/services/core-web/src/components/Forms/incidents/AddIncidentFollowUpForm.js
+++ b/services/core-web/src/components/Forms/incidents/AddIncidentFollowUpForm.js
@@ -35,12 +35,12 @@ const propTypes = {
 
 const renderRecommendations = ({ fields }) => [
   <div className="ant-col ant-form-item-label">
-    <label>Recommendations</label>
+    <label>Mine Manager Recommendations</label>
   </div>,
   fields.map((recommendation) => (
     <Field
       name={`${recommendation}.recommendation`}
-      placeholder="Provide recommendation actions"
+      placeholder="Write in each individual Mine Manager Recommendation here"
       component={renderConfig.AUTO_SIZE_FIELD}
     />
   )),


### PR DESCRIPTION
# Main

Change labels in Add incident - Follow up:

- Replace "Recommendations" for  "Mine Manager Recommendations"
- The text within the box should read - ‘Write in each individual Mine Manager Recommendation here’

# Other

# How to test
In Core, when creating an incident the labels should be updated:
![image](https://user-images.githubusercontent.com/10526131/150445298-9ea9c5bf-607b-4c44-8fd2-d5939b50fbce.png)


# Notes
https://bcmines.atlassian.net/browse/MDS-4118
