### PR TITLE
[MDS-3454] - Added existing mine names to core user access edit modal

### DIFF
--- a/services/core-api/app/api/mines/mine/models/mine.py
+++ b/services/core-api/app/api/mines/mine/models/mine.py
@@ -237,7 +237,7 @@ class Mine(SoftDeleteMixin, AuditMixin, Base):
                            column('mine_location_description'), column('mine_name'), column('mine_no'),
                            column('deleted_ind'), column('major_mine_ind'))
 
-        mines_q = select([mine_table]).where(mine_table.c.deleted_ind == False)
+        mines_q = select([mine_table]).where(mine_table.c.deleted_ind == False).limit(50)
 
         if term:
             mines_q = mines_q.where(mine_table.c.mine_name.ilike('%{}%'.format(term)))

--- a/services/core-api/app/api/mines/mine/models/mine.py
+++ b/services/core-api/app/api/mines/mine/models/mine.py
@@ -13,6 +13,7 @@ from app.api.mines.permits.permit.models.mine_permit_xref import MinePermitXref
 from app.api.mines.permits.permit.models.permit import Permit
 from app.api.mines.work_information.models.mine_work_information import MineWorkInformation
 from app.api.users.minespace.models.minespace_user_mine import MinespaceUserMine
+from app.api.utils.access_decorators import is_minespace_user
 from app.api.utils.models_mixins import SoftDeleteMixin, AuditMixin, Base
 from app.extensions import db
 
@@ -237,7 +238,10 @@ class Mine(SoftDeleteMixin, AuditMixin, Base):
                            column('mine_location_description'), column('mine_name'), column('mine_no'),
                            column('deleted_ind'), column('major_mine_ind'))
 
-        mines_q = select([mine_table]).where(mine_table.c.deleted_ind == False).limit(50)
+        mines_q = select([mine_table]).where(mine_table.c.deleted_ind == False)
+
+        if not (is_minespace_user()):
+            mines_q = mines_q.limit(100)
 
         if term:
             mines_q = mines_q.where(mine_table.c.mine_name.ilike('%{}%'.format(term)))

--- a/services/core-web/src/components/Forms/EditMinespaceUser.js
+++ b/services/core-web/src/components/Forms/EditMinespaceUser.js
@@ -19,46 +19,49 @@ const propTypes = {
   handleSearch: PropTypes.func.isRequired,
 };
 
-export const EditMinespaceUser = (props) => (
-  <Form layout="vertical" onSubmit={props.handleSubmit}>
-    <Col span={24}>
-      <Row>
-        <Col span={24}>
-          <Form.Item>
-            <Field
-              id="email_or_username"
-              name="email_or_username"
-              label="Email/BCeID username"
-              placeholder="Enter the users Email (BCeID username if email is not available)"
-              component={RenderField}
-              allowClear
-            />
-          </Form.Item>
-        </Col>
-        <Col span={24}>
-          <Form.Item>
-            <Field
-              id="mine_guids"
-              name="mine_guids"
-              label="Mines*"
-              placeholder="Select the mines this user can access"
-              component={renderConfig.MULTI_SELECT}
-              data={props.mines}
-              onChange={props.handleChange}
-              onSearch={props.handleSearch}
-              validate={[requiredList]}
-            />
-          </Form.Item>
-        </Col>
-      </Row>
-      <div className="right center-mobile">
-        <Button className="full-mobile" type="primary" htmlType="submit">
-          Edit Proponent
-        </Button>
-      </div>
-    </Col>
-  </Form>
-);
+export const EditMinespaceUser = (props) => {
+  const { mines, handleSubmit, handleChange, handleSearch } = props;
+  return (
+    <Form layout="vertical" onSubmit={handleSubmit}>
+      <Col span={24}>
+        <Row>
+          <Col span={24}>
+            <Form.Item>
+              <Field
+                id="email_or_username"
+                name="email_or_username"
+                label="Email/BCeID username"
+                placeholder="Enter the users Email (BCeID username if email is not available)"
+                component={RenderField}
+                allowClear
+              />
+            </Form.Item>
+          </Col>
+          <Col span={24}>
+            <Form.Item>
+              <Field
+                id="mine_guids"
+                name="mine_guids"
+                label="Mines*"
+                placeholder="Select the mines this user can access"
+                component={renderConfig.MULTI_SELECT}
+                data={mines}
+                onChange={handleChange}
+                onSearch={handleSearch}
+                validate={[requiredList]}
+              />
+            </Form.Item>
+          </Col>
+        </Row>
+        <div className="right center-mobile">
+          <Button className="full-mobile" type="primary" htmlType="submit">
+            Edit Proponent
+          </Button>
+        </div>
+      </Col>
+    </Form>
+  );
+};
 
 EditMinespaceUser.propTypes = propTypes;
 

