### PR TITLE
Update NOD Core list view status display

### DIFF
--- a/services/core-api/app/api/mines/notice_of_departure/models/notice_of_departure.py
+++ b/services/core-api/app/api/mines/notice_of_departure/models/notice_of_departure.py
@@ -21,7 +21,8 @@ class NodStatus(Enum):
     permit_amendment_required = auto(),
     additional_information_required = auto(),
     not_authorized = auto(),
-    withdrawn = auto()
+    withdrawn = auto(),
+    ministry_authorized = auto(),
 
 
 class NoticeOfDeparture(SoftDeleteMixin, AuditMixin, Base):

--- a/services/core-web/src/components/mine/NoticeOfDeparture/MineNoticeOfDepartureTable.js
+++ b/services/core-web/src/components/mine/NoticeOfDeparture/MineNoticeOfDepartureTable.js
@@ -3,20 +3,13 @@ import PropTypes from "prop-types";
 import { Button } from "antd";
 import { connect } from "react-redux";
 import { formatDate } from "@common/utils/helpers";
-import * as Strings from "@common/constants/strings";
+import {
+  NOTICE_OF_DEPARTURE_TYPE,
+  NOTICE_OF_DEPARTURE_STATUS,
+  EMPTY_FIELD,
+} from "@common/constants/strings";
 import CustomPropTypes from "@/customPropTypes";
 import CoreTable from "@/components/common/CoreTable";
-
-const NoticeOfDepartureType = {
-  non_substantial: "Non Substantial",
-  potentially_substantial: "Potentially Substantial",
-};
-
-const NoticeOfDepartureStatus = {
-  pending_review: "Pending Preview",
-  in_review: "In Review",
-  self_authorized: "Self Authorized",
-};
 
 const propTypes = {
   nods: PropTypes.arrayOf(CustomPropTypes.noticeOfDeparture).isRequired,
@@ -57,8 +50,8 @@ export class MineNoticeOfDepartureTable extends Component {
         ...other,
         key: nod_guid,
         nod_id: nod_guid,
-        nod_status: NoticeOfDepartureStatus[nod_status] || Strings.EMPTY_FIELD,
-        nod_type: NoticeOfDepartureType[nod_type] || Strings.EMPTY_FIELD,
+        nod_status: NOTICE_OF_DEPARTURE_STATUS[nod_status] || EMPTY_FIELD,
+        nod_type: NOTICE_OF_DEPARTURE_TYPE[nod_type] || EMPTY_FIELD,
         updated_at: formatDate(update_timestamp),
         submitted_at: formatDate(submission_timestamp) || formatDate(create_timestamp),
       })
