### PR TITLE
[MDS-4663] Changed wording from Personal to Basic BCeID

### DIFF
--- a/services/minespace-web/src/components/pages/LandingPage.js
+++ b/services/minespace-web/src/components/pages/LandingPage.js
@@ -124,8 +124,8 @@ export const LandingPage = (props) => (
       <Col sm={{ span: 24 }} xl={{ span: 12 }} xxl={{ span: 10 }}>
         <Typography.Title level={4}>How do I get access?</Typography.Title>
         <Typography.Paragraph>
-          You must have a <Typography.Text strong>Business or Personal BCeID</Typography.Text> and
-          then contact us to request access to MineSpace.
+          You must have a <Typography.Text strong>Business or Basic BCeID</Typography.Text> and then
+          contact us to request access to MineSpace.
         </Typography.Paragraph>
         <Typography.Paragraph strong>If you have a BCeID:</Typography.Paragraph>
         <Typography.Paragraph>
@@ -146,8 +146,8 @@ export const LandingPage = (props) => (
 
         <Typography.Title level={4}>Don&apos;t have a BCeID?</Typography.Title>
         <Typography.Paragraph>
-          In order to access MineSpace, you need to register for a Business or Personal BCeID. It
-          can take several weeks to process the request, so give yourself plenty of lead time.
+          In order to access MineSpace, you need to register for a Business or Basic BCeID. It can
+          take several weeks to process the request, so give yourself plenty of lead time.
         </Typography.Paragraph>
         <Typography.Paragraph>
           Once you have your BCeID, you can add employees and delegates. You can request that anyone

--- a/services/minespace-web/src/tests/components/landingPage/__snapshots__/LandingPage.spec.js.snap
+++ b/services/minespace-web/src/tests/components/landingPage/__snapshots__/LandingPage.spec.js.snap
@@ -196,7 +196,7 @@ exports[`LandingPage renders properly 1`] = `
         <Text
           strong={true}
         >
-          Business or Personal BCeID
+          Business or Basic BCeID
         </Text>
          and then contact us to request access to MineSpace.
       </Paragraph>
@@ -233,7 +233,7 @@ exports[`LandingPage renders properly 1`] = `
         Don't have a BCeID?
       </Title>
       <Paragraph>
-        In order to access MineSpace, you need to register for a Business or Personal BCeID. It can take several weeks to process the request, so give yourself plenty of lead time.
+        In order to access MineSpace, you need to register for a Business or Basic BCeID. It can take several weeks to process the request, so give yourself plenty of lead time.
       </Paragraph>
       <Paragraph>
         Once you have your BCeID, you can add employees and delegates. You can request that anyone added to your Business BCeID account be given access to MineSpace.


### PR DESCRIPTION
## Objective 

[MDS-4663](https://bcmines.atlassian.net/browse/MDS-4663)

_Why are you making this change? Provide a short explanation and/or screenshots_

Renamed BCeID Personal to BCeID basic on MS login screen

<img width="578" alt="image" src="https://user-images.githubusercontent.com/66635118/189670347-220d985b-d7c9-45cc-afe1-0753de14d651.png">
<img width="592" alt="image" src="https://user-images.githubusercontent.com/66635118/189670380-fa77b507-f5af-4102-945d-0e75461d100a.png">
