### PR TITLE
[MDS-4519] navigate from notification CORE

### DIFF
--- a/services/core-api/app/api/activity/models/activity_notification.py
+++ b/services/core-api/app/api/activity/models/activity_notification.py
@@ -119,6 +119,11 @@ class ActivityNotification(AuditMixin, Base):
         self.save()
 
     @classmethod
+    def mark_as_read_many(cls, activity_guids):
+        cls.query.filter(ActivityNotification.notification_guid.in_(activity_guids)).update({'notification_read': True}, synchronize_session=False)
+        db.session.commit()
+
+    @classmethod
     def find_all_by_recipient(cls, user, page, per_page):
         query = cls.query.filter_by(notification_recipient=user).order_by(cls.create_timestamp.desc())
 

--- a/services/core-api/app/api/activity/models/activity_notification.py
+++ b/services/core-api/app/api/activity/models/activity_notification.py
@@ -110,6 +110,10 @@ class ActivityNotification(AuditMixin, Base):
         db.session.bulk_save_objects(notifications)
         db.session.commit()
 
+    @classmethod
+    def find_by_guid(cls, notification_guid):
+        return cls.query.filter_by(notification_guid=notification_guid).first()
+
     def update(self, notification_read=True):
         self.notification_read = notification_read
         self.save()

--- a/services/core-api/app/api/activity/namespace.py
+++ b/services/core-api/app/api/activity/namespace.py
@@ -1,6 +1,9 @@
 from flask_restplus import Namespace
+
+from app.api.activity.resource.activities_mark_as_read import ActivityMarkAsReadResource
 from app.api.activity.resource.activity_list import ActivityListResource
 
 api = Namespace('activities', description='activities')
 
 api.add_resource(ActivityListResource, '')
+api.add_resource(ActivityMarkAsReadResource, '/mark-as-read')

--- a/services/core-api/app/api/activity/resource/activities_mark_as_read.py
+++ b/services/core-api/app/api/activity/resource/activities_mark_as_read.py
@@ -1,0 +1,22 @@
+from flask_restplus import Resource, reqparse
+
+from app.api.activity.models.activity_notification import ActivityNotification
+from app.api.utils.access_decorators import EDIT_DO, requires_any_of, MINESPACE_PROPONENT
+from app.api.utils.resources_mixins import UserMixin
+
+
+class ActivityMarkAsReadResource(Resource, UserMixin):
+    @requires_any_of([EDIT_DO, MINESPACE_PROPONENT])
+    def patch(self):
+        parser = reqparse.RequestParser()
+        parser.add_argument(
+            'activity_guids',
+            type=list,
+            location='json',
+            required=True,
+            help='List of activity guids to mark as read')
+        args = parser.parse_args()
+        activity_guids = args.get('activity_guids')
+        for activity_guid in activity_guids:
+            activity = ActivityNotification.find_by_guid(activity_guid)
+            ActivityNotification.update(activity)

--- a/services/core-api/app/api/activity/resource/activities_mark_as_read.py
+++ b/services/core-api/app/api/activity/resource/activities_mark_as_read.py
@@ -17,6 +17,4 @@ class ActivityMarkAsReadResource(Resource, UserMixin):
             help='List of activity guids to mark as read')
         args = parser.parse_args()
         activity_guids = args.get('activity_guids')
-        for activity_guid in activity_guids:
-            activity = ActivityNotification.find_by_guid(activity_guid)
-            ActivityNotification.update(activity)
+        ActivityNotification.mark_as_read_many(activity_guids)

--- a/services/core-web/common/actionCreators/activityActionCreator.js
+++ b/services/core-web/common/actionCreators/activityActionCreator.js
@@ -5,7 +5,7 @@ import { ENVIRONMENT } from "../constants/environment";
 import { GET_ACTIVITIES } from "../constants/reducerTypes";
 import CustomAxios from "../customAxios";
 import { storeActivities } from "../actions/activityActions";
