### PR TITLE
[MDS-4555] Review IRT after submission

### DIFF
--- a/migrations/sql/V2022.07.14.15.42__insert_new_information_requirements_table_status_code.sql
+++ b/migrations/sql/V2022.07.14.15.42__insert_new_information_requirements_table_status_code.sql
@@ -1,0 +1,1 @@
+INSERT INTO information_requirements_table_status_code (information_requirements_table_status_code, description, create_user, update_user) VALUES ('PRG', 'In Progress', 'system-mds', 'system-mds');

--- a/services/core-api/app/api/projects/information_requirements_table/models/information_requirements_table.py
+++ b/services/core-api/app/api/projects/information_requirements_table/models/information_requirements_table.py
@@ -86,7 +86,7 @@ class InformationRequirementsTable(SoftDeleteMixin, AuditMixin, Base):
 
     def update(self, irt_data, import_file=None, document_guid=None, add_to_session=True):
         if import_file and document_guid:
-            self.status_code = 'REC'
+            self.status_code = 'PRG'
             for requirement in self.requirements:
                 requirement_to_update = list(
                     filter(
@@ -152,7 +152,7 @@ class InformationRequirementsTable(SoftDeleteMixin, AuditMixin, Base):
             'project_guid':
             project.project_guid,
             'status_code':
-            'REC',
+            'PRG',
             'requirements':
             requirements
         })

--- a/services/core-api/app/api/projects/information_requirements_table/resources/information_requirements_table.py
+++ b/services/core-api/app/api/projects/information_requirements_table/resources/information_requirements_table.py
@@ -12,7 +12,6 @@ from app.api.projects.information_requirements_table.resources.information_requi
 
 
 class InformationRequirementsTableResource(Resource, UserMixin):
