### PR TITLE
[MDS-4549] Minespace - IRT - Display empty state when IRT has not been submitted

### DIFF
--- a/services/minespace-web/src/components/dashboard/mine/projects/ProjectStagesTable.js
+++ b/services/minespace-web/src/components/dashboard/mine/projects/ProjectStagesTable.js
@@ -17,6 +17,7 @@ export class ProjectStagesTable extends Component {
       stage_status: stage.status,
       stage_status_hash: stage.statusHash,
       stage_required: stage.required,
+      navigate_to: stage.navigateTo,
       stage,
     }));
 
@@ -70,32 +71,29 @@ export class ProjectStagesTable extends Component {
               )}
             >
               <Button className="full-mobile margin-small" type="secondary">
-                Edit
+                Resume
               </Button>
             </Link>
           );
         }
         if (record.project_stage === "IRT") {
+          let buttonLabel;
+          if (!record.stage_status) {
+            buttonLabel = "Start";
+          } else if (record.stage_status === "APV") {
+            buttonLabel = "View";
+          } else {
+            buttonLabel = "Resume";
+          }
+
           link = (
-            <Link
-              to={
-                record.stage_status === "APV"
-                  ? {
-                      pathname: `${routes.REVIEW_INFORMATION_REQUIREMENTS_TABLE.dynamicRoute(
-                        record.stage?.project_guid,
-                        record.stage?.payload?.irt_guid
-                      )}`,
-                      state: { current: 2 },
-                    }
-                  : routes.ADD_INFORMATION_REQUIREMENTS_TABLE.dynamicRoute(
-                      record.stage?.project_guid
-                    )
-              }
+            <Button
+              className="full-mobile margin-small"
+              type="secondary"
+              onClick={() => record?.navigate_to()}
             >
-              <Button className="full-mobile margin-small" type="secondary">
-                {record.stage_status ? "View" : "Start"}
-              </Button>
-            </Link>
+              {buttonLabel}
+            </Button>
           );
         }
         return link;

--- a/services/minespace-web/src/components/pages/Project/InformationRequirementsTableEntryTab.js
+++ b/services/minespace-web/src/components/pages/Project/InformationRequirementsTableEntryTab.js
@@ -1,0 +1,113 @@
+import React from "react";
+import { withRouter } from "react-router-dom";
+import { Row, Col, Typography, Steps, Button, Empty } from "antd";
+import PropTypes from "prop-types";
+import * as routes from "@/constants/routes";
+import CustomPropTypes from "@/customPropTypes";
+
+const propTypes = {
+  irt: CustomPropTypes.informationRequirementsTable.isRequired,
+  mrcReviewRequired: PropTypes.bool.isRequired,
+  match: PropTypes.shape({
+    params: PropTypes.shape({
+      projectGuid: PropTypes.string,
+    }),
+  }).isRequired,
+  history: PropTypes.shape({
+    push: PropTypes.func,
+  }).isRequired,
+};
+
+export const InformationRequirementsTableEntryTab = (props) => {
+  const irtExists = Boolean(props?.irt?.irt_guid);
+  const projectGuid = props?.irt?.project_guid || props.match.params?.projectGuid;
+  const irtGuid = props?.irt?.irt_guid;
+
+  const renderContent = () => {
+    const buttonContent = {
+      label: irtExists ? "Resume" : "Start",
+      link: irtExists
+        ? () =>
+            props.history.push({
+              pathname: `${routes.REVIEW_INFORMATION_REQUIREMENTS_TABLE.dynamicRoute(
+                projectGuid,
+                irtGuid
+              )}`,
+              state: { current: 2 },
+            })
+        : () =>
+            props.history.push(
+              `${routes.ADD_INFORMATION_REQUIREMENTS_TABLE.dynamicRoute(projectGuid)}`
+            ),
+    };
+
+    const entryGraphic = (
+      <Empty
+        image={Empty.PRESENTED_IMAGE_SIMPLE}
+        imageStyle={{ transform: "scale(2.0)" }}
+        description={false}
+      />
+    );
+
+    return !irtExists ? (
+      <div style={{ textAlign: "center" }}>
+        <br />
+        {entryGraphic}
+        <br />
+        <Typography.Paragraph>
+          <Typography.Title level={5}>Start new IRT submission</Typography.Title>
+          Based on your project description, an Information Requirements Table is{" "}
+          {props?.mrcReviewRequired ? <b>required</b> : <b>optional</b>}.
+        </Typography.Paragraph>
+        <Typography.Paragraph>
+          Start the final IRT submission process by clicking the button below.
+        </Typography.Paragraph>
+        <div>
+          <Button type="primary" onClick={buttonContent.link}>
+            {buttonContent.label}
+          </Button>
+        </div>
+      </div>
+    ) : (
+      <div style={{ textAlign: "center" }}>
+        <br />
+        {entryGraphic}
+        <br />
+        <Typography.Paragraph>
+          <Typography.Title level={5}>Resume IRT submission</Typography.Title>
+          <div style={{ width: "60%", margin: "0 auto" }}>
+            <Steps size="small" current={2}>
+              <Steps.Step title="Download Template" />
+              <Steps.Step title="Import File" />
+              <Steps.Step title="Review & Submit" />
+            </Steps>
+          </div>
+          <br />
+          Based on your project description, an Information Requirements Table is{" "}
+          {props?.mrcReviewRequired ? <b>required</b> : <b>optional</b>}.
+        </Typography.Paragraph>
+        <Typography.Paragraph>
+          Resume where you left off by clicking the button below.
+        </Typography.Paragraph>
+        <div>
+          <Button type="primary" onClick={buttonContent.link}>
+            {buttonContent.label}
+          </Button>
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <Row>
+      <Col span={24}>
+        <Typography.Title level={4}>Information Requirements Table</Typography.Title>
+      </Col>
+      <Col span={24}>{renderContent()}</Col>
+    </Row>
+  );
+};
+
+InformationRequirementsTableEntryTab.propTypes = propTypes;
+
+export default withRouter(InformationRequirementsTableEntryTab);

--- a/services/minespace-web/src/components/pages/Project/ProjectOverviewTab.js
+++ b/services/minespace-web/src/components/pages/Project/ProjectOverviewTab.js
@@ -29,6 +29,7 @@ const propTypes = {
   projectSummary: CustomPropTypes.projectSummary.isRequired,
   informationRequirementsTable: CustomPropTypes.informationRequirementsTable.isRequired,
   informationRequirementsTableStatusCodesHash: PropTypes.objectOf(PropTypes.string).isRequired,
+  irtNavigateTo: PropTypes.func.isRequired,
 };
 
 export class ProjectOverviewTab extends Component {
@@ -94,6 +95,8 @@ export class ProjectOverviewTab extends Component {
         payload: this.props.informationRequirementsTable,
         statusHash: this.props.informationRequirementsTableStatusCodesHash,
         required: this.props.project.mrc_review_required,
+        navigateTo: () =>
+          this.props.irtNavigateTo(this.props.informationRequirementsTable.status_code),
       });
     }
     // TODO: Add in ToC here

