### PR TITLE
MDS-4205: Error when loading permits searched by now_application_guid

### DIFF
--- a/services/core-api/app/api/mines/permits/permit/models/permit.py
+++ b/services/core-api/app/api/mines/permits/permit/models/permit.py
@@ -141,7 +141,8 @@ class Permit(SoftDeleteMixin, AuditMixin, Base):
             raise Exception('Unable to delete permit with attached bonds.')
 
         if self.permit_amendments and self.permit_status_code != 'D' and any(
-                amendment.now_application_guid is not None and amendment.is_generated_in_core for amendment in self.permit_amendments):
+                amendment.now_application_guid is not None and amendment.is_generated_in_core
+                for amendment in self.permit_amendments):
             raise Exception(
                 'Unable to delete permit generated in Core with linked NOW application in Core to one of its permit amendments.'
             )
@@ -194,7 +195,7 @@ class Permit(SoftDeleteMixin, AuditMixin, Base):
     def find_by_now_application_guid(cls, _now_application_guid):
         permit_amendment = PermitAmendment.find_by_now_application_guid(_now_application_guid)
         if permit_amendment is not None:
-            permit = permit_amendment.permit
+            permit = Permit.find_by_permit_id(permit_amendment.permit_id)
             permit._context_mine = permit_amendment.mine
             return permit
         return None


### PR DESCRIPTION
# Main

- Error when referring to _context_mine property in an empty permit object.

# Other
- N/A

# How to test
- Query this mine_guid in Metabase and recreate the scenario in your local:
```
select *
from permit_amendment pa
where pa.mine_guid='558524a0-94b1-41d5-8b7b-65225c44f2b6' and 
      pa.permit_amendment_status_code= 'DFT'
```
-  Create two permit amendments in Draft, one is generated in Core and the other not.

# Notes
https://bcmines.atlassian.net/browse/MDS-4205
