### PR TITLE
bugfix/mds-4170- NOD update timestamp on doc delete

### DIFF
--- a/services/core-api/app/api/mines/notice_of_departure/resources/notice_of_departure_document.py
+++ b/services/core-api/app/api/mines/notice_of_departure/resources/notice_of_departure_document.py
@@ -91,3 +91,10 @@ class MineNoticeOfDepartureDocumentResource(Resource, UserMixin):
             raise NotFound('Document not found')
 
         doc.delete()
+
+        nod = NoticeOfDeparture.find_one(nod_guid)
+
+        if not nod:
+            raise NotFound('Unable to fetch Notice of departure.')
+
+        nod.save()


### PR DESCRIPTION
## Objective 

[MDS-4170](https://bcmines.atlassian.net/browse/MDS-4170)

Saved nod after a document is deleted so the timestamp is updated

## Additional Information / Context 
