### PR TITLE
[MDS-4631] Added endpoint to create TSF EOR appointment

### DIFF
--- a/services/core-api/app/api/mines/namespace.py
+++ b/services/core-api/app/api/mines/namespace.py
@@ -34,6 +34,7 @@ from app.api.mines.status.resources.status import MineStatusXrefListResource
 from app.api.mines.subscription.resources.subscription import MineSubscriptionResource, MineSubscriptionListResource
 from app.api.mines.tailings.resources.tailings import MineTailingsStorageFacilityResource
 from app.api.mines.tailings.resources.tailings_list import MineTailingsStorageFacilityListResource
+from app.api.mines.tailings.party_appt.resources.party_appt_list import MineTailingsStorageFacilityPartyAppointmentResource
 from app.api.mines.variances.resources.variance import MineVarianceResource
 from app.api.mines.variances.resources.variance_list import MineVarianceListResource
 from app.api.mines.variances.resources.variance_document_upload import MineVarianceDocumentUploadResource
@@ -66,6 +67,8 @@ api.add_resource(MineRegionResource, '/region')
 api.add_resource(MineTailingsStorageFacilityListResource, '/<string:mine_guid>/tailings')
 api.add_resource(MineTailingsStorageFacilityResource,
                  '/<string:mine_guid>/tailings/<string:mine_tailings_storage_facility_guid>')
+api.add_resource(MineTailingsStorageFacilityPartyAppointmentResource,
+                 '/<string:mine_guid>/tailings/<string:mine_tailings_storage_facility_guid>/party_appt')
 api.add_resource(MineDocumentListResource, '/<string:mine_guid>/documents')
 
 api.add_resource(MineComplianceSummaryResource, '/<string:mine_no>/compliance/summary')