--- a/services/minespace-web/src/tests/components/project/informationRequirementsTableEntryTab/InformationRequirementsTableEntryTab.spec.js
+++ b/services/minespace-web/src/tests/components/project/informationRequirementsTableEntryTab/InformationRequirementsTableEntryTab.spec.js
@@ -1,0 +1,23 @@
+import React from "react";
+import { shallow } from "enzyme";
+import { InformationRequirementsTableEntryTab } from "@/components/pages/Project/InformationRequirementsTableEntryTab";
+import * as MOCK from "@/tests/mocks/dataMocks";
+
+const props = {};
+
+const setupProps = () => {
+  props.irt = MOCK.INFORMATION_REQUIREMENTS_TABLE;
+  props.match = { params: { projectGuid: "1234-5678-x" } };
+  props.history = { push: jest.fn() };
+};
+
+beforeEach(() => {
+  setupProps();
+});
+
+describe("InformationRequirementsTableEntryTab", () => {
+  it("renders properly", () => {
+    const component = shallow(<InformationRequirementsTableEntryTab {...props} />);
+    expect(component).toMatchSnapshot();
+  });
+});

--- a/services/minespace-web/src/tests/components/project/informationRequirementsTableEntryTab/__snapshots__/InformationRequirementsTableEntryTab.spec.js.snap
+++ b/services/minespace-web/src/tests/components/project/informationRequirementsTableEntryTab/__snapshots__/InformationRequirementsTableEntryTab.spec.js.snap
@@ -1,0 +1,66 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`InformationRequirementsTableEntryTab renders properly 1`] = `
+<Row>
+  <Col
+    span={24}
+  >
+    <Title
+      level={4}
+    >
+      Information Requirements Table
+    </Title>
+  </Col>
+  <Col
+    span={24}
+  >
+    <div
+      style={
+        Object {
+          "textAlign": "center",
+        }
+      }
+    >
+      <br />
+      <Empty
+        description={false}
+        image={<Simple />}
+        imageStyle={
+          Object {
+            "transform": "scale(2.0)",
+          }
+        }
+      />
+      <br />
+      <Paragraph>
+        <Title
+          level={5}
+        >
+          Start new IRT submission
+        </Title>
+        Based on your project description, an Information Requirements Table is
+         
+        <b>
+          optional
+        </b>
+        .
+      </Paragraph>
+      <Paragraph>
+        Start the final IRT submission process by clicking the button below.
+      </Paragraph>
+      <div>
+        <Button
+          block={false}
+          ghost={false}
+          htmlType="button"
+          loading={false}
+          onClick={[Function]}
+          type="primary"
+        >
+          Start
+        </Button>
+      </div>
+    </div>
+  </Col>
+</Row>
+`;

--- a/services/minespace-web/src/tests/components/project/projectOverviewTab/__snapshots__/ProjectOverviewTab.spec.js.snap
+++ b/services/minespace-web/src/tests/components/project/projectOverviewTab/__snapshots__/ProjectOverviewTab.spec.js.snap
@@ -116,6 +116,7 @@ exports[`ProjectOverviewTab renders properly 1`] = `
           },
           Object {
             "key": undefined,
+            "navigateTo": [Function],
             "payload": Object {
               "project_guid": "66d7e698-8820-456f-ac32-14917f3ebe88",
               "requirements": Array [


### PR DESCRIPTION
## Objective 

[MDS-4549](https://bcmines.atlassian.net/browse/MDS-4549)

_Why are you making this change? Provide a short explanation and/or screenshots_
- When clicking the IRT tab or the IRT "Start"/"Resume"(not APPROVED status) buttons a new entrance page will be shown which links to the flow: [see mock](https://www.figma.com/file/O7i6jpbKbju49HfL1OpozT/CORE-%26-Minespace-2021-2022?node-id=15699%3A17383)
- When clicking the IRT tab(when IRT status is APPROVED) or the IRT "View"(APPROVED status) button it will link to Step 3 of the IRT flow
