### PR TITLE
[MDS-4647] NoW Delay end reverts status

### DIFF
--- a/services/core-api/app/api/now_applications/resources/now_application_delay_resource.py
+++ b/services/core-api/app/api/now_applications/resources/now_application_delay_resource.py
@@ -48,7 +48,7 @@ class NOWApplicationDelayListResource(Resource, UserMixin):
         if not now_app:
             raise NotFound('Notice of Work Application not found')
 
-        ##ensure no nothers are already open
+        # ensure no nothers are already open
         if len([d for d in now_app.application_delays if d.end_date == None]) > 0:
             raise BadRequest("Close existing 'open' delay before opening a new one")
 
@@ -93,17 +93,15 @@ class NOWApplicationDelayResource(Resource, UserMixin):
     def put(self, now_application_guid, now_application_delay_guid):
         data = request.json
 
-        ### This block is what was causing the issue when a now progress was being edited and cause the now_application status to revert.
-        ### I am leaving it in in case it is needed down the road but as it stands we could think of a scenario where you could Edit a progress and this was still valid.
+        def change_now_status(now_app_guid):
+            now_app = NOWApplicationIdentity.find_by_guid(now_app_guid)
+            if not now_app:
+                raise NotFound('Notice of Work Application not found')
 
-        # now_app = NOWApplicationIdentity.find_by_guid(now_application_guid)
-        # if not now_app:
-        #     raise NotFound('Notice of Work Application not found')
-
-        # # change NoW status back to previous state
-        # if now_app.now_application is not None:
-        #     now_app.now_application.now_application_status_code = now_app.now_application.previous_application_status_code
-        # now_app.save()
+            # change NoW status back to previous state
+            if now_app.now_application is not None:
+                now_app.now_application.now_application_status_code = now_app.now_application.previous_application_status_code
+            now_app.save()
 
         now_delay = NOWApplicationDelay._schema().load(
             request.json, instance=NOWApplicationDelay.find_by_guid(now_application_delay_guid))
@@ -120,9 +118,12 @@ class NOWApplicationDelayResource(Resource, UserMixin):
             if end_date is not None:
                 if end_date < start_date:
                     raise BadRequest("The end date must be after the start date.")
+                if now_delay.end_date is None:
+                    change_now_status(now_application_guid)
                 now_delay.end_date = dateutil.parser.isoparse(end_date).astimezone(UTC)
         else:
             now_delay.end_date = datetime.now(tz=timezone.utc)
+            change_now_status(now_application_guid)
         now_delay.save()
 
         return now_delay

--- a/services/core-api/app/api/now_applications/resources/now_application_delay_resource.py
+++ b/services/core-api/app/api/now_applications/resources/now_application_delay_resource.py
@@ -93,6 +93,7 @@ class NOWApplicationDelayResource(Resource, UserMixin):
     def put(self, now_application_guid, now_application_delay_guid):
         data = request.json
 
+        # function to revert the now status to what it was before the delay was started.
         def change_now_status(now_app_guid):
             now_app = NOWApplicationIdentity.find_by_guid(now_app_guid)
             if not now_app:
@@ -119,10 +120,13 @@ class NOWApplicationDelayResource(Resource, UserMixin):
                 if end_date < start_date:
                     raise BadRequest("The end date must be after the start date.")
                 if now_delay.end_date is None:
+                    # if the now_delay.end_date is none than that means we are closing the delay for the first time and the
+                    # NoW status needs to revert.
                     change_now_status(now_application_guid)
                 now_delay.end_date = dateutil.parser.isoparse(end_date).astimezone(UTC)
         else:
             now_delay.end_date = datetime.now(tz=timezone.utc)
+            # Here we are closing it since we passed the edit check above.
             change_now_status(now_application_guid)
         now_delay.save()
 

--- a/services/core-web/src/components/noticeOfWork/applications/administrative/NOWProgressTable.js
+++ b/services/core-web/src/components/noticeOfWork/applications/administrative/NOWProgressTable.js
@@ -28,10 +28,10 @@ import {
 import { openModal, closeModal } from "@common/actions/modalActions";
 import { ClockCircleOutlined, CheckCircleOutlined, StopOutlined } from "@ant-design/icons";
 import { formatDate, getDurationTextInDays } from "@common/utils/helpers";
+import * as Strings from "@common/constants/strings";
 import CoreTable from "@/components/common/CoreTable";
 import { COLOR } from "@/constants/styles";
 import CustomPropTypes from "@/customPropTypes";
-import * as Strings from "@common/constants/strings";
 import { EDIT_OUTLINE_VIOLET } from "@/constants/assets";
 import { modalConfig } from "@/components/modalContent/config";
 import * as Permission from "@/constants/permissions";
@@ -431,6 +431,7 @@ export class NOWProgressTable extends Component {
       )
       .then(() => {
         this.props.fetchApplicationDelay(this.props.noticeOfWork.now_application_guid);
+        this.props.fetchNoticeOfWorkApplication(this.props.noticeOfWork.now_application_guid);
         this.props.closeModal();
       });
   };


### PR DESCRIPTION
When a delay is ended the status of the NoW is set back to the status from before the delay.

[MDS-4647](https://bcmines.atlassian.net/browse/MDS-46478)

<img width="1368" alt="image" src="https://user-images.githubusercontent.com/13022710/189232549-78d26a8f-0b06-432c-8c3c-740c1c78c528.png">

<img width="1092" alt="image" src="https://user-images.githubusercontent.com/13022710/189232851-beec241b-6e0f-4952-abf4-1d4f8697939a.png">

