### PR TITLE
[MDS-4563] Added prompt before uploading new nod checklist and warning text

### DIFF
--- a/services/minespace-web/src/components/Forms/noticeOfDeparture/AddNoticeOfDepartureForm.js
+++ b/services/minespace-web/src/components/Forms/noticeOfDeparture/AddNoticeOfDepartureForm.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import PropTypes from "prop-types";
 import { change, Field, reduxForm, FieldArray } from "redux-form";
-import { Button, Col, Popconfirm, Row, Typography } from "antd";
+import { Button, Col, Popconfirm, Row, Typography, Alert } from "antd";
 import { Form } from "@ant-design/compatible";
 import {
   maxLength,
@@ -249,6 +249,14 @@ const AddNoticeOfDepartureForm = (props) => {
           ) below. Remember your completed form must be signed by the Mine Manager and any
           supporting information included or uploaded.
         </Typography.Text>
+        {hasChecklist && (
+          <Alert
+            className="margin-y-large"
+            message="Note: Uploading a new self-assessment form will replace the existing version.  Additional files can be uploaded in the 'Upload Application Documents' section at the end of this form"
+            type="warning"
+            showIcon
+          />
+        )}
         <Form.Item className="margin-y-large">
           <Field
             onFileLoad={(documentName, document_manager_guid) => {

--- a/services/minespace-web/src/components/Forms/noticeOfDeparture/EditNoticeOfDepartureForm.js
+++ b/services/minespace-web/src/components/Forms/noticeOfDeparture/EditNoticeOfDepartureForm.js
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import { change, Field, FieldArray, reduxForm } from "redux-form";
-import { Button, Col, Popconfirm, Row, Typography } from "antd";
+import { Button, Col, Popconfirm, Row, Typography, Alert } from "antd";
 import { Form } from "@ant-design/compatible";
 import { maxLength, required, requiredRadioButton } from "@common/utils/Validate";
 import { resetForm } from "@common/utils/helpers";
@@ -115,6 +115,16 @@ const EditNoticeOfDepartureForm = (props) => {
     ).finally(() => setSubmitting(false));
   };
 
+  const handleBeforeUpload = () => {
+    if (checklist) {
+      // eslint-disable-next-line no-alert
+      return window.confirm(
+        "Uploading a new checklist will replace the previously uploaded file.  Are you sure you'd like to continue?"
+      );
+    }
+    return true;
+  };
+
   return (
     <div>
       <NoticeOfDepartureCallout nodStatus={nod_status} />
@@ -190,6 +200,14 @@ const EditNoticeOfDepartureForm = (props) => {
           ) below. Remember your completed form must be signed by the Mine Manager and any
           supporting information included or uploaded.
         </Typography.Text>
+        {hasChecklist && (
+          <Alert
+            className="margin-y-large"
+            message="Note: Uploading a new self-assessment form will replace the existing version.  Additional files can be uploaded in the 'Upload Application Documents' section at the end of this form"
+            type="warning"
+            showIcon
+          />
+        )}
         <Form.Item className="margin-y-large">
           <Field
             name="nod_self_assessment_form"
@@ -205,6 +223,7 @@ const EditNoticeOfDepartureForm = (props) => {
             mineGuid={mineGuid}
             allowMultiple
             setUploading={setUploading}
+            beforeUpload={handleBeforeUpload}
             component={NoticeOfDepartureFileUpload}
             labelIdle='<strong class="filepond--label-action">Self-Assessment Upload</strong><div>Accepted filetypes: .doc .docx .xlsx .pdf</div>'
             maxFiles={1}

--- a/services/minespace-web/src/components/Forms/noticeOfDeparture/NoticeOfDepartureFileUpload.js
+++ b/services/minespace-web/src/components/Forms/noticeOfDeparture/NoticeOfDepartureFileUpload.js
@@ -15,10 +15,12 @@ const propTypes = {
   labelIdle: PropTypes.string,
   // eslint-disable-next-line react/forbid-prop-types
   acceptedFileTypesMap: PropTypes.object.isRequired,
+  beforeUpload: PropTypes.func,
 };
 
 const defaultProps = {
   labelIdle: undefined,
+  beforeUpload: () => {},
 };
 
 export const NoticeOfDepartureFileUpload = (props) => {
@@ -49,6 +51,8 @@ export const NoticeOfDepartureFileUpload = (props) => {
       allowRevert
       onprocessfiles={() => setUploading(false)}
       allowMultiple={allowMultiple}
+      beforeAddFile={props.beforeUpload}
+      beforeDropFile={props.beforeUpload}
     />
   );
 };

--- a/services/minespace-web/src/components/common/FileUpload.js
+++ b/services/minespace-web/src/components/common/FileUpload.js
@@ -35,6 +35,8 @@ const propTypes = {
   labelIdle: PropTypes.string,
   onprocessfiles: PropTypes.func,
   importIsSuccessful: PropTypes.func,
+  beforeAddFile: PropTypes.func,
+  beforeDropFile: PropTypes.func,
 };
 
 const defaultProps = {
@@ -52,6 +54,8 @@ const defaultProps = {
   onprocessfiles: () => {},
   importIsSuccessful: () => {},
   labelIdle: 'Drag & Drop your files or <span class="filepond--label-action">Browse</span>',
+  beforeAddFile: () => {},
+  beforeDropFile: () => {},
 };
 
 class FileUpload extends React.Component {
@@ -126,6 +130,8 @@ class FileUpload extends React.Component {
     return (
       <div>
         <FilePond
+          beforeAddFile={this.props.beforeAddFile}
+          beforeDropFile={this.props.beforeDropFile}
           server={this.server}
           name="file"
           maxFiles={this.props.maxFiles}


### PR DESCRIPTION
## Objective 

[MDS-4563](https://bcmines.atlassian.net/browse/MDS-4563)

- Added text warning before nod self assessment upload field (only when one exists)
- Added window prompt to confirm overwrite of the previous file when uploading a new nod self-assessment

_Why are you making this change? Provide a short explanation and/or screenshots_
<img width="1438" alt="image" src="https://user-images.githubusercontent.com/83598933/186946217-2f5b665a-ae33-4fd3-94e8-00513d168a99.png">
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/83598933/186946337-2c92fef6-738f-4a18-bfd6-be854f3ca4d4.png">

