### PR TITLE
MDS-4579-hotfix - limit pr checks to core-web and minespace

### DIFF
--- a/.github/workflows/audit-frontend.yaml
+++ b/.github/workflows/audit-frontend.yaml
@@ -17,6 +17,9 @@ on:
       - reopened
       - synchronize
       - ready_for_review
+    paths:
+      - ./services/core-web/**
+      - ./services/minespace-web/**
 
 jobs:
   audit-frontend: # Audit for unused, vulnerable, and missing frontend packages


### PR DESCRIPTION
## Objective 

[MDS-4579](https://bcmines.atlassian.net/browse/MDS-4579)

Hotfix to limit frontend audit to frontend components
