### PR TITLE
bug/fix : Preamble_text

### DIFF
--- a/migrations/sql/V2022.02.22.13.20__update_preambule_text_column_to_existing_draft_permit_amendment_permit.sql
+++ b/migrations/sql/V2022.02.22.13.20__update_preambule_text_column_to_existing_draft_permit_amendment_permit.sql
@@ -5,7 +5,7 @@ from (select distinct pa.permit_amendment_id, case when atc.application_type_cod
 	  where pa.permit_amendment_status_code = 'DFT' and
       		pa.is_generated_in_core = true and
             pa.preamble_text is NULL and
-            pa.permit_id = nai.permit_id and
+            pa.now_application_guid = nai.now_application_guid and
       		nai.application_type_code = atc.application_type_code 
      ) as draft_permit_amendment_no_preamble_text
 where permit_amendment.permit_amendment_id = draft_permit_amendment_no_preamble_text.permit_amendment_id

--- a/migrations/sql/V2022.02.23.20.20__fix_update_preambule_text_column_to_existing_draft_permit_amendment_permit.sql
+++ b/migrations/sql/V2022.02.23.20.20__fix_update_preambule_text_column_to_existing_draft_permit_amendment_permit.sql
@@ -5,7 +5,7 @@ from (select distinct pa.permit_amendment_id, case when atc.application_type_cod
 	  where pa.permit_amendment_status_code = 'DFT' and
       		pa.is_generated_in_core = true and
             pa.preamble_text is NULL and
-            pa.permit_id = nai.permit_id and
+            pa.now_application_guid = nai.now_application_guid and
       		nai.application_type_code = atc.application_type_code 
      ) as draft_permit_amendment_no_preamble_text
 where permit_amendment.permit_amendment_id = draft_permit_amendment_no_preamble_text.permit_amendment_id

--- a/services/core-api/app/api/mines/permits/permit/resources/permit.py
+++ b/services/core-api/app/api/mines/permits/permit/resources/permit.py
@@ -182,16 +182,12 @@ class PermitListResource(Resource, UserMixin):
 
         is_generated_in_core = True if permit.permit_status_code == 'D' else False
 
-        preamble_text = get_preamble_text(
-            application_type_description) if is_generated_in_core else None
-
         amendment = PermitAmendment.create(
             permit,
             mine,
             data.get('received_date'),
             data.get('issue_date'),
             data.get('authorization_end_date'),
-            preamble_text,
             'OGP',
             description='Initial permit issued.',
             issuing_inspector_title=data.get('issuing_inspector_title'),
@@ -209,6 +205,15 @@ class PermitListResource(Resource, UserMixin):
         now_application_guid = data.get('now_application_guid')
         if now_application_guid is not None and permit.permit_status_code == 'D':
             application_identity = NOWApplicationIdentity.find_by_guid(now_application_guid)
+
+            application_type_description = None
+            if application_identity:
+                application_type = ApplicationTypeCode.find_by_application_type_code(
+                    application_identity.application_type_code)
+                application_type_description = 'application' if application_type.application_type_code == 'ADA' else application_type.description
+                amendment.preamble_text = get_preamble_text(
+                    application_type_description) if is_generated_in_core else None
+
             if application_identity.now_application:
                 now_type = application_identity.now_application.notice_of_work_type_code
 

--- a/services/core-api/app/api/mines/permits/permit_amendment/models/permit_amendment.py
+++ b/services/core-api/app/api/mines/permits/permit_amendment/models/permit_amendment.py
@@ -170,7 +170,6 @@ class PermitAmendment(SoftDeleteMixin, AuditMixin, Base):
                received_date,
                issue_date,
                authorization_end_date,
-               preamble_text,
                permit_amendment_type_code='AMD',
                description=None,
                liability_adjustment=None,
@@ -200,8 +199,7 @@ class PermitAmendment(SoftDeleteMixin, AuditMixin, Base):
             security_received_date=security_received_date,
             security_not_required=security_not_required,
             security_not_required_reason=security_not_required_reason,
-            is_generated_in_core=is_generated_in_core,
-            preamble_text=preamble_text)
+            is_generated_in_core=is_generated_in_core)
         permit._all_permit_amendments.append(new_pa)
         if add_to_session:
             new_pa.save(commit=False)

