### PR TITLE
[MDS-4530] Email notification for a successful major mine application submission, include list of documents

### DIFF
--- a/services/core-api/app/api/projects/major_mine_application/resources/major_mine_application_list.py
+++ b/services/core-api/app/api/projects/major_mine_application/resources/major_mine_application_list.py
@@ -38,6 +38,7 @@ class MajorMineApplicationListResource(Resource, UserMixin):
 
         try:
             major_mine_application.save()
+            major_mine_application.send_mma_submit_email()
 
         except Exception as e:
             raise InternalServerError(f'Error when saving: {e}')

--- a/services/core-api/app/api/services/email_service.py
+++ b/services/core-api/app/api/services/email_service.py
@@ -1,4 +1,5 @@
-import requests, json
+import requests
+import json
 
 from enum import Enum
 from flask import current_app
@@ -39,7 +40,7 @@ MINESPACE_NO_REPLY_SIGNATURE = f'''
     <hr />
     <p>This is a no-reply email address. If you need to contact the MDS team, please email us at: <a href="mailto: {Config.MDS_EMAIL}">{Config.MDS_EMAIL}</a>.</p>
     <br />
-    <img src="{MINESPACE_LOGO_BASE64_ENCODED}" width="820" height="106" alt="MinespaceLogo">
+    <img src="{MINESPACE_LOGO_BASE64_ENCODED}" width="410" height="53" alt="MinespaceLogo">
 </div>
 '''
 


### PR DESCRIPTION
## Objective 

[MDS-4530](https://bcmines.atlassian.net/browse/MDS-4530)

_Why are you making this change? Provide a short explanation and/or screenshots_
- Send new email when submitting a Major Mine Application that includes all different document types that were uploaded(screenshot doesn't include supporting and spatial documents): 
- Shrunk Minespace footer logo to half the original size after UX request

![image](https://user-images.githubusercontent.com/13891487/181634011-3354b4ac-255a-4a74-a895-2722c98fe02c.png)
