### PR TITLE
[MDS-3454] - Removed erroneous checks

### DIFF
--- a/services/core-api/app/api/mines/mine/models/mine.py
+++ b/services/core-api/app/api/mines/mine/models/mine.py
@@ -243,12 +243,6 @@ class Mine(SoftDeleteMixin, AuditMixin, Base):
         if (is_minespace_user()):
             mines_q = mines_q.limit(100)
 
-        if (is_minespace_user()):
-            mines_q = mines_q.limit(100)
-
-        if not (is_minespace_user()):
-            mines_q = mines_q.limit(100)
-
         if term:
             mines_q = mines_q.where(mine_table.c.mine_name.ilike('%{}%'.format(term)))
 


### PR DESCRIPTION
## Objective 

[MDS-3454](https://bcmines.atlassian.net/browse/MDS-3454)

Really not sure what happened here.  Must have been some odd rebase shenanigans.
Removed the two extra instances of adding a limit on fetching mines

_Why are you making this change? Provide a short explanation and/or screenshots_
