### PR TITLE
added check for checklist before delete

### DIFF
--- a/services/core-api/app/api/mines/notice_of_departure/models/notice_of_departure_document_xref.py
+++ b/services/core-api/app/api/mines/notice_of_departure/models/notice_of_departure_document_xref.py
@@ -38,4 +38,5 @@ class NoticeOfDepartureDocumentXref(SoftDeleteMixin, AuditMixin, Base):
     def delete_current_checklist(cls, nod_guid):
         checklist = cls.query.filter_by(
             nod_guid=nod_guid, deleted_ind=False, document_type='checklist').first()
-        checklist.delete()
+        if checklist:
+            checklist.delete()


### PR DESCRIPTION
## Objective 

- Added an `if checklist` check before deleting the old checklist on a nod put.
- This was causing new nods to fail since the initial addition of the self-assessment form is a put (when there isn't a previous one to delete