--- a/services/core-api/app/api/mines/permits/permit_amendment/resources/permit_amendment.py
+++ b/services/core-api/app/api/mines/permits/permit_amendment/resources/permit_amendment.py
@@ -109,13 +109,6 @@ class PermitAmendmentListResource(Resource, UserMixin):
             raise NotFound("Mine does not exist")
         # if str(pid) not in [m.mine_guid for m in permit.all_mines]:
         #     raise BadRequest('Permits mine_guid and provided mine_guid mismatch.')
-        identity = NOWApplicationIdentity.find_by_permit_id(permit.permit_id)
-        application_type_description = None
-        if identity:
-            application_type = ApplicationTypeCode.find_by_application_type_code(
-                identity.application_type_code)
-            application_type_description = 'application' if application_type.application_type_code == 'ADA' else application_type.description
-
         data = self.parser.parse_args()
         current_app.logger.info(f'creating permit_amendment with >> {data}')
 
@@ -178,8 +171,6 @@ class PermitAmendmentListResource(Resource, UserMixin):
         now_application_guid = data.get('now_application_guid')
         populate_with_conditions = data.get('populate_with_conditions', True)
         is_generated_in_core = True if permit_amendment_status_code == "DFT" and populate_with_conditions else False
-        preamble_text = get_preamble_text(
-            application_type_description) if is_generated_in_core else None
 
         new_pa = PermitAmendment.create(
             permit,
@@ -196,8 +187,7 @@ class PermitAmendmentListResource(Resource, UserMixin):
             issuing_inspector_title=data.get('issuing_inspector_title'),
             regional_office=data.get('regional_office'),
             now_application_guid=data.get('now_application_guid'),
-            is_generated_in_core=is_generated_in_core,
-            preamble_text=preamble_text)
+            is_generated_in_core=is_generated_in_core)
 
         uploadedFiles = data.get('uploadedFiles', [])
         for newFile in uploadedFiles:
@@ -210,6 +200,14 @@ class PermitAmendmentListResource(Resource, UserMixin):
 
         if now_application_guid is not None and permit_amendment_status_code == "DFT":
             application_identity = NOWApplicationIdentity.find_by_guid(now_application_guid)
+
+            application_type_description = None
+            if application_identity:
+                application_type = ApplicationTypeCode.find_by_application_type_code(
+                    application_identity.application_type_code)
+                application_type_description = 'application' if application_type.application_type_code == 'ADA' else application_type.description
+                new_pa.preamble_text = get_preamble_text(
+                    application_type_description) if is_generated_in_core else None
 
             def create_standard_conditions(application_identity):
                 now_type = application_identity.now_application.notice_of_work_type_code
@@ -344,7 +342,12 @@ class PermitAmendmentResource(Resource, UserMixin):
         location='json',
         store_missing=False,
         help='{ mine_commodity_code, mine_disturbance_code}.')
-    parser.add_argument('preamble_text', type=str, location='json', help='Preamble text.')
+    parser.add_argument(
+        'preamble_text',
+        type=str,
+        location='json',
+        store_missing=False,
+        help='Preamble text.')
 
     @api.doc(params={'permit_amendment_guid': 'Permit amendment guid.'})
     @requires_role_view_all

--- a/services/core-api/app/api/now_applications/models/now_application_identity.py
+++ b/services/core-api/app/api/now_applications/models/now_application_identity.py
@@ -91,10 +91,6 @@ class NOWApplicationIdentity(Base, AuditMixin):
         return cls.query.filter_by(mine_guid=mine_guid).first()
 
     @classmethod