--- a/services/core-api/app/api/mines/tailings/party_appt/resources/party_appt_list.py
+++ b/services/core-api/app/api/mines/tailings/party_appt/resources/party_appt_list.py
@@ -1,0 +1,134 @@
+import uuid
+
+from datetime import datetime, timezone
+from dateutil.tz import UTC
+
+import dateutil.parser
+
+from flask import request, current_app
+from flask_restplus import Resource
+from sqlalchemy import or_, exc as alch_exceptions
+from werkzeug.exceptions import BadRequest, InternalServerError, NotFound, Forbidden
+
+from app.api.parties.party.models.address import Address
+from app.extensions import api
+from app.api.utils.access_decorators import requires_role_view_all, requires_role_mine_edit
+from app.api.utils.resources_mixins import UserMixin
+from app.api.utils.custom_reqparser import CustomReqparser
+
+from app.api.mines.mine.models.mine import Mine
+from app.api.mines.permits.permit.models.permit import Permit
+from app.api.parties.party.models.party import Party
+from app.api.parties.party_appt.models.mine_party_appt import MinePartyAppointment
+from app.api.parties.party_appt.models.mine_party_appt_type import MinePartyAppointmentType
+from app.api.mines.tailings.models.tailings import MineTailingsStorageFacility
+from app.api.constants import PERMIT_LINKED_CONTACT_TYPES
+
+
+class MineTailingsStorageFacilityPartyAppointmentResource(Resource, UserMixin):
+    parser = CustomReqparser()
+    parser.add_argument('mine_guid', type=str, help='guid of the mine.')
+    parser.add_argument('mine_tailings_storage_facility_guid', type=str, help='guid of the tailings storage facility.')
+    parser.add_argument(
+        'party_name',
+        type=str,
+        help='Last name of the party (Person), or the Organization name (Organization).',
+        required=True)
+    parser.add_argument(
+        'phone_no', type=str, help='The primary phone number of the party. Ex: 123-123-1234', required=True)
+    parser.add_argument(
+        'last_name', type=str, help='Last name of the party, if the party is a person.')
+    parser.add_argument(
+        'first_name', type=str, help='First name of the party, if the party is a person.')
+    parser.add_argument('email', type=str, help='The primary email of the party.')
+    parser.add_argument(
+        'suite_no',
+        type=str,
+        store_missing=False,
+        help='The suite number of the party address. Ex: 123')
+    parser.add_argument(
+        'address_line_1',
+        type=str,
+        store_missing=False,
+        help='The first address line of the party address. Ex: 1234 Foo Road')
+    parser.add_argument(
+        'address_line_2',
+        type=str,
+        store_missing=False,
+        help='The second address line of the party address. Ex: 1234 Foo Road')
+    parser.add_argument(
+        'city',
+        type=str,
+        store_missing=False,
+        help='The city where the party is located. Ex: FooTown')
+    parser.add_argument(
+        'sub_division_code',
+        type=str,
+        store_missing=False,
+        help='The region code where the party is located. Ex: BC')
+    parser.add_argument(
+        'post_code',
+        type=str,
+        store_missing=False,
+        help='The postal code of the party address. Ex: A0B1C2')
+
+    @api.doc(params={
+        'mine_guid': 'GUID of the mine to which the tailings is associated',
+        'mine_tailings_storage_facility_guid': 'GUID of the tailings sotrage facility to create a party appointment for'
+    }, body=parser.parser)
+    @requires_role_mine_edit
+    def post(self, mine_guid, mine_tailings_storage_facility_guid):
+        mine = Mine.find_by_mine_guid(mine_guid)
+        data = self.parser.parse_args()
+        if not mine:
+            raise NotFound('Mine not found.')
+
+        mine_tsf = MineTailingsStorageFacility.find_by_tsf_guid(mine_tailings_storage_facility_guid)
+
+        if not mine_tsf:
+            raise NotFound("Tailing Storage Facility not found")
+
+        if mine.mine_guid != mine_tsf.mine_guid:
+            raise Forbidden("TSF is not associated with the given mine")
+
+        party = Party.create(
+            data.get('party_name'),
+            data.get('phone_no'),
+            'PER',
+            email=data.get('email'),
+            first_name=data.get('first_name'),
+            add_to_session=True)
+
+        if not party:
+            raise InternalServerError('Error: Failed to create party')
+
+        address = Address.create(
+            suite_no=data.get('suite_no'),
+            address_line_1=data.get('address_line_1'),
+            address_line_2=data.get('address_line_2'),
+            city=data.get('city'),
+            sub_division_code=data.get('sub_division_code'),
+            post_code=data.get('post_code'))
+        party.address.append(address)
+
+        party.save()
+
+        related_guid = mine_tsf.mine_tailings_storage_facility_guid
+        start_date = datetime.now(tz=timezone.utc)
+
+        MinePartyAppointment.end_current_appointment(
+            mine_guid=mine_guid,
+            mine_party_appt_type_code='EOR',
+            related_guid=related_guid,
+            new_appointment_start_date=start_date
+        )
+
+        new_eor = MinePartyAppointment.create(
+            mine=mine,
+            tsf=mine_tsf,
+            party_guid=party.party_guid,
+            mine_party_appt_type_code='EOR',
+            processed_by=self.get_user_info(),
+            start_date=start_date)
+        new_eor.assign_related_guid('EOR', related_guid)
+        new_eor.save()

--- a/services/core-api/app/api/parties/party_appt/resources/mine_party_appt_resource.py
+++ b/services/core-api/app/api/parties/party_appt/resources/mine_party_appt_resource.py
@@ -118,21 +118,13 @@ class MinePartyApptResource(Resource, UserMixin):
                 raise NotFound('TSF not found')
 
         if end_current:
