### PR TITLE
MDS-4175-Updated allowed additional nod doc file types

### DIFF
--- a/services/minespace-web/src/components/Forms/noticeOfDeparture/AddNoticeOfDepartureForm.js
+++ b/services/minespace-web/src/components/Forms/noticeOfDeparture/AddNoticeOfDepartureForm.js
@@ -75,7 +75,6 @@ const AddNoticeOfDepartureForm = (props) => {
     if (documentType === NOTICE_OF_DEPARTURE_DOCUMENT_TYPE.CHECKLIST) {
       setHasChecklist(true);
     }
-    setUploading(false);
   };
 
   useEffect(() => {

--- a/services/minespace-web/src/components/Forms/noticeOfDeparture/AddNoticeOfDepartureForm.js
+++ b/services/minespace-web/src/components/Forms/noticeOfDeparture/AddNoticeOfDepartureForm.js
@@ -13,7 +13,7 @@ import {
 import { resetForm } from "@common/utils/helpers";
 import { NOTICE_OF_DEPARTURE_DOCUMENT_TYPE } from "@common/constants/strings";
 import { NOD_TYPE_FIELD_VALUE, NOTICE_OF_DEPARTURE_DOWNLOAD_LINK } from "@/constants/strings";
-import { DOCUMENT, EXCEL, IMAGE, SPATIAL } from "@/constants/fileTypes";
+import { DOCUMENT, EXCEL, SPATIAL } from "@/constants/fileTypes";
 import { renderConfig } from "@/components/common/config";
 import * as FORM from "@/constants/forms";
 import CustomPropTypes from "@/customPropTypes";
@@ -189,6 +189,7 @@ const AddNoticeOfDepartureForm = (props) => {
             allowMultiple
             component={NoticeOfDepartureFileUpload}
             maxFiles={1}
+            labelIdle='<strong class="filepond--label-action">Self-Assessment Upload</strong><div>Accepted filetypes: .doc .docx .xlsx .pdf</div>'
             acceptedFileTypesMap={{ ...DOCUMENT, ...EXCEL }}
             uploadType={NOTICE_OF_DEPARTURE_DOCUMENT_TYPE.CHECKLIST}
             validate={[required]}
@@ -222,7 +223,8 @@ const AddNoticeOfDepartureForm = (props) => {
             onProcessFiles={() => setUploading(false)}
             component={NoticeOfDepartureFileUpload}
             setUploading={setUploading}
-            acceptedFileTypesMap={{ ...DOCUMENT, ...EXCEL, ...IMAGE, ...SPATIAL }}
+            labelIdle='<strong class="filepond--label-action">Supporting Document Upload</strong><div>Accepted filetypes: .kmz .doc .docx .xlsx .pdf</div>'
+            acceptedFileTypesMap={{ ...DOCUMENT, ...EXCEL, ...SPATIAL }}
             uploadType={NOTICE_OF_DEPARTURE_DOCUMENT_TYPE.OTHER}
             validate={[required]}
           />

--- a/services/minespace-web/src/components/Forms/noticeOfDeparture/AddNoticeOfDepartureForm.js
+++ b/services/minespace-web/src/components/Forms/noticeOfDeparture/AddNoticeOfDepartureForm.js
@@ -13,7 +13,7 @@ import {
 import { resetForm } from "@common/utils/helpers";
 import { NOTICE_OF_DEPARTURE_DOCUMENT_TYPE } from "@common/constants/strings";
 import { NOD_TYPE_FIELD_VALUE, NOTICE_OF_DEPARTURE_DOWNLOAD_LINK } from "@/constants/strings";
-import { DOCUMENT, EXCEL } from "@/constants/fileTypes";
+import { DOCUMENT, EXCEL, IMAGE, SPATIAL } from "@/constants/fileTypes";
 import { renderConfig } from "@/components/common/config";
 import * as FORM from "@/constants/forms";
 import CustomPropTypes from "@/customPropTypes";
@@ -222,7 +222,7 @@ const AddNoticeOfDepartureForm = (props) => {
             onProcessFiles={() => setUploading(false)}
             component={NoticeOfDepartureFileUpload}
             setUploading={setUploading}
-            acceptedFileTypesMap={{ ...DOCUMENT, ...EXCEL }}
+            acceptedFileTypesMap={{ ...DOCUMENT, ...EXCEL, ...IMAGE, ...SPATIAL }}
             uploadType={NOTICE_OF_DEPARTURE_DOCUMENT_TYPE.OTHER}
             validate={[required]}
           />

--- a/services/minespace-web/src/components/Forms/noticeOfDeparture/EditNoticeOfDepartureForm.js
+++ b/services/minespace-web/src/components/Forms/noticeOfDeparture/EditNoticeOfDepartureForm.js
@@ -9,7 +9,7 @@ import { resetForm } from "@common/utils/helpers";
 import { NOTICE_OF_DEPARTURE_DOCUMENT_TYPE } from "@common/constants/strings";
 import { getNoticeOfDeparture } from "@common/reducers/noticeOfDepartureReducer";
 import { downloadFileFromDocumentManager } from "@common/utils/actionlessNetworkCalls";
-import { DOCUMENT, EXCEL } from "@/constants/fileTypes";
+import { DOCUMENT, EXCEL, IMAGE, SPATIAL } from "@/constants/fileTypes";
 import { renderConfig } from "@/components/common/config";
 import * as FORM from "@/constants/forms";
 import CustomPropTypes from "@/customPropTypes";
@@ -229,7 +229,7 @@ let AddNoticeOfDepartureForm = (props) => {
             allowMultiple
             setUploading={setUploading}
             component={NoticeOfDepartureFileUpload}
-            acceptedFileTypesMap={{ ...DOCUMENT, ...EXCEL }}
+            acceptedFileTypesMap={{ ...DOCUMENT, ...EXCEL, ...IMAGE, ...SPATIAL }}
             uploadType={NOTICE_OF_DEPARTURE_DOCUMENT_TYPE.OTHER}
             validate={[required]}
           />

--- a/services/minespace-web/src/components/Forms/noticeOfDeparture/EditNoticeOfDepartureForm.js
+++ b/services/minespace-web/src/components/Forms/noticeOfDeparture/EditNoticeOfDepartureForm.js
@@ -178,6 +178,7 @@ let AddNoticeOfDepartureForm = (props) => {
             allowMultiple
             setUploading={setUploading}
             component={NoticeOfDepartureFileUpload}
+            labelIdle='<strong class="filepond--label-action">Self-Assessment Upload</strong><div>Accepted filetypes: .doc .docx .xlsx .pdf</div>'
             maxFiles={1}
             acceptedFileTypesMap={{ ...DOCUMENT, ...EXCEL }}
             uploadType={NOTICE_OF_DEPARTURE_DOCUMENT_TYPE.CHECKLIST}
@@ -204,7 +205,7 @@ let AddNoticeOfDepartureForm = (props) => {
           </Col>
         </Row>
         <h4 className="nod-modal-section-header">Upload Application Documents</h4>
-        <Typography.Text>
+        <Typography.Text className="">
           Please support your notice of departure by uploading additional supporting application
           documents. These items documents can include:
         </Typography.Text>
@@ -224,6 +225,7 @@ let AddNoticeOfDepartureForm = (props) => {
                 NOTICE_OF_DEPARTURE_DOCUMENT_TYPE.OTHER
               );
             }}
+            labelIdle='<strong class="filepond--label-action">Supporting Document Upload</strong><div>Accepted filetypes: .kmz .doc .docx .xlsx .pdf</div>'
             onRemoveFile={onRemoveFile}
             mineGuid={mineGuid}
             allowMultiple

--- a/services/minespace-web/src/components/Forms/noticeOfDeparture/EditNoticeOfDepartureForm.js
+++ b/services/minespace-web/src/components/Forms/noticeOfDeparture/EditNoticeOfDepartureForm.js
@@ -68,7 +68,6 @@ let AddNoticeOfDepartureForm = (props) => {
         document_manager_guid,
       },
     ]);
-    setUploading(false);
   };
 
   useEffect(() => {

--- a/services/minespace-web/src/components/Forms/noticeOfDeparture/NoticeOfDepartureFileUpload.js
+++ b/services/minespace-web/src/components/Forms/noticeOfDeparture/NoticeOfDepartureFileUpload.js
@@ -12,8 +12,13 @@ const propTypes = {
   allowMultiple: PropTypes.bool.isRequired,
   maxFiles: PropTypes.number.isRequired,
   setUploading: PropTypes.func.isRequired,
+  labelIdle: PropTypes.string,
   // eslint-disable-next-line react/forbid-prop-types
   acceptedFileTypesMap: PropTypes.object.isRequired,
+};
+
+const defaultProps = {
+  labelIdle: undefined,
 };
 
 export const NoticeOfDepartureFileUpload = (props) => {
@@ -26,6 +31,7 @@ export const NoticeOfDepartureFileUpload = (props) => {
     maxFiles,
     setUploading,
     acceptedFileTypesMap,
+    labelIdle,
   } = props;
   return (
     <Field
@@ -38,6 +44,7 @@ export const NoticeOfDepartureFileUpload = (props) => {
       uploadUrl={NOTICE_OF_DEPARTURE_DOCUMENTS(mineGuid)}
       acceptedFileTypesMap={acceptedFileTypesMap}
       onFileLoad={onFileLoad}
+      labelIdle={labelIdle}
       onRemoveFile={onRemoveFile}
       allowRevert
       allowMultiple={allowMultiple}
@@ -46,5 +53,6 @@ export const NoticeOfDepartureFileUpload = (props) => {
 };
 
 NoticeOfDepartureFileUpload.propTypes = propTypes;
+NoticeOfDepartureFileUpload.defaultProps = defaultProps;
 
 export default NoticeOfDepartureFileUpload;

--- a/services/minespace-web/src/components/Forms/noticeOfDeparture/NoticeOfDepartureFileUpload.js
+++ b/services/minespace-web/src/components/Forms/noticeOfDeparture/NoticeOfDepartureFileUpload.js
@@ -47,6 +47,7 @@ export const NoticeOfDepartureFileUpload = (props) => {
       labelIdle={labelIdle}
       onRemoveFile={onRemoveFile}
       allowRevert
+      onprocessfiles={() => setUploading(false)}
       allowMultiple={allowMultiple}
     />
   );

--- a/services/minespace-web/src/components/Forms/noticeOfDeparture/NoticeOfDepartureFileUpload.js
+++ b/services/minespace-web/src/components/Forms/noticeOfDeparture/NoticeOfDepartureFileUpload.js
@@ -3,7 +3,6 @@ import PropTypes from "prop-types";
 import { Field } from "redux-form";
 import { NOTICE_OF_DEPARTURE_DOCUMENTS } from "@/constants/API";
 import FileUpload from "@/components/common/FileUpload";
-import { DOCUMENT, EXCEL } from "@/constants/fileTypes";
 
 const propTypes = {
   onFileLoad: PropTypes.func.isRequired,
@@ -13,6 +12,8 @@ const propTypes = {
   allowMultiple: PropTypes.bool.isRequired,
   maxFiles: PropTypes.number.isRequired,
   setUploading: PropTypes.func.isRequired,
+  // eslint-disable-next-line react/forbid-prop-types
+  acceptedFileTypesMap: PropTypes.object.isRequired,
 };
 
 export const NoticeOfDepartureFileUpload = (props) => {
@@ -24,6 +25,7 @@ export const NoticeOfDepartureFileUpload = (props) => {
     allowMultiple,
     maxFiles,
     setUploading,
+    acceptedFileTypesMap,
   } = props;
   return (
     <Field
@@ -34,7 +36,7 @@ export const NoticeOfDepartureFileUpload = (props) => {
       maxFiles={maxFiles}
       onAbort={() => setUploading(false)}
       uploadUrl={NOTICE_OF_DEPARTURE_DOCUMENTS(mineGuid)}
-      acceptedFileTypesMap={{ ...DOCUMENT, ...EXCEL }}
+      acceptedFileTypesMap={acceptedFileTypesMap}
       onFileLoad={onFileLoad}
       onRemoveFile={onRemoveFile}
       allowRevert

--- a/services/minespace-web/src/components/common/FileUpload.js
+++ b/services/minespace-web/src/components/common/FileUpload.js
@@ -30,6 +30,7 @@ const propTypes = {
   maxFiles: PropTypes.number,
   projectGuid: PropTypes.string,
   labelIdle: PropTypes.string,
+  onprocessfiles: PropTypes.func,
 };
 
 const defaultProps = {
@@ -45,6 +46,7 @@ const defaultProps = {
   allowMultiple: true,
   maxFiles: null,
   projectGuid: null,
+  onprocessfiles: () => {},
   labelIdle: 'Drag & Drop your files or <span class="filepond--label-action">Browse</span>',
 };
 
@@ -109,6 +111,7 @@ class FileUpload extends React.Component {
           onremovefile={this.props.onRemoveFile}
           allowMultiple={this.props.allowMultiple}
           onaddfilestart={this.props.addFileStart}
+          onprocessfiles={this.props.onprocessfiles}
           labelIdle={this.props.labelIdle}
           onprocessfileabort={this.props.onAbort}
           maxFileSize={this.props.maxFileSize}

--- a/services/minespace-web/src/components/common/FileUpload.js
+++ b/services/minespace-web/src/components/common/FileUpload.js
@@ -29,6 +29,7 @@ const propTypes = {
   allowMultiple: PropTypes.bool,
   maxFiles: PropTypes.number,
   projectGuid: PropTypes.string,
+  labelIdle: PropTypes.string,
 };
 
 const defaultProps = {
@@ -44,6 +45,7 @@ const defaultProps = {
   allowMultiple: true,
   maxFiles: null,
   projectGuid: null,
+  labelIdle: 'Drag & Drop your files or <span class="filepond--label-action">Browse</span>',
 };
 
 class FileUpload extends React.Component {
@@ -107,6 +109,7 @@ class FileUpload extends React.Component {
           onremovefile={this.props.onRemoveFile}
           allowMultiple={this.props.allowMultiple}
           onaddfilestart={this.props.addFileStart}
+          labelIdle={this.props.labelIdle}
           onprocessfileabort={this.props.onAbort}
           maxFileSize={this.props.maxFileSize}
           allowFileTypeValidation={acceptedFileTypes.length > 0}


### PR DESCRIPTION
## Objective 

[MDS-4175](https://bcmines.atlassian.net/browse/MDS-4175)

- Updated allowed file types for NOD additional documents
- Changed `isUploading` to be dismissed after all upload processing is finished (rather than after file load which was getting triggered after the first upload was completed when multiple were queued at once).


## Additional Information / Context 