@@ -71,7 +64,7 @@ export class MineNoticeOfDepartureTable extends Component {
         dataIndex: "nod_title",
         sortField: "nod_title",
         sorter: (a, b) => (a.nod_title > b.nod_title ? -1 : 1),
-        render: (text) => <div title="Code">{text || Strings.EMPTY_FIELD}</div>,
+        render: (text) => <div title="Code">{text || EMPTY_FIELD}</div>,
       },
       {
         title: "NOD",
@@ -89,28 +82,28 @@ export class MineNoticeOfDepartureTable extends Component {
         dataIndex: "nod_type",
         sortField: "nod_type",
         sorter: (a, b) => (a.nod_type > b.nod_type ? -1 : 1),
-        render: (text) => <div title="Type">{text || Strings.EMPTY_FIELD}</div>,
+        render: (text) => <div title="Type">{text || EMPTY_FIELD}</div>,
       },
       {
         title: "Status",
         dataIndex: "nod_status",
         sortField: "nod_status",
         sorter: (a, b) => (a.nod_status > b.nod_status ? -1 : 1),
-        render: (text) => <div title="Status">{text || Strings.EMPTY_FIELD}</div>,
+        render: (text) => <div title="Status">{text || EMPTY_FIELD}</div>,
       },
       {
         title: "Submitted",
         dataIndex: "submitted_at",
         sortField: "submitted_at",
         sorter: (a, b) => (a.submitted_at > b.submitted_at ? -1 : 1),
-        render: (text) => <div title="Submission Date">{text || Strings.EMPTY_FIELD}</div>,
+        render: (text) => <div title="Submission Date">{text || EMPTY_FIELD}</div>,
       },
       {
         title: "Updated",
         dataIndex: "updated_at",
         sortField: "updated_at",
         sorter: (a, b) => (a.updated_at > b.updated_at ? -1 : 1),
-        render: (text) => <div title="Update Date">{text || Strings.EMPTY_FIELD}</div>,
+        render: (text) => <div title="Update Date">{text || EMPTY_FIELD}</div>,
       },
       {
         dataIndex: "actions",

--- a/services/core-web/src/components/modalContent/ViewNoticeOfDepartureModal.js
+++ b/services/core-web/src/components/modalContent/ViewNoticeOfDepartureModal.js
@@ -7,8 +7,8 @@ import {
   EMPTY_FIELD,
   NOTICE_OF_DEPARTURE_DOCUMENT_TYPE,
   NOTICE_OF_DEPARTURE_STATUS,
-  NOTICE_OF_DEPARTURE_TYPE,
   NOTICE_OF_DEPARTURE_STATUS_VALUES,
+  NOTICE_OF_DEPARTURE_TYPE,
 } from "@common/constants/strings";
 import CustomPropTypes from "@/customPropTypes";
 import CoreTable from "@/components/common/CoreTable";
@@ -18,9 +18,9 @@ import { downloadFileFromDocumentManager } from "@common/utils/actionlessNetwork
 import { formatDate } from "@common/utils/helpers";
 import {
   fetchDetailedNoticeOfDeparture,
+  fetchNoticesOfDeparture,
   removeFileFromDocumentManager,
   updateNoticeOfDeparture,
-  fetchNoticesOfDeparture,
 } from "@common/actionCreators/noticeOfDepartureActionCreator";
 import { getNoticeOfDeparture } from "@common/selectors/noticeOfDepartureSelectors";
 
@@ -28,6 +28,7 @@ const propTypes = {
   closeModal: PropTypes.func.isRequired,
   noticeOfDeparture: CustomPropTypes.noticeOfDeparture.isRequired,
   fetchDetailedNoticeOfDeparture: PropTypes.func.isRequired,
+  fetchNoticesOfDeparture: PropTypes.func.isRequired,
   updateNoticeOfDeparture: PropTypes.func.isRequired,
   mine: CustomPropTypes.mine.isRequired,
 };
@@ -50,18 +51,20 @@ export const ViewNoticeOfDepartureModal = (props) => {
   };
 
   const statuses = (() => {
-    const { self_authorized, ...coreStatuses} = NOTICE_OF_DEPARTURE_STATUS_VALUES;
+    const { self_authorized, ...coreStatuses } = NOTICE_OF_DEPARTURE_STATUS_VALUES;
     return Object.values(coreStatuses);
   })();
 
+  // eslint-disable-next-line no-return-assign
+  const handleChangeNodStatus = ({ value }) => (props.noticeOfDeparture.nod_status = value);
 
-  const handleChangeNodStatus = ({value}) => props.noticeOfDeparture.nod_status = value;
-
-  const updateNoticeOfDepartureStatus = async () => { 
-    await props.updateNoticeOfDeparture({ mineGuid: mine.mine_guid, nodGuid: nod_guid }, noticeOfDeparture );
+  const updateNoticeOfDepartureStatus = async () => {
+    await props.updateNoticeOfDeparture(
+      { mineGuid: mine.mine_guid, nodGuid: nod_guid },
+      noticeOfDeparture
+    );
     await props.fetchNoticesOfDeparture(mine.mine_guid);
     props.closeModal();
-
   };
 
   const fileColumns = (isSortable) => {
@@ -191,7 +194,13 @@ export const ViewNoticeOfDepartureModal = (props) => {
                 virtual={false}
                 labelInValue
                 onChange={handleChangeNodStatus}
-                defaultValue={{ value: noticeOfDeparture.nod_status }}
+                defaultValue={{
+                  value:
+                    noticeOfDeparture.nod_status !==
+                    NOTICE_OF_DEPARTURE_STATUS_VALUES.self_authorized
+                      ? noticeOfDeparture.nod_status
+                      : NOTICE_OF_DEPARTURE_STATUS.self_authorized,
+                }}
                 style={{ width: "100%" }}
               >
                 {statuses.map((value) => (
@@ -254,7 +263,7 @@ const mapDispatchToProps = (dispatch) =>
     {
       fetchDetailedNoticeOfDeparture,
       updateNoticeOfDeparture,
-      fetchNoticesOfDeparture
+      fetchNoticesOfDeparture,
     },
     dispatch
   );


### PR DESCRIPTION
## Objective 

[MDS-4419](https://bcmines.atlassian.net/browse/MDS-4419)

- Connected NOD list view status to the common string folder
- Added `ministry_authorized` to the enum in the API for saving
- added `fetchNoticesOfDeparture` to the propTypes in `ViewNoticeOfDepartureModal`

## Additional Information / Context 

![image](https://user-images.githubusercontent.com/83598933/168908716-66fa2001-1ef0-419e-9c3a-1e382af756f2.png)

