### PR TITLE
Freeze fs provider deployments

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -188,7 +188,7 @@ jobs:
           - name: metabase
           - name: metabase-postgres
           - name: docman
-          - name: filesystem-provider
+          # - name: filesystem-provider
           - name: nris
           - name: minespace
     steps:

--- a/.github/workflows/promote-to-prod.yaml
+++ b/.github/workflows/promote-to-prod.yaml
@@ -35,7 +35,7 @@ jobs:
           - name: metabase
           - name: metabase-postgres
           - name: docman
-          - name: filesystem-provider
+          # - name: filesystem-provider
           - name: nris
           - name: minespace
           - name: schemaspy
@@ -80,7 +80,7 @@ jobs:
           - name: metabase
           - name: metabase-postgres
           - name: docman
-          - name: filesystem-provider
+          # - name: filesystem-provider
           - name: nris
           - name: minespace
     steps:

--- a/.github/workflows/promote-to-test.yaml
+++ b/.github/workflows/promote-to-test.yaml
@@ -29,7 +29,7 @@ jobs:
           - name: metabase
           - name: metabase-postgres
           - name: docman
-          - name: filesystem-provider
+          # - name: filesystem-provider
           - name: nris
           - name: minespace
           - name: schemaspy
@@ -74,7 +74,7 @@ jobs:
           - name: metabase
           - name: metabase-postgres
           - name: docman
-          - name: filesystem-provider
+          # - name: filesystem-provider
           - name: nris
           - name: minespace
     steps:


### PR DESCRIPTION
# Main

- Remove fs provider from pipeline rollout until build permissions resolved to unblock team

# Other

- N/A

# How to test

- N/A

# Notes

- N/A
