### PR TITLE
[MDS-4630] updated notification mark as read behaviour

### DIFF
--- a/services/core-web/src/components/mine/NoticeOfDeparture/MineNoticeOfDeparture.js
+++ b/services/core-web/src/components/mine/NoticeOfDeparture/MineNoticeOfDeparture.js
@@ -15,6 +15,7 @@ import { fetchPermits } from "@common/actionCreators/permitActionCreator";
 import { modalConfig } from "@/components/modalContent/config";
 import CustomPropTypes from "@/customPropTypes";
 import { useLocation } from "react-router-dom";
+import { MINE_NOTICES_OF_DEPARTURE } from "@/constants/routes";
 import MineNoticeOfDepartureTable from "./MineNoticeOfDepartureTable";
 
 const propTypes = {
@@ -69,6 +70,11 @@ export const MineNoticeOfDeparture = (props) => {
     const nod = new URLSearchParams(location.search).get("nod");
     if (nod) {
       (async () => {
+        window.history.replaceState(
+          {},
+          document.title,
+          `${MINE_NOTICES_OF_DEPARTURE.dynamicRoute(mineGuid, "")}`
+        );
         await openNoticeOfDepartureModal(null, { nod_guid: nod });
       })();
     }

--- a/services/core-web/src/components/navigation/NotificationDrawer.js
+++ b/services/core-web/src/components/navigation/NotificationDrawer.js
@@ -12,7 +12,7 @@ import { formatDateTime } from "@common/utils/helpers";
 import { getActivities } from "@common/selectors/activitySelectors";
 import { getUserInfo } from "@common/selectors/authenticationSelectors";
 import { NOTICE_OF_DEPARTURE } from "@/constants/routes";
-import { Link } from "react-router-dom";
+import { useHistory } from "react-router-dom";
 import { storeActivities } from "@common/actions/activityActions";
 
 const propTypes = {
@@ -25,9 +25,23 @@ const propTypes = {
 
 const NotificationDrawer = (props) => {
   const [open, setOpen] = useState(false);
+  const history = useHistory();
 
-  const handleMarkAsRead = async () => {
+  const handleMarkAsRead = async (guid = null) => {
+    if (guid) {
+      await props.markActivitiesAsRead([guid]);
+    }
+
     const readActivities = props.activities.map((activity) => {
+      if (guid) {
+        if (activity.notification_guid === guid) {
+          return {
+            ...activity,
+            notification_read: true,
+          };
+        }
+        return activity;
+      }
       return {
         ...activity,
         notification_read: true,
@@ -44,7 +58,6 @@ const NotificationDrawer = (props) => {
       const handleClickOutside = (event) => {
         if (open) {
           if (ref.current && !ref.current.contains(event.target)) {
-            handleMarkAsRead();
             setOpen(!open);
           }
         }
@@ -57,6 +70,10 @@ const NotificationDrawer = (props) => {
   };
 
   const handleCollapse = () => {
+    setOpen(!open);
+  };
+
+  const handleMarkAllAsRead = async () => {
     const activitiesToMarkAsRead = props.activities.reduce((acc, activity) => {
       if (activity.notification_read === false) {
         acc.push(activity.notification_guid);
@@ -67,13 +84,11 @@ const NotificationDrawer = (props) => {
     if (activitiesToMarkAsRead.length > 0) {
       props.markActivitiesAsRead(activitiesToMarkAsRead);
     }
-    if (open) {
-      handleMarkAsRead();
-    }
-    setOpen(!open);
+    await handleMarkAsRead();
+    handleCollapse();
   };
 
-  const navigationHandler = (notification) => {
+  const navigationHandler = async (notification) => {
     switch (notification.notification_document.metadata.entity) {
       case "NoticeOfDeparture":
         return NOTICE_OF_DEPARTURE.dynamicRoute(
@@ -83,6 +98,13 @@ const NotificationDrawer = (props) => {
       default:
         return null;
     }
+  };
+
+  const activityClickHandler = async (notification) => {
+    await handleMarkAsRead(notification.notification_guid);
+    handleCollapse();
+    const route = await navigationHandler(notification);
+    history.push(route);
   };
 
   const modalRef = useRef(null);
@@ -123,7 +145,8 @@ const NotificationDrawer = (props) => {
             {(props.activities || [])?.map((activity) => (
               <div className="notification-list-item">
                 <div className={!activity.notification_read ? "notification-dot" : ""} />
-                <Link to={navigationHandler(activity)} onClick={handleCollapse}>
+                {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events */}
+                <div tabIndex="0" role="button" onClick={() => activityClickHandler(activity)}>
                   <Typography.Text>{activity.notification_document?.message}</Typography.Text>
                   <Row className="items-center margin-small" gutter={6}>
                     <Col>
@@ -148,11 +171,21 @@ const NotificationDrawer = (props) => {
                       </Typography.Text>
                     </Col>
                   </Row>
-                </Link>
+                </div>
               </div>
             ))}
           </Tabs.TabPane>
         </Tabs>
+        <div className="notification-button-all-container">
+          <Button
+            className="notification-button-all"
+            size="small"
+            type="text"
+            onClick={() => handleMarkAllAsRead()}
+          >
+            Mark all as read
+          </Button>
+        </div>
       </div>
     </div>
   );

--- a/services/core-web/src/styles/components/NotificationDrawer.scss
+++ b/services/core-web/src/styles/components/NotificationDrawer.scss
@@ -62,7 +62,7 @@
 }
 
 .notification-drawer-open {
-  padding: 24px 40px;
+  padding: 24px 16px;
   border: 1px solid #BBBBBB;
   height: 70vh;
   width: 564px;
@@ -72,6 +72,7 @@
   max-height: calc(70vh - 100px);
   overflow-y: auto;
   overflow-x: hidden;
+  padding-bottom: 100px;
 }
 
 .notification-container {
@@ -128,7 +129,6 @@
   color: #606060;
   font-size: 14px;
   font-weight: 400;
-
 }
 
 .notification-tab-pane {
@@ -150,4 +150,29 @@
   font-size: 1rem;
   font-weight: 700;
   margin-bottom: 10px;
+}
+
+.notification-button-all-container {
+  position: absolute;
+  bottom: 0;
+  height: 50px;
+  width: fit-content;
+  border-radius: 10px;
+  right: 50%;
+  transform: translateX(50%);
+  background-color: #FFFFFF;
+}
+
+.notification-button-all, .notification-button-all:active {
+  position: absolute;
+  bottom: 0;
+  right: 50%;
+  transform: translateX(50%);
+  background-color: #FFFFFF;
+  display: flex;
+  align-items: center;
+}
+
+.notification-button-all:hover {
+  background-color: #f0f6fd;
 }

--- a/services/minespace-web/src/components/dashboard/mine/noticeOfDeparture/NoticeOfDeparture.js
+++ b/services/minespace-web/src/components/dashboard/mine/noticeOfDeparture/NoticeOfDeparture.js
@@ -24,6 +24,7 @@ import {
 import NoticeOfDepartureTable from "@/components/dashboard/mine/noticeOfDeparture/NoticeOfDepartureTable";
 import { modalConfig } from "@/components/modalContent/config";
 import CustomPropTypes from "@/customPropTypes";
+import { MINE_DASHBOARD } from "@/constants/routes";
 
 const propTypes = {
   mine: CustomPropTypes.mine.isRequired,
@@ -162,10 +163,15 @@ export const NoticeOfDeparture = (props) => {
     const nod = new URLSearchParams(location.search).get("nod");
     if (nod) {
       (async () => {
+        window.history.replaceState(
+          {},
+          document.title,
+          `${MINE_DASHBOARD.dynamicRoute(mine.mine_guid, "nods")}`
+        );
         await openViewNoticeOfDepartureModal({ nod_guid: nod });
       })();
     }
-  }, [location.search]);
+  }, [location]);
 
   return (
     <Row>

--- a/services/minespace-web/src/styles/components/Header.scss
+++ b/services/minespace-web/src/styles/components/Header.scss
@@ -113,6 +113,7 @@
   max-height: calc(70vh - 100px);
   overflow-y: auto;
   overflow-x: hidden;
+  padding-bottom: 50px;
 }
 
 .notification-container {
@@ -185,4 +186,20 @@
   align-items: center;
   justify-content: center;
   transform: translate(60%, -60%);
+}
+
+.notification-button-all, .notification-button-all:active {
+  position: absolute;
+  bottom: 0;
+  right: 50%;
+  transform: translateX(50%);
+  background-color: #FFFFFF;
+  display: flex;
+  align-items: center;
+  border: 1px solid #BBBBBB;
+  margin-bottom: 10px;
+}
+
+.notification-button-all:hover {
+  background-color: #f0f6fd;
 }


### PR DESCRIPTION
## Objective 

[MDS-4630](https://bcmines.atlassian.net/browse/MDS-4630)

- Notifications are now marked as read when clicked on rather than when the drawer is opened
- Added a `Mark all as read` button to the bottom of the drawer which marks all unread notifications as read and closes the drawer
- Updated the Notice of Departure pages to remove the query once loaded so returning to this place in the history/refreshing won't re-open the modal once it's been dismissed.

<img width="1079" alt="image" src="https://user-images.githubusercontent.com/83598933/184989857-b6e608ea-26e4-482e-b74a-419c2fe3cb27.png">
