### PR TITLE
[MDS-4559] - validation on tsf when submitted from Core

### DIFF
--- a/services/core-api/app/api/mines/tailings/resources/tailings_list.py
+++ b/services/core-api/app/api/mines/tailings/resources/tailings_list.py
@@ -90,7 +90,6 @@ class MineTailingsStorageFacilityListResource(Resource, UserMixin):
         location='json',
         store_missing=False)
 
-
     @api.doc(description='Gets the tailing storage facilites for the given mine')
     @api.marshal_with(
         MINE_TSF_MODEL, envelope='mine_tailings_storage_facilities', as_list=True, code=200)
@@ -132,7 +131,8 @@ class MineTailingsStorageFacilityListResource(Resource, UserMixin):
             tsf_operating_status_code=data['tsf_operating_status_code'],
             notes=data['notes'],
             storage_location=data.get('storage_location'),
-            facility_type=data.get('facility_type'),
+            facility_type=FacilityType.tailings_storage_facility
+            if data.get('facility_type') == None else data.get('facility_type'),
             tailings_storage_facility_type=data.get('tailings_storage_facility_type'),
             mines_act_permit_no=data.get('mines_act_permit_no'),
         )


### PR DESCRIPTION
## Objective 

[MDS-4559](https://bcmines.atlassian.net/browse/MDS-4559)

Added checks for nulls in the api for `facility_type` on create and `facility_type`, `tailings_storage_facility_type` and `storage_location`.

Changed tsf `put` expected args from enums to strings where appropriate

_Why are you making this change? Provide a short explanation and/or screenshots_
