### PR TITLE
[MDS-4515] Bugfix - Fixed sass compilation error

### DIFF
--- a/services/minespace-web/src/styles/components/Header.scss
+++ b/services/minespace-web/src/styles/components/Header.scss
@@ -102,17 +102,15 @@
   box-shadow: 0 4px 4px rgba(0, 0, 0, 0.15);
 }
 
-$notification-drawer-height: 70vh;
-
 .notification-drawer-open {
   padding: 24px 0;
   border: 1px solid #BBBBBB;
-  height: $notification-drawer-height;
+  height: 70vh;
   width: 564px;
 }
 
 .notification-drawer .ant-tabs-content-holder {
-  max-height: calc($notification-drawer-height - 100px);
+  max-height: calc(70vh - 100px);
   overflow-y: auto;
   overflow-x: hidden;
 }


### PR DESCRIPTION
## Objective 

[MDS-4515](https://bcmines.atlassian.net/browse/MDS-4515)

Removed use of variable for notification-drawer height, to fix sass compilation error. 

![image](https://user-images.githubusercontent.com/66635118/184016284-2f4de899-632a-4466-8eb3-ae21fb0cc36a.png)


_Why are you making this change? Provide a short explanation and/or screenshots_