--- a/services/core-web/src/components/admin/MinespaceUserManagement.js
+++ b/services/core-web/src/components/admin/MinespaceUserManagement.js
@@ -106,6 +106,8 @@ export class MinespaceUserManagement extends Component {
         <NewMinespaceUser
           handleSubmit={this.handleCreateUser}
           minespaceUserEmailHash={this.props.minespaceUserEmailHash}
+          refresdata={this.refreshUserData}
+          handleSearch={this.ha}
         />
         <h3>MineSpace Users</h3>
         <MinespaceUserList

--- a/services/core-web/src/components/admin/NewMinespaceUser.js
+++ b/services/core-web/src/components/admin/NewMinespaceUser.js
@@ -5,8 +5,11 @@ import { getMineNames } from "@common/selectors/mineSelectors";
 
 import CustomPropTypes from "@/customPropTypes";
 import AddMinespaceUser from "@/components/Forms/AddMinespaceUser";
+import { bindActionCreators } from "redux";
+import { fetchMineNameList } from "@common/actionCreators/mineActionCreator";
 
 const propTypes = {
+  fetchMineNameList: PropTypes.func.isRequired,
   mines: PropTypes.arrayOf(CustomPropTypes.mineName),
   minespaceUserEmailHash: PropTypes.objectOf(PropTypes.any),
   handleSubmit: PropTypes.func.isRequired,
@@ -20,6 +23,16 @@ const defaultProps = {
 export const NewMinespaceUser = (props) => {
   const { mines, minespaceUserEmailHash, handleSubmit } = props;
 
+  const handleSearch = (name) => {
+    if (name.length > 0) {
+      props.fetchMineNameList({ name });
+    }
+  };
+
+  const handleChange = () => {
+    props.fetchMineNameList();
+  };
+
   return (
     <div>
       <h3>Create Proponent</h3>
@@ -31,6 +44,8 @@ export const NewMinespaceUser = (props) => {
           }))}
           minespaceUserEmailHash={minespaceUserEmailHash}
           onSubmit={handleSubmit}
+          handleChange={handleChange}
+          handleSearch={handleSearch}
         />
       )}
     </div>
@@ -41,7 +56,15 @@ const mapStateToProps = (state) => ({
   mines: getMineNames(state),
 });
 
+const mapDispatchToProps = (dispatch) =>
+  bindActionCreators(
+    {
+      fetchMineNameList,
+    },
+    dispatch
+  );
+
 NewMinespaceUser.propTypes = propTypes;
 NewMinespaceUser.defaultProps = defaultProps;
 
-export default connect(mapStateToProps)(NewMinespaceUser);
+export default connect(mapStateToProps, mapDispatchToProps)(NewMinespaceUser);

--- a/services/core-web/src/components/admin/UpdateMinespaceUser.js
+++ b/services/core-web/src/components/admin/UpdateMinespaceUser.js
@@ -42,6 +42,12 @@ export class UpdateMinespaceUser extends Component {
     }));
   };
 
