### PR TITLE
[MDS-3454] - enabled username field and added update in api

### DIFF
--- a/services/core-api/app/api/users/minespace/resources/minespace_user.py
+++ b/services/core-api/app/api/users/minespace/resources/minespace_user.py
@@ -77,6 +77,11 @@ class MinespaceUserResource(Resource, UserMixin):
         if not contact:
             raise NotFound('Contact not found.')
         data = self.parser.parse_args()
+
+        if data.get('email_or_username'):
+            if contact.email_or_username != data.get('email_or_username'):
+                contact.email_or_username = data.get('email_or_username')
+
         if not data.get('mine_guids'):
             raise BadRequest('Empty list mine_guids is not permitted. Please provide a list of mine GUIDS.')
 

--- a/services/core-web/src/components/Forms/EditMinespaceUser.js
+++ b/services/core-web/src/components/Forms/EditMinespaceUser.js
@@ -32,7 +32,6 @@ export const EditMinespaceUser = (props) => (
               placeholder="Enter the users Email (BCeID username if email is not available)"
               component={RenderField}
               allowClear
-              disabled
             />
           </Form.Item>
         </Col>


### PR DESCRIPTION
## Objective 

[MDS-3454](https://bcmines.atlassian.net/browse/MDS-3454)

- removed the disabled flag from the `email_or_username` field
- added logic to the api to capture and save the change in `email_or_username`
- The other AC of this ticket seem to already be in place (ie, viewing the mines by name rather than guid and being able to add/remove mines from a user's list of authorized mines)

_Why are you making this change? Provide a short explanation and/or screenshots_