-    def find_by_permit_id(cls, permit_id):
-        return cls.query.filter_by(permit_id=permit_id).first()
-
-    @classmethod
     def get_max_now_number_suffix(cls, mine_guid, year):
         suffix = cls.query.with_entities(
             func.max(cast(func.split_part(cls.now_number, '-', 3), sqlalchemy.Integer))).filter(

--- a/services/core-web/src/components/noticeOfWork/applications/process/ProcessPermit.js
+++ b/services/core-web/src/components/noticeOfWork/applications/process/ProcessPermit.js
@@ -4,7 +4,6 @@ import PropTypes from "prop-types";
 import moment from "moment";
 import { isEmpty } from "lodash";
 import { Button, Menu, Dropdown, Timeline, Result, Row, Col, notification } from "antd";
-import LinkButton from "@/components/common/buttons/LinkButton";
 import {
   DownOutlined,
   ClockCircleOutlined,
@@ -18,11 +17,6 @@ import {
   fetchDraftPermitByNOW,
 } from "@common/actionCreators/permitActionCreator";
 import { getNoticeOfWork, getNOWProgress } from "@common/selectors/noticeOfWorkSelectors";
-import { getDocumentContextTemplate } from "@/reducers/documentReducer";
-import {
-  generateNoticeOfWorkApplicationDocument,
-  fetchNoticeOfWorkApplicationContextTemplate,
-} from "@/actionCreators/documentActionCreator";
 import { connect } from "react-redux";
 import {
   formatDate,
@@ -41,18 +35,24 @@ import {
   fetchApplicationDelay,
   fetchImportedNoticeOfWorkApplication,
 } from "@common/actionCreators/noticeOfWorkActionCreator";
-import CustomPropTypes from "@/customPropTypes";
-import { modalConfig } from "@/components/modalContent/config";
 import { openModal, closeModal } from "@common/actions/modalActions";
 import {
   getDraftPermitForNOW,
   getDraftPermitAmendmentForNOW,
 } from "@common/selectors/permitSelectors";
+import { PERMIT_AMENDMENT_TYPES } from "@common/constants/strings";
+import { getDocumentContextTemplate } from "@/reducers/documentReducer";
+import {
+  generateNoticeOfWorkApplicationDocument,
+  fetchNoticeOfWorkApplicationContextTemplate,
+} from "@/actionCreators/documentActionCreator";
+import CustomPropTypes from "@/customPropTypes";
+import { modalConfig } from "@/components/modalContent/config";
 import AuthorizationWrapper from "@/components/common/wrappers/AuthorizationWrapper";
 import * as Permission from "@/constants/permissions";
 import * as route from "@/constants/routes";
 import NOWTabHeader from "@/components/noticeOfWork/applications/NOWTabHeader";
-import { PERMIT_AMENDMENT_TYPES } from "@common/constants/strings";
+import LinkButton from "@/components/common/buttons/LinkButton";
 import { APPLICATION_PROGRESS_TRACKING } from "@/constants/NOWConditions";
 
 /**
@@ -315,6 +315,7 @@ export class ProcessPermit extends Component {
       application_last_updated_date: noticeOfWork.last_updated_date
         ? formatDate(noticeOfWork.last_updated_date)
         : formatDate(noticeOfWork.submitted_date),
+        preamble_text: amendment.preamble_text,
     };
     permitGenObject.mine_no = noticeOfWork.mine_no;
     permitGenObject.is_draft = false;

--- a/services/core-web/src/components/noticeOfWork/applications/process/ProcessPermit.js
+++ b/services/core-web/src/components/noticeOfWork/applications/process/ProcessPermit.js
@@ -315,7 +315,7 @@ export class ProcessPermit extends Component {
       application_last_updated_date: noticeOfWork.last_updated_date
         ? formatDate(noticeOfWork.last_updated_date)
         : formatDate(noticeOfWork.submitted_date),
-        preamble_text: amendment.preamble_text,
+      preamble_text: amendment.preamble_text,
     };
     permitGenObject.mine_no = noticeOfWork.mine_no;
     permitGenObject.is_draft = false;


### PR DESCRIPTION
# Main
The only valid way to get a valid application_identity is through using now_application_guid field. The current version is causing errors because it is using permit_id to get an application_identity, but that is incorrect.  

- Fixes in backend:
1. The backend logic needs to be updated for permit amendment
2. New SQL update script to filter by now_application_guid.

# Other
- N/A

# How to test
- N/A

# Notes
https://bcmines.atlassian.net/browse/MDS-4150