+  filterUserMines = (userMines) => {
+    return userMines.map((mine) => {
+      return this.props.minespaceUserMines.find((m) => m.mine_guid === mine);
+    });
+  };
+
   render() {
     return (
       <div>
@@ -50,7 +56,7 @@ export class UpdateMinespaceUser extends Component {
           <EditMinespaceUser
             mines={this.parseMinesAsOptions([
               ...this.props.mines,
-              ...this.props.minespaceUserMines,
+              ...this.filterUserMines(this.props.initialValues.mineNames.map((mn) => mn.mine_guid)),
             ])}
             initalValueOptions={this.props.initialValues.mineNames}
             initialValues={{

--- a/services/core-web/src/components/admin/UpdateMinespaceUser.js
+++ b/services/core-web/src/components/admin/UpdateMinespaceUser.js
@@ -7,6 +7,7 @@ import { fetchMineNameList } from "@common/actionCreators/mineActionCreator";
 
 import CustomPropTypes from "@/customPropTypes";
 import EditMinespaceUser from "@/components/Forms/EditMinespaceUser";
+import { getMinespaceUserMines } from "@common/reducers/minespaceReducer";
 
 const propTypes = {
   fetchMineNameList: PropTypes.func.isRequired,
@@ -14,18 +15,16 @@ const propTypes = {
   minespaceUserEmailHash: PropTypes.objectOf(PropTypes.any),
   handleSubmit: PropTypes.func.isRequired,
   initialValues: PropTypes.objectOf(PropTypes.any).isRequired,
+  minespaceUserMines: PropTypes.arrayOf(CustomPropTypes.mineName),
 };
 
 const defaultProps = {
   mines: [],
   minespaceUserEmailHash: {},
+  minespaceUserMines: [],
 };
 
 export class UpdateMinespaceUser extends Component {
-  componentDidMount() {
-    this.props.fetchMineNameList();
-  }
-
   handleSearch = (name) => {
     if (name.length > 0) {
       this.props.fetchMineNameList({ name });
@@ -36,16 +35,24 @@ export class UpdateMinespaceUser extends Component {
     this.props.fetchMineNameList();
   };
 
+  parseMinesAsOptions = (mines) => {
+    return mines.map((mine) => ({
+      value: mine.mine_guid,
+      label: `${mine.mine_name} - ${mine.mine_no}`,
+    }));
+  };
+
   render() {
     return (
       <div>
         <h3>Edit Proponent</h3>
         {this.props.mines && (
           <EditMinespaceUser
-            mines={this.props.mines.map((mine) => ({
-              value: mine.mine_guid,
-              label: `${mine.mine_name} - ${mine.mine_no}`,
-            }))}
+            mines={this.parseMinesAsOptions([
+              ...this.props.mines,
+              ...this.props.minespaceUserMines,
+            ])}
+            initalValueOptions={this.props.initialValues.mineNames}
             initialValues={{
               ...this.props.initialValues,
               mine_guids: this.props.initialValues.mineNames.map((mn) => mn.mine_guid),
@@ -63,6 +70,7 @@ export class UpdateMinespaceUser extends Component {
 
 const mapStateToProps = (state) => ({
   mines: getMineNames(state),
+  minespaceUserMines: getMinespaceUserMines(state),
 });
 
 const mapDispatchToProps = (dispatch) =>

--- a/services/core-web/src/styles/settings/themeOverride.scss
+++ b/services/core-web/src/styles/settings/themeOverride.scss
@@ -16,12 +16,12 @@
 // VERTICAL TABS
 .vertical-tabs {
   &.ant-tabs {
-    padding-top: 0px !important;
+    padding-top: 0 !important;
   }
   &.ant-tabs .ant-tabs-ink-bar {
     background: transparent;
-    height: 0px;
-    top: 0px;
+    height: 0;
+    top: 0;
   }
   &.ant-tabs .ant-tabs-tab {
     color: #3D6DE7;
@@ -109,7 +109,7 @@
 // DRAWER
 .ant-drawer-body {
   -webkit-box-flex: 1;
-  -ms-flex-positive: 1;
+  -ms-flex: 1;
   flex-grow: 1;
   padding: 24px;
   height: 100vh;
@@ -124,7 +124,7 @@
 .ant-btn-secondary {
   position: inherit;
   margin: 10px;
-  padding: 0px 11px;
+  padding: 0 11px;
   color: $secondary-btn-color;
   border: 1px solid $secondary-btn-color;
 
@@ -234,11 +234,11 @@
   box-shadow: none;
   &:hover {
     border-style: none !important;
-    border: 0px;
+    border: 0;
   }
   &:focus {
     border-style: none !important;
-    border: 0px;
+    border: 0;
   }
 }
 
@@ -267,11 +267,11 @@
   height: 420px;
 
   &.ant-card-hoverable:hover {
-    box-shadow: 0px 4px 4px #7c66ad;
+    box-shadow: 0 4px 4px #7c66ad;
   }
 
   &.selected {
-    box-shadow: rgb(124, 102, 173) 0px 0px 10px 3px;
+    box-shadow: rgb(124, 102, 173) 0 0 10px 3px;
   }
 
   &.inherit-height {
@@ -287,14 +287,14 @@
 
   .ant-card-head {
     height: 70px;
-    align-items: "center";
+    align-items: center;
   }
 }
 
 .ant-card {
   margin-bottom: 20px;
   text-align: left;
-  box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+  box-shadow: 0 4px 4px rgba(0, 0, 0, 0.25);
 }
 
 .ant-card-body {
@@ -542,7 +542,6 @@
 input {
   box-sizing: border-box;
   margin: 0;
-  padding: 0;
   font-variant: tabular-nums;
   list-style: none;
   font-feature-settings: "tnum";
@@ -602,6 +601,10 @@ select {
   -ms-user-select: none;
   user-select: none;
   padding: 4px 11px;
+}
+
+.ant-select-multiple.ant-select-sm .ant-select-selection-search-input {
+  margin-top: -12px;
 }
 
 // update HTML select component to look like the ant design select. This block of code changes the default icon

--- a/services/core-web/src/tests/components/admin/__snapshots__/MinespaceUserManagement.spec.js.snap
+++ b/services/core-web/src/tests/components/admin/__snapshots__/MinespaceUserManagement.spec.js.snap
@@ -12,6 +12,7 @@ exports[`MinespaceUserManagement renders properly 1`] = `
   <Connect(NewMinespaceUser)
     handleSubmit={[Function]}
     minespaceUserEmailHash={Object {}}
+    refresdata={[Function]}
   />
   <h3>
     MineSpace Users

--- a/services/core-web/src/tests/components/admin/__snapshots__/NewMinespaceUser.spec.js.snap
+++ b/services/core-web/src/tests/components/admin/__snapshots__/NewMinespaceUser.spec.js.snap
@@ -11,6 +11,8 @@ exports[`NewMinespaceUser renders properly 1`] = `
     forceUnregisterOnUnmount={false}
     form="ADD_MINESPACE_USER"
     getFormState={[Function]}
+    handleChange={[Function]}
+    handleSearch={[Function]}
     initialValues={
       Object {
         "proponent_mine_access": Array [],


### PR DESCRIPTION
## Objective 

[MDS-3454](https://bcmines.atlassian.net/browse/MDS-3454)

- Added the options for the user's existing selection in the mine user access management edit modal
- Fixed some stylesheet bugs
- Fixed styling on multi-select input
- reinstated the limit on the api call for mine names.

_Why are you making this change? Provide a short explanation and/or screenshots_
