### PR TITLE
MDS-4175 & MDS-4430 - NOD additional Docs - Blank NOD link

### DIFF
--- a/services/core-api/app/api/mines/notice_of_departure/models/notice_of_departure.py
+++ b/services/core-api/app/api/mines/notice_of_departure/models/notice_of_departure.py
@@ -43,8 +43,8 @@ class NoticeOfDeparture(SoftDeleteMixin, AuditMixin, Base):
         'NoticeOfDepartureDocumentXref',
         lazy='select',
         primaryjoin=
-        "and_(NoticeOfDeparture.nod_guid==NoticeOfDepartureDocumentXref.nod_guid, NoticeOfDepartureDocumentXref.deleted_ind==False)"
-    )
+        "and_(NoticeOfDeparture.nod_guid==NoticeOfDepartureDocumentXref.nod_guid, NoticeOfDepartureDocumentXref.deleted_ind==False)",
+        order_by='desc(NoticeOfDepartureDocumentXref.create_timestamp)')
 
     mine_documents = db.relationship(
         'MineDocument',

--- a/services/core-web/src/components/modalContent/ViewNoticeOfDepartureModal.js
+++ b/services/core-web/src/components/modalContent/ViewNoticeOfDepartureModal.js
@@ -74,13 +74,10 @@ export const ViewNoticeOfDepartureModal = (props) => {
         dataIndex: "document_name",
         sortField: "document_name",
         sorter: isSortable ? (a, b) => a.document_name.localeCompare(b.document_name) : false,
-        render: (text) => (
+        render: (text, record) => (
           <div className="nod-table-link">
             {text ? (
-              <LinkButton
-                onClick={() => downloadFileFromDocumentManager(checklist[0])}
-                title="Download"
-              >
+              <LinkButton onClick={() => downloadFileFromDocumentManager(record)} title="Download">
                 {text}
               </LinkButton>
             ) : (
@@ -107,7 +104,7 @@ export const ViewNoticeOfDepartureModal = (props) => {
       },
       {
         dataIndex: "actions",
-        render: () => (
+        render: (text, record) => (
           <div className="btn--middle flex">
             <Popconfirm
               placement="topRight"
@@ -116,7 +113,7 @@ export const ViewNoticeOfDepartureModal = (props) => {
                 handleDeleteANoticeOfDepartureDocument({
                   mine_guid: mine.mine_guid,
                   nod_guid,
-                  ...checklist[0],
+                  ...record,
                 })
               }
               okText="Yes"

--- a/services/minespace-web/src/components/Forms/noticeOfDeparture/AddNoticeOfDepartureForm.js
+++ b/services/minespace-web/src/components/Forms/noticeOfDeparture/AddNoticeOfDepartureForm.js
@@ -189,6 +189,36 @@ const AddNoticeOfDepartureForm = (props) => {
             validate={[required]}
           />
         </Form.Item>
+        <h4 className="nod-modal-section-header">Upload Application Documents</h4>
+        <Typography.Text>
+          Please support your notice of departure by uploading additional supporting application
+          documents. These items documents can include:
+        </Typography.Text>
+        <ul>
+          <li>A detailed project description</li>
+          <li>Location (with map, showing Mine boundary)</li>
+          <li>Total disturbance area</li>
+          <li>Total new disturbance area</li>
+          <li>Relevant supporting info (management plans, field surveys, etc...)</li>
+        </ul>
+        <Form.Item className="margin-y-large">
+          <Field
+            onFileLoad={(documentName, document_manager_guid) => {
+              onFileLoad(
+                documentName,
+                document_manager_guid,
+                NOTICE_OF_DEPARTURE_DOCUMENT_TYPE.OTHER
+              );
+            }}
+            onRemoveFile={onRemoveFile}
+            mineGuid={mineGuid}
+            allowMultiple
+            component={NoticeOfDepartureFileUpload}
+            acceptedFileTypesMap={{ ...DOCUMENT, ...EXCEL }}
+            uploadType={NOTICE_OF_DEPARTURE_DOCUMENT_TYPE.OTHER}
+            validate={[required]}
+          />
+        </Form.Item>
         <div className="ant-modal-footer">
           <Popconfirm
             placement="top"

--- a/services/minespace-web/src/components/Forms/noticeOfDeparture/EditNoticeOfDepartureForm.js
+++ b/services/minespace-web/src/components/Forms/noticeOfDeparture/EditNoticeOfDepartureForm.js
@@ -41,6 +41,10 @@ let AddNoticeOfDepartureForm = (props) => {
     (doc) => doc.document_type === NOTICE_OF_DEPARTURE_DOCUMENT_TYPE.CHECKLIST
   );
 
+  const otherDocuments = noticeOfDeparture.documents.filter(
+    (doc) => doc.document_type !== NOTICE_OF_DEPARTURE_DOCUMENT_TYPE.CHECKLIST
+  );
+
   const handleNoticeOfDepartureSubmit = (values) => {
     setSubmitting(true);
     onSubmit(nod_guid, values, documentArray).finally(() => setSubmitting(false));
@@ -145,9 +149,16 @@ let AddNoticeOfDepartureForm = (props) => {
           Upload Notice of Departure Self-Assessment Form
         </h4>
         <Typography.Text>
-          Please upload your completed Self-assessment form (click here to download) below. Remember
-          your completed form must be signed by the Mine Manager and any supporting information
-          included or uploaded.
+          Please upload your completed Self-assessment form (
+          <a
+            href="https://www2.gov.bc.ca/gov/content/industry/mineral-exploration-mining/permitting/mines-act-permits/mines-act-departures-from-approval"
+            target="_blank"
+            rel="noreferrer"
+          >
+            click here to download
+          </a>
+          ) below. Remember your completed form must be signed by the Mine Manager and any
+          supporting information included or uploaded.
         </Typography.Text>
         <Form.Item className="margin-y-large">
           <Field
@@ -189,6 +200,70 @@ let AddNoticeOfDepartureForm = (props) => {
             </LinkButton>
           </Col>
         </Row>
+        <h4 className="nod-modal-section-header">Upload Application Documents</h4>
+        <Typography.Text>
+          Please support your notice of departure by uploading additional supporting application
+          documents. These items documents can include:
+        </Typography.Text>
+        <ul>
+          <li>A detailed project description</li>
+          <li>Location (with map, showing Mine boundary)</li>
+          <li>Total disturbance area</li>
+          <li>Total new disturbance area</li>
+          <li>Relevant supporting info (management plans, field surveys, etc...)</li>
+        </ul>
+        <Form.Item className="margin-y-large">
+          <Field
+            onFileLoad={(documentName, document_manager_guid) => {
+              onFileLoad(
+                documentName,
+                document_manager_guid,
+                NOTICE_OF_DEPARTURE_DOCUMENT_TYPE.OTHER
+              );
+            }}
+            onRemoveFile={onRemoveFile}
+            mineGuid={mineGuid}
+            allowMultiple
+            component={NoticeOfDepartureFileUpload}
+            acceptedFileTypesMap={{ ...DOCUMENT, ...EXCEL }}
+            uploadType={NOTICE_OF_DEPARTURE_DOCUMENT_TYPE.OTHER}
+            validate={[required]}
+          />
+        </Form.Item>
+        {otherDocuments.length > 0 && (
+          <div>
+            <Row>
+              <Col span={16}>
+                <p className="field-title">Uploaded File</p>
+              </Col>
+              <Col span={5}>
+                <p className="field-title">Upload Date</p>
+              </Col>
+              <Col span={3}>
+                <p className="field-title">&nbsp;</p>
+              </Col>
+            </Row>
+            {otherDocuments.map((document) => (
+              <Row>
+                <Col span={16}>
+                  <p>{document?.document_name || EMPTY_FIELD}</p>
+                </Col>
+                <Col span={5}>
+                  <p>{formatDate(document?.create_timestamp) || EMPTY_FIELD}</p>
+                </Col>
+                <Col span={3}>
+                  <LinkButton
+                    className="nod-table-link"
+                    onClick={() => downloadFileFromDocumentManager(document)}
+                    title={document?.document_name}
+                  >
+                    Download
+                  </LinkButton>
+                </Col>
+              </Row>
+            ))}
+          </div>
+        )}
         <div className="ant-modal-footer">
           <Popconfirm
             placement="top"

--- a/services/minespace-web/src/components/dashboard/mine/noticeOfDeparture/NoticeOfDepartureDetails.js
+++ b/services/minespace-web/src/components/dashboard/mine/noticeOfDeparture/NoticeOfDepartureDetails.js
@@ -1,15 +1,13 @@
 import React from "react";
 import { Col, Divider, Row } from "antd";
 import { downloadFileFromDocumentManager } from "@common/utils/actionlessNetworkCalls";
-import { NOTICE_OF_DEPARTURE_DOCUMENT_TYPE } from "@common/constants/strings";
-import CustomPropTypes from "@/customPropTypes";
 import {
   EMPTY_FIELD,
-} from "@/constants/strings";
-import {
+  NOTICE_OF_DEPARTURE_DOCUMENT_TYPE,
+  NOTICE_OF_DEPARTURE_STATUS,
   NOTICE_OF_DEPARTURE_TYPE,
-  NOTICE_OF_DEPARTURE_STATUS
 } from "@common/constants/strings";
+import CustomPropTypes from "@/customPropTypes";
 import LinkButton from "@/components/common/LinkButton";
 import { formatDate } from "@/utils/helpers";
 
@@ -29,9 +27,15 @@ export const NoticeOfDepartureDetails = (props) => {
     documents,
     submission_timestamp,
   } = noticeOfDeparture;
+
   const checklist =
     documents.find((doc) => doc.document_type === NOTICE_OF_DEPARTURE_DOCUMENT_TYPE.CHECKLIST) ||
     {};
+
+  const otherDocuments = noticeOfDeparture.documents.filter(
+    (doc) => doc.document_type !== NOTICE_OF_DEPARTURE_DOCUMENT_TYPE.CHECKLIST
+  );
+
   const submitted = formatDate(submission_timestamp);
 
   return (
@@ -83,11 +87,11 @@ export const NoticeOfDepartureDetails = (props) => {
             <p className="field-title">Uploaded File(s)</p>
             <p>{checklist.document_name || EMPTY_FIELD}</p>
           </Col>
-          <Col>
+          <Col span={5}>
             <p className="field-title">Upload Date</p>
             <p>{formatDate(checklist.create_timestamp) || EMPTY_FIELD}</p>
           </Col>
-          <Col>
+          <Col span={3}>
             <p className="field-title">&nbsp;</p>
             <p>
               {checklist.document_name ? (
@@ -103,6 +107,41 @@ export const NoticeOfDepartureDetails = (props) => {
             </p>
           </Col>
         </Row>
+        {otherDocuments.length > 0 && (
+          <div>
+            <h4 className="nod-modal-section-header">Application Documentation</h4>
+            <Row>
+              <Col span={16}>
+                <p className="field-title">Uploaded File</p>
+              </Col>
+              <Col span={5}>
+                <p className="field-title">Upload Date</p>
+              </Col>
+              <Col span={3}>
+                <p className="field-title">&nbsp;</p>
+              </Col>
+            </Row>
+            {otherDocuments.map((document) => (
+              <Row>
+                <Col span={16}>
+                  <p>{document?.document_name || EMPTY_FIELD}</p>
+                </Col>
+                <Col span={5}>
+                  <p>{formatDate(document?.create_timestamp) || EMPTY_FIELD}</p>
+                </Col>
+                <Col span={3}>
+                  <LinkButton
+                    className="nod-table-link"
+                    onClick={() => downloadFileFromDocumentManager(document)}
+                    title={document?.document_name}
+                  >
+                    Download
+                  </LinkButton>
+                </Col>
+              </Row>
+            ))}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/services/minespace-web/src/components/dashboard/mine/noticeOfDeparture/NoticeOfDepartureDetails.js
+++ b/services/minespace-web/src/components/dashboard/mine/noticeOfDeparture/NoticeOfDepartureDetails.js
@@ -131,7 +131,6 @@ export const NoticeOfDepartureDetails = (props) => {
                 </Col>
                 <Col span={3}>
                   <LinkButton
-                    className="nod-table-link"
                     onClick={() => downloadFileFromDocumentManager(document)}
                     title={document?.document_name}
                   >


### PR DESCRIPTION
## Objective 

[MDS-4175](https://bcmines.atlassian.net/browse/MDS-4175)

- Added link to blank NOD form on edit modal
- Added upload component for additional nod documents
- Updated all views in Minespace and Core where the additional documents should appear
- Updated the delete/download buttons on the Core NOD view modal to work with both the checklist and additional documents

## Additional Information / Context 

![image](https://user-images.githubusercontent.com/83598933/170554371-a991a1f5-0021-43b5-80ca-30e4f572d90c.png)
![image](https://user-images.githubusercontent.com/83598933/170554584-7d9ff6f8-2a67-4d6a-a118-2a273554df22.png)
![image](https://user-images.githubusercontent.com/83598933/170554989-eea2b457-fba6-4a7b-8121-7aacbb508f5a.png)
![image](https://user-images.githubusercontent.com/83598933/170555215-72ee392f-2ef2-4eb9-94bb-1e54d2aa9191.png)

