### PR TITLE
Set nod_status based on nod_type from minespace

### DIFF
--- a/services/core-api/app/api/mines/notice_of_departure/resources/notice_of_departure.py
+++ b/services/core-api/app/api/mines/notice_of_departure/resources/notice_of_departure.py
@@ -47,12 +47,18 @@ class NoticeOfDepartureResource(Resource, UserMixin):
             location='json',
             required=True,
             store_missing=False)
+        parser.add_argument(
+            'nod_status',
+            type=str,
+            help='Notice of Departure Status',
+            location='json',
+            store_missing=False)
         data = parser.parse_args()
 
         nod.nod_title = data.get('nod_title')
         nod.nod_description = data.get('nod_description')
+        nod.nod_status = NodStatus[data.get('nod_status')]
         nod.nod_type = NodType[data.get('nod_type')]
-        nod.nod_status = NodStatus.pending_review
 
         nod.save()
 

--- a/services/core-api/app/api/mines/notice_of_departure/resources/notice_of_departure_list.py
+++ b/services/core-api/app/api/mines/notice_of_departure/resources/notice_of_departure_list.py
@@ -76,6 +76,12 @@ class NoticeOfDepartureListResource(Resource, UserMixin):
             location='json',
             required=True,
             store_missing=False)
+        parser.add_argument(
+            'nod_status',
+            type=str,
+            help='Notice of Departure Status',
+            location='json',
+            store_missing=False)
         data = parser.parse_args()
 
         permit_guid = data.get('permit_guid')
@@ -84,14 +90,13 @@ class NoticeOfDepartureListResource(Resource, UserMixin):
 
         if not permit:
             raise NotFound('Either permit does not exist or does not belong to the mine')
-
         new_nod = NoticeOfDeparture.create(
             permit._context_mine,
             permit,
             nod_title=data.get('nod_title'),
             nod_description=data.get('nod_description'),
             nod_type=NodType[data.get('nod_type')],
-            nod_status=NodStatus.pending_review)
+            nod_status=NodStatus[data.get('nod_status')])
         new_nod.save()
 
         return new_nod

--- a/services/core-web/common/constants/strings.js
+++ b/services/core-web/common/constants/strings.js
@@ -142,12 +142,10 @@ export const NOTICE_OF_DEPARTURE_STATUS = {
   pending_review: "Pending Preview",
   in_review: "In Review",
   self_authorized: "Self Authorized",
-  ministry_authorized: "Ministry Authorized",
 };
 
 export const NOTICE_OF_DEPARTURE_STATUS_VALUES = {
   pending_review: "pending_review",
   in_review: "in_review",
   self_authorized: "self_authorized",
-  ministry_authorized: "ministry_authorized",
 };

--- a/services/core-web/common/constants/strings.js
+++ b/services/core-web/common/constants/strings.js
@@ -133,8 +133,21 @@ export const NOTICE_OF_DEPARTURE_TYPE = {
   potentially_substantial: "Potentially Substantial",
 };
 
+export const NOTICE_OF_DEPARTURE_TYPE_VALUES = {
+  non_substantial: "non_substantial",
+  potentially_substantial: "potentially_substantial",
+};
+
 export const NOTICE_OF_DEPARTURE_STATUS = {
   pending_review: "Pending Preview",
   in_review: "In Review",
   self_authorized: "Self Authorized",
+  ministry_authorized: "Ministry Authorized",
+};
+
+export const NOTICE_OF_DEPARTURE_STATUS_VALUES = {
+  pending_review: "pending_review",
+  in_review: "in_review",
+  self_authorized: "self_authorized",
+  ministry_authorized: "ministry_authorized",
 };

--- a/services/minespace-web/common/constants/strings.js
+++ b/services/minespace-web/common/constants/strings.js
@@ -142,12 +142,10 @@ export const NOTICE_OF_DEPARTURE_STATUS = {
   pending_review: "Pending Preview",
   in_review: "In Review",
   self_authorized: "Self Authorized",
-  ministry_authorized: "Ministry Authorized",
 };
 
 export const NOTICE_OF_DEPARTURE_STATUS_VALUES = {
   pending_review: "pending_review",
   in_review: "in_review",
   self_authorized: "self_authorized",
-  ministry_authorized: "ministry_authorized",
 };

--- a/services/minespace-web/common/constants/strings.js
+++ b/services/minespace-web/common/constants/strings.js
@@ -133,8 +133,21 @@ export const NOTICE_OF_DEPARTURE_TYPE = {
   potentially_substantial: "Potentially Substantial",
 };
 
+export const NOTICE_OF_DEPARTURE_TYPE_VALUES = {
+  non_substantial: "non_substantial",
+  potentially_substantial: "potentially_substantial",
+};
+
 export const NOTICE_OF_DEPARTURE_STATUS = {
   pending_review: "Pending Preview",
   in_review: "In Review",
   self_authorized: "Self Authorized",
+  ministry_authorized: "Ministry Authorized",
+};
+
+export const NOTICE_OF_DEPARTURE_STATUS_VALUES = {
+  pending_review: "pending_review",
+  in_review: "in_review",
+  self_authorized: "self_authorized",
+  ministry_authorized: "ministry_authorized",
 };

--- a/services/minespace-web/src/components/dashboard/mine/noticeOfDeparture/NoticeOfDeparture.js
+++ b/services/minespace-web/src/components/dashboard/mine/noticeOfDeparture/NoticeOfDeparture.js
@@ -20,6 +20,10 @@ import { modalConfig } from "@/components/modalContent/config";
 import CustomPropTypes from "@/customPropTypes";
 import { AuthorizationGuard } from "@/HOC/AuthorizationGuard";
 import * as Permission from "@/constants/permissions";
+import {
+  NOTICE_OF_DEPARTURE_TYPE_VALUES,
+  NOTICE_OF_DEPARTURE_STATUS_VALUES,
+} from "@common/constants/strings";
 
 const propTypes = {
   mine: CustomPropTypes.mine.isRequired,
@@ -72,12 +76,18 @@ export const NoticeOfDeparture = (props) => {
 
   const handleCreateNoticeOfDeparture = (permit_guid, values, documentArray) => {
     setIsLoaded(false);
-    return props.createNoticeOfDeparture(mine.mine_guid, values).then(async (response) => {
-      const { nod_guid } = response.data;
-      await handleAddDocuments(documentArray, nod_guid);
-      props.closeModal();
-      handleFetchNoticesOfDeparture();
-    });
+    const nod_status =
+      values.nod_type === NOTICE_OF_DEPARTURE_TYPE_VALUES.non_substantial
+        ? NOTICE_OF_DEPARTURE_STATUS_VALUES.self_authorized
+        : NOTICE_OF_DEPARTURE_STATUS_VALUES.pending_review;
+    return props
+      .createNoticeOfDeparture(mine.mine_guid, { ...values, nod_status })
+      .then(async (response) => {
+        const { nod_guid } = response.data;
+        await handleAddDocuments(documentArray, nod_guid);
+        props.closeModal();
+        handleFetchNoticesOfDeparture();
+      });
   };
 
   const handleUpdateNoticeOfDeparture = (nodGuid, values, documentArray) => {


### PR DESCRIPTION
## Objective 

When a user selects `non_substantial` for the nod type Minespace will pass an `nod_status` of `self_authorized`, otherwise it will pass an `nod_status` of `pending_review`.

## Additional Information / Context 

![image](https://user-images.githubusercontent.com/83598933/168380608-68684428-a3d3-495d-82b8-f2e5e49d6d49.png)

