### PR TITLE
hotfix/Removed dropping columns in project migration

### DIFF
--- a/migrations/sql/V2022.04.21.08.35__project_datafix.sql
+++ b/migrations/sql/V2022.04.21.08.35__project_datafix.sql
@@ -2,7 +2,7 @@
 INSERT INTO project (mine_guid, project_title, project_lead_party_guid, proponent_project_id, create_user,update_user)
   SELECT ps.mine_guid, ps.project_summary_title, ps.project_summary_lead_party_guid, ps.proponent_project_id, 'system-mds','system-mds'
   FROM project_summary ps
-  WHERE mine_guid not in (select mine_guid
+  WHERE ps.mine_guid not in (select mine_guid
 								   from project);
 
 -- Update project_summary to include FK to newly created projects
@@ -13,12 +13,3 @@ INSERT INTO project_contact(project_guid, name, job_title, company_name, email, 
   SELECT pr.project_guid, psc.name, psc.job_title, psc.company_name, psc.email, psc.phone_number, psc.phone_extension, psc.is_primary, psc.deleted_ind, psc.create_user, psc.update_user
   FROM project_summary_contact psc, project pr, project_summary ps
   WHERE psc.project_summary_guid = ps.project_summary_guid and pr.project_guid = ps.project_guid;
-
--- Drop legacy tables, columns, and constraints
-ALTER TABLE project_summary
-DROP CONSTRAINT IF EXISTS mine_guid_fkey,
-DROP COLUMN IF EXISTS mine_guid,
-DROP CONSTRAINT IF EXISTS project_summary_lead_party_guid_fkey,
-DROP COLUMN IF EXISTS project_summary_lead_party_guid,
-DROP COLUMN IF EXISTS project_summary_title,
-DROP COLUMN IF EXISTS proponent_project_id;

--- a/migrations/sql/V2022.04.25.11.52__drop_columns_project_summary.sql
+++ b/migrations/sql/V2022.04.25.11.52__drop_columns_project_summary.sql
@@ -1,0 +1,8 @@
+-- Drop legacy tables, columns, and constraints
+ALTER TABLE project_summary
+DROP CONSTRAINT IF EXISTS mine_guid_fkey,
+DROP COLUMN IF EXISTS mine_guid,
+DROP CONSTRAINT IF EXISTS project_summary_lead_party_guid_fkey,
+DROP COLUMN IF EXISTS project_summary_lead_party_guid,
+DROP COLUMN IF EXISTS project_summary_title,
+DROP COLUMN IF EXISTS proponent_project_id;


### PR DESCRIPTION
# Main
-Separation of concerns: Keep DML in migration for copying data from project_summary table to project table  and remove DDL to be considered in a separated migration.

# Other
-N/A

# How to test
- N/A

# Notes
- N/A