-import { ACTIVITIES } from "../constants/API";
+import { ACTIVITIES, ACTIVITIES_MARK_AS_READ } from "../constants/API";
 
 // eslint-disable-next-line import/prefer-default-export
 export const fetchActivities = (user, page = 1, per_page = 20) => (dispatch) => {
@@ -25,6 +25,24 @@ export const fetchActivities = (user, page = 1, per_page = 20) => (dispatch) => 
     .then((response) => {
       dispatch(success(GET_ACTIVITIES));
       dispatch(storeActivities(response.data));
+      return response;
+    })
+    .catch((err) => {
+      dispatch(error(GET_ACTIVITIES));
+      throw new Error(err);
+    })
+    .finally(() => dispatch(hideLoading()));
+};
+
+export const markActivitiesAsRead = (activity_guids) => (dispatch) => {
+  dispatch(showLoading());
+  const headers = {
+    ...createRequestHeader(),
+  };
+  return CustomAxios()
+    .patch(`${ENVIRONMENT.apiUrl}${ACTIVITIES_MARK_AS_READ()}`, { activity_guids }, headers)
+    .then((response) => {
+      dispatch(success(GET_ACTIVITIES));
       return response;
     })
     .catch((err) => {

--- a/services/core-web/common/constants/API.js
+++ b/services/core-web/common/constants/API.js
@@ -287,4 +287,5 @@ export const ORGBOOK_SEARCH = (search) => `/orgbook/search?${queryString.stringi
 export const ORGBOOK_CREDENTIAL = (credentialId) => `/orgbook/credential/${credentialId}`;
 
 // Activities
-export const ACTIVITIES = () => '/activities';
+export const ACTIVITIES = () => "/activities";
+export const ACTIVITIES_MARK_AS_READ = () => "/activities/mark-as-read";

--- a/services/core-web/src/components/mine/NoticeOfDeparture/MineNoticeOfDeparture.js
+++ b/services/core-web/src/components/mine/NoticeOfDeparture/MineNoticeOfDeparture.js
@@ -14,6 +14,7 @@ import { getNoticesOfDeparture } from "@common/selectors/noticeOfDepartureSelect
 import { fetchPermits } from "@common/actionCreators/permitActionCreator";
 import { modalConfig } from "@/components/modalContent/config";
 import CustomPropTypes from "@/customPropTypes";
+import { useLocation } from "react-router-dom";
 import MineNoticeOfDepartureTable from "./MineNoticeOfDepartureTable";
 
 const propTypes = {
@@ -30,6 +31,7 @@ export const MineNoticeOfDeparture = (props) => {
   const [isLoaded, setIsLoaded] = useState(false);
   const { mines, mineGuid, nods } = props;
   const mine = mines[mineGuid];
+  const location = useLocation();
 
   const handleFetchPermits = () => {
     props.fetchPermits(mineGuid).then(() => setIsLoaded(true));
@@ -44,7 +46,9 @@ export const MineNoticeOfDeparture = (props) => {
   }, []);
 
   const openNoticeOfDepartureModal = async (event, selectedNoticeOfDeparture) => {
-    event.preventDefault();
+    if (event) {
+      event.preventDefault();
+    }
     const detailedNoticeOfDeparture = await props.fetchDetailedNoticeOfDeparture(
       selectedNoticeOfDeparture.nod_guid
     );
@@ -60,6 +64,15 @@ export const MineNoticeOfDeparture = (props) => {
       content: modalConfig.VIEW_NOTICE_OF_DEPARTURE_MODAL,
     });
   };
+
+  useEffect(() => {
+    const nod = new URLSearchParams(location.search).get("nod");
+    if (nod) {
+      (async () => {
+        await openNoticeOfDepartureModal(null, { nod_guid: nod });
+      })();
+    }
+  }, [location]);
 
   const renderNoticeOfDepartureTables = (selectedMine) => (
     <div>

--- a/services/core-web/src/components/navigation/NotificationDrawer.js
+++ b/services/core-web/src/components/navigation/NotificationDrawer.js
@@ -3,43 +3,90 @@ import { Badge, Button, Col, Row, Tabs, Typography } from "antd";
 import { BellOutlined } from "@ant-design/icons";
 import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
-import { fetchActivities } from "@common/actionCreators/activityActionCreator";
+import {
+  fetchActivities,
+  markActivitiesAsRead,
+} from "@common/actionCreators/activityActionCreator";
 import PropTypes from "prop-types";
 import { formatDateTime } from "@common/utils/helpers";
 import { getActivities } from "@common/selectors/activitySelectors";
 import { getUserInfo } from "@common/selectors/authenticationSelectors";
+import { NOTICE_OF_DEPARTURE } from "@/constants/routes";
+import { Link } from "react-router-dom";
+import { storeActivities } from "@common/actions/activityActions";
 
 const propTypes = {
   fetchActivities: PropTypes.func.isRequired,
+  markActivitiesAsRead: PropTypes.func.isRequired,
   userInfo: PropTypes.objectOf(PropTypes.string).isRequired,
   activities: PropTypes.objectOf(PropTypes.string).isRequired,
-};
-
-const outsideClickHandler = (ref, setOpen, open) => {
-  useEffect(() => {
-    const handleClickOutside = (event) => {
-      if (open) {
-        if (ref.current && !ref.current.contains(event.target)) {
-          setOpen(!open);
-        }
-      }
-    };
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
-    };
-  }, [ref, open]);
+  storeActivities: PropTypes.func.isRequired,
 };
 
 const NotificationDrawer = (props) => {
   const [open, setOpen] = useState(false);
 
+  const handleMarkAsRead = async () => {
+    const readActivities = props.activities.map((activity) => {
+      return {
+        ...activity,
+        notification_read: true,
+      };
+    });
+    await props.storeActivities({
+      records: readActivities,
+      totalActivities: readActivities.length,
+    });
+  };
+
+  const outsideClickHandler = (ref) => {
+    useEffect(() => {
+      const handleClickOutside = (event) => {
+        if (open) {
+          if (ref.current && !ref.current.contains(event.target)) {
+            handleMarkAsRead();
+            setOpen(!open);
+          }
+        }
+      };
+      document.addEventListener("mousedown", handleClickOutside);
+      return () => {
+        document.removeEventListener("mousedown", handleClickOutside);
+      };
+    }, [ref, open]);
+  };
+
   const handleCollapse = () => {
+    const activitiesToMarkAsRead = props.activities.reduce((acc, activity) => {
+      if (activity.notification_read === false) {
+        acc.push(activity.notification_guid);
+      }
+      return acc;
+    }, []);
+
+    if (activitiesToMarkAsRead.length > 0) {
+      props.markActivitiesAsRead(activitiesToMarkAsRead);
+    }
+    if (open) {
+      handleMarkAsRead();
+    }
     setOpen(!open);
   };
 
+  const navigationHandler = (notification) => {
+    switch (notification.notification_document.metadata.entity) {
+      case "NoticeOfDeparture":
+        return NOTICE_OF_DEPARTURE.dynamicRoute(
+          notification.notification_document.metadata.mine.mine_guid,
+          notification.notification_document.metadata.entity_guid
+        );
+      default:
+        return null;
+    }
+  };
+
   const modalRef = useRef(null);
-  outsideClickHandler(modalRef, setOpen, open);
+  outsideClickHandler(modalRef);
 
   useEffect(() => {
     if (props.userInfo?.preferred_username) {
@@ -76,30 +123,32 @@ const NotificationDrawer = (props) => {
             {(props.activities || [])?.map((activity) => (
               <div className="notification-list-item">
                 <div className={!activity.notification_read ? "notification-dot" : ""} />
-                <Typography.Text>{activity.notification_document?.message}</Typography.Text>
-                <Row className="items-center margin-small" gutter={6}>
-                  <Col>
-                    <Typography.Text className="notification-info-text">
-                      {activity.notification_document?.metadata?.mine?.mine_name}
-                    </Typography.Text>
-                  </Col>
-                  <Col>
-                    <div className="notification-separator" />
-                  </Col>
-                  <Col>
-                    <Typography.Text className="notification-info-text">
-                      {activity.notification_document?.metadata?.permit?.permit_no}
-                    </Typography.Text>
-                  </Col>
-                  <Col>
-                    <div className="notification-separator" />
-                  </Col>
-                  <Col>
-                    <Typography.Text className="notification-info-text">
-                      {formatDateTime(activity.create_timestamp)}
-                    </Typography.Text>
-                  </Col>
-                </Row>
+                <Link to={navigationHandler(activity)} onClick={handleCollapse}>
+                  <Typography.Text>{activity.notification_document?.message}</Typography.Text>
+                  <Row className="items-center margin-small" gutter={6}>
+                    <Col>
+                      <Typography.Text className="notification-info-text">
+                        {activity.notification_document?.metadata?.mine?.mine_name}
+                      </Typography.Text>
+                    </Col>
+                    <Col>
+                      <div className="notification-separator" />
+                    </Col>
+                    <Col>
+                      <Typography.Text className="notification-info-text">
+                        {activity.notification_document?.metadata?.permit?.permit_no}
+                      </Typography.Text>
+                    </Col>
+                    <Col>
+                      <div className="notification-separator" />
+                    </Col>
+                    <Col>
+                      <Typography.Text className="notification-info-text">
+                        {formatDateTime(activity.create_timestamp)}
+                      </Typography.Text>
+                    </Col>
+                  </Row>
+                </Link>
               </div>
             ))}
           </Tabs.TabPane>
@@ -118,6 +167,8 @@ const mapDispatchToProps = (dispatch) =>
   bindActionCreators(
     {
       fetchActivities,
+      markActivitiesAsRead,
+      storeActivities,
     },
     dispatch
   );

--- a/services/core-web/src/constants/routes.js
+++ b/services/core-web/src/constants/routes.js
@@ -161,6 +161,13 @@ export const MINE_NOTICES_OF_DEPARTURE = {
   component: MineNoticeOfDeparture,
 };
 
+export const NOTICE_OF_DEPARTURE = {
+  route: "/mine-dashboard/:id/permits-and-approvals/notices-of-departure",
+  dynamicRoute: (id, nodGuid) =>
+    `/mine-dashboard/${id}/permits-and-approvals/notices-of-departure?nod=${nodGuid}`,
+  component: MineNoticeOfDeparture,
+};
+
 // Projects
 export const MINE_PRE_APPLICATIONS = {
   route: "/mine-dashboard/:id/permits-and-approvals/pre-applications",

--- a/services/core-web/src/styles/components/NotificationDrawer.scss
+++ b/services/core-web/src/styles/components/NotificationDrawer.scss
@@ -57,6 +57,10 @@
   box-shadow: 0 4px 4px rgba(0, 0, 0, 0.15);
 }
 
+.notification-drawer a {
+  text-decoration: none;
+}
+
 .notification-drawer-open {
   padding: 24px 40px;
   border: 1px solid #BBBBBB;

--- a/services/core-web/src/tests/components/mine/NoticeOfDeparture/MineNoticeOfDeparture.spec.js
+++ b/services/core-web/src/tests/components/mine/NoticeOfDeparture/MineNoticeOfDeparture.spec.js
@@ -6,16 +6,34 @@ import * as MOCK from "@/tests/mocks/dataMocks";
 const dispatchProps = {};
 const reducerProps = {};
 
+function mockFunction() {
+  const original = require.requireActual("react-router-dom");
+  return {
+    ...original,
+    useLocation: jest.fn().mockReturnValue({
+      pathname: "/mine/notice-of-departure",
+      search: "",
+      hash: "",
+      state: null,
+      key: "5nvxpbdafa",
+    }),
+  };
+}
+
+jest.mock("react-router-dom", () => mockFunction());
+
 const setupDispatchProps = () => {
   dispatchProps.openModal = jest.fn();
   dispatchProps.closeModal = jest.fn();
   dispatchProps.fetchNoticesOfDeparture = jest.fn(() => Promise.resolve());
+  dispatchProps.fetchDetailedNoticeOfDeparture = jest.fn(() => Promise.resolve());
   dispatchProps.fetchPermits = jest.fn(() => Promise.resolve());
 };
 
 const setupReducerProps = () => {
   reducerProps.mines = MOCK.MINES.mines;
   [reducerProps.mineGuid] = MOCK.MINES.mineIds;
+  reducerProps.nods = MOCK.NOTICES_OF_DEPARTURE.records;
 };
 
 beforeEach(() => {

--- a/services/core-web/src/tests/components/mine/NoticeOfDeparture/__snapshots__/MineNoticeOfDeparture.spec.js.snap
+++ b/services/core-web/src/tests/components/mine/NoticeOfDeparture/__snapshots__/MineNoticeOfDeparture.spec.js.snap
@@ -77,6 +77,29 @@ exports[`MineNoticeOfDeparture renders properly 1`] = `
           },
         }
       }
