### PR TITLE
[MDS-4690] [MDS-4691] addressed TSF bug issue

### DIFF
--- a/services/core-api/app/api/mines/tailings/resources/tailings_list.py
+++ b/services/core-api/app/api/mines/tailings/resources/tailings_list.py
@@ -2,7 +2,7 @@ from decimal import Decimal
 from datetime import datetime, timezone
 from flask import current_app
 from flask_restplus import Resource, reqparse
-from werkzeug.exceptions import InternalServerError, NotFound
+from werkzeug.exceptions import InternalServerError, NotFound, BadRequest
 
 from app.extensions import api, db
 from app.api.utils.access_decorators import requires_role_view_all, requires_any_of, \
@@ -113,6 +113,14 @@ class MineTailingsStorageFacilityListResource(Resource, UserMixin):
 
         mine_tsf_list = mine.mine_tailings_storage_facilities
         is_mine_first_tsf = len(mine_tsf_list) == 0
+
+        # Check if the mine already has a TSF with the same name
+        for mine_tsf in mine_tsf_list:
+            if mine_tsf.mine_tailings_storage_facility_name == data.get(
+                    'mine_tailings_storage_facility_name'):
+                raise BadRequest(
+                    'Mine already has a TSF with the same name: {}'.format(
+                        data.get('mine_tailings_storage_facility_name')))
 
         mine_tsf = MineTailingsStorageFacility.create(
             mine,

--- a/services/core-web/common/actionCreators/mineActionCreator.js
+++ b/services/core-web/common/actionCreators/mineActionCreator.js
@@ -94,7 +94,7 @@ export const removeMineType = (mineGuid, mineTypeGuid, tenure) => (dispatch) => 
 
 export const createTailingsStorageFacility = (mine_guid, payload) => (dispatch) => {
   dispatch(request(reducerTypes.CREATE_TSF));
-  dispatch(showLoading("modal"));
+  dispatch(showLoading());
   return CustomAxios()
     .post(ENVIRONMENT.apiUrl + API.MINE_TSFS(mine_guid), payload, createRequestHeader())
     .then((response) => {
@@ -110,12 +110,12 @@ export const createTailingsStorageFacility = (mine_guid, payload) => (dispatch) 
       dispatch(error(reducerTypes.CREATE_TSF));
       throw new Error(err);
     })
-    .finally(() => dispatch(hideLoading("modal")));
+    .finally(() => dispatch(hideLoading()));
 };
 
 export const updateTailingsStorageFacility = (mineGuid, TSFGuid, payload) => (dispatch) => {
   dispatch(request(reducerTypes.UPDATE_TSF));
-  dispatch(showLoading("modal"));
+  dispatch(showLoading());
   return CustomAxios()
     .put(`${ENVIRONMENT.apiUrl}${API.MINE_TSF(mineGuid, TSFGuid)}`, payload, createRequestHeader())
     .then((response) => {
@@ -131,7 +131,7 @@ export const updateTailingsStorageFacility = (mineGuid, TSFGuid, payload) => (di
       dispatch(error(reducerTypes.UPDATE_TSF));
       throw new Error(err);
     })
-    .finally(() => dispatch(hideLoading("modal")));
+    .finally(() => dispatch(hideLoading()));
 };
 
 export const fetchMineRecords = (params) => (dispatch) => {

--- a/services/minespace-web/common/actionCreators/mineActionCreator.js
+++ b/services/minespace-web/common/actionCreators/mineActionCreator.js
@@ -94,7 +94,7 @@ export const removeMineType = (mineGuid, mineTypeGuid, tenure) => (dispatch) => 
 
 export const createTailingsStorageFacility = (mine_guid, payload) => (dispatch) => {
   dispatch(request(reducerTypes.CREATE_TSF));
-  dispatch(showLoading("modal"));
+  dispatch(showLoading());
   return CustomAxios()
     .post(ENVIRONMENT.apiUrl + API.MINE_TSFS(mine_guid), payload, createRequestHeader())
     .then((response) => {
@@ -110,12 +110,12 @@ export const createTailingsStorageFacility = (mine_guid, payload) => (dispatch) 
       dispatch(error(reducerTypes.CREATE_TSF));
       throw new Error(err);
     })
-    .finally(() => dispatch(hideLoading("modal")));
+    .finally(() => dispatch(hideLoading()));
 };
 
 export const updateTailingsStorageFacility = (mineGuid, TSFGuid, payload) => (dispatch) => {
   dispatch(request(reducerTypes.UPDATE_TSF));
-  dispatch(showLoading("modal"));
+  dispatch(showLoading());
   return CustomAxios()
     .put(`${ENVIRONMENT.apiUrl}${API.MINE_TSF(mineGuid, TSFGuid)}`, payload, createRequestHeader())
     .then((response) => {
@@ -131,7 +131,7 @@ export const updateTailingsStorageFacility = (mineGuid, TSFGuid, payload) => (di
       dispatch(error(reducerTypes.UPDATE_TSF));
       throw new Error(err);
     })
-    .finally(() => dispatch(hideLoading("modal")));
+    .finally(() => dispatch(hideLoading()));
 };
 
 export const fetchMineRecords = (params) => (dispatch) => {

--- a/services/minespace-web/src/components/Forms/tailing/tailingsStorageFacility/BasicInformation.js
+++ b/services/minespace-web/src/components/Forms/tailing/tailingsStorageFacility/BasicInformation.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import { Col, Row, Typography } from "antd";
 import { Field } from "redux-form";
 import {
@@ -18,97 +18,123 @@ import {
   CONSEQUENCE_CLASSIFICATION_STATUS_CODE,
 } from "@common/constants/strings";
 import { renderConfig } from "@/components/common/config";
+import { connect } from "react-redux";
+import PropTypes from "prop-types";
+import CustomPropTypes from "@/customPropTypes";
+import { getPermits } from "@common/selectors/permitSelectors";
 
-const propTypes = {};
+const propTypes = {
+  permits: PropTypes.arrayOf(CustomPropTypes.permit).isRequired,
+};
 
-export const BasicInformation = () => (
-  <>
-    <Typography.Title level={3}>Basic Information</Typography.Title>
-    <Field
-      id="facility_type"
-      name="facility_type"
-      label="Facility Type"
-      component={renderConfig.SELECT}
-      data={FACILITY_TYPES}
-      validate={[requiredList, validateSelectOptions(FACILITY_TYPES)]}
-    />
-    <Field
-      id="mines_act_permit_no"
-      name="mines_act_permit_no"
-      label="Mines Act Permit Number"
-      component={renderConfig.FIELD}
-      validate={[maxLength(300), required]}
-    />
-    <Field
-      id="tailings_storage_facility_type"
-      name="tailings_storage_facility_type"
-      label="Tailings Storage Facility Type"
-      component={renderConfig.SELECT}
-      validate={[requiredList, validateSelectOptions(TSF_TYPES)]}
-      data={TSF_TYPES}
-    />
-    <Field
-      id="storage_location"
-      name="storage_location"
-      label="Underground or Above Ground?"
-      component={renderConfig.SELECT}
-      data={STORAGE_LOCATION}
-      validate={[requiredList, validateSelectOptions(STORAGE_LOCATION)]}
-    />
-    <Field
-      id="mine_tailings_storage_facility_name"
-      name="mine_tailings_storage_facility_name"
-      label="Facility Name"
-      component={renderConfig.FIELD}
-      validate={[maxLength(300), required]}
-    />
-    <Row gutter={16}>
-      <Col span={12}>
-        <Field
-          id="latitude"
-          name="latitude"
-          label="Latitude"
-          component={renderConfig.FIELD}
-          validate={[lat, required]}
-        />
-      </Col>
-      <Col span={12}>
-        <Field
-          id="longitude"
-          name="longitude"
-          label="Longitude"
-          component={renderConfig.FIELD}
-          validate={[lon, required]}
-        />
-      </Col>
-    </Row>
-    <Field
-      id="consequence_classification_status_code"
-      name="consequence_classification_status_code"
-      label="Consequence Classification"
-      component={renderConfig.SELECT}
-      data={CONSEQUENCE_CLASSIFICATION_STATUS_CODE}
-      validate={[requiredList, validateSelectOptions(CONSEQUENCE_CLASSIFICATION_STATUS_CODE)]}
-    />
-    <Field
-      id="tsf_operating_status_code"
-      name="tsf_operating_status_code"
-      label="Operating Status"
-      data={TSF_OPERATING_STATUS_CODE}
-      component={renderConfig.SELECT}
-      validate={[requiredList, validateSelectOptions(TSF_OPERATING_STATUS_CODE)]}
-    />
-    <Field
-      id="itrb_exemption_status_code"
-      name="itrb_exemption_status_code"
-      label="Independent Tailings Review Board Member"
-      component={renderConfig.SELECT}
-      data={TSF_INDEPENDENT_TAILINGS_REVIEW_BOARD}
-      validate={[maxLength(300), required]}
-    />
-  </>
-);
+export const BasicInformation = (props) => {
+  const [permitOptions, setPermitOptions] = useState([]);
+  const { permits } = props;
+
+  useEffect(() => {
+    if (permits.length > 0) {
+      setPermitOptions(
+        permits.map((permit) => ({
+          label: permit.permit_no,
+          value: permit.permit_guid,
+        }))
+      );
+    }
+  }, [permits]);
+  return (
+    <>
+      <Typography.Title level={3}>Basic Information</Typography.Title>
+      <Field
+        id="facility_type"
+        name="facility_type"
+        label="Facility Type"
+        component={renderConfig.SELECT}
+        data={FACILITY_TYPES}
+        validate={[requiredList, validateSelectOptions(FACILITY_TYPES)]}
+      />
+      <Field
+        label="Mines Act Permit Number"
+        id="mines_act_permit_no"
+        name="mines_act_permit_no"
+        component={renderConfig.SELECT}
+        validate={[requiredList, validateSelectOptions(permitOptions)]}
+        data={permitOptions}
+      />
+      <Field
+        id="tailings_storage_facility_type"
+        name="tailings_storage_facility_type"
+        label="Tailings Storage Facility Type"
+        component={renderConfig.SELECT}
+        validate={[requiredList, validateSelectOptions(TSF_TYPES)]}
+        data={TSF_TYPES}
+      />
+      <Field
+        id="storage_location"
+        name="storage_location"
+        label="Underground or Above Ground?"
+        component={renderConfig.SELECT}
+        data={STORAGE_LOCATION}
+        validate={[requiredList, validateSelectOptions(STORAGE_LOCATION)]}
+      />
+      <Field
+        id="mine_tailings_storage_facility_name"
+        name="mine_tailings_storage_facility_name"
+        label="Facility Name"
+        component={renderConfig.FIELD}
+        validate={[maxLength(60), required]}
+      />
+      <Row gutter={16}>
+        <Col span={12}>
+          <Field
+            id="latitude"
+            name="latitude"
+            label="Latitude"
+            component={renderConfig.FIELD}
+            validate={[lat, required]}
+          />
+        </Col>
+        <Col span={12}>
+          <Field
+            id="longitude"
+            name="longitude"
+            label="Longitude"
+            component={renderConfig.FIELD}
+            validate={[lon, required]}
+          />
+        </Col>
+      </Row>
+      <Field
+        id="consequence_classification_status_code"
+        name="consequence_classification_status_code"
+        label="Consequence Classification"
+        component={renderConfig.SELECT}
+        data={CONSEQUENCE_CLASSIFICATION_STATUS_CODE}
+        validate={[requiredList, validateSelectOptions(CONSEQUENCE_CLASSIFICATION_STATUS_CODE)]}
+      />
+      <Field
+        id="tsf_operating_status_code"
+        name="tsf_operating_status_code"
+        label="Operating Status"
+        data={TSF_OPERATING_STATUS_CODE}
+        component={renderConfig.SELECT}
+        validate={[requiredList, validateSelectOptions(TSF_OPERATING_STATUS_CODE)]}
+      />
+      <Field
+        id="itrb_exemption_status_code"
+        name="itrb_exemption_status_code"
+        label="Independent Tailings Review Board Member"
+        component={renderConfig.SELECT}
+        data={TSF_INDEPENDENT_TAILINGS_REVIEW_BOARD}
+        validate={[maxLength(300), required]}
+      />
+    </>
+  );
+};
 
 BasicInformation.propTypes = propTypes;
 
-export default BasicInformation;
+const mapStateToProps = (state) => ({
+  permits: getPermits(state),
+});
+
+export default connect(mapStateToProps)(BasicInformation);

--- a/services/minespace-web/src/components/common/SteppedForm.js
+++ b/services/minespace-web/src/components/common/SteppedForm.js
@@ -15,18 +15,16 @@ const propTypes = {
   handleSaveData: PropTypes.func,
   activeTab: PropTypes.string.isRequired,
   errors: PropTypes.arrayOf(PropTypes.string).isRequired,
-  fetching: PropTypes.bool,
 };
 
 const defaultProps = {
   handleSaveDraft: undefined,
-  fetching: false,
   handleSaveData: undefined,
 };
 
 const SteppedForm = (props) => {
   // eslint-disable-next-line no-unused-vars
-  const { children, handleTabChange, activeTab, handleSaveDraft, handleSaveData, fetching } = props;
+  const { children, handleTabChange, activeTab, handleSaveDraft, handleSaveData } = props;
   const [tabIndex, setTabIndex] = useState(0);
   const tabs = children.map((child) => child.key);
 
@@ -86,7 +84,6 @@ const SteppedForm = (props) => {
                 <div>
                   {handleSaveDraft && (
                     <Button
-                      disabled={fetching}
                       type="text"
                       className="full-mobile draft-button"
                       onClick={handleSaveDraft}

--- a/services/minespace-web/src/components/common/SteppedForm.js
+++ b/services/minespace-web/src/components/common/SteppedForm.js
@@ -12,17 +12,21 @@ const propTypes = {
   children: PropTypes.arrayOf(PropTypes.node).isRequired,
   handleTabChange: PropTypes.func.isRequired,
   handleSaveDraft: PropTypes.func,
+  handleSaveData: PropTypes.func,
   activeTab: PropTypes.string.isRequired,
   errors: PropTypes.arrayOf(PropTypes.string).isRequired,
+  fetching: PropTypes.bool,
 };
 
 const defaultProps = {
   handleSaveDraft: undefined,
+  fetching: false,
+  handleSaveData: undefined,
 };
 
 const SteppedForm = (props) => {
   // eslint-disable-next-line no-unused-vars
-  const { children, handleTabChange, activeTab, handleSaveDraft } = props;
+  const { children, handleTabChange, activeTab, handleSaveDraft, handleSaveData, fetching } = props;
   const [tabIndex, setTabIndex] = useState(0);
   const tabs = children.map((child) => child.key);
 
@@ -37,8 +41,11 @@ const SteppedForm = (props) => {
   }, [activeTab]);
 
   const handleTabClick = (tab) => {
-    setTabIndex(indexOf(tabs, tab));
-    handleTabChange(tab);
+    if (tabIndex !== tabs.indexOf(tab)) {
+      handleTabChange(tab);
+      setTabIndex(indexOf(tabs, tab));
+      handleTabChange(tab);
+    }
   };
 
   const isFirst = tabIndex === 0;
@@ -70,7 +77,7 @@ const SteppedForm = (props) => {
             <Form layout="vertical">{children.find((child) => child.key === tabs[tabIndex])}</Form>
             <Row justify={isFirst ? "end" : "space-between"}>
               {!isFirst && (
-                <Button type="secondary" onClick={() => handleTabClick(tabs[tabIndex - 1])}>
+                <Button type="primary" onClick={() => handleTabClick(tabs[tabIndex - 1])}>
                   <LeftOutlined /> Back
                 </Button>
               )}
@@ -79,6 +86,7 @@ const SteppedForm = (props) => {
                 <div>
                   {handleSaveDraft && (
                     <Button
+                      disabled={fetching}
                       type="text"
                       className="full-mobile draft-button"
                       onClick={handleSaveDraft}

--- a/services/minespace-web/src/components/pages/Tailings/TailingsSummaryPage.js
+++ b/services/minespace-web/src/components/pages/Tailings/TailingsSummaryPage.js
@@ -66,7 +66,6 @@ export const TailingsSummaryPage = (props) => {
   const { mines, match, history, formErrors, formValues, eors } = props;
   const [isLoaded, setIsLoaded] = useState(false);
   const [tsfGuid, setTsfGuid] = useState(null);
-  const [isSaving, setIsSaving] = useState(false);
 
   const handleFetchData = async () => {
     const { tailingsStorageFacilityGuid } = match?.params;
@@ -88,7 +87,6 @@ export const TailingsSummaryPage = (props) => {
 
   const handleSaveData = async (e) => {
     e.preventDefault();
-    setIsSaving(true);
     props.submit(FORM.ADD_TAILINGS_STORAGE_FACILITY);
     const errors = Object.keys(flattenObject(formErrors));
     // TODO: implement saving of EOR
@@ -111,7 +109,6 @@ export const TailingsSummaryPage = (props) => {
         setTsfGuid(newTsf.data.mine_tailings_storage_facility_guid);
       }
     }
-    setIsSaving(false);
   };
 
   const handleTabChange = async (newActiveTab) => {
@@ -155,7 +152,6 @@ export const TailingsSummaryPage = (props) => {
         </Row>
         <Divider />
         <SteppedForm
-          fetching={isSaving}
           handleSaveData={handleSaveData}
           handleTabChange={handleTabChange}
           handleSaveDraft={handleSaveData}
@@ -186,7 +182,6 @@ export const TailingsSummaryPage = (props) => {
   );
 };
 
-// const selector = formValueSelector(FORM.ADD_TAILINGS_STORAGE_FACILITY);
 const mapStateToProps = (state) => ({
   anyTouched: state.form[FORM.ADD_TAILINGS_STORAGE_FACILITY]?.anyTouched || false,
   fieldsTouched: state.form[FORM.ADD_TAILINGS_STORAGE_FACILITY]?.fields || {},

--- a/services/minespace-web/src/tests/components/Forms/tailing/AddTailingsSummary/__snapshots__/BasicInformation.spec.js.snap
+++ b/services/minespace-web/src/tests/components/Forms/tailing/AddTailingsSummary/__snapshots__/BasicInformation.spec.js.snap
@@ -29,6 +29,7 @@ exports[`BasicInformation renders properly 1`] = `
   />
   <Field
     component={[Function]}
+    data={Array []}
     id="mines_act_permit_no"
     label="Mines Act Permit Number"
     name="mines_act_permit_no"

--- a/services/minespace-web/src/tests/components/common/__snapshots__/SteppedForm.spec.js.snap
+++ b/services/minespace-web/src/tests/components/common/__snapshots__/SteppedForm.spec.js.snap
@@ -60,6 +60,7 @@ exports[`SteppedForm renders properly 1`] = `
           <Button
             block={false}
             className="full-mobile draft-button"
+            disabled={false}
             ghost={false}
             htmlType="button"
             loading={false}

--- a/services/minespace-web/src/tests/components/common/__snapshots__/SteppedForm.spec.js.snap
+++ b/services/minespace-web/src/tests/components/common/__snapshots__/SteppedForm.spec.js.snap
@@ -60,7 +60,6 @@ exports[`SteppedForm renders properly 1`] = `
           <Button
             block={false}
             className="full-mobile draft-button"
-            disabled={false}
             ghost={false}
             htmlType="button"
             loading={false}


### PR DESCRIPTION
## Objective 

[MDS-4690](https://bcmines.atlassian.net/browse/MDS-4690)
[MDS-4691](https://bcmines.atlassian.net/browse/MDS-4691)
[MDS-4692](https://bcmines.atlassian.net/browse/MDS-4692)
[MDS-4693](https://bcmines.atlassian.net/browse/MDS-4693)

- Disabled tab switching functionality when clicking on current tab
- added fetching param to stepped for to disable buttons when fetching
- Converted permit text field to a dropdown including the relevant permits only.
- Added check within POST to ensure TSF has unique name
  - The existing validator does not work for insert because the required fields do not exist at the time of the check.
- Updating `showLoading` when TSF is being saved so the scope is no longer `modal`

![image](https://user-images.githubusercontent.com/83598933/190214046-1bcce10b-db9c-4738-930b-393784df8825.png)

