### PR TITLE
[MDS-4761] Fixed intermittent validation error that pops up when assigning EoR/QP

### DIFF
--- a/services/minespace-web/src/components/Forms/tailing/tailingsStorageFacility/EngineerOfRecord.js
+++ b/services/minespace-web/src/components/Forms/tailing/tailingsStorageFacility/EngineerOfRecord.js
@@ -38,6 +38,11 @@ const propTypes = {
   setUploadedFiles: PropTypes.func.isRequired,
   mineGuid: PropTypes.string.isRequired,
   partyRelationships: PropTypes.arrayOf(PropTypes.objectOf(PropTypes.any)).isRequired,
+  loading: PropTypes.bool,
+};
+
+const defaultProps = {
+  loading: false,
 };
 
 const columns = [
@@ -57,7 +62,7 @@ const columns = [
 ];
 
 export const EngineerOfRecord = (props) => {
-  const { mineGuid, uploadedFiles, setUploadedFiles, partyRelationships } = props;
+  const { mineGuid, uploadedFiles, setUploadedFiles, partyRelationships, loading } = props;
 
   const [, setUploading] = useState(false);
   const [currentEor, setCurrentEor] = useState(null);
@@ -128,7 +133,7 @@ export const EngineerOfRecord = (props) => {
   };
 
   const validateEorStartDateOverlap = (val) => {
-    if (props.formValues?.engineer_of_record?.mine_party_appt_guid) {
+    if (props.formValues?.engineer_of_record?.mine_party_appt_guid || loading) {
       // Skip validation for existing EoRs
       return undefined;
     }
@@ -279,7 +284,8 @@ export const EngineerOfRecord = (props) => {
               label="Start Date"
               disabled={
                 !!props.formValues?.engineer_of_record?.mine_party_appt_guid ||
-                !props.formValues?.engineer_of_record?.party_guid
+                !props.formValues?.engineer_of_record?.party_guid ||
+                loading
               }
               component={renderConfig.DATE}
               validate={[required, dateNotInFuture, validateEorStartDateOverlap]}
@@ -292,7 +298,8 @@ export const EngineerOfRecord = (props) => {
               label="End Date (Optional)"
               disabled={
                 !!props.formValues?.engineer_of_record?.mine_party_appt_guid ||
-                !props.formValues?.engineer_of_record?.party_guid
+                !props.formValues?.engineer_of_record?.party_guid ||
+                loading
               }
               validate={[dateInFuture]}
               component={renderConfig.DATE}
@@ -320,5 +327,6 @@ const mapStateToProps = (state) => ({
 });
 
 EngineerOfRecord.propTypes = propTypes;
+EngineerOfRecord.defaultProps = defaultProps;
 
 export default connect(mapStateToProps, mapDispatchToProps)(EngineerOfRecord);

--- a/services/minespace-web/src/components/Forms/tailing/tailingsStorageFacility/QualifiedPerson.js
+++ b/services/minespace-web/src/components/Forms/tailing/tailingsStorageFacility/QualifiedPerson.js
@@ -28,6 +28,11 @@ const propTypes = {
   formValues: PropTypes.objectOf(TSFType).isRequired,
   partyRelationships: PropTypes.arrayOf(PropTypes.objectOf(PropTypes.any)).isRequired,
   mineGuid: PropTypes.string.isRequired,
+  loading: PropTypes.bool,
+};
+
+const defaultProps = {
+  loading: false,
 };
 
 export const QualifiedPerson = (props) => {
@@ -58,7 +63,7 @@ export const QualifiedPerson = (props) => {
   };
 
   const validateQPStartDateOverlap = (val) => {
-    if (props.formValues?.qualified_person?.mine_party_appt_guid) {
+    if (props.formValues?.qualified_person?.mine_party_appt_guid || props.loading) {
       // Skip validation for existing TQPs
       return undefined;
     }
@@ -142,7 +147,8 @@ export const QualifiedPerson = (props) => {
               label="Start Date"
               disabled={
                 !!props.formValues?.qualified_person?.mine_party_appt_guid ||
-                !props.formValues?.qualified_person?.party_guid
+                !props.formValues?.qualified_person?.party_guid ||
+                props.loading
               }
               component={renderConfig.DATE}
               validate={[required, dateNotInFuture, validateQPStartDateOverlap]}
@@ -155,7 +161,8 @@ export const QualifiedPerson = (props) => {
               label="End Date (Optional)"
               disabled={
                 !!props.formValues?.qualified_person?.mine_party_appt_guid ||
-                !props.formValues?.qualified_person?.party_guid
+                !props.formValues?.qualified_person?.party_guid ||
+                props.loading
               }
               validate={[dateInFuture]}
               component={renderConfig.DATE}
@@ -183,5 +190,6 @@ const mapStateToProps = (state) => ({
 });
 
 QualifiedPerson.propTypes = propTypes;
+QualifiedPerson.defaultProps = defaultProps;
 
 export default connect(mapStateToProps, mapDispatchToProps)(QualifiedPerson);


### PR DESCRIPTION
## Objective 

[MDS-4761](https://bcmines.atlassian.net/browse/MDS-4761)

After assigning a new EoR / QP to a TSF, the validation message indicating an overlap of start dates with previous EoRs briefly flashes. The cause of this is that we do a full reload of all party relationships for the TSF after submission as to populate dropdowns / the EoR pages etc, this causes the validation to be performed against the newly added record for a brief second before React has had a chance to navigate to the next page.
