### PR TITLE
Bugfix/mds 4450 4445 4451

### DIFF
--- a/services/core-web/src/components/modalContent/ViewNoticeOfDepartureModal.js
+++ b/services/core-web/src/components/modalContent/ViewNoticeOfDepartureModal.js
@@ -237,13 +237,17 @@ export const ViewNoticeOfDepartureModal = (props) => {
         >
           Update
         </Button>
-        <Button
-          className="full-mobile nod-cancel-button"
-          type="secondary"
-          onClick={props.closeModal}
+        <Popconfirm
+          placement="top"
+          title="Are you sure you want to cancel?"
+          okText="Yes"
+          cancelText="No"
+          onConfirm={props.closeModal}
         >
-          Cancel
-        </Button>
+          <Button className="full-mobile nod-cancel-button" type="secondary">
+            Cancel
+          </Button>
+        </Popconfirm>
       </div>
     </div>
   );

--- a/services/core-web/src/tests/components/modalContent/__snapshots__/ViewNoticeOfDepartureModal.spec.js.snap
+++ b/services/core-web/src/tests/components/modalContent/__snapshots__/ViewNoticeOfDepartureModal.spec.js.snap
@@ -351,17 +351,29 @@ exports[`ViewNoticeOfDepartureModal renders properly 1`] = `
     >
       Update
     </Button>
-    <Button
-      block={false}
-      className="full-mobile nod-cancel-button"
-      ghost={false}
-      htmlType="button"
-      loading={false}
-      onClick={[MockFunction]}
-      type="secondary"
+    <ForwardRef
+      cancelText="No"
+      disabled={false}
+      icon={<ForwardRef(ExclamationCircleFilled) />}
+      okText="Yes"
+      okType="primary"
+      onConfirm={[MockFunction]}
+      placement="top"
+      title="Are you sure you want to cancel?"
+      transitionName="zoom-big"
+      trigger="click"
     >
-      Cancel
-    </Button>
+      <Button
+        block={false}
+        className="full-mobile nod-cancel-button"
+        ghost={false}
+        htmlType="button"
+        loading={false}
+        type="secondary"
+      >
+        Cancel
+      </Button>
+    </ForwardRef>
   </div>
 </div>
 `;