+      nods={
+        Array [
+          Object {
+            "create_timestamp": "2020-04-20 11:58",
+            "nod_description": "Some description",
+            "nod_guid": "0d3ec917-179f-4dbc-80a3-4c993fdfe596",
+            "nod_no": "NOD-X-45564456-01",
+            "nod_status": "pending_review",
+            "nod_title": "Some title",
+            "nod_type": "potentially_substaintial",
+            "permit": Object {
+              "current_permittee": "Haynes, Park and Brown",
+              "permit_guid": "10d3ec917-179f-4dbc-80a3-4c993fdfe596",
+              "permit_id": 1,
+              "permit_no": "M-7594809",
+              "permit_prefix": "M",
+              "permit_status_code": "C",
+            },
+            "submission_timestamp": "2020-04-20 11:58",
+            "update_timestamp": "2020-04-20 11:58",
+          },
+        ]
+      }
       openViewNodModal={[Function]}
       updateNoticeOfDeparture={[Function]}
     />

--- a/services/core-web/src/tests/routes/__snapshots__/DashboardRoutes.spec.js.snap
+++ b/services/core-web/src/tests/routes/__snapshots__/DashboardRoutes.spec.js.snap
@@ -216,6 +216,19 @@ exports[`DashboardRoutes  renders properly 1`] = `
         "$$typeof": Symbol(react.memo),
         "WrappedComponent": [Function],
         "compare": null,
+        "displayName": "Connect(MineNoticeOfDeparture)",
+        "type": [Function],
+      }
+    }
+    exact={true}
+    path="/mine-dashboard/:id/permits-and-approvals/notices-of-departure"
+  />
+  <Route
+    component={
+      Object {
+        "$$typeof": Symbol(react.memo),
+        "WrappedComponent": [Function],
+        "compare": null,
         "displayName": "Connect(MineProject)",
         "type": [Function],
       }

--- a/services/minespace-web/common/actionCreators/activityActionCreator.js
+++ b/services/minespace-web/common/actionCreators/activityActionCreator.js
@@ -5,7 +5,7 @@ import { ENVIRONMENT } from "../constants/environment";
 import { GET_ACTIVITIES } from "../constants/reducerTypes";
 import CustomAxios from "../customAxios";
 import { storeActivities } from "../actions/activityActions";
-import { ACTIVITIES } from "../constants/API";
+import { ACTIVITIES, ACTIVITIES_MARK_AS_READ } from "../constants/API";
 
 // eslint-disable-next-line import/prefer-default-export
 export const fetchActivities = (user, page = 1, per_page = 20) => (dispatch) => {
@@ -25,6 +25,24 @@ export const fetchActivities = (user, page = 1, per_page = 20) => (dispatch) => 
     .then((response) => {
       dispatch(success(GET_ACTIVITIES));
       dispatch(storeActivities(response.data));
+      return response;
+    })
+    .catch((err) => {
+      dispatch(error(GET_ACTIVITIES));
+      throw new Error(err);
+    })
+    .finally(() => dispatch(hideLoading()));
+};
+
+export const markActivitiesAsRead = (activity_guids) => (dispatch) => {
+  dispatch(showLoading());
+  const headers = {
+    ...createRequestHeader(),
+  };
+  return CustomAxios()
+    .patch(`${ENVIRONMENT.apiUrl}${ACTIVITIES_MARK_AS_READ()}`, { activity_guids }, headers)
+    .then((response) => {
+      dispatch(success(GET_ACTIVITIES));
       return response;
     })
     .catch((err) => {

--- a/services/minespace-web/common/constants/API.js
+++ b/services/minespace-web/common/constants/API.js
@@ -287,4 +287,5 @@ export const ORGBOOK_SEARCH = (search) => `/orgbook/search?${queryString.stringi
 export const ORGBOOK_CREDENTIAL = (credentialId) => `/orgbook/credential/${credentialId}`;
 
 // Activities
-export const ACTIVITIES = () => '/activities';
+export const ACTIVITIES = () => "/activities";
+export const ACTIVITIES_MARK_AS_READ = () => "/activities/mark-as-read";


### PR DESCRIPTION
## Objective 

[MDS-4519](https://bcmines.atlassian.net/browse/MDS-4519)

- Added a query param to the MineNoticeOfDeparture page to open the selected nod when present
- Made activities clickable to navigate to the MineNoticeOfDeparture page with the appropriate queryParam
- Did an initial pass of the markAsRead functionality.
- This will be refined in an upcoming ticket as per this mornings discussion with Rebecca and Tanya

For the markAsRead functionality on the backend, feel free to look at it for any optimizations.  I was unsure about fetching the activities on the backend.  Currently I fetch each one and mark it as read, but I'm sure there's a better way of doing them as a batch.

_Why are you making this change? Provide a short explanation and/or screenshots_
