### PR TITLE
[MDS-4646] Notice of Work delay dates off by 1 day

### DIFF
--- a/services/core-web/src/components/noticeOfWork/applications/administrative/NOWProgressTable.js
+++ b/services/core-web/src/components/noticeOfWork/applications/administrative/NOWProgressTable.js
@@ -386,7 +386,12 @@ export class NOWProgressTable extends Component {
   ];
 
   handleUpdateProgressDates = (values) => {
-    const payload = { ...values, date_override: true };
+    const payload = {
+      ...values,
+      date_override: true,
+      start_date: moment(values.start_date),
+      end_date: values?.end_date ?? moment(values.end_date),
+    };
     this.props
       .updateNoticeOfWorkApplicationProgress(
         this.props.noticeOfWork.now_application_guid,
@@ -420,8 +425,11 @@ export class NOWProgressTable extends Component {
 
   handleUpdateDelayDates = (values) => {
     const payload = {
-      date_override: true,
       ...values,
+      date_override: true,
+
+      start_date: moment(values.start_date),
+      end_date: values?.end_date ?? moment(values.end_date),
     };
     this.props
       .updateApplicationDelay(

--- a/services/core-web/src/components/noticeOfWork/applications/administrative/NOWProgressTable.js
+++ b/services/core-web/src/components/noticeOfWork/applications/administrative/NOWProgressTable.js
@@ -427,7 +427,6 @@ export class NOWProgressTable extends Component {
     const payload = {
       ...values,
       date_override: true,
-
       start_date: moment(values.start_date),
       end_date: values?.end_date ?? moment(values.end_date),
     };


### PR DESCRIPTION
## Objective 

[MDS-4646](https://bcmines.atlassian.net/browse/MDS-4646)

_Changes_

- Fix PUT payload on both Progress Dates and Delay Dates to cast start/end dates as a moment objects before reaching the API for consistent date formatting in and out

NOTE: I updated the Progress Dates as well because I discovered it had the same issue as delays.
