### PR TITLE
Mds 4186 view nod modal

### DIFF
--- a/services/minespace-web/src/components/dashboard/mine/noticeOfDeparture/NoticeOfDeparture.js
+++ b/services/minespace-web/src/components/dashboard/mine/noticeOfDeparture/NoticeOfDeparture.js
@@ -74,6 +74,16 @@ export class NoticeOfDeparture extends Component {
     });
   };
 
+  openViewNoticeOfDepartureModal = (noticeOfDeparture) => {
+    this.props.openModal({
+      props: {
+        noticeOfDeparture,
+        title: "View Notice of Departure",
+      },
+      content: modalConfig.VIEW_NOTICE_OF_DEPARTURE,
+    });
+  };
+
   render() {
     return (
       <Row>
@@ -91,7 +101,11 @@ export class NoticeOfDeparture extends Component {
             The below table displays all of the&nbsp; notices of departure and their associated
             permits &nbsp;associated with this mine.
           </Typography.Paragraph>
-          <NoticeOfDepartureTable isLoaded={this.state.isLoaded} data={this.props.nods} />
+          <NoticeOfDepartureTable
+            isLoaded={this.state.isLoaded}
+            data={this.props.nods}
+            openViewNoticeOfDepartureModal={this.openViewNoticeOfDepartureModal}
+          />
         </Col>
       </Row>
     );

--- a/services/minespace-web/src/components/dashboard/mine/noticeOfDeparture/NoticeOfDepartureDetails.js
+++ b/services/minespace-web/src/components/dashboard/mine/noticeOfDeparture/NoticeOfDepartureDetails.js
@@ -7,17 +7,15 @@ const propTypes = {
 };
 
 export const NoticeOfDepartureDetails = (props) => {
+  const { nod_title, permit, nod_guid } = props.noticeOfDeparture;
+
   return (
     <div>
       <Typography.Title level={4}>Basic Information</Typography.Title>
       <Descriptions colon={false} layout="vertical" column={1} size="middle">
-        <Descriptions.Item label="Departure Project Title">
-          {props.noticeOfDeparture.nod_title}
-        </Descriptions.Item>
-        <Descriptions.Item label="Permit #">
-          {props.noticeOfDeparture.permit.permit_no}
-        </Descriptions.Item>
-        <Descriptions.Item label="NOD #">{props.noticeOfDeparture.nod_guid}</Descriptions.Item>
+        <Descriptions.Item label="Departure Project Title">{nod_title}</Descriptions.Item>
+        <Descriptions.Item label="Permit #">{permit.permit_no}</Descriptions.Item>
+        <Descriptions.Item label="NOD #">{nod_guid}</Descriptions.Item>
       </Descriptions>
     </div>
   );

--- a/services/minespace-web/src/components/dashboard/mine/noticeOfDeparture/NoticeOfDepartureDetails.js
+++ b/services/minespace-web/src/components/dashboard/mine/noticeOfDeparture/NoticeOfDepartureDetails.js
@@ -1,5 +1,5 @@
 import React from "react";
-// import PropTypes from "prop-types";
+import { Descriptions, Typography } from "antd";
 import CustomPropTypes from "@/customPropTypes";
 
 const propTypes = {
@@ -7,10 +7,18 @@ const propTypes = {
 };
 
 export const NoticeOfDepartureDetails = (props) => {
-  console.log(props.noticeOfDeparture);
   return (
     <div>
-      <p>hello</p>
+      <Typography.Title level={4}>Basic Information</Typography.Title>
+      <Descriptions colon={false} layout="vertical" column={1} size="middle">
+        <Descriptions.Item label="Departure Project Title">
+          {props.noticeOfDeparture.nod_title}
+        </Descriptions.Item>
+        <Descriptions.Item label="Permit #">
+          {props.noticeOfDeparture.permit.permit_no}
+        </Descriptions.Item>
+        <Descriptions.Item label="NOD #">{props.noticeOfDeparture.nod_guid}</Descriptions.Item>
+      </Descriptions>
     </div>
   );
 };

--- a/services/minespace-web/src/components/dashboard/mine/noticeOfDeparture/NoticeOfDepartureDetails.js
+++ b/services/minespace-web/src/components/dashboard/mine/noticeOfDeparture/NoticeOfDepartureDetails.js
@@ -1,0 +1,20 @@
+import React from "react";
+// import PropTypes from "prop-types";
+import CustomPropTypes from "@/customPropTypes";
+
+const propTypes = {
+  noticeOfDeparture: CustomPropTypes.noticeOfDeparture.isRequired,
+};
+
+export const NoticeOfDepartureDetails = (props) => {
+  console.log(props.noticeOfDeparture);
+  return (
+    <div>
+      <p>hello</p>
+    </div>
+  );
+};
+
+NoticeOfDepartureDetails.propTypes = propTypes;
+
+export default NoticeOfDepartureDetails;

--- a/services/minespace-web/src/components/dashboard/mine/noticeOfDeparture/NoticeOfDepartureTable.js
+++ b/services/minespace-web/src/components/dashboard/mine/noticeOfDeparture/NoticeOfDepartureTable.js
@@ -3,59 +3,61 @@ import { Button, Table } from "antd";
 import PropTypes from "prop-types";
 import CustomPropTypes from "@/customPropTypes";
 
-const columns = [
-  {
-    title: "Title",
-    dataIndex: "nod_title",
-    key: "nod_title",
-    sorter: (a, b) => (a.nod_title > b.nod_title ? -1 : 1),
-  },
-  {
-    title: "NOD #",
-    dataIndex: "nod_guid",
-    key: "nod_guid",
-    sorter: (a, b) => (a.nod_guid > b.nod_guid ? -1 : 1),
-  },
-  {
-    title: "Permit #",
-    dataIndex: ["permit", "permit_no"],
-    key: ["permit", "permit_no"],
-    sorter: (a, b) => (a.permit.permit_no > b.permit.permit_no ? -1 : 1),
-  },
-  {
-    title: "Type",
-    dataIndex: "type",
-    key: "type",
-    sorter: (a, b) => (a.type > b.type ? -1 : 1),
-  },
-  {
-    title: "Status",
-    dataIndex: "status",
-    key: "status",
-    sorter: (a, b) => (a.status > b.status ? -1 : 1),
-    defaultSortOrder: "ascend",
-  },
-  {
-    render: () => (
-      <Button
-        type="primary"
-        size="small"
-        onClick={() => {
-          // TODO: Create/Integrate Modal
-        }}
-      >
-        View
-      </Button>
-    ),
-  },
-];
-
 const propTypes = {
   data: PropTypes.arrayOf(CustomPropTypes.noticeOfDeparture).isRequired,
+  openViewNoticeOfDepartureModal: PropTypes.func.isRequired,
   isLoaded: PropTypes.bool.isRequired,
 };
 
 const NoticeOfDepartureTable = (props) => {
+  const handleOpenModal = (event, noticeOfDeparture) => {
+    event.preventDefault();
+    props.openViewNoticeOfDepartureModal(noticeOfDeparture);
+  };
+
+  const columns = [
+    {
+      title: "Title",
+      dataIndex: "nod_title",
+      key: "nod_title",
+      sorter: (a, b) => (a.nod_title > b.nod_title ? -1 : 1),
+    },
+    {
+      title: "NOD #",
+      dataIndex: "nod_guid",
+      key: "nod_guid",
+      sorter: (a, b) => (a.nod_guid > b.nod_guid ? -1 : 1),
+    },
+    {
+      title: "Permit #",
+      dataIndex: ["permit", "permit_no"],
+      key: ["permit", "permit_no"],
+      sorter: (a, b) => (a.permit.permit_no > b.permit.permit_no ? -1 : 1),
+    },
+    {
+      title: "Type",
+      dataIndex: "type",
+      key: "type",
+      sorter: (a, b) => (a.type > b.type ? -1 : 1),
+    },
+    {
+      title: "Status",
+      dataIndex: "status",
+      key: "status",
+      sorter: (a, b) => (a.status > b.status ? -1 : 1),
+      defaultSortOrder: "ascend",
+    },
+    {
+      render: (text, record) => (
+        <div title="" align="right">
+          <Button type="primary" size="small" onClick={(event) => handleOpenModal(event, record)}>
+            View
+          </Button>
+        </div>
+      ),
+    },
+  ];
+
   return (
     <Table
       loading={!props.isLoaded}

--- a/services/minespace-web/src/components/modalContent/config.js
+++ b/services/minespace-web/src/components/modalContent/config.js
@@ -6,7 +6,8 @@ import EditVarianceModal from "@/components/modalContent/variances/EditVarianceM
 import ViewIncidentModal from "@/components/modalContent/incidents/ViewIncidentModal";
 import AddTailingsModal from "@/components/modalContent/tailing/AddTailingsModal";
 import AddIncidentModal from "@/components/modalContent/incidents/AddIncidentModal";
-import AddNODModal from "@/components/modalContent/noticeOfDeparture/AddNoticeOfDepartureModal";
+import AddNoticeOfDepartureModal from "@/components/modalContent/noticeOfDeparture/AddNoticeOfDepartureModal";
+import ViewNoticeOfDepartureModal from "@/components/modalContent/noticeOfDeparture/ViewNoticeOfDepartureModal";
 
 export const modalConfig = {
   ADD_REPORT: AddReportModal,
@@ -17,7 +18,8 @@ export const modalConfig = {
   VIEW_INCIDENT: ViewIncidentModal,
   ADD_TAILINGS: AddTailingsModal,
   ADD_INCIDENT: AddIncidentModal,
-  ADD_NOTICE_OF_DEPARTURE: AddNODModal,
+  ADD_NOTICE_OF_DEPARTURE: AddNoticeOfDepartureModal,
+  VIEW_NOTICE_OF_DEPARTURE: ViewNoticeOfDepartureModal,
 };
 
 export default modalConfig;

--- a/services/minespace-web/src/components/modalContent/noticeOfDeparture/ViewNoticeOfDepartureModal.js
+++ b/services/minespace-web/src/components/modalContent/noticeOfDeparture/ViewNoticeOfDepartureModal.js
@@ -1,0 +1,19 @@
+import React from "react";
+// import PropTypes from "prop-types";
+import NoticeOfDepartureDetails from "@/components/dashboard/mine/noticeOfDeparture/NoticeOfDepartureDetails";
+import CustomPropTypes from "@/customPropTypes";
+
+const propTypes = {
+  // closeModal: PropTypes.func.isRequired,
+  noticeOfDeparture: CustomPropTypes.noticeOfDeparture.isRequired,
+};
+
+export const ViewNoticeOfDepartureModal = (props) => (
+  <div>
+    <NoticeOfDepartureDetails noticeOfDeparture={props.noticeOfDeparture} />
+  </div>
+);
+
+ViewNoticeOfDepartureModal.propTypes = propTypes;
+
+export default ViewNoticeOfDepartureModal;

--- a/services/minespace-web/src/components/modalContent/noticeOfDeparture/ViewNoticeOfDepartureModal.js
+++ b/services/minespace-web/src/components/modalContent/noticeOfDeparture/ViewNoticeOfDepartureModal.js
@@ -1,16 +1,20 @@
 import React from "react";
-// import PropTypes from "prop-types";
+import PropTypes from "prop-types";
+import { Button } from "antd";
 import NoticeOfDepartureDetails from "@/components/dashboard/mine/noticeOfDeparture/NoticeOfDepartureDetails";
 import CustomPropTypes from "@/customPropTypes";
 
 const propTypes = {
-  // closeModal: PropTypes.func.isRequired,
+  closeModal: PropTypes.func.isRequired,
   noticeOfDeparture: CustomPropTypes.noticeOfDeparture.isRequired,
 };
 
 export const ViewNoticeOfDepartureModal = (props) => (
   <div>
     <NoticeOfDepartureDetails noticeOfDeparture={props.noticeOfDeparture} />
+    <div className="ant-modal-footer">
+      <Button onClick={props.closeModal}>Close</Button>
+    </div>
   </div>
 );
 

--- a/services/minespace-web/src/tests/components/dashboard/mine/noticeOfDeparture/__snapshots__/noticeOfDeparture.spec.js.snap
+++ b/services/minespace-web/src/tests/components/dashboard/mine/noticeOfDeparture/__snapshots__/noticeOfDeparture.spec.js.snap
@@ -48,6 +48,7 @@ exports[`NoticesOfDeparture renders properly 1`] = `
         ]
       }
       isLoaded={false}
+      openViewNoticeOfDepartureModal={[Function]}
     />
   </Col>
 </Row>

--- a/services/minespace-web/src/tests/components/modalContent/ViewNoticeOfDepartureModal.spec.js
+++ b/services/minespace-web/src/tests/components/modalContent/ViewNoticeOfDepartureModal.spec.js
@@ -22,7 +22,7 @@ beforeEach(() => {
   setupProps();
 });
 
-describe("AddIncidentModal", () => {
+describe("ViewNoticeOfDepartureModal", () => {
   it("renders properly", () => {
     const component = shallow(<ViewNoticeOfDepartureModal {...dispatchProps} {...props} />);
     expect(component).toMatchSnapshot();

--- a/services/minespace-web/src/tests/components/modalContent/ViewNoticeOfDepartureModal.spec.js
+++ b/services/minespace-web/src/tests/components/modalContent/ViewNoticeOfDepartureModal.spec.js
@@ -1,0 +1,30 @@
+import React from "react";
+import { shallow } from "enzyme";
+import * as MOCK from "@/tests/mocks/dataMocks";
+import ViewNoticeOfDepartureModal from "@/components/modalContent/noticeOfDeparture/ViewNoticeOfDepartureModal";
+
+const dispatchProps = {};
+const props = {};
+
+const setupDispatchProps = () => {
+  dispatchProps.onSubmit = jest.fn();
+  dispatchProps.closeModal = jest.fn();
+  dispatchProps.afterClose = jest.fn();
+};
+
+const setupProps = () => {
+  // eslint-disable-next-line prefer-destructuring
+  props.noticeOfDeparture = MOCK.NOTICES_OF_DEPARTURE.records[0];
+};
+
+beforeEach(() => {
+  setupDispatchProps();
+  setupProps();
+});
+
+describe("AddIncidentModal", () => {
+  it("renders properly", () => {
+    const component = shallow(<ViewNoticeOfDepartureModal {...dispatchProps} {...props} />);
+    expect(component).toMatchSnapshot();
+  });
+});

--- a/services/minespace-web/src/tests/components/modalContent/__snapshots__/ViewNoticeOfDepartureModal.spec.js.snap
+++ b/services/minespace-web/src/tests/components/modalContent/__snapshots__/ViewNoticeOfDepartureModal.spec.js.snap
@@ -1,39 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AddIncidentModal renders properly 1`] = `
-<div>
-  <NoticeOfDepartureDetails
-    noticeOfDeparture={
-      Object {
-        "nod_guid": "4ca454f5-7982-4936-bfb9-84f5976fdefe",
-        "nod_title": "ff",
-        "permit": Object {
-          "current_permittee": "Haynes, Park and Brown",
-          "permit_guid": "d378ca4d-310a-4644-95cf-4d8dc47f294b",
-          "permit_id": 22,
-          "permit_no": "M-7594809",
-          "permit_prefix": "M",
-          "permit_status_code": "C",
-        },
-      }
-    }
-  />
-  <div
-    className="ant-modal-footer"
-  >
-    <Button
-      block={false}
-      ghost={false}
-      htmlType="button"
-      loading={false}
-      onClick={[MockFunction]}
-    >
-      Close
-    </Button>
-  </div>
-</div>
-`;
-
 exports[`ViewNoticeOfDepartureModal renders properly 1`] = `
 <div>
   <NoticeOfDepartureDetails

--- a/services/minespace-web/src/tests/components/modalContent/__snapshots__/ViewNoticeOfDepartureModal.spec.js.snap
+++ b/services/minespace-web/src/tests/components/modalContent/__snapshots__/ViewNoticeOfDepartureModal.spec.js.snap
@@ -1,0 +1,35 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AddIncidentModal renders properly 1`] = `
+<div>
+  <NoticeOfDepartureDetails
+    noticeOfDeparture={
+      Object {
+        "nod_guid": "4ca454f5-7982-4936-bfb9-84f5976fdefe",
+        "nod_title": "ff",
+        "permit": Object {
+          "current_permittee": "Haynes, Park and Brown",
+          "permit_guid": "d378ca4d-310a-4644-95cf-4d8dc47f294b",
+          "permit_id": 22,
+          "permit_no": "M-7594809",
+          "permit_prefix": "M",
+          "permit_status_code": "C",
+        },
+      }
+    }
+  />
+  <div
+    className="ant-modal-footer"
+  >
+    <Button
+      block={false}
+      ghost={false}
+      htmlType="button"
+      loading={false}
+      onClick={[MockFunction]}
+    >
+      Close
+    </Button>
+  </div>
+</div>
+`;

--- a/services/minespace-web/src/tests/components/modalContent/__snapshots__/ViewNoticeOfDepartureModal.spec.js.snap
+++ b/services/minespace-web/src/tests/components/modalContent/__snapshots__/ViewNoticeOfDepartureModal.spec.js.snap
@@ -33,3 +33,37 @@ exports[`AddIncidentModal renders properly 1`] = `
   </div>
 </div>
 `;
+
+exports[`ViewNoticeOfDepartureModal renders properly 1`] = `
+<div>
+  <NoticeOfDepartureDetails
+    noticeOfDeparture={
+      Object {
+        "nod_guid": "4ca454f5-7982-4936-bfb9-84f5976fdefe",
+        "nod_title": "ff",
+        "permit": Object {
+          "current_permittee": "Haynes, Park and Brown",
+          "permit_guid": "d378ca4d-310a-4644-95cf-4d8dc47f294b",
+          "permit_id": 22,
+          "permit_no": "M-7594809",
+          "permit_prefix": "M",
+          "permit_status_code": "C",
+        },
+      }
+    }
+  />
+  <div
+    className="ant-modal-footer"
+  >
+    <Button
+      block={false}
+      ghost={false}
+      htmlType="button"
+      loading={false}
+      onClick={[MockFunction]}
+    >
+      Close
+    </Button>
+  </div>
+</div>
+`;


### PR DESCRIPTION
# Main

- Created the view modal to view notices of departure from the table

# Other

- N/A

# How to test

- Click on the `view` button next to a created NOD and make sure a modal opens with the correct information

# Notes

Currently using `nod_guid` in place of the `nod_no` until that becomes available.

![image](https://user-images.githubusercontent.com/83598933/163463790-89df7f6d-3fe3-4ba2-a1e9-3608ad47c247.png)

