### PR TITLE
[MDS-3454] minespace user access

### DIFF
--- a/services/core-api/app/api/mines/mine/models/mine.py
+++ b/services/core-api/app/api/mines/mine/models/mine.py
@@ -238,7 +238,7 @@ class Mine(SoftDeleteMixin, AuditMixin, Base):
                            column('mine_location_description'), column('mine_name'), column('mine_no'),
                            column('deleted_ind'), column('major_mine_ind'))
 
-        mines_q = select([mine_table]).where(mine_table.c.deleted_ind == False)
+        mines_q = select([mine_table]).where(mine_table.c.deleted_ind == False).limit(50)
 
         if not (is_minespace_user()):
             mines_q = mines_q.limit(100)

--- a/services/core-api/app/api/mines/mine/models/mine.py
+++ b/services/core-api/app/api/mines/mine/models/mine.py
@@ -240,7 +240,7 @@ class Mine(SoftDeleteMixin, AuditMixin, Base):
 
         mines_q = select([mine_table]).where(mine_table.c.deleted_ind == False)
 
-        if not (is_minespace_user()):
+        if (is_minespace_user()):
             mines_q = mines_q.limit(100)
 
         if not (is_minespace_user()):

--- a/services/core-api/app/api/mines/mine/models/mine.py
+++ b/services/core-api/app/api/mines/mine/models/mine.py
@@ -238,7 +238,10 @@ class Mine(SoftDeleteMixin, AuditMixin, Base):
                            column('mine_location_description'), column('mine_name'), column('mine_no'),
                            column('deleted_ind'), column('major_mine_ind'))
 
-        mines_q = select([mine_table]).where(mine_table.c.deleted_ind == False).limit(50)
+        mines_q = select([mine_table]).where(mine_table.c.deleted_ind == False)
+
+        if not (is_minespace_user()):
+            mines_q = mines_q.limit(100)
 
         if not (is_minespace_user()):
             mines_q = mines_q.limit(100)

--- a/services/core-web/src/components/admin/UpdateMinespaceUser.js
+++ b/services/core-web/src/components/admin/UpdateMinespaceUser.js
@@ -42,10 +42,14 @@ export class UpdateMinespaceUser extends Component {
     }));
   };
 
-  filterUserMines = (userMines) => {
-    return userMines.map((mine) => {
-      return this.props.minespaceUserMines.find((m) => m.mine_guid === mine);
-    });
+  filterUserMines = () => {
+    if (this.props.initialValues.mineNames) {
+      const userMines = this.props.initialValues.mineNames.map((mn) => mn.mine_guid);
+      return userMines.map((mine) => {
+        return this.props.minespaceUserMines.find((m) => m.mine_guid === mine);
+      });
+    }
+    return [];
   };
 
   render() {
@@ -54,10 +58,7 @@ export class UpdateMinespaceUser extends Component {
         <h3>Edit Proponent</h3>
         {this.props.mines && (
           <EditMinespaceUser
-            mines={this.parseMinesAsOptions([
-              ...this.props.mines,
-              ...this.filterUserMines(this.props.initialValues.mineNames.map((mn) => mn.mine_guid)),
-            ])}
+            mines={this.parseMinesAsOptions([...this.props.mines, ...this.filterUserMines()])}
             initalValueOptions={this.props.initialValues.mineNames}
             initialValues={{
               ...this.props.initialValues,


### PR DESCRIPTION
## Objective 

[MDS-3454](https://bcmines.atlassian.net/browse/MDS-3454)

- Updated boolean check from to remove `not` for the limit return for minespace users
- added a check on `UpdateMinespaceUser.js` to only add the filtered list if it's been loaded.

_Why are you making this change? Provide a short explanation and/or screenshots_
