### PR TITLE
Add customresource for argocd management

### DIFF
--- a/openshift4/argocd/gitopsteam.mds.yaml
+++ b/openshift4/argocd/gitopsteam.mds.yaml
@@ -20,11 +20,11 @@ spec:
     admins:
       - jon-funk
       - vyasworks
+      - wilson496
 
 
     # Recommended for contributors who actively push to your project.
     writers:
-      - wilson496
 
     # Recommended for project managers who need to manage the repository without
     # access to sensitive or destructive actions.

--- a/openshift4/argocd/gitopsteam.mds.yaml
+++ b/openshift4/argocd/gitopsteam.mds.yaml
@@ -1,0 +1,53 @@
+# GitOpsTeam - create this CRD in your tools namespace in order to enable
+# Argo CD for your project
+apiVersion: warden.devops.gov.bc.ca/v1alpha1
+kind: GitOpsTeam
+metadata:
+  name: gitopsteam-4c2ba9
+  namespace: 4c2ba9-tools
+spec:
+  # gitOpsMembers defines the git repo access (tenant-gitops-XYZ)
+  # Note that users with repo access will have to accept an invitation from
+  # GitHub to join the bcgov-c GitHub organization if they are not already
+  # members.
+  # -----------------------------------------------------------------------
+  gitOpsMembers:
+
+    # Full admin access to the repo, including repo deletion, adding of users
+    # Recommended for people who need full access to the project, including
+    # sensitive and destructive actions like managing security or deleting a
+    # repository.
+    admins:
+      - jon-funk
+      - vyasworks
+
+
+    # Recommended for contributors who actively push to your project.
+    writers:
+      - wilson496
+
+    # Recommended for project managers who need to manage the repository without
+    # access to sensitive or destructive actions.
+    maintainers:
+
+    # Recommended for non-code contributors who want to view or discuss your
+    # project.
+    readers:
+
+    # Recommended for contributors who need to manage issues and pull requests
+    # without write access.
+    triage:
+
+  # projectMembers defines access to the Argo CD UI
+  # -----------------------------------------------
+  projectMembers:
+
+    # Project Maintainers have full access to the Argo CD Project, including the
+    # ability create, edit, and delete Applications within the Project
+    maintainers:
+      - jon-funk@github
+      - wilson496@github
+      - vyasworks@github
+
+    # Project Readers have read-only access to the Project in the Argo CD UI
+    readers:


### PR DESCRIPTION
# Main

- Adds manifest for version controlling argocd team space
- Previously, this was manually managed by platform services, but now they have an available custom resource we can provision to control things ourselves

# Other

- N/A

# How to test

- N/A

# Notes

- N/A
