### PR TITLE
[MDS-4182] - send email on non-substantial nod create

### DIFF
--- a/services/core-api/.env-example
+++ b/services/core-api/.env-example
@@ -54,3 +54,4 @@ COMMON_SERVICES_EMAIL_HOST=https://ches-dev.apps.silver.devops.gov.bc.ca/api/v1
 # If you want to send emails locally, set EMAIL_ENABLED to 1 and use your personal email for EMAIL_RECIPIENT_OVERRIDE.
 EMAIL_ENABLED=0
 EMAIL_RECIPIENT_OVERRIDE=
+ENVIRONMENT_NAME=local

--- a/services/core-api/app/__init__.py
+++ b/services/core-api/app/__init__.py
@@ -117,13 +117,15 @@ def register_routes(app):
 
         def get_health(self):
             service = {
-                'database': False,
-                'cache': False,
-                'nris': False,
-                'docgen': False,
-                'docman': False
+                'database': True,
+                'cache': True,
+                'nris': True,
+                'docgen': True,
+                'docman': True
             }
             status = 200
+            if (Config.ENVIRONMENT_NAME == 'local'):
+                return service, status
 
             try:
                 service['database'] = get_database_status()

--- a/services/core-api/app/api/constants.py
+++ b/services/core-api/app/api/constants.py
@@ -1,3 +1,5 @@
+from app.config import Config
+
 MINE_OPERATION_STATUS = {
     'abandoned': {
         'value': 'ABN',
@@ -165,7 +167,7 @@ MINE_REPORT_TYPE = {
 PERMIT_LINKED_CONTACT_TYPES = ['PMT', 'THD', 'LDO', 'MOR']
 
 MDS_EMAIL = 'mds@gov.bc.ca'
-MAJOR_MINES_OFFICE_EMAIL = 'PermRecl@gov.bc.ca'
+MAJOR_MINES_OFFICE_EMAIL = Config.MAJOR_MINES_OFFICE_EMAIL
 VARIANCE_APPLICATION_EMAIL = 'hermanus.henning@gov.bc.ca'
 MINESPACE_TSF_UPDATE_EMAIL = [
     'permrecl@gov.bc.ca', 'mark.smith@gov.bc.ca', 'victor.marques@gov.bc.ca', MDS_EMAIL

--- a/services/core-api/app/config.py
+++ b/services/core-api/app/config.py
@@ -59,6 +59,7 @@ class Config(object):
                                               'https://minespace.gov.bc.ca')
     MDS_NO_REPLY_EMAIL = os.environ.get('MDS_NO_REPLY_EMAIL', 'noreply-mds@gov.bc.ca')
     MDS_EMAIL = os.environ.get('MDS_EMAIL', 'mds@gov.bc.ca')
+    MAJOR_MINES_OFFICE_EMAIL = os.environ.get('MAJOR_MINES_OFFICE_EMAIL', 'PermRecl@gov.bc.ca')
     EMA_AUTH_LINK = os.environ.get(
         'EMA_AUTH_LINK',
         'https://www2.gov.bc.ca/gov/content/environment/waste-management/waste-discharge-authorization'


### PR DESCRIPTION
## Objective 

[MDS-4182](https://bcmines.atlassian.net/browse/MDS-4182)

- Send an email if a non-substantial nod was created. 

- [x] Send an email if a non-substantial nod was created. 
~~- [ ] Add a config map or secret for MAJOR_MINES_OFFICE_EMAIL env var (discuss with @v-y-a-s)~~

_Why are you making this change? Provide a short explanation and/or screenshots_
