### PR TITLE
[MDS-4638] - made sure notification drawer is off screen when closed

### DIFF
--- a/services/minespace-web/src/styles/components/Header.scss
+++ b/services/minespace-web/src/styles/components/Header.scss
@@ -109,6 +109,7 @@
   height: 70vh;
   opacity: 0;
   z-index: 1000;
+  transform: translateX(10000px);
 }
 
 .notification-drawer-open {


### PR DESCRIPTION
## Objective 

[MDS-4638](https://bcmines.atlassian.net/browse/MDS-4638)

Added `transform: translateX(10000px);` to the base state of the notification drawer so it is off screen and not clickable when closed.