--- a/services/minespace-web/src/components/Forms/noticeOfDeparture/AddNoticeOfDepartureForm.js
+++ b/services/minespace-web/src/components/Forms/noticeOfDeparture/AddNoticeOfDepartureForm.js
@@ -218,8 +218,6 @@ const AddNoticeOfDepartureForm = (props) => {
             onRemoveFile={onRemoveFile}
             mineGuid={mineGuid}
             allowMultiple
-            onProcessFileStart={() => setUploading(true)}
-            onProcessFiles={() => setUploading(false)}
             component={NoticeOfDepartureFileUpload}
             setUploading={setUploading}
             labelIdle='<strong class="filepond--label-action">Supporting Document Upload</strong><div>Accepted filetypes: .kmz .doc .docx .xlsx .pdf</div>'

--- a/services/minespace-web/src/components/Forms/noticeOfDeparture/EditNoticeOfDepartureForm.js
+++ b/services/minespace-web/src/components/Forms/noticeOfDeparture/EditNoticeOfDepartureForm.js
@@ -31,7 +31,7 @@ const propTypes = {
 };
 
 // eslint-disable-next-line import/no-mutable-exports
-let AddNoticeOfDepartureForm = (props) => {
+let EditNoticeOfDepartureForm = (props) => {
   const { onSubmit, closeModal, handleSubmit, mineGuid, noticeOfDeparture, pristine } = props;
   const { permit, nod_guid } = noticeOfDeparture;
   const [submitting, setSubmitting] = useState(false);
@@ -295,21 +295,21 @@ let AddNoticeOfDepartureForm = (props) => {
   );
 };
 
-AddNoticeOfDepartureForm.propTypes = propTypes;
+EditNoticeOfDepartureForm.propTypes = propTypes;
 
 const mapStateToProps = (state) => ({
   initialValues: getNoticeOfDeparture(state),
 });
 
-AddNoticeOfDepartureForm = reduxForm({
+EditNoticeOfDepartureForm = reduxForm({
   form: FORM.EDIT_NOTICE_OF_DEPARTURE,
   onSubmitSuccess: resetForm(FORM.EDIT_NOTICE_OF_DEPARTURE),
   destroyOnUnmount: true,
   forceUnregisterOnUnmount: true,
   touchOnBlur: true,
   enableReinitialize: true,
-})(AddNoticeOfDepartureForm);
+})(EditNoticeOfDepartureForm);
 
-AddNoticeOfDepartureForm = connect(mapStateToProps)(AddNoticeOfDepartureForm);
+EditNoticeOfDepartureForm = connect(mapStateToProps)(EditNoticeOfDepartureForm);
 
-export default AddNoticeOfDepartureForm;
+export default EditNoticeOfDepartureForm;

--- a/services/minespace-web/src/components/Forms/noticeOfDeparture/EditNoticeOfDepartureForm.js
+++ b/services/minespace-web/src/components/Forms/noticeOfDeparture/EditNoticeOfDepartureForm.js
@@ -9,7 +9,7 @@ import { resetForm } from "@common/utils/helpers";
 import { NOTICE_OF_DEPARTURE_DOCUMENT_TYPE } from "@common/constants/strings";
 import { getNoticeOfDeparture } from "@common/reducers/noticeOfDepartureReducer";
 import { downloadFileFromDocumentManager } from "@common/utils/actionlessNetworkCalls";
-import { DOCUMENT, EXCEL, IMAGE, SPATIAL } from "@/constants/fileTypes";
+import { DOCUMENT, EXCEL, SPATIAL } from "@/constants/fileTypes";
 import { renderConfig } from "@/components/common/config";
 import * as FORM from "@/constants/forms";
 import CustomPropTypes from "@/customPropTypes";
@@ -25,13 +25,14 @@ const propTypes = {
   onSubmit: PropTypes.func.isRequired,
   closeModal: PropTypes.func.isRequired,
   handleSubmit: PropTypes.func.isRequired,
+  pristine: PropTypes.bool.isRequired,
   mineGuid: PropTypes.string.isRequired,
   noticeOfDeparture: CustomPropTypes.noticeOfDeparture.isRequired,
 };
 
 // eslint-disable-next-line import/no-mutable-exports
 let AddNoticeOfDepartureForm = (props) => {
-  const { onSubmit, closeModal, handleSubmit, mineGuid, noticeOfDeparture } = props;
+  const { onSubmit, closeModal, handleSubmit, mineGuid, noticeOfDeparture, pristine } = props;
   const { permit, nod_guid } = noticeOfDeparture;
   const [submitting, setSubmitting] = useState(false);
   const [uploadedFiles, setUploadedFiles] = useState([]);
@@ -74,13 +75,14 @@ let AddNoticeOfDepartureForm = (props) => {
     change("uploadedFiles", documentArray);
   }, [documentArray]);
 
-  const onRemoveFile = (fileItem) => {
+  const onRemoveFile = (_, fileItem) => {
     setDocumentArray(
       documentArray.filter((document) => document.document_manager_guid !== fileItem.serverId)
     );
     setUploadedFiles(
       uploadedFiles.filter((file) => file.document_manager_guid !== fileItem.serverId)
     );
+    setUploading(false);
   };
 
   return (
@@ -230,7 +232,7 @@ let AddNoticeOfDepartureForm = (props) => {
             allowMultiple
             setUploading={setUploading}
             component={NoticeOfDepartureFileUpload}
-            acceptedFileTypesMap={{ ...DOCUMENT, ...EXCEL, ...IMAGE, ...SPATIAL }}
+            acceptedFileTypesMap={{ ...DOCUMENT, ...EXCEL, ...SPATIAL }}
             uploadType={NOTICE_OF_DEPARTURE_DOCUMENT_TYPE.OTHER}
             validate={[required]}
           />
@@ -276,12 +278,11 @@ let AddNoticeOfDepartureForm = (props) => {
             okText="Yes"
             cancelText="No"
             onConfirm={closeModal}
-            disabled={submitting}
           >
             <Button disabled={submitting}>Cancel</Button>
           </Popconfirm>
           <Button
-            disabled={submitting || uploading}
+            disabled={submitting || uploading || (pristine && documentArray.length === 0)}
             type="primary"
             className="full-mobile margin-small"
             htmlType="submit"

--- a/services/minespace-web/src/components/dashboard/mine/noticeOfDeparture/NoticeOfDeparture.js
+++ b/services/minespace-web/src/components/dashboard/mine/noticeOfDeparture/NoticeOfDeparture.js
@@ -96,6 +96,7 @@ export const NoticeOfDeparture = (props) => {
       values.nod_type === NOTICE_OF_DEPARTURE_TYPE_VALUES.non_substantial
         ? NOTICE_OF_DEPARTURE_STATUS_VALUES.self_determined_non_substantial
         : NOTICE_OF_DEPARTURE_STATUS_VALUES.pending_review;
+
     return props
       .updateNoticeOfDeparture({ mineGuid: mine.mine_guid, nodGuid }, { ...values, nod_status })
       .then(async (response) => {


### PR DESCRIPTION
## Objective 

[MDS-4450](https://bcmines.atlassian.net/browse/MDS-4450)
[MDS-4445](https://bcmines.atlassian.net/browse/MDS-4445)
[MDS-4451](https://bcmines.atlassian.net/browse/MDS-4451)

- Disabled edit nod form submit on Minespace if the form is pristine
- Enabled nod form submit on Minespace after dismissing error file (this was causing the submit button to be unavailable until refresh).  There is a recent open issue regarding this on Stack Overflow.  The solution I used sets `uploading` to false when a file is removed.  This was the best option I could find based on the current capabilities, but it has the additional effect of setting `uploading` to false when _any_ file is removed.  It won't upload the errored file at any rate, so it shouldn't cause much of any issue, but there doesn't seem to be a better solution within `filepond` at this point in time.
- Added `popConfirm` to CoreWeb on cancelling the `ViewNoticeOfDepartureModal`

## Additional Information / Context 

![image](https://user-images.githubusercontent.com/83598933/171064367-fd784b50-6a05-48f8-ae7f-e8acd2808271.png)
![image](https://user-images.githubusercontent.com/83598933/171064451-50079ad3-1b95-43b4-8163-f1e85034e38e.png)

