### PR TITLE
hotfix/Update livenessProbe and readinessProbe path for 2.4.1 version of docgen.

### DIFF
--- a/openshift4/templates/docgen.dc.yaml
+++ b/openshift4/templates/docgen.dc.yaml
@@ -120,7 +120,7 @@ objects:
               livenessProbe:
                 failureThreshold: 3
                 httpGet:
-                  path: /health
+                  path: /api/v2/health
                   port: ${{PORT}}
                   scheme: HTTP
                 initialDelaySeconds: 25
@@ -130,7 +130,7 @@ objects:
               readinessProbe:
                 failureThreshold: 3
                 httpGet:
-                  path: /health
+                  path: /api/v2/health
                   port: ${{PORT}}
                   scheme: HTTP
                 initialDelaySeconds: 25


### PR DESCRIPTION
# Main
- Update path in probes for docgen after upgrade.

# Other
- N/A

# How to test
- N/A

# Notes
-N/A