### PR TITLE
mds-3528 - increased minHeight of element within collapse

### DIFF
--- a/services/core-web/src/components/Forms/parties/AddRolesForm.js
+++ b/services/core-web/src/components/Forms/parties/AddRolesForm.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import { Field, reduxForm } from "redux-form";
 import { Form } from "@ant-design/compatible";
 import "@ant-design/compatible/assets/index.css";
-import { Collapse, Button, Popconfirm, Col, Row } from "antd";
+import { Button, Col, Collapse, Popconfirm, Row } from "antd";
 import { PlusOutlined } from "@ant-design/icons";
 import { required } from "@common/utils/Validate";
 import CustomPropTypes from "@/customPropTypes";
@@ -59,7 +59,7 @@ export const AddRolesForm = (props) => (
       <Collapse accordion activeKey={[props.activeKey]} onChange={props.handleActivePanelChange}>
         {props.roleNumbers.map((roleNumber) => (
           <Collapse.Panel header={panelHeader(props.removeField, roleNumber)} key={roleNumber}>
-            <Row gutter={16}>
+            <Row gutter={16} style={{ minHeight: "250px" }}>
               <Col span={12}>
                 <Form.Item label="Role *">
                   <Field


### PR DESCRIPTION
# Main

- Added `minHeight` to the contents of the collapse.  The select input height was a little bit taller than the height of the rest of the container.  Tried adjusting the z-index as well, but the collapse just cuts off anything that extends past it's height. 

# Other

- N/A

# How to test

- N/A

# Notes

![image](https://user-images.githubusercontent.com/83598933/163881720-6f44d709-31d0-4261-b718-5d84ce826c4e.png)
