### PR TITLE
[MDS-4489] minespace-web IRT - Disable ability to upload IRT based on status code

### DIFF
--- a/services/core-api/app/api/projects/information_requirements_table/models/information_requirements_table.py
+++ b/services/core-api/app/api/projects/information_requirements_table/models/information_requirements_table.py
@@ -64,7 +64,7 @@ class InformationRequirementsTable(SoftDeleteMixin, AuditMixin, Base):
 
     def send_irt_approval_email(self):
         recipients = [contact.email for contact in self.project.contacts]
-        link = f'{Config.MINESPACE_PRODUCTION_URL}/projects/{self.project.project_guid}/information-requirements-table/review/intro-project-overview'
+        link = f'{Config.MINESPACE_PRODUCTION_URL}/projects/{self.project.project_guid}/information-requirements-table/{self.irt_guid}/review/intro-project-overview'
 
         subject = f'IRT Notification for {self.project.mine_name}:{self.project.project_title}'
         body = f'<p>An IRT has been approved for {self.project.mine_name}:(Mine no: {self.project.mine_no})-{self.project.project_title}.</p>'

--- a/services/minespace-web/src/components/dashboard/mine/projects/ProjectStagesTable.js
+++ b/services/minespace-web/src/components/dashboard/mine/projects/ProjectStagesTable.js
@@ -65,9 +65,18 @@ export class ProjectStagesTable extends Component {
         if (record.project_stage === "IRT") {
           link = (
             <Link
-              to={routes.ADD_INFORMATION_REQUIREMENTS_TABLE.dynamicRoute(
-                record.stage?.project_guid
-              )}
+              to={
+                record.stage_status === "APV"
+                  ? {
+                      pathname: `${routes.REVIEW_INFORMATION_REQUIREMENTS_TABLE.dynamicRoute(
+                        record.stage?.project_guid
+                      )}`,
+                      state: { current: 2 },
+                    }
+                  : routes.ADD_INFORMATION_REQUIREMENTS_TABLE.dynamicRoute(
+                      record.stage?.project_guid
+                    )
+              }
             >
               <Button className="full-mobile margin-small" type="secondary">
                 {record.stage_status ? "View" : "Start"}

--- a/services/minespace-web/src/components/dashboard/mine/projects/ProjectStagesTable.js
+++ b/services/minespace-web/src/components/dashboard/mine/projects/ProjectStagesTable.js
@@ -69,7 +69,8 @@ export class ProjectStagesTable extends Component {
                 record.stage_status === "APV"
                   ? {
                       pathname: `${routes.REVIEW_INFORMATION_REQUIREMENTS_TABLE.dynamicRoute(
-                        record.stage?.project_guid
+                        record.stage?.project_guid,
+                        record.stage?.payload?.irt_guid
                       )}`,
                       state: { current: 2 },
                     }

--- a/services/minespace-web/src/components/pages/Project/InformationRequirementsTablePage.js
+++ b/services/minespace-web/src/components/pages/Project/InformationRequirementsTablePage.js
@@ -99,7 +99,8 @@ const StepForms = (
           next();
           props.history.push({
             pathname: `${routes.REVIEW_INFORMATION_REQUIREMENTS_TABLE.dynamicRoute(
-              props.project?.project_guid
+              props.project?.project_guid,
+              props.project?.information_requirements_table?.irt_guid
             )}`,
             state: { current: 2 },
           });
@@ -148,12 +149,15 @@ const StepForms = (
             routes.ADD_INFORMATION_REQUIREMENTS_TABLE.dynamicRoute(props.project.project_guid)
           );
         }}
-        disabled={state.submitting}
+        disabled={props.project?.information_requirements_table?.status_code === "APV"}
       >
         Back
       </Button>,
       <Link
-        to={routes.REVIEW_INFORMATION_REQUIREMENTS_TABLE.dynamicRoute(props.project?.project_guid)}
+        to={routes.REVIEW_INFORMATION_REQUIREMENTS_TABLE.dynamicRoute(
+          props.project?.project_guid,
+          props.project?.information_requirements_table?.irt_guid
+        )}
       >
         <Button
           type="primary"
@@ -194,6 +198,7 @@ export class InformationRequirementsTablePage extends Component {
   handleTabChange = (activeTab) => {
     const url = routes.REVIEW_INFORMATION_REQUIREMENTS_TABLE.dynamicRoute(
       this.props.match.params?.projectGuid,
+      this.props.match.params?.irtGuid,
       activeTab
     );
     this.setState({ activeTab });
@@ -205,6 +210,7 @@ export class InformationRequirementsTablePage extends Component {
   prev = () => this.setState((prevState) => ({ current: prevState.current - 1 }));
 
   importIsSuccessful = () => {
+    this.handleFetchData();
     this.setState((state) => ({ uploadedSuccessfully: !state.uploadedSuccessfully }));
   };
 

--- a/services/minespace-web/src/components/pages/Project/InformationRequirementsTablePage.js
+++ b/services/minespace-web/src/components/pages/Project/InformationRequirementsTablePage.js
@@ -181,6 +181,9 @@ export class InformationRequirementsTablePage extends Component {
   };
 
   componentDidMount() {
+    this.setState((prevState) => ({
+      current: this.props.location?.state?.current || prevState.current,
+    }));
     this.handleFetchData();
   }
 

--- a/services/minespace-web/src/components/pages/Project/ProjectPage.js
+++ b/services/minespace-web/src/components/pages/Project/ProjectPage.js
@@ -71,8 +71,22 @@ export class ProjectPage extends Component {
 
   handleTabChange = (activeTab) => {
     this.setState({ activeTab });
-    const url = router.EDIT_PROJECT.dynamicRoute(this.props.match.params?.projectGuid, activeTab);
-    this.props.history.push(url);
+    if (activeTab === "overview") {
+      const url = router.EDIT_PROJECT.dynamicRoute(this.props.match.params?.projectGuid, activeTab);
+      this.props.history.push(url);
+    } else if (activeTab === "intro-project-overview") {
+      const url = router.REVIEW_INFORMATION_REQUIREMENTS_TABLE.dynamicRoute(
+        this.props.match.params?.projectGuid,
+        this.props.project?.information_requirements_table?.irt_guid,
+        activeTab
+      );
+      this.props.history.push({ pathname: url, state: { current: 2 } });
+    } else if (activeTab === "new") {
+      const url = router.ADD_INFORMATION_REQUIREMENTS_TABLE.dynamicRoute(
+        this.props.match.params?.projectGuid
+      );
+      this.props.history.push(url);
+    }
   };
 
   render() {
@@ -102,11 +116,16 @@ export class ProjectPage extends Component {
                 <Tabs.TabPane tab="Overview" key="overview">
                   <ProjectOverviewTab />
                 </Tabs.TabPane>
-                {!IN_PROD() && (
-                  <Tabs.TabPane tab="IRT" key="information-requirements-table/new">
-                    <InformationRequirementsTablePage match={this.props.match} />
-                  </Tabs.TabPane>
-                )}
+                {!IN_PROD() &&
+                  (this.props.project?.information_requirements_table?.irt_guid ? (
+                    <Tabs.TabPane tab="IRT" key="intro-project-overview">
+                      <InformationRequirementsTablePage />
+                    </Tabs.TabPane>
+                  ) : (
+                    <Tabs.TabPane tab="IRT" key="new">
+                      <InformationRequirementsTablePage />
+                    </Tabs.TabPane>
+                  ))}
               </Tabs>
             </Col>
           </Row>

--- a/services/minespace-web/src/constants/routes.js
+++ b/services/minespace-web/src/constants/routes.js
@@ -55,9 +55,9 @@ export const ADD_INFORMATION_REQUIREMENTS_TABLE = {
 };
 
 export const REVIEW_INFORMATION_REQUIREMENTS_TABLE = {
-  route: "/projects/:projectGuid/information-requirements-table/review/:tab",
-  dynamicRoute: (projectGuid, tab = "intro-project-overview") =>
-    `/projects/${projectGuid}/information-requirements-table/review/${tab}`,
+  route: "/projects/:projectGuid/information-requirements-table/:irtGuid/review/:tab",
+  dynamicRoute: (projectGuid, irtGuid, tab = "intro-project-overview") =>
+    `/projects/${projectGuid}/information-requirements-table/${irtGuid}/review/${tab}`,
   component: InformationRequirementsTablePage,
 };
 

--- a/services/minespace-web/src/tests/routes/__snapshots__/Routes.spec.js.snap
+++ b/services/minespace-web/src/tests/routes/__snapshots__/Routes.spec.js.snap
@@ -113,7 +113,7 @@ exports[`PrivateRoutes  renders properly 1`] = `
         "type": [Function],
       }
     }
-    path="/projects/:projectGuid/information-requirements-table/review/:tab"
+    path="/projects/:projectGuid/information-requirements-table/:irtGuid/review/:tab"
   />
   <Route
     component={


### PR DESCRIPTION
## Objective 

https://bcmines.atlassian.net/browse/MDS-4489

- Just IRTs under a different status code than "APV- Review Complete" should be able to upload an IRT spreadsheet.
- IRTs with a "APV-Review Complete" status should not be able to import a new IRT and they should be taken to step 3 directly when clicking on IRT Tab or View Button.

**To test:**
**Approved IRT ( IRT with "APV-Review Complete")**
a) Select any major mine and Select Applications.
b) Create/ Select the current application and click on Start an IRT.
c) Import IRT and then Submit IRT (sending you an email)
d) Go to Core-api to access the mine
e) Select Major Projects and the Project
f) Select the IRT and approve.
g) When back on Minespace-web and clicking on View IRT, the user is redirected to step 3 to check the approved IRT.

**Not approved IRT:**
a) Select any major mine and Select Applications.
b) Select the current application and click on Start an IRT.
c) Import IRT and then Submit IRT (sending you an email)
d) Go back to Projects and click on View IRT, the user is redirected to step 1 to start over again.
