### PR TITLE
MDS-4037: Display Additional Project Summary form fields in Minespace

### DIFF
--- a/services/minespace-web/src/components/dashboard/mine/projectSummaries/ProjectSummariesTable.js
+++ b/services/minespace-web/src/components/dashboard/mine/projectSummaries/ProjectSummariesTable.js
@@ -28,8 +28,10 @@ export class ProjectSummariesTable extends Component {
       mine_guid: projectSummary.mine_guid,
       project_summary_guid: projectSummary.project_summary_guid,
       project_summary_id: projectSummary.project_summary_id,
+      project_title: projectSummary.project_summary_title,
       status_code: codeHash[projectSummary.status_code],
       update_user: projectSummary.update_user,
+      create_timestamp: formatDate(projectSummary.create_timestamp),
       update_timestamp: formatDate(projectSummary.update_timestamp),
       documents: projectSummary.documents,
       handleDeleteDraft,
@@ -37,10 +39,10 @@ export class ProjectSummariesTable extends Component {
 
   columns = () => [
     {
-      title: "Project #",
-      dataIndex: "project_summary_id",
-      sorter: (a, b) => (a.project_summary_id > b.project_summary_id ? -1 : 1),
-      render: (text) => <div title="Project Description No.">{text}</div>,
+      title: "Project Title",
+      dataIndex: "project_title",
+      sorter: (a, b) => (a.project_name > b.project_name ? -1 : 1),
+      render: (text) => <div title="Project Name">{text}</div>,
     },
     {
       title: "Last Updated",
@@ -53,6 +55,15 @@ export class ProjectSummariesTable extends Component {
       dataIndex: "update_user",
       render: (text) => <div title="Last Updated By">{text}</div>,
       sorter: (a, b) => (a.update_user > b.update_user ? -1 : 1),
+    },
+    {
+      title: "First Submitted",
+      dataIndex: "create_timestamp",
+      sorter: dateSorter("create_timestamp"),
+      render: (text, record) => {
+        if (record.status_code !== "Draft") return <div title="First Submitted">{text}</div>;
+        return "N/A";
+      },
     },
     {
       title: "Status",

--- a/services/minespace-web/src/tests/components/dashboard/mine/projectSummaries/__snapshots__/ProjectSummariesTable.spec.js.snap
+++ b/services/minespace-web/src/tests/components/dashboard/mine/projectSummaries/__snapshots__/ProjectSummariesTable.spec.js.snap
@@ -5,10 +5,10 @@ exports[`ProjectSummariesTable renders properly 1`] = `
   columns={
     Array [
       Object {
-        "dataIndex": "project_summary_id",
+        "dataIndex": "project_title",
         "render": [Function],
         "sorter": [Function],
-        "title": "Project #",
+        "title": "Project Title",
       },
       Object {
         "dataIndex": "update_timestamp",
@@ -21,6 +21,12 @@ exports[`ProjectSummariesTable renders properly 1`] = `
         "render": [Function],
         "sorter": [Function],
         "title": "Last Updated By",
+      },
+      Object {
+        "dataIndex": "create_timestamp",
+        "render": [Function],
+        "sorter": [Function],
+        "title": "First Submitted",
       },
       Object {
         "dataIndex": "status_code",
@@ -43,6 +49,7 @@ exports[`ProjectSummariesTable renders properly 1`] = `
   dataSource={
     Array [
       Object {
+        "create_timestamp": undefined,
         "documents": Array [],
         "handleDeleteDraft": undefined,
         "key": "81324623978135",
@@ -57,6 +64,7 @@ exports[`ProjectSummariesTable renders properly 1`] = `
         },
         "project_summary_guid": "81324623978135",
         "project_summary_id": undefined,
+        "project_title": undefined,
         "status_code": "Open",
         "update_timestamp": undefined,
         "update_user": undefined,


### PR DESCRIPTION
# Main
In Minespace, under Project Description table conduct the following changes
- Add two fields:
 -  Project Title
 -  First Submitted: N/A if the status is Draft
- Remove Project # field 

# Other
- N/A

# How to test
- Create Project Descriptions with Draft and Open status.
- Confirm the table is showing the fields in correct order:
![image](https://user-images.githubusercontent.com/10526131/151445503-21733833-c226-41da-9840-44e6bc0a3866.png)

# Notes
https://bcmines.atlassian.net/browse/MDS-4037

