### PR TITLE
[MDS-4628] Default to showing max 20 notifications in activity feed

### DIFF
--- a/services/core-web/common/actionCreators/activityActionCreator.js
+++ b/services/core-web/common/actionCreators/activityActionCreator.js
@@ -8,7 +8,7 @@ import { storeActivities } from "../actions/activityActions";
 import { ACTIVITIES } from "../constants/API";
 
 // eslint-disable-next-line import/prefer-default-export
-export const fetchActivities = (user, page = 1, per_page = 25) => (dispatch) => {
+export const fetchActivities = (user, page = 1, per_page = 20) => (dispatch) => {
   dispatch(storeActivities({}));
   dispatch(request(GET_ACTIVITIES));
   dispatch(showLoading());

--- a/services/minespace-web/common/actionCreators/activityActionCreator.js
+++ b/services/minespace-web/common/actionCreators/activityActionCreator.js
@@ -8,7 +8,7 @@ import { storeActivities } from "../actions/activityActions";
 import { ACTIVITIES } from "../constants/API";
 
 // eslint-disable-next-line import/prefer-default-export
-export const fetchActivities = (user, page = 1, per_page = 25) => (dispatch) => {
+export const fetchActivities = (user, page = 1, per_page = 20) => (dispatch) => {
   dispatch(storeActivities({}));
   dispatch(request(GET_ACTIVITIES));
   dispatch(showLoading());


### PR DESCRIPTION
## Objective 

[MDS-4528](https://bcmines.atlassian.net/browse/MDS-4528)

_Why are you making this change? Provide a short explanation and/or screenshots_

Display max 20 notifications in activity feed instead of 25.