### PR TITLE
[MDS-4518] Make NOD notifications link to NOD table

### DIFF
--- a/services/minespace-web/src/components/dashboard/mine/MineDashboard.js
+++ b/services/minespace-web/src/components/dashboard/mine/MineDashboard.js
@@ -52,36 +52,21 @@ export class MineDashboard extends Component {
 
   componentDidMount() {
     const { id, activeTab } = this.props.match.params;
-    this.props.fetchPartyRelationships({
-      mine_guid: id,
-      relationships: "party",
-      include_permit_contacts: "true",
-    });
-    if (activeTab) {
-      this.setState({ activeTab });
-    } else {
-      this.handleTabChange(initialTab);
-    }
-    this.props
-      .fetchMineRecordById(id)
-      .then(({ data }) => {
-        this.props.fetchEMLIContactsByRegion(data.mine_region, data.major_mine_ind);
-      })
-      .then(() => {
-        this.setState({ isLoaded: true });
-      })
-      .catch(() => {
-        this.setState({ mineNotFound: true });
-      });
+
+    this.loadMine(id, activeTab);
   }
 
   componentWillReceiveProps(nextProps) {
-    const { activeTab } = nextProps.match.params;
+    const { activeTab, id } = nextProps.match.params;
     if (activeTab !== this.state.activeTab) {
       this.setState({ activeTab });
     }
     if (!nextProps.staticContentLoadingIsComplete) {
       this.loadStaticContent();
+    }
+
+    if (nextProps.match.params.id !== this.props.match.params.id) {
+      this.loadMine(id, activeTab);
     }
   }
 
@@ -99,6 +84,33 @@ export class MineDashboard extends Component {
       activeTab
     );
   };
