### PR TITLE
Add revision limits to dcs

### DIFF
--- a/openshift4/templates/backend.dc.yaml
+++ b/openshift4/templates/backend.dc.yaml
@@ -122,6 +122,7 @@ objects:
               namespace: ${IMAGE_NAMESPACE}
         - type: ConfigChange
       replicas: ${{REPLICA_MIN}}
+      revisionHistoryLimit: 5
       test: false
       selector:
         name: ${NAME}

--- a/openshift4/templates/docgen.dc.yaml
+++ b/openshift4/templates/docgen.dc.yaml
@@ -84,6 +84,7 @@ objects:
               name: ${NAME}:${TAG}
               namespace: ${IMAGE_NAMESPACE}
       replicas: ${{REPLICA_MIN}}
+      revisionHistoryLimit: 5
       selector:
         name: ${NAME}
       template:

--- a/openshift4/templates/docman.dc.yaml
+++ b/openshift4/templates/docman.dc.yaml
@@ -134,6 +134,7 @@ objects:
               namespace: 4c2ba9-tools
         - type: ConfigChange
       replicas: ${{REPLICA_MIN}}
+      revisionHistoryLimit: 5
       test: false
       selector:
         name: ${NAME}

--- a/openshift4/templates/filesystem-provider.dc.yaml
+++ b/openshift4/templates/filesystem-provider.dc.yaml
@@ -45,6 +45,7 @@ objects:
               name: ${NAME}:${TAG}
               namespace: 4c2ba9-tools
       replicas: 1
+      revisionHistoryLimit: 5
       selector:
         name: ${NAME}
       template:

--- a/openshift4/templates/frontend.dc.yaml
+++ b/openshift4/templates/frontend.dc.yaml
@@ -122,6 +122,7 @@ objects:
               namespace: ${IMAGE_NAMESPACE}
         - type: ConfigChange
       replicas: ${{REPLICA_MIN}}
+      revisionHistoryLimit: 5
       selector:
         name: ${NAME}
       template:

--- a/openshift4/templates/metabase.dc.yaml
+++ b/openshift4/templates/metabase.dc.yaml
@@ -90,6 +90,7 @@ objects:
               name: ${NAME}:${TAG}
               namespace: ${IMAGE_NAMESPACE}
       replicas: 3
+      revisionHistoryLimit: 5
       selector:
         name: ${NAME}
       template:

--- a/openshift4/templates/minespace.dc.yaml
+++ b/openshift4/templates/minespace.dc.yaml
@@ -128,6 +128,7 @@ objects:
               namespace: ${IMAGE_NAMESPACE}
         - type: ConfigChange
       replicas: ${{REPLICA_MIN}}
+      revisionHistoryLimit: 5
       selector:
         name: ${NAME}
       template:

--- a/openshift4/templates/nginx.dc.yaml
+++ b/openshift4/templates/nginx.dc.yaml
@@ -90,6 +90,7 @@ objects:
               namespace: ${IMAGE_NAMESPACE}
         - type: ConfigChange
       replicas: ${{REPLICA_MIN}}
+      revisionHistoryLimit: 5
       selector:
         name: ${NAME}
       template:

--- a/openshift4/templates/nris.dc.yaml
+++ b/openshift4/templates/nris.dc.yaml
@@ -95,6 +95,7 @@ objects:
               namespace: 4c2ba9-tools
         - type: ConfigChange
       replicas: ${{REPLICA_MIN}}
+      revisionHistoryLimit: 5
       test: false
       selector:
         name: ${NAME}

--- a/openshift4/templates/redis.dc.yaml
+++ b/openshift4/templates/redis.dc.yaml
@@ -58,6 +58,7 @@ objects:
             lastTriggeredImage: ""
         - type: ConfigChange
       replicas: 1
+      revisionHistoryLimit: 5
       selector:
         name: ${NAME}
       template:

--- a/openshift4/templates/schemaspy.dc.yaml
+++ b/openshift4/templates/schemaspy.dc.yaml
@@ -39,6 +39,7 @@ objects:
       name: ${NAME}
     spec:
       replicas: 3
+      revisionHistoryLimit: 5
       selector:
         name: ${NAME}
       strategy:


### PR DESCRIPTION
# Main

- Explicitly set the revision limits on dcs
- This controls the number of replicationcontrollers that can exist under the dc, which keep images around while they persist

# Other

- N/A

# How to test

- N/A

# Notes

- N/A
