### PR TITLE
[MDS-4667] Added hard number of max retries for NoW import

### DIFF
--- a/services/document-manager/backend/app/tasks/import_now_submission_documents.py
+++ b/services/document-manager/backend/app/tasks/import_now_submission_documents.py
@@ -49,9 +49,10 @@ def task_result(job_id, task_id, success, message, success_docs, errors, doc_ids
     return json.dumps(result)
 
 
+
 @celery.task(
     bind=True,
-    max_retries=None,
+    max_retries=100,
     acks_late=True,
     task_reject_on_worker_lost=True,
     autoretry_for=(Exception, ))


### PR DESCRIPTION
## Objective 

[MDS-4667](https://bcmines.atlassian.net/browse/MDS-4667)

_Why are you making this change? Provide a short explanation and/or screenshots_

Set the max number of retries of a NoW import job to 100, as currently a failed NoW import job will retry in perpetuity until it succeeds. 

![image](https://user-images.githubusercontent.com/66635118/189692881-f90af770-9888-44c3-9f4a-17fb22d02a71.png)