+
+  loadMine(id, activeTab) {
+    this.setState({ isLoaded: false });
+
+    this.props.fetchPartyRelationships({
+      mine_guid: id,
+      relationships: "party",
+      include_permit_contacts: "true",
+    });
+    if (activeTab) {
+      this.setState({ activeTab });
+    } else {
+      this.handleTabChange(initialTab);
+    }
+
+    this.props
+      .fetchMineRecordById(id)
+      .then(({ data }) => {
+        this.props.fetchEMLIContactsByRegion(data.mine_region, data.major_mine_ind);
+      })
+      .then(() => {
+        this.setState({ isLoaded: true });
+      })
+      .catch(() => {
+        this.setState({ mineNotFound: true });
+      });
+  }
 
   render() {
     const { id } = this.props.match.params;

--- a/services/minespace-web/src/components/dashboard/mine/noticeOfDeparture/NoticeOfDeparture.js
+++ b/services/minespace-web/src/components/dashboard/mine/noticeOfDeparture/NoticeOfDeparture.js
@@ -13,6 +13,8 @@ import { getNoticesOfDeparture } from "@common/selectors/noticeOfDepartureSelect
 import { connect } from "react-redux";
 import { bindActionCreators } from "redux";
 import PropTypes from "prop-types";
+import { useLocation } from "react-router-dom";
+
 import { getPermits } from "@common/selectors/permitSelectors";
 import { fetchPermits } from "@common/actionCreators/permitActionCreator";
 import {
@@ -42,6 +44,7 @@ const defaultProps = {};
 export const NoticeOfDeparture = (props) => {
   const { mine, nods, permits } = props;
   const [isLoaded, setIsLoaded] = useState(false);
+  const location = useLocation();
 
   const handleFetchPermits = async () => {
     await props.fetchPermits(mine.mine_guid);
@@ -154,6 +157,15 @@ export const NoticeOfDeparture = (props) => {
       content: modalConfig.EDIT_NOTICE_OF_DEPARTURE,
     });
   };
+
+  useEffect(() => {
+    const nod = new URLSearchParams(location.search).get("nod");
+    if (nod) {
+      (async () => {
+        await openViewNoticeOfDepartureModal({ nod_guid: nod });
+      })();
+    }
+  }, [location.search]);
 
   return (
     <Row>

--- a/services/minespace-web/src/components/layout/NotificationDrawer.js
+++ b/services/minespace-web/src/components/layout/NotificationDrawer.js
@@ -3,43 +3,93 @@ import { Badge, Button, Col, Row, Tabs, Typography } from "antd";
 import { BellOutlined } from "@ant-design/icons";
 import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
-import { fetchActivities } from "@common/actionCreators/activityActionCreator";
+import {
+  fetchActivities,
+  markActivitiesAsRead,
+} from "@common/actionCreators/activityActionCreator";
 import PropTypes from "prop-types";
 import { formatDateTime } from "@common/utils/helpers";
 import { getActivities } from "@common/selectors/activitySelectors";
-import { getUserInfo } from "@/selectors/authenticationSelectors";
+import { getUserInfo } from "@common/selectors/authenticationSelectors";
+import { Link } from "react-router-dom";
+import { storeActivities } from "@common/actions/activityActions";
+import { MINE_DASHBOARD } from "@/constants/routes";
 
 const propTypes = {
   fetchActivities: PropTypes.func.isRequired,
+  markActivitiesAsRead: PropTypes.func.isRequired,
   userInfo: PropTypes.objectOf(PropTypes.string).isRequired,
   activities: PropTypes.objectOf(PropTypes.string).isRequired,
-};
-
-const outsideClickHandler = (ref, setOpen, open) => {
-  useEffect(() => {
-    const handleClickOutside = (event) => {
-      if (open) {
-        if (ref.current && !ref.current.contains(event.target)) {
-          setOpen(!open);
-        }
-      }
-    };
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
-    };
-  }, [ref, open]);
+  storeActivities: PropTypes.func.isRequired,
 };
 
 const NotificationDrawer = (props) => {
   const [open, setOpen] = useState(false);
 
+  const handleMarkAsRead = async () => {
+    const readActivities = props.activities.map((activity) => {
+      return {
+        ...activity,
+        notification_read: true,
+      };
+    });
+    await props.storeActivities({
+      records: readActivities,
+      totalActivities: readActivities.length,
+    });
+  };
+
+  const outsideClickHandler = (ref) => {
+    useEffect(() => {
+      const handleClickOutside = (event) => {
+        if (open) {
+          if (ref.current && !ref.current.contains(event.target)) {
+            handleMarkAsRead();
+            setOpen(!open);
+          }
+        }
+      };
+      document.addEventListener("mousedown", handleClickOutside);
+      return () => {
+        document.removeEventListener("mousedown", handleClickOutside);
+      };
+    }, [ref, open]);
+  };
+
   const handleCollapse = () => {
+    const activitiesToMarkAsRead = props.activities.reduce((acc, activity) => {
+      if (activity.notification_read === false) {
+        acc.push(activity.notification_guid);
+      }
+      return acc;
+    }, []);
+
+    if (activitiesToMarkAsRead.length > 0) {
+      props.markActivitiesAsRead(activitiesToMarkAsRead);
+    }
+    if (open) {
+      handleMarkAsRead();
+    }
     setOpen(!open);
   };
 
+  const navigationHandler = (notification) => {
+    switch (notification.notification_document.metadata.entity) {
+      case "NoticeOfDeparture":
+        return MINE_DASHBOARD.dynamicRoute(
+          notification.notification_document.metadata.mine.mine_guid,
+          "nods",
+          {
+            nod: notification.notification_document.metadata.entity_guid,
+          }
+        );
+      default:
+        return null;
+    }
+  };
+
   const modalRef = useRef(null);
-  outsideClickHandler(modalRef, setOpen, open);
+  outsideClickHandler(modalRef);
 
   useEffect(() => {
     if (props.userInfo?.preferred_username) {
@@ -50,9 +100,9 @@ const NotificationDrawer = (props) => {
   return (
     <div ref={modalRef}>
       <Button
-        className="notification-button"
         onClick={handleCollapse}
         type="text"
+        className={`notification-button ${open ? "notification-button-open" : ""}`}
         icon={
           <Badge
             className="notification-badge"
@@ -70,13 +120,17 @@ const NotificationDrawer = (props) => {
         >
           <Tabs.TabPane
             className="notification-tab-pane"
-            tab={<Typography.Title level={5}>Mine Activity</Typography.Title>}
+            tab={
+              <Typography.Title level={5} className="notification-tab-header">
+                Mine Activity
+              </Typography.Title>
+            }
             key="1"
           >
             {(props.activities || [])?.map((activity) => (
-              <div>
-                <div className="notification-list-item">
-                  <div className={!activity.notification_read ? "notification-dot" : ""} />
+              <div className="notification-list-item">
+                <div className={!activity.notification_read ? "notification-dot" : ""} />
+                <Link to={navigationHandler(activity)} onClick={handleCollapse}>
                   <Typography.Text>{activity.notification_document?.message}</Typography.Text>
                   <Row className="items-center margin-small" gutter={6}>
                     <Col>
@@ -101,7 +155,7 @@ const NotificationDrawer = (props) => {
                       </Typography.Text>
                     </Col>
                   </Row>
-                </div>
+                </Link>
               </div>
             ))}
           </Tabs.TabPane>
@@ -120,6 +174,8 @@ const mapDispatchToProps = (dispatch) =>
   bindActionCreators(
     {
       fetchActivities,
+      markActivitiesAsRead,
+      storeActivities,
     },
     dispatch
   );

--- a/services/minespace-web/src/styles/components/Header.scss
+++ b/services/minespace-web/src/styles/components/Header.scss
@@ -150,6 +150,10 @@
   text-decoration: none;
 }
 
+.notification-drawer a {
+  text-decoration: none;
+}
+
 .notification-dot {
   position: absolute;
   left: 12px;

--- a/services/minespace-web/src/tests/components/dashboard/mine/noticeOfDeparture/noticeOfDeparture.spec.js
+++ b/services/minespace-web/src/tests/components/dashboard/mine/noticeOfDeparture/noticeOfDeparture.spec.js
@@ -6,6 +6,22 @@ import { NoticeOfDeparture } from "@/components/dashboard/mine/noticeOfDeparture
 const dispatchProps = {};
 const reducerProps = {};
 
+function mockFunction() {
+  const original = require.requireActual("react-router-dom");
+  return {
+    ...original,
+    useLocation: jest.fn().mockReturnValue({
+      pathname: "/mine/notice-of-departure",
+      search: "",
+      hash: "",
+      state: null,
+      key: "5nvxpbdafa",
+    }),
+  };
+}
+
+jest.mock("react-router-dom", () => mockFunction());
+
 const setupDispatchProps = () => {
   dispatchProps.openModal = jest.fn();
   dispatchProps.closeModal = jest.fn();
@@ -18,6 +34,7 @@ const setupReducerProps = () => {
   reducerProps.mine = MOCK.MINES.mines[MOCK.MINES.mineIds[0]];
   reducerProps.permits = MOCK.PERMITS.permits;
   reducerProps.nods = MOCK.NOTICES_OF_DEPARTURE.records;
+  reducerProps.isAuthenticated = true;
 };
 
 beforeEach(() => {


### PR DESCRIPTION
## Objective 

[MDS-4518](https://bcmines.atlassian.net/browse/MDS-4518)

Made NOD activity notifications clickable, takes you to the NOD table for the associated mine and pops up the NOD detail modal. Added functionality to mark notifications as read when the modal closes to match Core functionality - to be updated in future ticket

_Why are you making this change? Provide a short explanation and/or screenshots_
