### PR TITLE
[MDS-3544] Move Permit MX-2-16 to correct mine

### DIFF
--- a/services/core-api/app/api/mines/mine/models/mine.py
+++ b/services/core-api/app/api/mines/mine/models/mine.py
@@ -64,8 +64,7 @@ class Mine(SoftDeleteMixin, AuditMixin, Base):
         order_by='desc(Permit.create_timestamp)',
         lazy='select',
         secondary='mine_permit_xref',
-        secondaryjoin=
-        'and_(foreign(MinePermitXref.permit_id) == remote(Permit.permit_id),Permit.deleted_ind == False)'
+        secondaryjoin='and_(foreign(MinePermitXref.permit_id) == remote(Permit.permit_id),Permit.deleted_ind == False,MinePermitXref.deleted_ind == False)'
     )
 
     # across all permit_identities
@@ -75,15 +74,13 @@ class Mine(SoftDeleteMixin, AuditMixin, Base):
         'MineType',
         backref='mine',
         order_by='desc(MineType.update_timestamp)',
-        primaryjoin=
-        'and_(MineType.mine_guid == Mine.mine_guid, MineType.active_ind==True, MineType.now_application_guid==None)',
+        primaryjoin='and_(MineType.mine_guid == Mine.mine_guid, MineType.active_ind==True, MineType.now_application_guid==None)',
         lazy='selectin')
 
     mine_documents = db.relationship(
         'MineDocument',
         backref='mine',
-        primaryjoin=
-        'and_(MineDocument.mine_guid == Mine.mine_guid, MineDocument.deleted_ind == False)',
+        primaryjoin='and_(MineDocument.mine_guid == Mine.mine_guid, MineDocument.deleted_ind == False)',
         lazy='select')
 
     mine_party_appt = db.relationship('MinePartyAppointment', backref="mine", lazy='select')
@@ -92,8 +89,7 @@ class Mine(SoftDeleteMixin, AuditMixin, Base):
         'MineIncident',
         backref='mine',
         lazy='select',
-        primaryjoin=
-        'and_(MineIncident.mine_guid == Mine.mine_guid, MineIncident.deleted_ind == False)')
+        primaryjoin='and_(MineIncident.mine_guid == Mine.mine_guid, MineIncident.deleted_ind == False)')
 
     mine_reports = db.relationship('MineReport', lazy='select')
 
@@ -101,8 +97,7 @@ class Mine(SoftDeleteMixin, AuditMixin, Base):
         'ExplosivesPermit',
         backref='mine',
         lazy='select',
-        primaryjoin=
-        'and_(ExplosivesPermit.mine_guid == Mine.mine_guid, ExplosivesPermit.deleted_ind == False)')
+        primaryjoin='and_(ExplosivesPermit.mine_guid == Mine.mine_guid, ExplosivesPermit.deleted_ind == False)')
 
     projects = db.relationship(
         'Project',
@@ -114,15 +109,13 @@ class Mine(SoftDeleteMixin, AuditMixin, Base):
         'MineWorkInformation',
         lazy='selectin',
         order_by='desc(MineWorkInformation.created_timestamp)',
-        primaryjoin=
-        'and_(MineWorkInformation.mine_guid == Mine.mine_guid, MineWorkInformation.deleted_ind == False)'
+        primaryjoin='and_(MineWorkInformation.mine_guid == Mine.mine_guid, MineWorkInformation.deleted_ind == False)'
     )
 
     comments = db.relationship(
         'MineComment',
         order_by='MineComment.comment_datetime',
-        primaryjoin=
-        'and_(MineComment.mine_guid == Mine.mine_guid, MineComment.deleted_ind == False)',
+        primaryjoin='and_(MineComment.mine_guid == Mine.mine_guid, MineComment.deleted_ind == False)',
         lazy='joined')
 
     region = db.relationship('MineRegionCode', lazy='select')

