### PR TITLE
MDS-4030: Re-generate permit and letter for ESUP applications

### DIFF
--- a/services/core-web/src/components/mine/ExplosivesPermit/MineExplosivesPermitTable.js
+++ b/services/core-web/src/components/mine/ExplosivesPermit/MineExplosivesPermitTable.js
@@ -276,6 +276,11 @@ export class MineExplosivesPermitTable extends Component {
       render: (text, record) => {
         const isApproved = record.application_status === "APP";
         const isProcessed = record.application_status !== "REC";
+        const hasDocuments =
+          record.documents?.filter((doc) =>
+            ["LET", "PER"].includes(doc.explosives_permit_document_type_code)
+          )?.length > 0;
+        const isCoreSource = record.originating_system === "Core";
         const approvedMenu = (
           <Menu>
             <Menu.Item key="0">
@@ -385,6 +390,20 @@ export class MineExplosivesPermitTable extends Component {
           (isApproved && this.props.isPermitTab);
         return (
           <div className="btn--middle flex">
+            {isApproved && !hasDocuments && isCoreSource && (
+              <AuthorizationWrapper permission={Permission.EDIT_EXPLOSIVES_PERMITS}>
+                <Button
+                  type="secondary"
+                  className="full-mobile"
+                  htmlType="submit"
+                  onClick={(event) =>
+                    this.props.handleOpenExplosivesPermitDecisionModal(event, record)
+                  }
+                >
+                  Re-generate docs
+                </Button>
+              </AuthorizationWrapper>
+            )}
             {showActions && (
               <AuthorizationWrapper permission={Permission.EDIT_EXPLOSIVES_PERMITS}>
                 <Dropdown


### PR DESCRIPTION
# Main

- Provide the means to Re-generate the permit and letter of ESUP applications with Approved status

# Other
- N/A

# How to test
-  Go to Permit & Approvals > Applications and select Explosives Storage & Use Permit Applications.
-  Create a new ESUP application and add some documents.
-  Approve the application.
-  Delete manually the letter and permit from explosives_permit_document_xref and mine_document related to those mine_document_guids.
-  Click on  "Re-generate docs" button.
![image](https://user-images.githubusercontent.com/10526131/158654048-35133db2-636c-48b2-83bf-6069be4eb260.png)
 - Confirm permit and letter are generated while additional documents are not affected.
 - Button disappears after creation of the permit and letter for approved ESUP applications.

# Notes
https://bcmines.atlassian.net/browse/MDS-4030
https://bcmines.atlassian.net/browse/MDS-4074

