### PR TITLE
Get back backend tag in github actions for prod deployment.

### DIFF
--- a/.github/workflows/promote-to-prod.yaml
+++ b/.github/workflows/promote-to-prod.yaml
@@ -27,7 +27,7 @@ jobs:
         include:
           - name: nginx
           - name: frontend
-          # - name: backend
+          - name: backend
           - name: flyway
           - name: tusd
           - name: docgen
@@ -73,7 +73,7 @@ jobs:
         include:
           - name: nginx
           - name: frontend
-          # - name: backend
+          - name: backend
           - name: docgen
           - name: dbbackup
           - name: metabase


### PR DESCRIPTION
## Objective 
Deploy to Production

Why are you making this change? 
Getting back backend tag to deploy to Production.

## Additional Information / Context 
Alternative workflow considering ArgoCd is not fully ready for deployment.
