### PR TITLE
[MDS-4601] Project Summary form bug on minespace

### DIFF
--- a/services/minespace-web/src/components/Forms/projects/majorMineApplication/MajorMineApplicationForm.js
+++ b/services/minespace-web/src/components/Forms/projects/majorMineApplication/MajorMineApplicationForm.js
@@ -13,6 +13,7 @@ import {
   MAJOR_MINES_APPLICATION_DOCUMENT_TYPE,
   MAJOR_MINES_APPLICATION_DOCUMENT_TYPE_CODE,
 } from "@common/constants/strings";
+import { resetForm } from "@common/utils/helpers";
 import * as routes from "@/constants/routes";
 import * as FORM from "@/constants/forms";
 import { renderConfig } from "@/components/common/config";
@@ -263,6 +264,7 @@ export default compose(
     destroyOnUnmount: false,
     forceUnregisterOnUnmount: true,
     touchOnBlur: true,
+    onSubmitSuccess: resetForm(FORM.ADD_MINE_MAJOR_APPLICATION),
     onSubmit: () => {},
   })
 )(MajorMineApplicationForm);

--- a/services/minespace-web/src/components/Forms/projects/projectSummary/ProjectSummaryForm.js
+++ b/services/minespace-web/src/components/Forms/projects/projectSummary/ProjectSummaryForm.js
@@ -2,7 +2,7 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import { withRouter } from "react-router-dom";
-import { flattenObject } from "@common/utils/helpers";
+import { flattenObject , resetForm } from "@common/utils/helpers";
 import { compose, bindActionCreators } from "redux";
 import { isNil } from "lodash";
 import {
@@ -256,6 +256,7 @@ export default compose(
     form: FORM.ADD_EDIT_PROJECT_SUMMARY,
     touchOnBlur: true,
     touchOnChange: false,
+    onSubmitSuccess: resetForm(FORM.ADD_EDIT_PROJECT_SUMMARY),
     onSubmit: () => {},
   })
 )(withRouter(ProjectSummaryForm));


### PR DESCRIPTION
## Objective 
When updating a project summary in Minespace the form was never being reset after the submission so the dirty flag was never being cleared. This caused a warning to pop up when the user would try to go back to the overview after updating.

[MDS-4601](https://bcmines.atlassian.net/browse/MDS-4601)
