### PR TITLE
[MDS-4558] Removed extra space above callouts in NOD create/view modals

### DIFF
--- a/services/minespace-web/src/components/common/Callout.js
+++ b/services/minespace-web/src/components/common/Callout.js
@@ -15,7 +15,7 @@ const Callout = (props) => {
   const { severity } = props;
 
   return (
-    <div className={`bcgov-callout--${severity} nod-callout-text`}>
+    <div className={`bcgov-callout--${severity} nod-callout-text`} style={props.style}>
       <p>{props.message}</p>
     </div>
   );

--- a/services/minespace-web/src/components/dashboard/mine/noticeOfDeparture/NoticeOfDepartureCallout.js
+++ b/services/minespace-web/src/components/dashboard/mine/noticeOfDeparture/NoticeOfDepartureCallout.js
@@ -71,6 +71,7 @@ const NoticeOfDepartureCallout = (props) => {
 
   return (
     <Callout
+      style={{ marginTop: 0 }}
       message={
         <div className="nod-callout">
           <h4>{title}</h4>


### PR DESCRIPTION
## Objective 

[MDS-4558](https://bcmines.atlassian.net/browse/MDS-4558)

_Why are you making this change? Provide a short explanation and/or screenshots_

Removed extra space above callouts in NOD modals.

![image](https://user-images.githubusercontent.com/66635118/182718200-17c926fe-72fa-42ed-b9a1-089577902b77.png)
