### PR TITLE
[MDS-4629] made notification bell only show when logged in.

### DIFF
--- a/services/minespace-web/src/App.js
+++ b/services/minespace-web/src/App.js
@@ -1,6 +1,5 @@
 import React, { Fragment, Component } from "react";
-import { compose } from "redux";
-import { bindActionCreators } from "redux";
+import { compose, bindActionCreators } from "redux";
 import { connect } from "react-redux";
 import { BrowserRouter } from "react-router-dom";
 // eslint-disable-next-line
@@ -8,10 +7,10 @@ import { hot } from "react-hot-loader";
 import { LoadingOutlined } from "@ant-design/icons";
 import { Layout, BackTop, Row, Col, Spin } from "antd";
 import { loadBulkStaticContent } from "@common/actionCreators/staticContentActionCreator";
-import { isAuthenticated } from "@/selectors/authenticationSelectors";
 import { getStaticContentLoadingIsComplete } from "@common/selectors/staticContentSelectors";
 import MediaQuery from "react-responsive";
-import Routes from "./routes/Routes";
+import * as PropTypes from "prop-types";
+import { isAuthenticated } from "@/selectors/authenticationSelectors";
 import { Header } from "@/components/layout/Header";
 import { Footer } from "@/components/layout/Footer";
 import ModalWrapper from "@/components/common/wrappers/ModalWrapper";
@@ -19,12 +18,24 @@ import DocumentViewer from "@/components/syncfusion/DocumentViewer";
 import AuthenticationGuard from "@/HOC/AuthenticationGuard";
 import WarningBanner from "@/components/common/WarningBanner";
 import { detectIE } from "@/utils/environmentUtils";
+import Routes from "./routes/Routes";
 import configureStore from "./store/configureStore";
 import { MatomoLinkTracing } from "../common/utils/trackers";
 
 export const store = configureStore();
 
 Spin.setDefaultIndicator(<LoadingOutlined style={{ fontSize: 40 }} />);
+
+const propTypes = {
+  loadBulkStaticContent: PropTypes.func.isRequired,
+  isAuthenticated: PropTypes.bool,
+  staticContentLoadingIsComplete: PropTypes.bool,
+};
+
+const defaultProps = {
+  isAuthenticated: false,
+  staticContentLoadingIsComplete: false,
+};
 
 class App extends Component {
   state = { isIE: true, isMobile: true };
@@ -62,7 +73,13 @@ class App extends Component {
         <Fragment>
           <MatomoLinkTracing />
           <Layout>
-            <Header xs={xs} lg={lg} xl={xl} xxl={xxl} />
+            <Header
+              xs={xs}
+              lg={lg}
+              xl={xl}
+              xxl={xxl}
+              isAuthenticated={this.props.isAuthenticated}
+            />
             <Layout>
               <Layout.Content>
                 {this.state.isIE && <WarningBanner type="IE" onClose={this.handleBannerClose} />}
@@ -101,6 +118,9 @@ const mapDispatchToProps = (dispatch) =>
     },
     dispatch
   );
+
+App.propTypes = propTypes;
+App.defaultProps = defaultProps;
 
 export default compose(
   hot(module),

--- a/services/minespace-web/src/components/layout/Header.js
+++ b/services/minespace-web/src/components/layout/Header.js
@@ -1,5 +1,4 @@
 import React from "react";
-import { connect } from "react-redux";
 import { Col, Layout, Row } from "antd";
 import { Link } from "react-router-dom";
 import PropTypes from "prop-types";
@@ -8,15 +7,13 @@ import HeaderDropdown from "@/components/layout/HeaderDropdown";
 import * as routes from "@/constants/routes";
 import { BC_GOV } from "@/constants/assets";
 import NotificationDrawer from "@/components/layout/NotificationDrawer";
-import { isAuthenticated } from "@/selectors/authenticationSelectors";
-import { getUserInfo } from "@/reducers/authenticationReducer";
 
 const propTypes = {
   xs: PropTypes.number.isRequired,
   lg: PropTypes.number.isRequired,
   xl: PropTypes.number.isRequired,
   xxl: PropTypes.number.isRequired,
-  isAuthenticated: PropTypes.bool.isRequired,
+  isAuthenticated: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -39,7 +36,7 @@ export const Header = (props) => {
             </div>
             <div className="inline-flex items-center">
               <HeaderDropdown />
-              {!IN_PROD() && <NotificationDrawer />}
+              {!IN_PROD() && props.isAuthenticated && <NotificationDrawer />}
             </div>
           </div>
         </Col>
@@ -51,11 +48,4 @@ export const Header = (props) => {
 Header.propTypes = propTypes;
 Header.defaultProps = defaultProps;
 
-const mapStateToProps = (state) => {
-  return {
-    isAuthenticated: isAuthenticated(state),
-    userInfo: getUserInfo(state),
-  };
-};
-
-export default connect(mapStateToProps)(Header);
+export default Header;


### PR DESCRIPTION
## Objective 

[MDS-4629](https://bcmines.atlassian.net/browse/MDS-4629)

Passed in `isAuthorized` as prop from App.js and used it to flag the display of the notification bell.
Cleaned up missing props validation in App.js 🏕️ 🔥 

Note:  Importing `isAuthorized` from the state wasn't working as expected and updating dynamically.  Passing it from App.js works correctly.

<img width="1048" alt="image" src="https://user-images.githubusercontent.com/83598933/184739042-2b67ba2a-fba6-4a9b-aab1-27b26084d29f.png">
<img width="1047" alt="image" src="https://user-images.githubusercontent.com/83598933/184738698-db195704-de11-49cb-8bff-b1347ae1edf7.png">

