### PR TITLE
MDS-4350-Message Tool in Communication related to a Mine not appearing

### DIFF
--- a/services/core-web/src/components/common/comments/CommentPanel.js
+++ b/services/core-web/src/components/common/comments/CommentPanel.js
@@ -40,7 +40,7 @@ const defaultProps = {
 export const CommentPanel = (props) => {
   const createPermission = props.userRoles.includes(USER_ROLES[props?.createPermission])
     ? props.createPermission
-    : Permission.ADMIN;
+    : null;
 
   return (
     <React.Fragment>


### PR DESCRIPTION
## Objective 

https://bcmines.atlassian.net/browse/MDS-4350

Currently, Core users with no Admin privileges cannot create new comments under Communication for a mine. To post comments should be widely available among all Core Users.

## Additional Information / Context 
Login in Core and select a mine. Then, at the top right click on Options > Communication to display a dialog box to insert comments:
![image](https://user-images.githubusercontent.com/10526131/166317780-e96560f0-562a-4418-a60d-37b837a5021a.png)

With the current change, Core users with no Admin privileges can post comments:
![image](https://user-images.githubusercontent.com/10526131/166318083-2240373d-8c85-49b5-afaa-294f1f2b8995.png)

The sections affected are the following:
- Create comment for a mine (explained above)
- Create comment for incident (requires "core_edit_incidents" permission to get access to the button to open comment dialog)
- Create comment for report (requires "core_edit_reports" permission to get access to open comment dialog)

The changes in the PR apply for invokations to CommentPanel component not having value in createPermission, so if there ir no special privilege, the user could see the comment dialog.