-            if mine_party_appt_type_code == 'EOR':
-                current_mpa = MinePartyAppointment.find_current_appointments(
-                    mine_guid=mine_guid,
-                    mine_party_appt_type_code=mine_party_appt_type_code,
-                    mine_tailings_storage_facility_guid=related_guid)
-            elif mine_party_appt_type_code in PERMIT_LINKED_CONTACT_TYPES:
-                current_mpa = MinePartyAppointment.find_current_appointments(
-                    mine_party_appt_type_code=mine_party_appt_type_code, permit_id=permit.permit_id)
-            else:
-                current_mpa = MinePartyAppointment.find_current_appointments(
-                    mine_guid=mine_guid, mine_party_appt_type_code=mine_party_appt_type_code)
-            if len(current_mpa) != 1:
-                raise BadRequest('There is currently not exactly one active appointment.')
-            current_mpa[0].end_date = start_date - timedelta(days=1)
-            current_mpa[0].save()
+            MinePartyAppointment.end_current_appointment(
+                mine_guid=mine_guid,
+                mine_party_appt_type_code=mine_party_appt_type_code,
+                permit=permit,
+                related_guid=related_guid,
+                new_appointment_start_date=start_date
+            )
 
         new_mpa = MinePartyAppointment.create(
             mine=mine,

--- a/services/core-api/tests/mines/tailings/party_apps/test_party_apps_resource.py
+++ b/services/core-api/tests/mines/tailings/party_apps/test_party_apps_resource.py
@@ -1,0 +1,79 @@
+import uuid
+import json
+from app.extensions import db
+from app.api.mines.tailings.models.tailings import MineTailingsStorageFacility
+from app.api.mines.reports.models.mine_report_definition import MineReportDefinition
+from app.api.mines.reports.models.mine_report import MineReport
+from tests.factories import MineFactory, MineTailingsStorageFacilityFactory
+
+
+def test_post_mine_tailings_storage_facility_by_mine_guid(test_client, db_session, auth_headers):
+    """Should create an EOR record and return a 200 response"""
+
+    tsf = MineTailingsStorageFacilityFactory()
+
+    org_mine_tsf_list_len = len(tsf.engineer_of_records)
+    data = {
+        'party_name': 'LastName',
+        'phone_no': '240-359-2232',
+        'last_name': 'A name',
+        'first_name': 'A first name',
+        'email': 'test@email.com',
+        'address_line_1': 'Addr1',
+        'address_line_2': 'Addr2',
+        'city': 'Victoria',
+        'sub_division_code': 'BC',
+        'post_code': 'V4D1B3',
+    }
+
+    post_resp = test_client.post(
+        f'/mines/{tsf.mine.mine_guid}/tailings/{tsf.mine_tailings_storage_facility_guid}/party_appt', data=data, headers=auth_headers['full_auth_header'])
+    assert post_resp.status_code == 200
+    assert len(tsf.engineer_of_records) == org_mine_tsf_list_len + 1
+
+    assert tsf.engineer_of_record.party.party_name == 'LastName'
+
+def test_post_mine_tailings_storage_facility_by_mine_guid_should_update_current_eor(test_client, db_session, auth_headers):
+    """Should create two EOR records and set the active one to the last created"""
+
+    tsf = MineTailingsStorageFacilityFactory()
+
+    org_mine_tsf_list_len = len(tsf.engineer_of_records)
+    eor_data = {
+        'party_name': 'LastName',
+        'phone_no': '240-359-2232',
+        'first_name': 'A first name',
+        'email': 'test@email.com',
+        'address_line_1': 'Addr1',
+        'address_line_2': 'Addr2',
+        'city': 'Victoria',
+        'sub_division_code': 'BC',
+        'post_code': 'V4D1B3',
+    }
+
+    post_resp = test_client.post(
+        f'/mines/{tsf.mine.mine_guid}/tailings/{tsf.mine_tailings_storage_facility_guid}/party_appt', data=eor_data, headers=auth_headers['full_auth_header'])
+    assert post_resp.status_code == 200
+
+    new_eor_data = {
+        'party_name': 'EOR2',
+        'phone_no': '240-359-2232',
+        'first_name': 'Another first name',
+        'email': 'test2@email.com',
+        'address_line_1': 'Addr3',
+        'address_line_2': 'Addr4',
+        'city': 'Vancouver',
+        'sub_division_code': 'BC',
+        'post_code': 'V4D1B3',
+    }
+
+    post_resp2 = test_client.post(
+        f'/mines/{tsf.mine.mine_guid}/tailings/{tsf.mine_tailings_storage_facility_guid}/party_appt', data=new_eor_data, headers=auth_headers['full_auth_header'])
+
+    assert post_resp2.status_code == 200
+
+    assert len(tsf.engineer_of_records) == org_mine_tsf_list_len + 2
+
+
+
+    assert tsf.engineer_of_record.party.party_name == 'EOR2'


### PR DESCRIPTION
## Objective 

[MDS-4631](https://bcmines.atlassian.net/browse/MDS-4631)

Added endpoint to create TSF EOR appointment, for use by MineSpace web. This endpoint creates a `party` with the given info, and associates it with a TSF through a `MinePartyAppointment`. The previous EOR appointments term will be updated to not overlap with the new appointment.

Why a new endpoint for this instead of using the existing party creation + TSF update endpoints? The creation of a party is currently not exposed to MineSpace users at all. We still only want the MS users to be able to create a `party` within the context of a TSF EOR appointment - so this will allow us to restrict that.

_Why are you making this change? Provide a short explanation and/or screenshots_
