### PR TITLE
Feature/mds 4307 core view nod attachments

### DIFF
--- a/services/core-web/common/actionCreators/noticeOfDepartureActionCreator.js
+++ b/services/core-web/common/actionCreators/noticeOfDepartureActionCreator.js
@@ -15,7 +15,10 @@ import {
   NOTICE_OF_DEPARTURE,
 } from "../constants/API";
 import { createRequestHeader } from "../utils/RequestHeaders";
-import { storeNoticesOfDeparture } from "../actions/noticeOfDepartureActions";
+import {
+  storeNoticesOfDeparture,
+  storeNoticeOfDeparture,
+} from "../actions/noticeOfDepartureActions";
 
 export const createNoticeOfDeparture = (mine_guid, payload) => (dispatch) => {
   dispatch(request(CREATE_NOTICE_OF_DEPARTURE));
@@ -59,6 +62,7 @@ export const fetchDetailedNoticeOfDeparture = (mine_guid, nod_guid) => (dispatch
     .get(`${ENVIRONMENT.apiUrl}${NOTICE_OF_DEPARTURE(mine_guid, nod_guid)}`, createRequestHeader())
     .then((response) => {
       dispatch(success(GET_DETAILED_NOTICE_OF_DEPARTURE));
+      dispatch(storeNoticeOfDeparture(response.data));
       return response;
     })
     .catch(() => dispatch(error(GET_DETAILED_NOTICE_OF_DEPARTURE)))

--- a/services/core-web/common/constants/strings.js
+++ b/services/core-web/common/constants/strings.js
@@ -127,3 +127,14 @@ export const NOTICE_OF_DEPARTURE_DOCUMENT_TYPE = {
   CHECKLIST: "checklist",
   OTHER: "other",
 };
+
+export const NOTICE_OF_DEPARTURE_TYPE = {
+  non_substantial: "Non Substantial",
+  potentially_substantial: "Potentially Substantial",
+};
+
+export const NOTICE_OF_DEPARTURE_STATUS = {
+  pending_review: "Pending Preview",
+  in_review: "In Review",
+  self_authorized: "Self Authorized",
+};

--- a/services/core-web/src/components/modalContent/ViewNoticeOfDepartureModal.js
+++ b/services/core-web/src/components/modalContent/ViewNoticeOfDepartureModal.js
@@ -1,8 +1,18 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { Button } from "antd";
-import * as Strings from "@common/constants/strings";
+import { Button, Col, Row } from "antd";
+import {
+  EMPTY_FIELD,
+  NOTICE_OF_DEPARTURE_DOCUMENT_TYPE,
+  NOTICE_OF_DEPARTURE_TYPE,
+  NOTICE_OF_DEPARTURE_STATUS,
+} from "@common/constants/strings";
 import CustomPropTypes from "@/customPropTypes";
+import CoreTable from "@/components/common/CoreTable";
+import { TRASHCAN } from "@/constants/assets";
+import LinkButton from "@/components/common/buttons/LinkButton";
+import { downloadFileFromDocumentManager } from "@common/utils/actionlessNetworkCalls";
+import { formatDate } from "@common/utils/helpers";
 
 const propTypes = {
   closeModal: PropTypes.func.isRequired,
@@ -11,6 +21,56 @@ const propTypes = {
 
 export const ViewNoticeOfDepartureModal = (props) => {
   const { noticeOfDeparture } = props;
+  const checklist = noticeOfDeparture.documents.find(
+    (doc) => doc.document_type === NOTICE_OF_DEPARTURE_DOCUMENT_TYPE.CHECKLIST
+  );
+  const otherDocuments = noticeOfDeparture.documents.filter(
+    (doc) => doc.document_type !== NOTICE_OF_DEPARTURE_DOCUMENT_TYPE.CHECKLIST
+  );
+
+  const fileColumns = [
+    {
+      title: "Name",
+      dataIndex: "document_name",
+      sortField: "document_name",
+      sorter: (a, b) => (a.document_name > b.document_name ? -1 : 1),
+      render: (text) => (
+        <div className="nod-table-link">
+          {text ? (
+            <LinkButton onClick={() => downloadFileFromDocumentManager(checklist)} title="Download">
+              {text}
+            </LinkButton>
+          ) : (
+            <div>{EMPTY_FIELD}</div>
+          )}
+        </div>
+      ),
+    },
+    {
+      title: "Category",
+      dataIndex: "document_category",
+      sortField: "document_category",
+      sorter: (a, b) => (a.document_category > b.document_category ? -1 : 1),
+      render: (text) => <div title="Id">{text || EMPTY_FIELD}</div>,
+    },
+    {
+      title: "Uploaded",
+      dataIndex: "create_timestamp",
+      sortField: "create_timestamp",
+      sorter: (a, b) => (a.create_timestamp > b.create_timestamp ? -1 : 1),
+      render: (text) => <div title="Type">{formatDate(text) || EMPTY_FIELD}</div>,
+    },
+    {
+      dataIndex: "actions",
+      render: () => (
+        <div className="btn--middle flex">
+          <button type="button" onClick={() => {}}>
+            <img name="remove" src={TRASHCAN} alt="Remove Document" />
+          </button>
+        </div>
+      ),
+    },
+  ];
 
   return (
     <div>
@@ -18,32 +78,82 @@ export const ViewNoticeOfDepartureModal = (props) => {
         <h4 className="nod-modal-section-header">Basic Information</h4>
         <div className="content--light-grey nod-section-padding">
           <div className="inline-flex padding-sm">
-            <p className="field-title">Departure Project Title</p>
-            <p>{noticeOfDeparture.nod_title || Strings.EMPTY_FIELD}</p>
+            <p className="field-title margin-large--right">Departure Project Title</p>
+            <p>{noticeOfDeparture.nod_title || EMPTY_FIELD}</p>
           </div>
           <div className="inline-flex padding-sm">
-            <p className="field-title">Departure Summary</p>
-            <p>{noticeOfDeparture.nod_description || Strings.EMPTY_FIELD}</p>
+            <p className="field-title margin-large--right">Departure Summary</p>
+            <p>{noticeOfDeparture.nod_description || EMPTY_FIELD}</p>
           </div>
           <div className="inline-flex padding-sm">
-            <p className="field-title">Permit #</p>
-            <p>{noticeOfDeparture.permit.permit_no || Strings.EMPTY_FIELD}</p>
+            <p className="field-title margin-large--right">Permit #</p>
+            <p>{noticeOfDeparture?.permit.permit_no || EMPTY_FIELD}</p>
           </div>
           <div>
             <div className="inline-flex padding-sm">
-              <p className="field-title">NOD #</p>
-              <p>{noticeOfDeparture.key || Strings.EMPTY_FIELD}</p>
+              <p className="field-title margin-large--right">NOD #</p>
+              <p>{noticeOfDeparture.nod_guid || EMPTY_FIELD}</p>
             </div>
             <div className="inline-flex padding-sm">
-              <p className="field-title">Declared Type</p>
-              <p>{noticeOfDeparture.nod_type || Strings.EMPTY_FIELD}</p>
+              <p className="field-title margin-large--right">Declared Type</p>
+              <p>{NOTICE_OF_DEPARTURE_TYPE[noticeOfDeparture.nod_type] || EMPTY_FIELD}</p>
             </div>
           </div>
           <div className="inline-flex padding-sm">
-            <p className="field-title">Submitted</p>
-            <p>{noticeOfDeparture.submitted_at || Strings.EMPTY_FIELD}</p>
+            <p className="field-title margin-large--right">Mine Manager</p>
+            <p>{formatDate(noticeOfDeparture.mine_manager_name) || EMPTY_FIELD}</p>
+          </div>
+          <div className="inline-flex padding-sm">
+            <p className="field-title margin-large--right">Submitted</p>
+            <p>{formatDate(noticeOfDeparture.submission_timestamp) || EMPTY_FIELD}</p>
           </div>
         </div>
+        <h4 className="nod-modal-section-header padding-md--top">Self-Assessment Form</h4>
+        <CoreTable
+          condition
+          columns={fileColumns}
+          dataSource={[checklist]}
+          tableProps={{ pagination: false }}
+        />
+        <h4 className="nod-modal-section-header padding-md--top">Application Documentation</h4>
+        <CoreTable
+          condition
+          columns={fileColumns}
+          dataSource={otherDocuments}
+          tableProps={{ pagination: false }}
+        />
+        <Row justify="space-between" className="padding-md--top" gutter={24}>
+          <Col span={12}>
+            <p className="field-title">Technical Operations Director</p>
+            <p className="content--light-grey padding-md">{EMPTY_FIELD}</p>
+          </Col>
+          <Col span={12}>
+            <p className="field-title">NOD Review Status</p>
+            <p className="content--light-grey padding-md">
+              {NOTICE_OF_DEPARTURE_STATUS[noticeOfDeparture.nod_status] || EMPTY_FIELD}
+            </p>
+          </Col>
+        </Row>
+        <Row justify="space-between" className="padding-md--top">
+          <Col span={8}>
+            <div className="inline-flex padding-sm">
+              <p className="field-title">Created By</p>
+              <p>{noticeOfDeparture.created_by || EMPTY_FIELD}</p>
+            </div>
+          </Col>
+          <Col span={8}>
+            <div className="inline-flex padding-sm">
+              <p className="field-title">Updated By</p>
+              <p>{noticeOfDeparture.updated_by || EMPTY_FIELD}</p>
+            </div>
+          </Col>
+          <Col span={8}>
+            <div className="inline-flex padding-sm">
+              <p className="field-title">Updated Date</p>
+              <p>{formatDate(noticeOfDeparture.update_timestamp) || EMPTY_FIELD}</p>
+            </div>
+          </Col>
+        </Row>
       </div>
 
       <div className="right center-mobile">

--- a/services/core-web/src/styles/components/NoticeOfDeparture.scss
+++ b/services/core-web/src/styles/components/NoticeOfDeparture.scss
@@ -21,3 +21,7 @@
     color: #FFFFFF;
   }
 }
+
+.nod-table-link > a {
+  color: #333;
+}

--- a/services/core-web/src/styles/generic/layout.scss
+++ b/services/core-web/src/styles/generic/layout.scss
@@ -355,7 +355,19 @@ html {
 }
 
 .margin-large {
-  margin: $default-margin-lg;
+  &--left {
+    margin-left: $default-margin-lg !important;
+  }
+  &--right {
+    margin-right: $default-margin-lg !important;
+  }
+  &--top {
+    margin-top: $default-margin-lg !important;
+  }
+  &--bottom {
+    margin-bottom: $default-margin-lg !important;
+  }
+  margin: $default-margin-lg !important;
 }
 
 .margin-xlarge {

--- a/services/core-web/src/tests/actionCreators/noticeOfDepartureActionCreator.spec.js
+++ b/services/core-web/src/tests/actionCreators/noticeOfDepartureActionCreator.spec.js
@@ -97,7 +97,7 @@ describe("`fetchDetailedNoticeOfDeparture` action creator", () => {
     )(dispatch).then(() => {
       expect(requestSpy).toHaveBeenCalledTimes(1);
       expect(successSpy).toHaveBeenCalledTimes(1);
-      expect(dispatch).toHaveBeenCalledTimes(4);
+      expect(dispatch).toHaveBeenCalledTimes(5);
     });
   });
 

--- a/services/core-web/src/tests/components/modalContent/ViewNoticeOfDepartureModal.spec.js
+++ b/services/core-web/src/tests/components/modalContent/ViewNoticeOfDepartureModal.spec.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { shallow } from "enzyme";
-import * as Mock from "@/tests/mocks/dataMocks";
 import ViewNoticeOfDepartureModal from "@/components/modalContent/ViewNoticeOfDepartureModal";
+import { NOTICE_OF_DEPARTURE_DETAILS } from "@/tests/mocks/dataMocks";
 
 const dispatchProps = {};
 const props = {};
@@ -12,7 +12,7 @@ const setupDispatchProps = () => {
 
 const setupProps = () => {
   // eslint-disable-next-line prefer-destructuring
-  props.noticeOfDeparture = Mock.NOTICES_OF_DEPARTURE.records[0];
+  props.noticeOfDeparture = NOTICE_OF_DEPARTURE_DETAILS;
 };
 
 beforeEach(() => {

--- a/services/core-web/src/tests/components/modalContent/__snapshots__/ViewNoticeOfDepartureModal.spec.js.snap
+++ b/services/core-web/src/tests/components/modalContent/__snapshots__/ViewNoticeOfDepartureModal.spec.js.snap
@@ -15,36 +15,36 @@ exports[`ViewNoticeOfDepartureModal renders properly 1`] = `
         className="inline-flex padding-sm"
       >
         <p
-          className="field-title"
+          className="field-title margin-large--right"
         >
           Departure Project Title
         </p>
         <p>
-          Some title
+          Test with checklist 1
         </p>
       </div>
       <div
         className="inline-flex padding-sm"
       >
         <p
-          className="field-title"
+          className="field-title margin-large--right"
         >
           Departure Summary
         </p>
         <p>
-          Some description
+          Checklist description
         </p>
       </div>
       <div
         className="inline-flex padding-sm"
       >
         <p
-          className="field-title"
+          className="field-title margin-large--right"
         >
           Permit #
         </p>
         <p>
-          M-7594809
+          CX-6515762
         </p>
       </div>
       <div>
@@ -52,24 +52,24 @@ exports[`ViewNoticeOfDepartureModal renders properly 1`] = `
           className="inline-flex padding-sm"
         >
           <p
-            className="field-title"
+            className="field-title margin-large--right"
           >
             NOD #
           </p>
           <p>
-            N/A
+            56c75a01-248f-4e2c-961a-131790205682
           </p>
         </div>
         <div
           className="inline-flex padding-sm"
         >
           <p
-            className="field-title"
+            className="field-title margin-large--right"
           >
             Declared Type
           </p>
           <p>
-            potentially_substaintial
+            Potentially Substantial
           </p>
         </div>
       </div>
@@ -77,15 +77,212 @@ exports[`ViewNoticeOfDepartureModal renders properly 1`] = `
         className="inline-flex padding-sm"
       >
         <p
-          className="field-title"
+          className="field-title margin-large--right"
         >
-          Submitted
+          Mine Manager
         </p>
         <p>
           N/A
         </p>
       </div>
+      <div
+        className="inline-flex padding-sm"
+      >
+        <p
+          className="field-title margin-large--right"
+        >
+          Submitted
+        </p>
+        <p>
+          May 05 2022
+        </p>
+      </div>
     </div>
+    <h4
+      className="nod-modal-section-header padding-md--top"
+    >
+      Self-Assessment Form
+    </h4>
+    <CoreTable
+      columns={
+        Array [
+          Object {
+            "dataIndex": "document_name",
+            "render": [Function],
+            "sortField": "document_name",
+            "sorter": [Function],
+            "title": "Name",
+          },
+          Object {
+            "dataIndex": "document_category",
+            "render": [Function],
+            "sortField": "document_category",
+            "sorter": [Function],
+            "title": "Category",
+          },
+          Object {
+            "dataIndex": "create_timestamp",
+            "render": [Function],
+            "sortField": "create_timestamp",
+            "sorter": [Function],
+            "title": "Uploaded",
+          },
+          Object {
+            "dataIndex": "actions",
+            "render": [Function],
+          },
+        ]
+      }
+      condition={true}
+      dataSource={
+        Array [
+          Object {
+            "create_timestamp": "2022-05-05T15:44:49.419460+00:00",
+            "document_manager_guid": "8e1e0182-fef4-4f93-b76a-d2b65b6f3908",
+            "document_name": "Excel_Comments_Template.xlsx",
+            "document_type": "checklist",
+            "mine_document_guid": "f678c3b6-8514-43fb-a147-a6caf5deeb50",
+            "mine_guid": "29050da9-5d9e-4a80-9f6d-1d06f02fc589",
+            "upload_date": null,
+          },
+        ]
+      }
+      tableProps={
+        Object {
+          "pagination": false,
+        }
+      }
+    />
+    <h4
+      className="nod-modal-section-header padding-md--top"
+    >
+      Application Documentation
+    </h4>
+    <CoreTable
+      columns={
+        Array [
+          Object {
+            "dataIndex": "document_name",
+            "render": [Function],
+            "sortField": "document_name",
+            "sorter": [Function],
+            "title": "Name",
+          },
+          Object {
+            "dataIndex": "document_category",
+            "render": [Function],
+            "sortField": "document_category",
+            "sorter": [Function],
+            "title": "Category",
+          },
+          Object {
+            "dataIndex": "create_timestamp",
+            "render": [Function],
+            "sortField": "create_timestamp",
+            "sorter": [Function],
+            "title": "Uploaded",
+          },
+          Object {
+            "dataIndex": "actions",
+            "render": [Function],
+          },
+        ]
+      }
+      condition={true}
+      dataSource={Array []}
+      tableProps={
+        Object {
+          "pagination": false,
+        }
+      }
+    />
+    <Row
+      className="padding-md--top"
+      gutter={24}
+      justify="space-between"
+    >
+      <Col
+        span={12}
+      >
+        <p
+          className="field-title"
+        >
+          Technical Operations Director
+        </p>
+        <p
+          className="content--light-grey padding-md"
+        >
+          N/A
+        </p>
+      </Col>
+      <Col
+        span={12}
+      >
+        <p
+          className="field-title"
+        >
+          NOD Review Status
+        </p>
+        <p
+          className="content--light-grey padding-md"
+        >
+          Pending Preview
+        </p>
+      </Col>
+    </Row>
+    <Row
+      className="padding-md--top"
+      justify="space-between"
+    >
+      <Col
+        span={8}
+      >
+        <div
+          className="inline-flex padding-sm"
+        >
+          <p
+            className="field-title"
+          >
+            Created By
+          </p>
+          <p>
+            N/A
+          </p>
+        </div>
+      </Col>
+      <Col
+        span={8}
+      >
+        <div
+          className="inline-flex padding-sm"
+        >
+          <p
+            className="field-title"
+          >
+            Updated By
+          </p>
+          <p>
+            N/A
+          </p>
+        </div>
+      </Col>
+      <Col
+        span={8}
+      >
+        <div
+          className="inline-flex padding-sm"
+        >
+          <p
+            className="field-title"
+          >
+            Updated Date
+          </p>
+          <p>
+            May 05 2022
+          </p>
+        </div>
+      </Col>
+    </Row>
   </div>
   <div
     className="right center-mobile"

--- a/services/minespace-web/common/actionCreators/noticeOfDepartureActionCreator.js
+++ b/services/minespace-web/common/actionCreators/noticeOfDepartureActionCreator.js
@@ -15,7 +15,10 @@ import {
   NOTICE_OF_DEPARTURE,
 } from "../constants/API";
 import { createRequestHeader } from "../utils/RequestHeaders";
-import { storeNoticesOfDeparture } from "../actions/noticeOfDepartureActions";
+import {
+  storeNoticesOfDeparture,
+  storeNoticeOfDeparture,
+} from "../actions/noticeOfDepartureActions";
 
 export const createNoticeOfDeparture = (mine_guid, payload) => (dispatch) => {
   dispatch(request(CREATE_NOTICE_OF_DEPARTURE));
@@ -59,6 +62,7 @@ export const fetchDetailedNoticeOfDeparture = (mine_guid, nod_guid) => (dispatch
     .get(`${ENVIRONMENT.apiUrl}${NOTICE_OF_DEPARTURE(mine_guid, nod_guid)}`, createRequestHeader())
     .then((response) => {
       dispatch(success(GET_DETAILED_NOTICE_OF_DEPARTURE));
+      dispatch(storeNoticeOfDeparture(response.data));
       return response;
     })
     .catch(() => dispatch(error(GET_DETAILED_NOTICE_OF_DEPARTURE)))

--- a/services/minespace-web/common/constants/strings.js
+++ b/services/minespace-web/common/constants/strings.js
@@ -127,3 +127,14 @@ export const NOTICE_OF_DEPARTURE_DOCUMENT_TYPE = {
   CHECKLIST: "checklist",
   OTHER: "other",
 };
+
+export const NOTICE_OF_DEPARTURE_TYPE = {
+  non_substantial: "Non Substantial",
+  potentially_substantial: "Potentially Substantial",
+};
+
+export const NOTICE_OF_DEPARTURE_STATUS = {
+  pending_review: "Pending Preview",
+  in_review: "In Review",
+  self_authorized: "Self Authorized",
+};


### PR DESCRIPTION
## Objective 

[MDS-](https://bcmines.atlassian.net/browse/MDS-####)

- Added self-assessment document to `CORE` notice of departure detailed modal view
- File is downloadable by clicking on the file name
- Additional application documentation will display properly, but it doesn't exist yet, so will currently show `No Data Yet`
- Added info fields as required in the AC
- Left `Technical Operations Director` and `NOD Review Status` fields as static text for now.  They will be converted to select fields in a future ticket.

## Additional Information / Context 
![image](https://user-images.githubusercontent.com/83598933/167507639-828ccdd3-c466-44e0-81f3-3c426ee29797.png)
