### PR TITLE
[MDS-4759] Added logging for failed NRIS download requests

### DIFF
--- a/services/core-api/app/api/services/nris_download_service.py
+++ b/services/core-api/app/api/services/nris_download_service.py
@@ -58,9 +58,20 @@ class NRISDownloadService():
         file_download_req = requests.get(
             f'{file_url}', stream=True, headers={"Authorization": f"Bearer {_nris_token}"})
 
+        try:
+            file_download_req.raise_for_status()
+        except:
+            current_app.logger.error('Failed to download file from NRIS - HTTP Status: {}, message: {}'.format(
+                file_download_req.status_code,
+                str(file_download_req.content or '','utf-8')
+            ))
+
+            raise
+
         file_download_resp = Response(
             stream_with_context(
                 file_download_req.iter_content(chunk_size=Config.DOCUMENT_UPLOAD_CHUNK_SIZE_BYTES)))
+
 
         file_download_resp.headers['Content-Type'] = file_download_req.headers['Content-Type']
         file_download_resp.headers[


### PR DESCRIPTION
## Objective 

[MDS-4759](https://bcmines.atlassian.net/browse/MDS-4759)

- Added logging for when an NRIS file download fails to enable investigation of failed Inspection report downloads in production
- Fail hard when a download fails so we don't download empty files on failure