### PR TITLE
Add Gov link to incidents tab in Minespace.

### DIFF
--- a/services/minespace-web/src/components/dashboard/mine/incidents/Incidents.js
+++ b/services/minespace-web/src/components/dashboard/mine/incidents/Incidents.js
@@ -107,6 +107,17 @@ export class Incidents extends Component {
             </Typography.Text>
             .
           </Typography.Paragraph>
+          <Typography.Paragraph>
+            <a
+              href="https://www2.gov.bc.ca/gov/content/industry/mineral-exploration-mining/health-safety/incident-information"
+              target="_blank"
+              rel="noopener noreferrer"
+              alt="Incident Information"
+            >
+              Click here
+            </a>{" "}
+            for more information on mining incidents and dangerous occurrences in British Columbia.
+          </Typography.Paragraph>
           <IncidentsTable isLoaded={this.state.isLoaded} data={this.props.incidents} />
         </Col>
       </Row>

--- a/services/minespace-web/src/tests/components/dashboard/mine/incidents/__snapshots__/Incidents.spec.js.snap
+++ b/services/minespace-web/src/tests/components/dashboard/mine/incidents/__snapshots__/Incidents.spec.js.snap
@@ -39,6 +39,18 @@ exports[`MineIncidents renders properly 1`] = `
       </Text>
       .
     </Paragraph>
+    <Paragraph>
+      <a
+        alt="Incident Information"
+        href="https://www2.gov.bc.ca/gov/content/industry/mineral-exploration-mining/health-safety/incident-information"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        Click here
+      </a>
+       
+      for more information on mining incidents and dangerous occurrences in British Columbia.
+    </Paragraph>
     <Connect(IncidentsTable)
       data={
         Array [


### PR DESCRIPTION
# Main

- Add Gov link to Incidents tab in Minespace

# Other
- N/A

# How to test
- Go to incidents in Minespace
- Click on link that opens up in a new tab:
![image](https://user-images.githubusercontent.com/10526131/158660272-72f16c12-5fd8-46b0-8c93-3c4f453e5d73.png)

- Link opened in new tab:
https://www2.gov.bc.ca/gov/content/industry/mineral-exploration-mining/health-safety/incident-information

# Notes
https://bcmines.atlassian.net/browse/MDS-4148