### PR TITLE
[MDS-4631] Open up endpoint to create Mine Party Appt (EORs only) to Minespace proponents

### DIFF
--- a/services/core-api/app/api/utils/access_decorators.py
+++ b/services/core-api/app/api/utils/access_decorators.py
@@ -36,6 +36,8 @@ def is_minespace_user():
 def can_edit_now_dates():
     return jwt.validate_roles([EDIT_NOW_DATES])
 
+def can_edit_mines():
+    return jwt.validate_roles([MINE_EDIT])
 
 def requires_role_edit_emli_contacts(func):
     return _inner_wrapper(func, EDIT_EMLI_CONTACTS)

--- a/services/core-api/tests/auth/test_expected_auth.py
+++ b/services/core-api/tests/auth/test_expected_auth.py
@@ -64,7 +64,7 @@ from app.api.projects.information_requirements_table.resources.requirements impo
      (MineListResource, "post", [MINE_EDIT]),
      (MineListSearch, "get", [VIEW_ALL, MINESPACE_PROPONENT]),
      (MineMapResource, "get", [VIEW_ALL, MINESPACE_PROPONENT]),
-     (MinePartyApptResource, "get", [VIEW_ALL]), (MinePartyApptResource, "post", [MINE_EDIT]),
+     (MinePartyApptResource, "get", [VIEW_ALL]), (MinePartyApptResource, "post", [MINE_EDIT, MINESPACE_PROPONENT]),
      (MinePartyApptResource, "put", [MINE_EDIT]), (MinePartyApptResource, "delete", [MINE_EDIT]),
      (MinePartyApptTypeResource, "get", [VIEW_ALL]), (MineRegionResource, "get", [VIEW_ALL]),
      (MineResource, "get", [VIEW_ALL, MINESPACE_PROPONENT]),


### PR DESCRIPTION
## Objective 

[MDS-4631](https://bcmines.atlassian.net/browse/MDS-4631)

_Why are you making this change? Provide a short explanation and/or screenshots_

Opened up endpoint to create Mine Party Appt (EORs only) to Minespace proponents.
- (for now) they should only be able to create EOR appointments
- (for now) The party being appointed as an EOR must already be associated with the mine

This will be used on the Minespace side to assign EORs to a TSF