-
     @api.doc(
         description='Get a Information Requirements Table by GUID.',
         params={
@@ -53,14 +52,13 @@ class InformationRequirementsTableResource(Resource, UserMixin):
                 sanitized_irt_requirements = InformationRequirementsTableListResource.build_irt_payload_from_excel(
                     import_file)
                 irt_updated = irt.update(sanitized_irt_requirements, import_file, document_guid)
-                data = {'status_code': 'REC'}
+                return irt_updated
 
+            irt_updated = irt.update(data)
             if irt.status_code != 'APV' and data['status_code'] == 'APV':
-                irt_updated = irt.update(data)
                 irt.send_irt_approval_email()
-            elif irt.status_code != 'UNR' and data['status_code'] == 'UNR':
+            elif irt.status_code != 'REC' and data['status_code'] == 'REC':
                 irt.send_irt_submit_email()
-                irt_updated = irt.update(data)
 
             return irt_updated
 

--- a/services/core-web/common/utils/helpers.js
+++ b/services/core-web/common/utils/helpers.js
@@ -515,5 +515,11 @@ export const formatBooleanToString = (value, defaultValue) => {
 };
 
 export const formatUrlToUpperCaseString = (url) => {
-  return startCase(url.replace("-", " "));
+  const stopWords = ["what", "which", "who", "and", "but"];
+  let urlArr = url.split("-");
+  return urlArr
+    .map((word, i) => {
+      return stopWords.includes(word) ? [word] : word.charAt(0).toUpperCase() + word.slice(1);
+    })
+    .join(" ");
 };

--- a/services/minespace-web/common/utils/helpers.js
+++ b/services/minespace-web/common/utils/helpers.js
@@ -515,5 +515,11 @@ export const formatBooleanToString = (value, defaultValue) => {
 };
 
 export const formatUrlToUpperCaseString = (url) => {
-  return startCase(url.replace("-", " "));
+  const stopWords = ["what", "which", "who", "and", "but"];
+  let urlArr = url.split("-");
+  return urlArr
+    .map((word, i) => {
+      return stopWords.includes(word) ? [word] : word.charAt(0).toUpperCase() + word.slice(1);
+    })
+    .join(" ");
 };

--- a/services/minespace-web/src/components/Forms/projects/informationRequirementsTable/IRTDownloadTemplate.js
+++ b/services/minespace-web/src/components/Forms/projects/informationRequirementsTable/IRTDownloadTemplate.js
@@ -19,7 +19,7 @@ export class IRTDownloadTemplate extends Component {
     return (
       <Row>
         <Col>
-          <Typography.Title level={4}>Download IRT template</Typography.Title>
+          <Typography.Title level={3}>Download IRT template</Typography.Title>
           <Typography.Paragraph>
             The first step in composing an IRT is to download the official{" "}
             <LinkButton
@@ -57,6 +57,7 @@ export class IRTDownloadTemplate extends Component {
             </a>
             &nbsp;closest to your project location.
           </Typography.Paragraph>
+          <br />
           <Typography.Paragraph>
             <div>
               <Button

--- a/services/minespace-web/src/components/Forms/projects/informationRequirementsTable/IRTFileImport.js
+++ b/services/minespace-web/src/components/Forms/projects/informationRequirementsTable/IRTFileImport.js
@@ -1,28 +1,32 @@
 import React, { Component } from "react";
+import { connect } from "react-redux";
+import { withRouter } from "react-router-dom";
+import { Field, change, formValueSelector, reduxForm } from "redux-form";
+import { bindActionCreators, compose } from "redux";
 import PropTypes from "prop-types";
 import customPropTypes from "@/customPropTypes";
-import { Field, change, formValueSelector, reduxForm } from "redux-form";
+import { Alert, Typography, Row, Col } from "antd";
+import { Form } from "@ant-design/compatible";
+import { remove } from "lodash";
+import * as FORM from "@/constants/forms";
+import { ENVIRONMENT } from "@common/constants/environment";
+import LinkButton from "@/components/common/LinkButton";
+import * as API from "@common/constants/API";
+import { MODERN_EXCEL } from "@/constants/fileTypes";
+import DocumentTable from "@/components/common/DocumentTable";
 import {
   createInformationRequirementsTable,
   updateInformationRequirementsTableByFile,
 } from "@common/actionCreators/projectActionCreator";
 import { getProject } from "@common/selectors/projectSelectors";
-import { Form } from "@ant-design/compatible";
-import { connect } from "react-redux";
-import { remove } from "lodash";
-import { Typography, Row, Col } from "antd";
-import { bindActionCreators, compose } from "redux";
-import { withRouter } from "react-router-dom";
 import IRTFileUpload from "@/components/Forms/projects/informationRequirementsTable/IRTFileUpload";
-import * as FORM from "@/constants/forms";
-import { MODERN_EXCEL } from "@/constants/fileTypes";
-import DocumentTable from "@/components/common/DocumentTable";
 
 const propTypes = {
   change: PropTypes.func.isRequired,
   createInformationRequirementsTable: PropTypes.func.isRequired,
   updateInformationRequirementsTableByFile: PropTypes.func.isRequired,
   importIsSuccessful: PropTypes.func.isRequired,
+  downloadIRTTemplate: PropTypes.func.isRequired,
   project: customPropTypes.project.isRequired,
   documents: PropTypes.arrayOf(PropTypes.objectOf(PropTypes.string)).isRequired,
   informationRequirementsTableDocumentTypesHash: PropTypes.objectOf(PropTypes.string).isRequired,
@@ -54,7 +58,7 @@ export class IRTFileImport extends Component {
       <>
         <Row>
           <Col span={24}>
-            <Typography.Title level={4}>Import final IRT file</Typography.Title>
+            <Typography.Title level={4}>Import a new IRT</Typography.Title>
             <Typography.Paragraph>
               Please upload your final IRT file.
               <ul>
@@ -63,6 +67,19 @@ export class IRTFileImport extends Component {
                 <li>Maximum individual file size is 400 MB</li>
                 <li>You can only upload one file at a time</li>
               </ul>
+            </Typography.Paragraph>
+            <Typography.Paragraph>
+              Download{" "}
+              <LinkButton
+                onClick={() => {
+                  this.props.downloadIRTTemplate(
+                    ENVIRONMENT.apiUrl + API.INFORMATION_REQUIREMENTS_TABLE_TEMPLATE_DOWNLOAD
+                  );
+                }}
+              >
+                IRT template
+              </LinkButton>{" "}
+              here.
             </Typography.Paragraph>
             <Form.Item wrapperCol={{ lg: 24 }} style={{ width: "100%", marginRight: 0 }}>
               <DocumentTable
@@ -74,6 +91,16 @@ export class IRTFileImport extends Component {
                 categoryDataIndex="information_requirements_table_document_type_code"
                 uploadDateIndex="upload_date"
               />
+              <br />
+              {this.props.project?.information_requirements_table?.status_code === "REC" && (
+                <Alert
+                  message="Re-uploading a new file will replace all the data imported from the current final IRT."
+                  description=""
+                  type="info"
+                  showIcon
+                />
+              )}
+              <br />
               <Field
                 id="final_irt"
                 name="final_irt"

--- a/services/minespace-web/src/components/Forms/projects/informationRequirementsTable/InformationRequirementsTableCallout.js
+++ b/services/minespace-web/src/components/Forms/projects/informationRequirementsTable/InformationRequirementsTableCallout.js
@@ -47,7 +47,7 @@ const InformationRequirementsTableCallout = (props) => {
   return (
     <Callout
       message={
-        <div className="bcgov-callout">
+        <div className="information-requirements-table-callout">
           <h4>{title}</h4>
           <p>{message}</p>
         </div>

--- a/services/minespace-web/src/components/Forms/projects/informationRequirementsTable/InformationRequirementsTableCallout.js
+++ b/services/minespace-web/src/components/Forms/projects/informationRequirementsTable/InformationRequirementsTableCallout.js
@@ -1,0 +1,62 @@
+import React from "react";
+import { CALLOUT_SEVERITY } from "@common/constants/strings";
+import PropTypes from "prop-types";
+import Callout from "@/components/common/Callout";
+
+const propTypes = {
+  informationRequirementsTableStatus: PropTypes.string.isRequired,
+};
+
+const calloutContent = (informationRequirementsTableStatus) => {
+  switch (informationRequirementsTableStatus) {
+    case "PRG":
+      return {
+        message:
+          "Review imported data before submission. Check the requirements and comments fields that are required for the project.",
+        title: "",
+        severity: CALLOUT_SEVERITY.info,
+      };
+    case "REC":
+      return {
+        message:
+          "Your IRT is pending review. You can make changes to the final IRT by uploading a new one and resubmit it. No changes can be made once the submission is in review.",
+        title: "Pending Review",
+        severity: CALLOUT_SEVERITY.warning,
+      };
+    case "UNR":
+      return {
+        message: "Your IRT is in the process of being reviewed. No edits can be made at this time.",
+        title: "In Review",
+        severity: CALLOUT_SEVERITY.warning,
+      };
+    case "APV":
+      return {
+        message: "Your IRT has been reviewed. You can proceed to Table of Concordance.",
+        title: "Review Complete",
+        severity: CALLOUT_SEVERITY.success,
+      };
+    default:
+      return null;
+  }
+};
+
+const InformationRequirementsTableCallout = (props) => {
+  const { informationRequirementsTableStatus } = props;
+  const { title, message, severity } = calloutContent(informationRequirementsTableStatus);
+
+  return (
+    <Callout
+      message={
+        <div className="bcgov-callout">
+          <h4>{title}</h4>
+          <p>{message}</p>
+        </div>
+      }
+      severity={severity}
+    />
+  );
+};
+
+InformationRequirementsTableCallout.propTypes = propTypes;
+
+export default InformationRequirementsTableCallout;

--- a/services/minespace-web/src/components/Forms/projects/informationRequirementsTable/InformationRequirementsTableForm.js
+++ b/services/minespace-web/src/components/Forms/projects/informationRequirementsTable/InformationRequirementsTableForm.js
@@ -1,10 +1,10 @@
 import React, { Component } from "react";
+import CustomPropTypes from "@/customPropTypes";
 import PropTypes from "prop-types";
 import { formatUrlToUpperCaseString } from "@common/utils/helpers";
 import { Form } from "@ant-design/compatible";
 import "@ant-design/compatible/assets/index.css";
 import { Row, Col, Tabs } from "antd";
-import CustomPropTypes from "@/customPropTypes";
 import ReviewSubmitInformationRequirementsTable from "@/components/Forms/projects/informationRequirementsTable/ReviewSubmitInformationRequirementsTable";
 
 const propTypes = {
@@ -12,24 +12,13 @@ const propTypes = {
   requirements: CustomPropTypes.requirements.isRequired,
   tab: PropTypes.string.isRequired,
   handleTabChange: PropTypes.func.isRequired,
+  sideMenuOptions: PropTypes.arrayOf(PropTypes.string).isRequired,
 };
-
-const tabs = [
-  "intro-project-overview",
-  "baseline-information",
-  "mine-plan",
-  "reclamation-closure-plan",
-  "modelling-mitigation-discharges",
-  "environmental-assessment-predictions",
-  "environmental-monitoring",
-  "health-safety",
-  "management-plan",
-];
 
 export class InformationRequirementsTableForm extends Component {
   state = {
     tabIndex: 0,
-    activeTab: tabs[0],
+    activeTab: this.props.sideMenuOptions ? this.props.sideMenuOptions[0] : null,
   };
 
   mergedRequirements = [];
@@ -41,14 +30,14 @@ export class InformationRequirementsTableForm extends Component {
         ({ deleted_ind }) => deleted_ind === false
       )
     );
-    this.setState({ tabIndex: tabs.indexOf(this.props.tab) });
+    this.setState({ tabIndex: this.props.sideMenuOptions.indexOf(this.props.tab) });
   }
 
   componentWillUpdate(nextProps) {
     const tabChanged = nextProps.tab !== this.props.tab;
     if (tabChanged) {
       // eslint-disable-next-line react/no-will-update-set-state
-      this.setState({ tabIndex: tabs.indexOf(nextProps.tab) });
+      this.setState({ tabIndex: this.props.sideMenuOptions.indexOf(nextProps.tab) });
     }
   }
 
@@ -73,11 +62,11 @@ export class InformationRequirementsTableForm extends Component {
             <Tabs
               tabPosition="left"
               activeKey={this.state.activeTab}
-              defaultActiveKey={tabs[0]}
+              defaultActiveKey={this.props.sideMenuOptions[0]}
               onChange={(tab) => this.props.handleTabChange(tab)}
               className="vertical-tabs"
             >
-              {tabs.map((tab) => {
+              {this.props.sideMenuOptions.map((tab) => {
                 return (
                   <Tabs.TabPane
                     tab={formatUrlToUpperCaseString(tab)}

--- a/services/minespace-web/src/components/common/DocumentTable.js
+++ b/services/minespace-web/src/components/common/DocumentTable.js
@@ -56,7 +56,7 @@ export const DocumentTable = (props) => {
     render: (text) => <div title="Date/Time">{formatDateTime(text) || Strings.EMPTY_FIELD}</div>,
   };
 
-  const ImportedByColumn = {
+  const importedByColumn = {
     title: "Imported By",
     dataIndex: "create_user",
     render: (text) => (text ? <div title="User">{text}</div> : null),
@@ -64,7 +64,7 @@ export const DocumentTable = (props) => {
 
   if (props.documentParent === "Information Requirements Table") {
     columns.push(uploadDateTimeColumn);
-    columns.push(ImportedByColumn);
+    columns.push(importedByColumn);
   } else {
     columns.push(uploadDateColumn);
   }

--- a/services/minespace-web/src/components/common/DocumentTable.js
+++ b/services/minespace-web/src/components/common/DocumentTable.js
@@ -1,5 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
+import moment from "moment";
 import { Table } from "antd";
 import { formatDate, formatDateTime, truncateFilename } from "@common/utils/helpers";
 import { downloadFileFromDocumentManager } from "@common/utils/actionlessNetworkCalls";
@@ -40,27 +41,32 @@ export const DocumentTable = (props) => {
       dataIndex: props.categoryDataIndex,
       render: (text) => <div title="Category">{props.documentCategoryOptionsHash[text]}</div>,
     },
-    {
-      title: "Upload Date",
-      dataIndex: props.uploadDateIndex,
-      render: (text) => (
-        <div title="Upload Date">
-          {props.documentParent === "Information Requirements Table"
-            ? formatDateTime(text)
-            : formatDate(text) || Strings.EMPTY_FIELD}
-        </div>
-      ),
-    },
   ];
 
-  const userColumn = {
-    title: "User",
+  const uploadDateColumn = {
+    title: "Upload Date",
+    dataIndex: props.uploadDateIndex,
+    render: (text) => <div title="Upload Date">{formatDate(text) || Strings.EMPTY_FIELD}</div>,
+  };
+
+  const uploadDateTimeColumn = {
+    title: "Date/Time",
+    dataIndex: props.uploadDateIndex,
+    sorter: (a, b) => (moment(a.uploadDateIndex) > moment(b.uploadDateIndex) ? -1 : 1),
+    render: (text) => <div title="Date/Time">{formatDateTime(text) || Strings.EMPTY_FIELD}</div>,
+  };
+
+  const ImportedByColumn = {
+    title: "Imported By",
     dataIndex: "create_user",
     render: (text) => (text ? <div title="User">{text}</div> : null),
   };
 
   if (props.documentParent === "Information Requirements Table") {
-    columns.push(userColumn);
+    columns.push(uploadDateTimeColumn);
+    columns.push(ImportedByColumn);
+  } else {
+    columns.push(uploadDateColumn);
   }
 
   return (

--- a/services/minespace-web/src/components/modalContent/config.js
+++ b/services/minespace-web/src/components/modalContent/config.js
@@ -9,6 +9,7 @@ import AddIncidentModal from "@/components/modalContent/incidents/AddIncidentMod
 import AddNoticeOfDepartureModal from "@/components/modalContent/noticeOfDeparture/AddNoticeOfDepartureModal";
 import ViewNoticeOfDepartureModal from "@/components/modalContent/noticeOfDeparture/ViewNoticeOfDepartureModal";
 import EditNoticeOfDepartureModal from "@/components/modalContent/noticeOfDeparture/EditNoticeOfDepartureModal";
+import ViewFileHistoryModal from "./informationRequirementsTable/ViewFileHistoryModal";
 
 export const modalConfig = {
   ADD_REPORT: AddReportModal,
@@ -22,6 +23,7 @@ export const modalConfig = {
   ADD_NOTICE_OF_DEPARTURE: AddNoticeOfDepartureModal,
   VIEW_NOTICE_OF_DEPARTURE: ViewNoticeOfDepartureModal,
   EDIT_NOTICE_OF_DEPARTURE: EditNoticeOfDepartureModal,
+  VIEW_FILE_HISTORY: ViewFileHistoryModal,
 };
 
 export default modalConfig;

--- a/services/minespace-web/src/components/modalContent/informationRequirementsTable/ViewFileHistoryModal.js
+++ b/services/minespace-web/src/components/modalContent/informationRequirementsTable/ViewFileHistoryModal.js
@@ -1,0 +1,32 @@
+import React from "react";
+import PropTypes from "prop-types";
+import CustomPropTypes from "@/customPropTypes";
+import { Button } from "antd";
+import DocumentTable from "@/components/common/DocumentTable";
+
+const propTypes = {
+  project: CustomPropTypes.project.isRequired,
+  documentCategoryOptionsHash: PropTypes.objectOf(PropTypes.string).isRequired,
+  closeModal: PropTypes.func.isRequired,
+};
+
+const ViewFileHistoryModal = (props) => {
+  return (
+    <div>
+      <DocumentTable
+        documents={props.project?.information_requirements_table?.documents}
+        documentCategoryOptionsHash={props.documentCategoryOptionsHash}
+        documentParent="Information Requirements Table"
+        categoryDataIndex="information_requirements_table_document_type_code"
+        uploadDateIndex="upload_date"
+      />
+      <div className="ant-modal-footer">
+        <Button onClick={props.closeModal}>Close</Button>
+      </div>
+    </div>
+  );
+};
+
+ViewFileHistoryModal.propTypes = propTypes;
+
+export default ViewFileHistoryModal;

--- a/services/minespace-web/src/components/pages/Project/InformationRequirementsTablePage.js
+++ b/services/minespace-web/src/components/pages/Project/InformationRequirementsTablePage.js
@@ -416,16 +416,12 @@ export class InformationRequirementsTablePage extends Component {
             </Steps>
             <br />
             <br />
-
-            <div>
+            <Col span={24}>
               <InformationRequirementsTableCallout
                 informationRequirementsTableStatus={
                   this.props.project?.information_requirements_table?.status_code || "PRG"
                 }
               />
-            </div>
-
-            <Col span={24}>
               <div>{Forms[this.props.location.state?.current || this.state.current].content}</div>
             </Col>
           </Row>

--- a/services/minespace-web/src/components/pages/Project/InformationRequirementsTablePage.js
+++ b/services/minespace-web/src/components/pages/Project/InformationRequirementsTablePage.js
@@ -2,14 +2,14 @@ import React, { Component } from "react";
 import { connect } from "react-redux";
 import { bindActionCreators } from "redux";
 import { Link, withRouter } from "react-router-dom";
-import { Row, Col, Button, Typography, Steps } from "antd";
+import { Row, Col, Button, Typography, Steps, Popconfirm } from "antd";
 import { ArrowLeftOutlined, DownloadOutlined, HourglassOutlined } from "@ant-design/icons";
 import PropTypes from "prop-types";
 import CustomPropTypes from "@/customPropTypes";
 import * as routes from "@/constants/routes";
 import { ENVIRONMENT } from "@common/constants/environment";
 import * as API from "@common/constants/API";
-
+import AuthorizationWrapper from "@/components/common/wrappers/AuthorizationWrapper";
 import { getProject, getRequirements } from "@common/selectors/projectSelectors";
 import { openModal } from "@common/actions/modalActions";
 import { clearInformationRequirementsTable } from "@common/actions/projectActions";
@@ -209,17 +209,26 @@ const StepForms = (
                 props.project?.information_requirements_table?.irt_guid
               )}
             >
-              <Button
-                id="submit_irt"
-                type="primary"
-                htmlType="submit"
-                onClick={() => {
-                  handleIRTUpdate({ status_code: "REC" }, "IRT submitted ");
-                }}
-                disabled={state.submitting}
-              >
-                Submit IRT
-              </Button>
+              <AuthorizationWrapper>
+                <Popconfirm
+                  placement="topRight"
+                  title="Are you sure you want to submit your final IRT, no changes could be made after submitting?"
+                  onConfirm={() =>
+                    handleIRTUpdate(
+                      {
+                        status_code: "REC",
+                      },
+                      "Successfully submitted final IRT."
+                    )
+                  }
+                  okText="Yes"
+                  cancelText="No"
+                >
+                  <Button id="submit_irt" type="primary">
+                    Submit IRT
+                  </Button>
+                </Popconfirm>
+              </AuthorizationWrapper>
             </Link>
           </>
         ) : (

--- a/services/minespace-web/src/components/pages/Project/InformationRequirementsTablePage.js
+++ b/services/minespace-web/src/components/pages/Project/InformationRequirementsTablePage.js
@@ -11,6 +11,7 @@ import { ENVIRONMENT } from "@common/constants/environment";
 import * as API from "@common/constants/API";
 
 import { getProject, getRequirements } from "@common/selectors/projectSelectors";
+import { openModal } from "@common/actions/modalActions";
 import { clearInformationRequirementsTable } from "@common/actions/projectActions";
 import {
   fetchProjectById,
@@ -22,6 +23,7 @@ import { getInformationRequirementsTableDocumentTypesHash } from "@common/select
 import IRTDownloadTemplate from "@/components/Forms/projects/informationRequirementsTable/IRTDownloadTemplate";
 import IRTFileImport from "@/components/Forms/projects/informationRequirementsTable/IRTFileImport";
 import { InformationRequirementsTableForm } from "@/components/Forms/projects/informationRequirementsTable/InformationRequirementsTableForm";
+import modalConfig from "@/components/modalContent/config";
 
 const propTypes = {
   project: CustomPropTypes.project.isRequired,
@@ -45,6 +47,7 @@ const propTypes = {
       current: PropTypes.number,
     },
   }).isRequired,
+  openModal: PropTypes.func.isRequired,
 };
 
 const tabs = [
@@ -67,7 +70,8 @@ const StepForms = (
   handleTabChange,
   handleIRTUpdate,
   importIsSuccessful,
-  downloadIRTTemplate
+  downloadIRTTemplate,
+  openViewFileHistoryModal
 ) => [
   {
     title: "Download Template",
@@ -252,7 +256,12 @@ const StepForms = (
               Download IRT template
             </Button>
 
-            <Button type="ghost" style={{ border: "none" }} className="full-mobile">
+            <Button
+              type="ghost"
+              style={{ border: "none" }}
+              className="full-mobile"
+              onClick={(event) => openViewFileHistoryModal(event)}
+            >
               <HourglassOutlined />
               File History
             </Button>
@@ -372,6 +381,18 @@ export class InformationRequirementsTablePage extends Component {
     anchor.remove();
   };
 
+  openViewFileHistoryModal = () => {
+    this.props.openModal({
+      props: {
+        project: this.props.project,
+        title: " View File History",
+        documentCategoryOptionsHash: this.props.informationRequirementsTableDocumentTypesHash,
+        width: 650,
+      },
+      content: modalConfig.VIEW_FILE_HISTORY,
+    });
+  };
+
   render() {
     const title =
       this.props.project.information_requirements_table?.status_code !== "PRG"
@@ -386,7 +407,8 @@ export class InformationRequirementsTablePage extends Component {
       this.handleTabChange,
       this.handleIRTUpdate,
       this.importIsSuccessful,
-      this.downloadIRTTemplate
+      this.downloadIRTTemplate,
+      this.openViewFileHistoryModal
     );
 
     return (
@@ -462,6 +484,7 @@ const mapDispatchToProps = (dispatch) =>
       fetchProjectById,
       fetchRequirements,
       updateInformationRequirementsTable,
+      openModal,
     },
     dispatch
   );

--- a/services/minespace-web/src/components/pages/Project/InformationRequirementsTablePage.js
+++ b/services/minespace-web/src/components/pages/Project/InformationRequirementsTablePage.js
@@ -54,12 +54,12 @@ const tabs = [
   "introduction-and-project-overview",
   "baseline-information",
   "mine-plan",
-  "reclamation-closure-plan",
-  "modelling-mitigation-discharges",
+  "reclamation-and-closure-plan",
+  "modelling-mitigation-and-discharges",
   "environmental-assessment-predictions",
   "environmental-monitoring",
-  "health-safety",
-  "management-plan",
+  "health-and-safety",
+  "management-plans",
 ];
 
 const StepForms = (

--- a/services/minespace-web/src/components/pages/Project/InformationRequirementsTablePage.js
+++ b/services/minespace-web/src/components/pages/Project/InformationRequirementsTablePage.js
@@ -33,7 +33,7 @@ const propTypes = {
   clearInformationRequirementsTable: PropTypes.func.isRequired,
   // eslint-disable-next-line react/no-unused-prop-types
   informationRequirementsTableDocumentTypesHash: PropTypes.objectOf(PropTypes.string).isRequired,
-  history: PropTypes.shape({ push: PropTypes.func }).isRequired,
+  history: PropTypes.shape({ push: PropTypes.func, replace: PropTypes.func }).isRequired,
   match: PropTypes.shape({
     params: {
       projectGuid: PropTypes.string,
@@ -306,9 +306,25 @@ export class InformationRequirementsTablePage extends Component {
     });
   };
 
-  next = () => this.setState((prevState) => ({ current: prevState.current + 1 }));
+  next = () => {
+    if (this.props.location?.state?.current) {
+      this.setState(() => ({ current: this.props.location?.state?.current + 1 }));
+      // eslint-disable-next-line no-restricted-globals
+      this.props.history.replace(location.state, null);
+    } else {
+      this.setState((prevState) => ({ current: prevState.current + 1 }));
+    }
+  };
 
-  prev = () => this.setState((prevState) => ({ current: prevState.current - 1 }));
+  prev = () => {
+    if (this.props.location?.state?.current) {
+      this.setState(() => ({ current: this.props.location?.state?.current - 1 }));
+      // eslint-disable-next-line no-restricted-globals
+      this.props.history.replace(location.state, null);
+    } else {
+      this.setState((prevState) => ({ current: prevState.current - 1 }));
+    }
+  };
 
   importIsSuccessful = () => {
     this.setState((state) => ({
@@ -404,12 +420,12 @@ export class InformationRequirementsTablePage extends Component {
             </Col>
             <Col span={12}>
               <div style={{ display: "inline", float: "right" }}>
-                <p>{Forms[this.props.location.state?.current || this.state.current].buttons}</p>
+                <p>{Forms[this.state.current].buttons}</p>
               </div>
             </Col>
           </Row>
           <Row>
-            <Steps current={this.props.location.state?.current || this.state.current}>
+            <Steps current={this.state.current}>
               {Forms.map((step) => (
                 <Steps.Step key={step.title} title={step.title} />
               ))}
@@ -422,7 +438,7 @@ export class InformationRequirementsTablePage extends Component {
                   this.props.project?.information_requirements_table?.status_code || "PRG"
                 }
               />
-              <div>{Forms[this.props.location.state?.current || this.state.current].content}</div>
+              <div>{Forms[this.state.current].content}</div>
             </Col>
           </Row>
         </>

--- a/services/minespace-web/src/constants/routes.js
+++ b/services/minespace-web/src/constants/routes.js
@@ -54,9 +54,16 @@ export const ADD_INFORMATION_REQUIREMENTS_TABLE = {
   component: InformationRequirementsTablePage,
 };
 
+export const RESUBMIT_INFORMATION_REQUIREMENTS_TABLE = {
+  route: "/projects/:projectGuid/information-requirements-table/:irtGuid/resubmit",
+  dynamicRoute: (projectGuid, irtGuid) =>
+    `/projects/${projectGuid}/information-requirements-table/${irtGuid}/resubmit`,
+  component: InformationRequirementsTablePage,
+};
+
 export const REVIEW_INFORMATION_REQUIREMENTS_TABLE = {
   route: "/projects/:projectGuid/information-requirements-table/:irtGuid/review/:tab",
-  dynamicRoute: (projectGuid, irtGuid, tab = "intro-project-overview") =>
+  dynamicRoute: (projectGuid, irtGuid, tab = "introduction-and-project-overview") =>
     `/projects/${projectGuid}/information-requirements-table/${irtGuid}/review/${tab}`,
   component: InformationRequirementsTablePage,
 };

--- a/services/minespace-web/src/routes/Routes.js
+++ b/services/minespace-web/src/routes/Routes.js
@@ -39,6 +39,10 @@ const Routes = () => (
       component={AuthenticationGuard()(routes.ADD_INFORMATION_REQUIREMENTS_TABLE.component)}
     />
     <Route
+      path={routes.RESUBMIT_INFORMATION_REQUIREMENTS_TABLE.route}
+      component={AuthenticationGuard()(routes.RESUBMIT_INFORMATION_REQUIREMENTS_TABLE.component)}
+    />
+    <Route
       path={routes.REVIEW_INFORMATION_REQUIREMENTS_TABLE.route}
       component={AuthenticationGuard()(routes.REVIEW_INFORMATION_REQUIREMENTS_TABLE.component)}
     />

--- a/services/minespace-web/src/styles/components/InformationRequirementsTable.scss
+++ b/services/minespace-web/src/styles/components/InformationRequirementsTable.scss
@@ -1,0 +1,9 @@
+.information-requirements-table-callout > h4 {
+    color: $font-colour;
+    font-weight: 700;
+  }
+  
+  .information-requirements-table-callout > p {
+    font-size: 1rem;
+    margin-bottom: 0;
+  }

--- a/services/minespace-web/src/styles/index.scss
+++ b/services/minespace-web/src/styles/index.scss
@@ -30,6 +30,7 @@
 @import "./components/LandingPage.scss";
 @import "./components/Callout.scss";
 @import "./components/NoticeOfDeparture.scss";
+@import "./components/InformationRequirementsTable.scss";
 
 // UTILITIES - utilities and helper classes. This layer has the highest specificity.
 @import "./generic/helpers.scss";

--- a/services/minespace-web/src/tests/routes/__snapshots__/Routes.spec.js.snap
+++ b/services/minespace-web/src/tests/routes/__snapshots__/Routes.spec.js.snap
@@ -113,6 +113,18 @@ exports[`PrivateRoutes  renders properly 1`] = `
         "type": [Function],
       }
     }
+    path="/projects/:projectGuid/information-requirements-table/:irtGuid/resubmit"
+  />
+  <Route
+    component={
+      Object {
+        "$$typeof": Symbol(react.memo),
+        "WrappedComponent": [Function],
+        "compare": null,
+        "displayName": "Connect(authenticationGuard)",
+        "type": [Function],
+      }
+    }
     path="/projects/:projectGuid/information-requirements-table/:irtGuid/review/:tab"
   />
   <Route


### PR DESCRIPTION
## Objective 

[MDS-4555](https://bcmines.atlassian.net/browse/MDS-4555)

- Add new status field “In progress” when IRT imported but not submitted to EMLI.
- Render informative messages related to IRT status.
- Move buttons to the top.
- Modifications in labels for side menu.
- Added modal to File History button


The workflow is kept the same for a brand new IRT application:
1.- Starting a new IRT takes us to step 1 :
![image](https://user-images.githubusercontent.com/10526131/180132467-f458da64-b720-4125-9527-b9ae2e544ba7.png)

2.- Then, step 2 to import a new IRT:
![image](https://user-images.githubusercontent.com/10526131/180132596-441c4da1-8ec9-4094-938d-d978aa468feb.png)

3.- Review & Submit the IRT:
![image](https://user-images.githubusercontent.com/10526131/180132704-fb30ff29-e86d-4253-b1b3-7958f23ef110.png)

The workflow for existing IRT application is changed. Once the IRT is submitted, the user is presented with a condense view containing three buttons at the top to Resubmit IRT (which takes the user to import a new IRT), Download IRT template to download IRT spreadsheet and File History to open a model with the IRT submission history:
![image](https://user-images.githubusercontent.com/10526131/180132962-fef3d083-652b-490f-9e23-7a6f7e2c18f9.png)

![image](https://user-images.githubusercontent.com/10526131/180133100-35a7c725-790b-48f1-ab55-2c6bca3cbf64.png)


