### PR TITLE
MDS-4082: Add additional client delay reason NoW

### DIFF
--- a/migrations/sql/V2022.01.27.16.09__insert_now_application_delay_type.sql
+++ b/migrations/sql/V2022.01.27.16.09__insert_now_application_delay_type.sql
@@ -4,7 +4,7 @@ INSERT INTO now_application_delay_type (
     create_user,
     update_user
     )
-VALUES 
+VALUES
     ('NRT', 'Nation Requests Additional Time','system-mds', 'system-mds')
 
 ON CONFLICT DO NOTHING;

--- a/migrations/sql/V2022.01.27.16.09__insert_now_application_delay_type.sql
+++ b/migrations/sql/V2022.01.27.16.09__insert_now_application_delay_type.sql
@@ -1,0 +1,10 @@
+INSERT INTO now_application_delay_type (
+    delay_type_code,
+    description,
+    create_user,
+    update_user
+    )
+VALUES 
+    ('NRT', 'Nation Requests Additional Time','system-mds', 'system-mds')
+
+ON CONFLICT DO NOTHING;

--- a/services/core-api/app/api/now_applications/resources/now_application_delay_resource.py
+++ b/services/core-api/app/api/now_applications/resources/now_application_delay_resource.py
@@ -56,7 +56,8 @@ class NOWApplicationDelayListResource(Resource, UserMixin):
 
         # update now status
         if now_app.now_application is not None:
-            if now_delay.delay_type_code is not None and now_delay.delay_type_code == "OAB":
+            if now_delay.delay_type_code is not None and now_delay.delay_type_code in ("OAB",
+                                                                                       "NRT"):
                 now_app.now_application.previous_application_status_code = now_app.now_application.now_application_status_code
                 now_app.now_application.now_application_status_code = "GVD"
             else:


### PR DESCRIPTION
# Main

- Add one client delay reason in NoW:
  Nation Requests Additional Time

# Other
- N/A

# How to test
- Open any NoW under Browse Notices of Work
- Go to Administrative tab
-  Start Delay:
   1.  Click on Manage Delay and select Start Delay from the dropdown.
   2.  Select the new client delay reason under the drop down:
  ![image](https://user-images.githubusercontent.com/10526131/151598563-77d93ae0-57a0-45cc-b8b9-e59c27c47171.png)
   3.  Click on Start Delay:
  ![image](https://user-images.githubusercontent.com/10526131/151598422-fd375def-a720-4c34-bdfc-04940c9e4e6c.png)
   4.  Confirm the now_application_status_code is updated from REC ( Received) to CDI (Client Delayed)  when the delay starts:
    select *
    from now_application na 
    where na.now_application_id = 10
   ![image](https://user-images.githubusercontent.com/10526131/151615588-76e48f70-b865-4eb1-b0fd-dc930c231e75.png)
   5.  A new record is created in now_application_delay with the proper now_application_guid. The field start_date contains a 
   value of today and delay_type_code is NRT, the end_date value is null when the delay started.
   select *
   from now_application_delay nad  
   where nad.now_application_guid ='297a3051-d2c1-48bc-bfe9-a124b10c374a'
   ![image](https://user-images.githubusercontent.com/10526131/151617619-ea58d5db-3efb-4df2-ba15-73a41da695c2.png)
   6.  Check the UI:
  ![image](https://user-images.githubusercontent.com/10526131/151599059-80b558cd-ddd2-4b33-b364-a8b2b98fb73d.png)

- Stop Delay:
  1.  Click on Manage Delay and select Stop Delay from the dropdown
  2.  Add a comment in Stop Delay modal and click on Stop Delay.
  ![image](https://user-images.githubusercontent.com/10526131/151617812-6b181729-25c7-4ee7-aa52-49c25d86af35.png)
  3.  The status changes in now_application.now_application_status_code from CDI to REC, there is no delay:
  ![image](https://user-images.githubusercontent.com/10526131/151617975-2652453b-f152-4110-a045-ef6a2a8389bc.png)
  4.- Confirm the end_date in the now_application_delay table is filled:
  ![image](https://user-images.githubusercontent.com/10526131/151618178-b99cd469-c0a3-4e27-a322-f1e714357984.png)
  5.  Check the UI, the yellow banner for the delay is gone:
  ![image](https://user-images.githubusercontent.com/10526131/151618285-52d9f500-5253-4646-aa1b-ffa0533eb35d.png)




 
# Notes
https://bcmines.atlassian.net/browse/MDS-4082