--- a/services/core-api/sql/transfer_mine_permit_xref_record.sql
+++ b/services/core-api/sql/transfer_mine_permit_xref_record.sql
@@ -1,6 +1,8 @@
+-- NOTE: Much of the logic was originally derived from delete_mine_permit_xref_record.sql
 -- Transfers all objects associated with a permit/mine pair to another mine. The tree of objects to transfer:
--- 
+--
 --mine_permit_xref (mine_guid, permit_id)
+--  explosives_permit (mine_guid, permit_guid)
 --	mine_report (mine_guid, permit_id)
 --		mine_report_submission (mine_report_id)
 --			mine_report_comment (mine_report_submission_id)
@@ -9,11 +11,11 @@
 --		permit_conditions (permit_amendment_id)
 --	now_application_identity (mine_guid, permit_id)
 --		now_application (now_application_id)
---			now_party_appointment (now_application_id) * Should we check for dangling 'party' records and delete those?
+--			now_party_appointment (now_application_id)
 --			activity_summary (now_application_id)
 --			now_application_review (now_application_id)
 --				now_application_document_xref (now_application_id)
---					mine_document (mine_document_guid) * Should we check for dangling 'mine_document' records and delete those? What about the actual files?
+--					mine_document (mine_document_guid)
 --			state_of_land (now_application_id)
 --			blasting_operation (now_application_id)
 --			now_application_placer_xref (now_application_id)
