### PR TITLE
[MDS-4515] nod drawer - moved mark all as read - improved animation

### DIFF
--- a/services/core-web/src/components/navigation/NotificationDrawer.js
+++ b/services/core-web/src/components/navigation/NotificationDrawer.js
@@ -142,6 +142,16 @@ const NotificationDrawer = (props) => {
             tab={<Typography className="notification-tab-header">Mine Activity</Typography>}
             key="1"
           >
+            <div className="notification-button-all-container">
+              <Button
+                className="notification-button-all"
+                size="small"
+                type="text"
+                onClick={() => handleMarkAllAsRead()}
+              >
+                Mark all as read
+              </Button>
+            </div>
             {(props.activities || [])?.map((activity) => (
               <div className="notification-list-item">
                 <div className={!activity.notification_read ? "notification-dot" : ""} />
@@ -176,16 +186,6 @@ const NotificationDrawer = (props) => {
             ))}
           </Tabs.TabPane>
         </Tabs>
-        <div className="notification-button-all-container">
-          <Button
-            className="notification-button-all"
-            size="small"
-            type="text"
-            onClick={() => handleMarkAllAsRead()}
-          >
-            Mark all as read
-          </Button>
-        </div>
       </div>
     </div>
   );

--- a/services/core-web/src/styles/components/NotificationDrawer.scss
+++ b/services/core-web/src/styles/components/NotificationDrawer.scss
@@ -44,29 +44,35 @@
   background-color: #5E46A1;
 }
 
+@keyframes fadeIn {
+  0% { opacity: 0; top: 52px; transform: translateX(10000px);}
+  1% { transform: translateX(0);}
+  100% { opacity: 1; top: 62px; transform: translateX(0); }
+}
+
 .notification-drawer {
-  height: 0;
-  width: 0;
+  width: 564px;
   position: absolute;
-  overflow: hidden;
   right: 0;
-  top: 62px;
+  top: 52px;
+  overflow: hidden;
   background-color: #FFF;
-  transition: all 0.2s ease-in-out;
-  z-index: 1000;
   box-shadow: 0 4px 4px rgba(0, 0, 0, 0.15);
+  opacity: 0;
+  height: 70vh;
+  padding: 0 16px 24px 16px;
+  border: 1px solid #BBBBBB;
+  transform: translateX(10000px);
+}
+
+.notification-drawer-open {
+  animation: fadeIn 0.3s both ease-in-out;
 }
 
 .notification-drawer a {
   text-decoration: none;
 }
 
-.notification-drawer-open {
-  padding: 24px 16px;
-  border: 1px solid #BBBBBB;
-  height: 70vh;
-  width: 564px;
-}
 
 .notification-drawer .ant-tabs-content-holder {
   max-height: calc(70vh - 100px);
@@ -153,26 +159,29 @@
 }
 
 .notification-button-all-container {
-  position: absolute;
-  bottom: 0;
-  height: 50px;
-  width: fit-content;
-  border-radius: 10px;
-  right: 50%;
-  transform: translateX(50%);
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
   background-color: #FFFFFF;
 }
 
 .notification-button-all, .notification-button-all:active {
-  position: absolute;
-  bottom: 0;
-  right: 50%;
-  transform: translateX(50%);
+  border: none;
   background-color: #FFFFFF;
   display: flex;
   align-items: center;
+  transition: 0.3s ease-in-out;
+}
+
+.notification-button-all > span {
+  font-size: 14px;
 }
 
 .notification-button-all:hover {
-  background-color: #f0f6fd;
+  background-color: #FFFFFF;
+  border: none;
+}
+
+.notification-button-all:hover > span {
+  text-decoration: underline;
 }

--- a/services/minespace-web/src/components/layout/NotificationDrawer.js
+++ b/services/minespace-web/src/components/layout/NotificationDrawer.js
@@ -149,6 +149,16 @@ const NotificationDrawer = (props) => {
             }
             key="1"
           >
+            <div className="notification-button-all-container">
+              <Button
+                className="notification-button-all"
+                size="small"
+                type="text"
+                onClick={() => handleMarkAllAsRead()}
+              >
+                Mark all as read
+              </Button>
+            </div>
             {(props.activities || [])?.map((activity) => (
               <div className="notification-list-item">
                 <div className={!activity.notification_read ? "notification-dot" : ""} />
@@ -183,16 +193,6 @@ const NotificationDrawer = (props) => {
             ))}
           </Tabs.TabPane>
         </Tabs>
-        <div className="notification-button-all-container">
-          <Button
-            className="notification-button-all"
-            size="small"
-            type="text"
-            onClick={() => handleMarkAllAsRead()}
-          >
-            Mark all as read
-          </Button>
-        </div>
       </div>
     </div>
   );

--- a/services/minespace-web/src/styles/components/Header.scss
+++ b/services/minespace-web/src/styles/components/Header.scss
@@ -89,24 +89,30 @@
   font-size: 24px;
 }
 
+@keyframes fadeIn {
+  0% { opacity: 0; top: 70px; transform: translateX(10000px);}
+  1% { transform: translateX(0);}
+  100% { opacity: 1; top: 80px; transform: translateX(0); }
+}
+
 .notification-drawer {
-  height: 0;
-  width: 0;
+  width: 564px;
   position: absolute;
-  overflow: hidden;
   right: 0;
-  top: 80px;
+  top: 70px;
+  overflow: hidden;
   background-color: $white;
-  transition: all 0.2s ease-in-out;
-  z-index: 1000;
+  transition: opacity 0.3s, height 0s, top 0.3s ease-in-out;
   box-shadow: 0 4px 4px rgba(0, 0, 0, 0.15);
+  border: 1px solid #BBBBBB;
+  padding: 0 16px 24px 16px;
+  height: 70vh;
+  opacity: 0;
+  z-index: 1000;
 }
 
 .notification-drawer-open {
-  padding: 24px 0;
-  border: 1px solid #BBBBBB;
-  height: 70vh;
-  width: 564px;
+  animation: fadeIn 0.3s both ease-in-out;
 }
 
 .notification-drawer .ant-tabs-content-holder {
@@ -188,18 +194,30 @@
   transform: translate(60%, -60%);
 }
 
+.notification-button-all-container {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  background-color: #FFFFFF;
+}
+
 .notification-button-all, .notification-button-all:active {
-  position: absolute;
-  bottom: 0;
-  right: 50%;
-  transform: translateX(50%);
+  border: none;
   background-color: #FFFFFF;
   display: flex;
   align-items: center;
-  border: 1px solid #BBBBBB;
-  margin-bottom: 10px;
+  transition: 0.3s ease-in-out;
+}
+
+.notification-button-all > span {
+  font-size: 14px;
 }
 
 .notification-button-all:hover {
-  background-color: #f0f6fd;
+  background-color: #FFFFFF;
+  border: none;
+}
+
+.notification-button-all:hover > span {
+  text-decoration: underline;
 }


### PR DESCRIPTION
## Objective 

[MDS-4515](https://bcmines.atlassian.net/browse/MDS-4515)

- Moved "Mark all as read" button to top right of modal
- Improved open/close animation as per request by Roop

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/83598933/185257775-0147ef4d-de95-4e18-8dbd-b12558747f16.png">

<img width="1092" alt="image" src="https://user-images.githubusercontent.com/83598933/185257802-3811dd98-4a75-4c37-bf89-519c424cce2c.png">

