### PR TITLE
[MDS-3744] - Abandoned mines banner

### DIFF
--- a/services/core-web/package-lock.json
+++ b/services/core-web/package-lock.json
@@ -6300,9 +6300,9 @@
       }
     },
     "date-fns": {
-      "version": "2.22.1",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.22.1.tgz",
-      "integrity": "sha512-yUFPQjrxEmIsMqlHhAhmxkuH769baF21Kk+nZwZGyrMoyLA+LugaQtC0+Tqf9CBUUULWwUJt6Q5ySI3LJDDCGg=="
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
+      "integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw=="
     },
     "dayjs": {
       "version": "1.10.5",

--- a/services/core-web/package.json
+++ b/services/core-web/package.json
@@ -33,6 +33,7 @@
     "axios-mock-adapter": "^1.17.0",
     "core-js": "^3.1.4",
     "cypress": "^9.5.1",
+    "date-fns": "^2.28.0",
     "dotenv": "^9.0.0",
     "enzyme": "^3.10.0",
     "enzyme-adapter-react-16": "^1.14.0",

--- a/services/core-web/src/components/mine/ContactInfo/PartyRelationships/DefaultContact.js
+++ b/services/core-web/src/components/mine/ContactInfo/PartyRelationships/DefaultContact.js
@@ -39,20 +39,24 @@ export const DefaultContact = (props) => {
       headStyle={cardHeadStyle}
       bordered={false}
       title={
-        <div className="flex flex-between">
-          <div className="flex items-center">
-            <h4 className="margin-large--right">{props.partyRelationshipTitle}</h4>
-            {props.partyRelationshipSubTitle && <p>({props.partyRelationshipSubTitle})</p>}
+        <div>
+          <div className="flex flex-between">
+            <div className="flex items-center">
+              <h4 className="margin-large--right">{props.partyRelationshipTitle}</h4>
+              {props.partyRelationshipSubTitle && <p>({props.partyRelationshipSubTitle})</p>}
+            </div>
           </div>
           {!props.compact && (
-            <Link
-              to={router.RELATIONSHIP_PROFILE.dynamicRoute(
-                props.mine.mine_guid,
-                props.partyRelationship.mine_party_appt_type_code
-              )}
-            >
-              <Button className="margin-none">See History</Button>
-            </Link>
+            <div className="padding-md--top">
+              <Link
+                to={router.RELATIONSHIP_PROFILE.dynamicRoute(
+                  props.mine.mine_guid,
+                  props.partyRelationship.mine_party_appt_type_code
+                )}
+              >
+                <Button className="margin-none">See History</Button>
+              </Link>
+            </div>
           )}
         </div>
       }

--- a/services/core-web/src/components/mine/MineDashboard.js
+++ b/services/core-web/src/components/mine/MineDashboard.js
@@ -2,6 +2,7 @@ import React, { Component } from "react";
 import { connect } from "react-redux";
 import PropTypes from "prop-types";
 import { bindActionCreators } from "redux";
+import moment from "moment";
 import { Menu, Button, Dropdown, Popconfirm, Tooltip, Drawer } from "antd";
 import {
   DownOutlined,
@@ -36,12 +37,13 @@ import { storePermits } from "@common/actions/permitActions";
 import { storeMine } from "@common/actions/mineActions";
 import * as Strings from "@common/constants/strings";
 import { detectProdEnvironment } from "@common/utils/environmentUtils";
+import { fetchMineNoticeOfWorkApplications } from "@common/actionCreators/noticeOfWorkActionCreator";
+import { fetchExplosivesPermits } from "@common/actionCreators/explosivesPermitActionCreator";
+import { getPartyRelationships } from "@common/selectors/partiesSelectors";
 import MineNavigation from "@/components/mine/MineNavigation";
 import Loading from "@/components/common/Loading";
 import CustomPropTypes from "@/customPropTypes";
 import * as Permission from "@/constants/permissions";
-import { fetchMineNoticeOfWorkApplications } from "@common/actionCreators/noticeOfWorkActionCreator";
-import { fetchExplosivesPermits } from "@common/actionCreators/explosivesPermitActionCreator";
 import AuthorizationWrapper from "@/components/common/wrappers/AuthorizationWrapper";
 import MineDashboardRoutes from "@/routes/MineDashboardRoutes";
 import {
@@ -80,6 +82,37 @@ const propTypes = {
   setMineVerifiedStatus: PropTypes.func.isRequired,
   fetchMineVerifiedStatuses: PropTypes.func.isRequired,
   fetchExplosivesPermits: PropTypes.func.isRequired,
+  partyRelationships: PropTypes.arrayOf(CustomPropTypes.partyRelationship),
+};
+
+const defaultProps = {
+  partyRelationships: [],
+};
+
+const hasDAMRole = (partyRelationships) => {
+  const today = moment().utc();
+  return partyRelationships.reduce((acc, pr) => {
+    if (
+      pr.mine_party_appt_type_code === "DAM" &&
+      (!pr.end_date || today.isSameOrBefore(pr.end_date, "day"))
+    ) {
+      acc = true;
+    }
+    return acc;
+  }, false);
+};
+
+const hasCCSRole = (partyRelationships) => {
+  const today = moment().utc();
+  return partyRelationships.reduce((acc, pr) => {
+    if (
+      pr.mine_party_appt_type_code === "CCS" &&
+      (!pr.end_date || today.isSameOrBefore(pr.end_date, "day"))
+    ) {
+      acc = true;
+    }
+    return acc;
+  }, false);
 };
 
 export class MineDashboard extends Component {
@@ -300,6 +333,8 @@ export class MineDashboard extends Component {
       </Menu>
     );
 
+    const DAMRole = hasDAMRole(this.props.partyRelationships);
+    const CSSRole = hasCCSRole(this.props.partyRelationships);
     return (
       <div>
         <Drawer
@@ -321,13 +356,19 @@ export class MineDashboard extends Component {
         </Drawer>
         {this.state.isLoaded && (
           <div>
-            {mine.mine_status[0].status_values.includes("ABN") && (
+            {(DAMRole || CSSRole) && (
               <div className="abandoned-mine">
                 <div className="flex items-center">
                   <ExclamationCircleOutlined className="margin-large--right" />
                   <div>
                     <h4>This is an abandoned mine</h4>
-                    <p>Contact the director of abandoned mines for access to this site</p>
+                    <p>
+                      Contact the{" "}
+                      {DAMRole
+                        ? "Director of Abandoned Mines"
+                        : "Manager, Crown Contaminated Sites"}{" "}
+                      for access to this site
+                    </p>
                   </div>
                 </div>
               </div>
@@ -403,6 +444,7 @@ const mapStateToProps = (state) => ({
   mines: getMines(state),
   subscribed: getIsUserSubscribed(state),
   userInfo: getUserInfo(state),
+  partyRelationships: getPartyRelationships(state),
 });
 
 const mapDispatchToProps = (dispatch) =>
@@ -430,5 +472,6 @@ const mapDispatchToProps = (dispatch) =>
   );
 
 MineDashboard.propTypes = propTypes;
+MineDashboard.defaultProps = defaultProps;
 
 export default connect(mapStateToProps, mapDispatchToProps)(MineDashboard);

--- a/services/core-web/src/components/mine/MineDashboard.js
+++ b/services/core-web/src/components/mine/MineDashboard.js
@@ -2,7 +2,7 @@ import React, { Component } from "react";
 import { connect } from "react-redux";
 import PropTypes from "prop-types";
 import { bindActionCreators } from "redux";
-import moment from "moment";
+import { isFuture } from "date-fns";
 import { Menu, Button, Dropdown, Popconfirm, Tooltip, Drawer } from "antd";
 import {
   DownOutlined,
@@ -90,12 +90,9 @@ const defaultProps = {
 };
 
 const hasDAMRole = (partyRelationships) => {
-  const today = moment().utc();
   return partyRelationships.reduce((acc, pr) => {
-    if (
-      pr.mine_party_appt_type_code === "DAM" &&
-      (!pr.end_date || today.isSameOrBefore(pr.end_date, "day"))
-    ) {
+    const endDate = pr.end_date ? new Date(pr.end_date) : null;
+    if (pr.mine_party_appt_type_code === "DAM" && (!endDate || isFuture(endDate))) {
       acc = true;
     }
     return acc;
@@ -103,12 +100,9 @@ const hasDAMRole = (partyRelationships) => {
 };
 
 const hasCCSRole = (partyRelationships) => {
-  const today = moment().utc();
   return partyRelationships.reduce((acc, pr) => {
-    if (
-      pr.mine_party_appt_type_code === "CCS" &&
-      (!pr.end_date || today.isSameOrBefore(pr.end_date, "day"))
-    ) {
+    const endDate = pr.end_date ? new Date(pr.end_date) : null;
+    if (pr.mine_party_appt_type_code === "CCS" && (!endDate || isFuture(endDate))) {
       acc = true;
     }
     return acc;

--- a/services/core-web/src/tests/components/mine/ContactInfo/PartyRelationships/__snapshots__/DefaultContact.spec.js.snap
+++ b/services/core-web/src/tests/components/mine/ContactInfo/PartyRelationships/__snapshots__/DefaultContact.spec.js.snap
@@ -9,36 +9,42 @@ exports[`DefaultContact renders properly 1`] = `
     }
   }
   title={
-    <div
-      className="flex flex-between"
-    >
+    <div>
       <div
-        className="flex items-center"
+        className="flex flex-between"
       >
-        <h4
-          className="margin-large--right"
+        <div
+          className="flex items-center"
         >
-          Permittee
-        </h4>
-        <p>
-          (
-          Permittee since
-          )
-        </p>
+          <h4
+            className="margin-large--right"
+          >
+            Permittee
+          </h4>
+          <p>
+            (
+            Permittee since
+            )
+          </p>
+        </div>
       </div>
-      <ForwardRef
-        to="/dashboard/3124624567/history/PMT"
+      <div
+        className="padding-md--top"
       >
-        <ForwardRef(InternalButton)
-          block={false}
-          className="margin-none"
-          ghost={false}
-          htmlType="button"
-          loading={false}
+        <ForwardRef
+          to="/dashboard/3124624567/history/PMT"
         >
-          See History
-        </ForwardRef(InternalButton)>
-      </ForwardRef>
+          <ForwardRef(InternalButton)
+            block={false}
+            className="margin-none"
+            ghost={false}
+            htmlType="button"
+            loading={false}
+          >
+            See History
+          </ForwardRef(InternalButton)>
+        </ForwardRef>
+      </div>
     </div>
   }
 >


### PR DESCRIPTION
## Objective 

[MDS-3744](https://bcmines.atlassian.net/browse/MDS-3744)

- Updated logic for displaying the banner only if either of the new roles is present (rather than if a mine is flagged as abandoned)
- Made banner text dynamic based on combination of those new roles added.
- Small update to the default contact styling to keep the `See History` button from being cut off.

## Additional Information / Context 