@@ -28,20 +30,23 @@ CREATE OR REPLACE FUNCTION transfer_mine_permit_xref(_permit_no varchar, _source
 
 DECLARE
 	_permit_id integer;
+	_permit_guid uuid;
 	_source_mine_guid uuid;
 	_destination_mine_guid uuid;
-	_record record;
-	mine_report_ids integer[];
-	mine_report_submission_ids integer[];
-	permit_amendment_ids integer[];
-	now_application_guids uuid[];
-	now_application_ids integer[];
-	activity_summary_ids integer[];
+	_permit_amendment_ids integer[];
+	_now_application_guids uuid[];
+	_now_application_ids integer[];
+	_mine_document_guids uuid[];
+	_mine_permit_xref_record record;
 
 BEGIN
 
-	-- Get the permit_id associated with the source permit number.
+	-- Get the permit_id, permit_guid associated with the source permit number.
 	SELECT permit_id INTO _permit_id
+	FROM permit
+	WHERE permit_no = _permit_no;
+
+	SELECT permit_guid INTO _permit_guid
 	FROM permit
 	WHERE permit_no = _permit_no;
 
@@ -55,121 +60,88 @@ BEGIN
 	FROM mine
 	WHERE mine_no = _destination_mine_no;
 
-	-- RAISE NOTICE 'Deleting records associated with the mine_permit_xref record with permit_id % and mine_guid %', _permit_id, _mine_guid;
 	RAISE NOTICE 'Transferring records associated with the mine_permit_xref record with permit_id % and mine_guid % to mine_guid %', _permit_id, _source_mine_guid, _destination_mine_guid;
 
-	-- Delete the records associated with mine reports.
-	-- RAISE NOTICE 'Deleting records associated with mine reports';
+	-- Transfer the records associated with explosive permits.
+	RAISE NOTICE 'Transferring records associated with explosives permits';
+
+	UPDATE explosives_permit SET mine_guid = _destination_mine_guid
+	WHERE mine_guid = _source_mine_guid AND permit_guid = _permit_guid;
+
 	-- Transfer the records associated with mine reports.
 	RAISE NOTICE 'Transferring records associated with mine reports';
 
-	SELECT array_agg(mine_report_id) INTO mine_report_ids
-	FROM mine_report
-	WHERE mine_guid = _mine_guid AND permit_id = _permit_id;
+	UPDATE mine_report SET mine_guid = _destination_mine_guid
+	WHERE mine_guid = _source_mine_guid AND permit_id = _permit_id;
 
-	SELECT array_agg(mine_report_submission_id) INTO mine_report_submission_ids
-	FROM mine_report_submission
-	WHERE mine_report_id = ANY(mine_report_ids);
+	-- Transfer the records associated with Notices of Work.
+	RAISE NOTICE 'Transferring records associated with Notices of Work';
 
-	DELETE FROM mine_report_comment
-	WHERE mine_report_submission_id = ANY(mine_report_submission_ids);
-
-	DELETE FROM mine_report_submission
-	WHERE mine_report_submission_id = ANY(mine_report_submission_ids);
-
-	DELETE FROM mine_report
-	WHERE mine_report_id = ANY(mine_report_ids);
-
-	-- Delete the records associated with permit amendments.
-	RAISE NOTICE 'Deleting records associated with permit amendments';
-
-	SELECT array_agg(permit_amendment_id) INTO permit_amendment_ids
+	SELECT array_agg(permit_amendment_id) INTO _permit_amendment_ids
 	FROM permit_amendment
-	WHERE mine_guid = _mine_guid AND permit_id = _permit_id;
+	WHERE mine_guid = _source_mine_guid AND permit_id = _permit_id;
 
-	SELECT array_agg(now_application_guid) INTO now_application_guids
+	SELECT array_agg(now_application_guid) INTO _now_application_guids
 	FROM permit_amendment
-	WHERE permit_amendment_id = ANY(permit_amendment_ids); 
+	WHERE permit_amendment_id = ANY(_permit_amendment_ids);
 
-	DELETE FROM permit_amendment_document
-	WHERE permit_amendment_id = ANY(permit_amendment_ids);
-
-	DELETE FROM permit_conditions
-	WHERE permit_amendment_id = ANY(permit_amendment_ids);
-
-	DELETE FROM permit_amendment
-	WHERE permit_amendment_id = ANY(permit_amendment_ids);
-
-	-- Delete the records associated with Notices of Work.
-	RAISE NOTICE 'Deleting records associated with Notices of Work';	
-
-	SELECT array_agg(now_application_id) INTO now_application_ids
+	SELECT array_agg(now_application_id) INTO _now_application_ids
 	FROM now_application_identity
-	WHERE now_application_guid = ANY(now_application_guids);
+	WHERE now_application_guid = ANY(_now_application_guids);
 
-	SELECT array_agg(activity_summary_id) INTO activity_summary_ids
-	FROM activity_summary
-	WHERE now_application_id = ANY(now_application_ids);
+	-- Documents Uploaded
+	SELECT array_agg(mine_document_guid) INTO _mine_document_guids
+	FROM now_application_document_xref
+	WHERE now_application_id = ANY(_now_application_ids);
 
-	-- TODO: What to do about potential dangling 'party' records?
-	DELETE FROM now_party_appointment
-	WHERE now_application_id = ANY(now_application_ids);
+	UPDATE mine_document SET mine_guid = _destination_mine_guid
+	WHERE mine_guid = _source_mine_guid AND mine_document_guid = ANY(_mine_document_guids);
 
-	DELETE FROM now_application_placer_xref
-	WHERE now_application_id = ANY(now_application_ids);
+	-- Documents Imported
+	SELECT array_agg(mine_document_guid) INTO _mine_document_guids
+	FROM now_application_document_identity_xref
+	WHERE now_application_id = ANY(_now_application_ids);
 
-	DELETE FROM placer_operation
-	WHERE activity_summary_id = ANY(activity_summary_ids);
+	UPDATE mine_document SET mine_guid = _destination_mine_guid
+	WHERE mine_guid = _source_mine_guid AND mine_document_guid = ANY(_mine_document_guids);
 
-	DELETE FROM now_application_settling_pond_xref
-	WHERE now_application_id = ANY(now_application_ids);
 
-	DELETE FROM settling_pond
-	WHERE activity_summary_id = ANY(activity_summary_ids);
+	UPDATE now_application_identity SET mine_guid = _destination_mine_guid
+	WHERE mine_guid = _source_mine_guid AND now_application_guid = ANY(_now_application_guids);
 
-	DELETE FROM activity_summary
-	WHERE activity_summary_id = ANY(activity_summary_ids);
+	---- Transfer the parent xref record ----
+	RAISE NOTICE 'Transferring the parent xref record';
+	
+	-- Create new destination parent xref record
+	SELECT start_date, end_date, create_user, create_timestamp, update_user, update_timestamp INTO _mine_permit_xref_record
+	FROM mine_permit_xref WHERE mine_guid = _source_mine_guid AND permit_id = _permit_id
+	LIMIT 1; 
 
-	DELETE FROM state_of_land
-	WHERE now_application_id = ANY(now_application_ids);
+	INSERT INTO mine_permit_xref (mine_guid, permit_id, start_date, end_date, create_user, create_timestamp, update_user, update_timestamp)
+	VALUES(
+		_destination_mine_guid, _permit_id, _mine_permit_xref_record.start_date, _mine_permit_xref_record.end_date, 
+		_mine_permit_xref_record.create_user, _mine_permit_xref_record.create_timestamp, _mine_permit_xref_record.update_user,
+		_mine_permit_xref_record.update_timestamp
+	);
 
-	DELETE FROM blasting_operation
-	WHERE now_application_id = ANY(now_application_ids);
+	-- Mark source parent xref as deleted
+	UPDATE mine_permit_xref SET deleted_ind = true
+	WHERE mine_guid = _source_mine_guid AND permit_id = _permit_id;
 
-	DELETE FROM now_application_progress
-	WHERE now_application_id = ANY(now_application_ids);
+	-- Transfer the records associated with permit amendments.
+	RAISE NOTICE 'Transferring records associated with permit amendments';
 
-	-- TODO: What to do about potential dangling 'mine_document' records? What about the actual files?
-	DELETE FROM now_application_document_xref
-	WHERE now_application_id = ANY(now_application_ids);
+	UPDATE permit_amendment SET mine_guid = _destination_mine_guid
+	WHERE mine_guid = _source_mine_guid AND permit_id = _permit_id;
 
-	DELETE FROM now_application_review
-	WHERE now_application_id = ANY(now_application_ids);
-
-	DELETE FROM now_application
-	WHERE now_application_id = ANY(now_application_ids);
-
-	DELETE FROM now_application_identity
-	WHERE now_application_guid = ANY(now_application_guids);
-
-	-- Delete the record.
-	RAISE NOTICE 'Deleting the record';
-
-	DELETE FROM mine_permit_xref
-	WHERE mine_guid = _mine_guid AND permit_id = _permit_id;
-
-	RAISE NOTICE 'Successfully deleted all records';
+	RAISE NOTICE 'Successfully transferred all records';
 END;
 
 $$ LANGUAGE PLPGSQL;
 
 -- Call the function.
--- NOTE: Manually check/add the records to delete here before running this script.
--- SELECT delete_mine_permit_xref('MX-1-113', '0100086');
--- SELECT delete_mine_permit_xref('MX-1-134', '0100138');
-
--- Ran Aug 4th, 2022
--- SELECT delete_mine_permit_xref('G-10-63', '1000798')
+-- NOTE: Manually check/add the records to transfer here before running this script.
+SELECT transfer_mine_permit_xref('MX-4-471', '1620643', '1630768');
 
 -- Drop the function.
-DROP FUNCTION delete_mine_permit_xref(varchar, varchar, varchar);
+DROP FUNCTION transfer_mine_permit_xref(varchar, varchar, varchar);

--- a/services/core-api/sql/transfer_mine_permit_xref_record.sql
+++ b/services/core-api/sql/transfer_mine_permit_xref_record.sql
@@ -1,0 +1,175 @@
+-- Transfers all objects associated with a permit/mine pair to another mine. The tree of objects to transfer:
+-- 
+--mine_permit_xref (mine_guid, permit_id)
+--	mine_report (mine_guid, permit_id)
+--		mine_report_submission (mine_report_id)
+--			mine_report_comment (mine_report_submission_id)
+--	permit_amendment (mine_guid, permit_id)
+--		permit_amendment_document (permit_amendment_id)
+--		permit_conditions (permit_amendment_id)
+--	now_application_identity (mine_guid, permit_id)
+--		now_application (now_application_id)
+--			now_party_appointment (now_application_id) * Should we check for dangling 'party' records and delete those?
+--			activity_summary (now_application_id)
+--			now_application_review (now_application_id)
+--				now_application_document_xref (now_application_id)
+--					mine_document (mine_document_guid) * Should we check for dangling 'mine_document' records and delete those? What about the actual files?
+--			state_of_land (now_application_id)
+--			blasting_operation (now_application_id)
+--			now_application_placer_xref (now_application_id)
+--				placer_operation (activity_summary_id)
+--			now_application_settling_pond_xref (now_application_id)
+--				settling_pond (activity_summary_id)
+--			now_application_progress (now_application_id)
+--
+
+-- Create the function.
+CREATE OR REPLACE FUNCTION transfer_mine_permit_xref(_permit_no varchar, _source_mine_no varchar, _destination_mine_no varchar) RETURNS VOID AS $$
+
+DECLARE
+	_permit_id integer;
+	_source_mine_guid uuid;
+	_destination_mine_guid uuid;
+	_record record;
+	mine_report_ids integer[];
+	mine_report_submission_ids integer[];
+	permit_amendment_ids integer[];
+	now_application_guids uuid[];
+	now_application_ids integer[];
+	activity_summary_ids integer[];
+
+BEGIN
+
+	-- Get the permit_id associated with the source permit number.
+	SELECT permit_id INTO _permit_id
+	FROM permit
+	WHERE permit_no = _permit_no;
+
+	-- Get the mine_guid associated with the source mine number.
+	SELECT mine_guid INTO _source_mine_guid
+	FROM mine
+	WHERE mine_no = _source_mine_no;
+
+	-- Get the mine_guid associated with the destination mine number.
+	SELECT mine_guid INTO _destination_mine_guid
+	FROM mine
+	WHERE mine_no = _destination_mine_no;
+
+	-- RAISE NOTICE 'Deleting records associated with the mine_permit_xref record with permit_id % and mine_guid %', _permit_id, _mine_guid;
+	RAISE NOTICE 'Transferring records associated with the mine_permit_xref record with permit_id % and mine_guid % to mine_guid %', _permit_id, _source_mine_guid, _destination_mine_guid;
+
+	-- Delete the records associated with mine reports.
+	-- RAISE NOTICE 'Deleting records associated with mine reports';
+	-- Transfer the records associated with mine reports.
+	RAISE NOTICE 'Transferring records associated with mine reports';
+
+	SELECT array_agg(mine_report_id) INTO mine_report_ids
+	FROM mine_report
+	WHERE mine_guid = _mine_guid AND permit_id = _permit_id;
+
+	SELECT array_agg(mine_report_submission_id) INTO mine_report_submission_ids
+	FROM mine_report_submission
+	WHERE mine_report_id = ANY(mine_report_ids);
+
+	DELETE FROM mine_report_comment
+	WHERE mine_report_submission_id = ANY(mine_report_submission_ids);
+
+	DELETE FROM mine_report_submission
+	WHERE mine_report_submission_id = ANY(mine_report_submission_ids);
+
+	DELETE FROM mine_report
+	WHERE mine_report_id = ANY(mine_report_ids);
+
+	-- Delete the records associated with permit amendments.
+	RAISE NOTICE 'Deleting records associated with permit amendments';
+
+	SELECT array_agg(permit_amendment_id) INTO permit_amendment_ids
+	FROM permit_amendment
+	WHERE mine_guid = _mine_guid AND permit_id = _permit_id;
+
+	SELECT array_agg(now_application_guid) INTO now_application_guids
+	FROM permit_amendment
+	WHERE permit_amendment_id = ANY(permit_amendment_ids); 
+
+	DELETE FROM permit_amendment_document
+	WHERE permit_amendment_id = ANY(permit_amendment_ids);
+
+	DELETE FROM permit_conditions
+	WHERE permit_amendment_id = ANY(permit_amendment_ids);
+
+	DELETE FROM permit_amendment
+	WHERE permit_amendment_id = ANY(permit_amendment_ids);
+
+	-- Delete the records associated with Notices of Work.
+	RAISE NOTICE 'Deleting records associated with Notices of Work';	
+
+	SELECT array_agg(now_application_id) INTO now_application_ids
+	FROM now_application_identity
+	WHERE now_application_guid = ANY(now_application_guids);
+
+	SELECT array_agg(activity_summary_id) INTO activity_summary_ids
+	FROM activity_summary
+	WHERE now_application_id = ANY(now_application_ids);
+
+	-- TODO: What to do about potential dangling 'party' records?
+	DELETE FROM now_party_appointment
+	WHERE now_application_id = ANY(now_application_ids);
+
+	DELETE FROM now_application_placer_xref
+	WHERE now_application_id = ANY(now_application_ids);
+
+	DELETE FROM placer_operation
+	WHERE activity_summary_id = ANY(activity_summary_ids);
+
+	DELETE FROM now_application_settling_pond_xref
+	WHERE now_application_id = ANY(now_application_ids);
+
+	DELETE FROM settling_pond
+	WHERE activity_summary_id = ANY(activity_summary_ids);
+
+	DELETE FROM activity_summary
+	WHERE activity_summary_id = ANY(activity_summary_ids);
+
+	DELETE FROM state_of_land
+	WHERE now_application_id = ANY(now_application_ids);
+
+	DELETE FROM blasting_operation
+	WHERE now_application_id = ANY(now_application_ids);
+
+	DELETE FROM now_application_progress
+	WHERE now_application_id = ANY(now_application_ids);
+
+	-- TODO: What to do about potential dangling 'mine_document' records? What about the actual files?
+	DELETE FROM now_application_document_xref
+	WHERE now_application_id = ANY(now_application_ids);
+
+	DELETE FROM now_application_review
+	WHERE now_application_id = ANY(now_application_ids);
+
+	DELETE FROM now_application
+	WHERE now_application_id = ANY(now_application_ids);
+
+	DELETE FROM now_application_identity
+	WHERE now_application_guid = ANY(now_application_guids);
+
+	-- Delete the record.
+	RAISE NOTICE 'Deleting the record';
+
+	DELETE FROM mine_permit_xref
+	WHERE mine_guid = _mine_guid AND permit_id = _permit_id;
+
+	RAISE NOTICE 'Successfully deleted all records';
+END;
+
+$$ LANGUAGE PLPGSQL;
+
+-- Call the function.
+-- NOTE: Manually check/add the records to delete here before running this script.
+-- SELECT delete_mine_permit_xref('MX-1-113', '0100086');
+-- SELECT delete_mine_permit_xref('MX-1-134', '0100138');
+
+-- Ran Aug 4th, 2022
+-- SELECT delete_mine_permit_xref('G-10-63', '1000798')
+
+-- Drop the function.
+DROP FUNCTION delete_mine_permit_xref(varchar, varchar, varchar);

--- a/services/core-api/sql/transfer_mine_permit_xref_record.sql
+++ b/services/core-api/sql/transfer_mine_permit_xref_record.sql
@@ -141,7 +141,7 @@ $$ LANGUAGE PLPGSQL;
 
 -- Call the function.
 -- NOTE: Manually check/add the records to transfer here before running this script.
-SELECT transfer_mine_permit_xref('MX-4-471', '1620643', '1630768');
+-- SELECT transfer_mine_permit_xref('MX-2-16', '0200115', '0200198');
 
 -- Drop the function.
 DROP FUNCTION transfer_mine_permit_xref(varchar, varchar, varchar);


### PR DESCRIPTION
## Objective 

[MDS-3544](https://bcmines.atlassian.net/browse/MDS-3544)

_Why are you making this change? Provide a short explanation and/or screenshots_

- Created a reusable function to be used in place of running manual SQL statements to transfer mine_permit_xref and related entities from one mine to another
- Excluded deleted mine_permit_xref from response model