### PR TITLE
[MDS-3454] Reverted mines model query to original

### DIFF
--- a/services/core-api/app/api/mines/response_models.py
+++ b/services/core-api/app/api/mines/response_models.py
@@ -385,6 +385,8 @@ MINE_SEARCH_MODEL = api.model(
         'longitude': fields.String(default=''),
         'mine_guid': fields.String,
         'mine_location_description': fields.String(default=''),
+        'deleted_ind': fields.Boolean,
+        'major_mine_ind': fields.Boolean
     })
 
 MINE_LIST_MODEL = api.model(

--- a/services/core-api/app/api/mines/response_models.py
+++ b/services/core-api/app/api/mines/response_models.py
@@ -385,8 +385,6 @@ MINE_SEARCH_MODEL = api.model(
         'longitude': fields.String(default=''),
         'mine_guid': fields.String,
         'mine_location_description': fields.String(default=''),
-        'deleted_ind': fields.Boolean,
-        'major_mine_ind': fields.Boolean
     })
 
 MINE_LIST_MODEL = api.model(

--- a/services/core-api/tests/mines/mine/resources/test_mine_list_by_name_resource.py
+++ b/services/core-api/tests/mines/mine/resources/test_mine_list_by_name_resource.py
@@ -9,8 +9,6 @@ def test_get_mines_by_list(test_client, db_session, auth_headers):
     get_resp = test_client.get('/mines/search', headers=auth_headers['full_auth_header'])
     get_data = json.loads(get_resp.data.decode())
     context = {
-        'deleted_ind': mine.deleted_ind,
-        'major_mine_ind': mine.major_mine_ind,
         'mine_guid': str(mine.mine_guid),
         'mine_name': mine.mine_name,
         'mine_no': mine.mine_no,
@@ -18,8 +16,9 @@ def test_get_mines_by_list(test_client, db_session, auth_headers):
         'longitude': str(mine.longitude),
         'mine_location_description': mine.mine_location_description,
     }
+
     assert get_resp.status_code == 200
-    assert get_data['mines'] == []
+    assert get_data['mines'][0] == context
 
 
 def test_get_mines_by_list_search_by_name(test_client, db_session, auth_headers):
@@ -29,8 +28,6 @@ def test_get_mines_by_list_search_by_name(test_client, db_session, auth_headers)
         f'/mines/search?name={mine.mine_name}', headers=auth_headers['full_auth_header'])
     get_data = json.loads(get_resp.data.decode())
     context = {
-        'deleted_ind': mine.deleted_ind,
-        'major_mine_ind': mine.major_mine_ind,
         'mine_guid': str(mine.mine_guid),
         'mine_name': mine.mine_name,
         'mine_no': mine.mine_no,
@@ -39,7 +36,7 @@ def test_get_mines_by_list_search_by_name(test_client, db_session, auth_headers)
         'mine_location_description': mine.mine_location_description,
     }
     assert get_resp.status_code == 200
-    assert get_data['mines'] == []
+    assert get_data['mines'][0] == context
     
 
 

--- a/services/core-api/tests/mines/mine/resources/test_mine_list_by_name_resource.py
+++ b/services/core-api/tests/mines/mine/resources/test_mine_list_by_name_resource.py
@@ -9,6 +9,8 @@ def test_get_mines_by_list(test_client, db_session, auth_headers):
     get_resp = test_client.get('/mines/search', headers=auth_headers['full_auth_header'])
     get_data = json.loads(get_resp.data.decode())
     context = {
+        'deleted_ind': mine.deleted_ind,
+        'major_mine_ind': mine.major_mine_ind,
         'mine_guid': str(mine.mine_guid),
         'mine_name': mine.mine_name,
         'mine_no': mine.mine_no,
@@ -16,7 +18,6 @@ def test_get_mines_by_list(test_client, db_session, auth_headers):
         'longitude': str(mine.longitude),
         'mine_location_description': mine.mine_location_description,
     }
-
     assert get_resp.status_code == 200
     assert get_data['mines'][0] == context
 
@@ -28,6 +29,8 @@ def test_get_mines_by_list_search_by_name(test_client, db_session, auth_headers)
         f'/mines/search?name={mine.mine_name}', headers=auth_headers['full_auth_header'])
     get_data = json.loads(get_resp.data.decode())
     context = {
+        'deleted_ind': mine.deleted_ind,
+        'major_mine_ind': mine.major_mine_ind,
         'mine_guid': str(mine.mine_guid),
         'mine_name': mine.mine_name,
         'mine_no': mine.mine_no,


### PR DESCRIPTION
## Objective 

[MDS-3454](https://bcmines.atlassian.net/browse/MDS-3454)

Reverted query in mine.py to it's original state to utilize it's filtering of mines in minespace

_Why are you making this change? Provide a short explanation and/or screenshots_
