### PR TITLE
[MDS-4717] Final report received notifications

### DIFF
--- a/services/core-api/app/api/mines/incidents/resources/mine_incidents.py
+++ b/services/core-api/app/api/mines/incidents/resources/mine_incidents.py
@@ -325,6 +325,10 @@ class MineIncidentResource(Resource, UserMixin):
                     incident.send_awaiting_final_report_email(True)
                     incident.send_awaiting_final_report_email(False)
                     trigger_notifcation(f'A new Mine Incident has been created for ({incident.mine_name})', incident.mine_table, 'MineIncident', incident.mine_incident_guid, {})
+                if value == 'FRS':
+                    incident.send_final_report_received_email(True)
+                    incident.send_final_report_received_email(False)
+                    trigger_notifcation(f'A final report has been submitted for ({incident.mine_incident_report_no}) on ({incident.mine_name})', incident.mine_table, 'MineIncident', incident.mine_incident_guid, {})
                 setattr(incident, key, value)
             else:
                 setattr(incident, key, value)

--- a/services/minespace-web/src/components/layout/NotificationDrawer.js
+++ b/services/minespace-web/src/components/layout/NotificationDrawer.js
@@ -13,7 +13,7 @@ import { getActivities } from "@common/selectors/activitySelectors";
 import { getUserInfo } from "@common/selectors/authenticationSelectors";
 import { storeActivities } from "@common/actions/activityActions";
 import { useHistory } from "react-router-dom";
-import { MINE_DASHBOARD } from "@/constants/routes";
+import { MINE_DASHBOARD, EDIT_MINE_INCIDENT } from "@/constants/routes";
 
 const propTypes = {
   fetchActivities: PropTypes.func.isRequired,
@@ -98,6 +98,11 @@ const NotificationDrawer = (props) => {
             nod: notification.notification_document.metadata.entity_guid,
           }
         );
+      case "MineIncident":
+        return EDIT_MINE_INCIDENT.dynamicRoute(
+          notification.notification_document.metadata.mine.mine_guid,
+          notification.notification_document.metadata.entity_guid
+        );
       default:
         return null;
     }
@@ -171,17 +176,21 @@ const NotificationDrawer = (props) => {
                         {activity.notification_document?.metadata?.mine?.mine_name}
                       </Typography.Text>
                     </Col>
-                    <Col>
-                      <div className="notification-separator" />
-                    </Col>
-                    <Col>
-                      <Typography.Text className="notification-info-text">
-                        {activity.notification_document?.metadata?.permit?.permit_no}
-                      </Typography.Text>
-                    </Col>
-                    <Col>
-                      <div className="notification-separator" />
-                    </Col>
+                    {activity.notification_document?.metadata?.permit && (
+                      <>
+                        <Col>
+                          <div className="notification-separator" />
+                        </Col>
+                        <Col>
+                          <Typography.Text className="notification-info-text">
+                            {activity.notification_document?.metadata?.permit?.permit_no}
+                          </Typography.Text>
+                        </Col>
+                        <Col>
+                          <div className="notification-separator" />
+                        </Col>
+                      </>
+                    )}
                     <Col>
                       <Typography.Text className="notification-info-text">
                         {formatDateTime(activity.create_timestamp)}


### PR DESCRIPTION
## Objective 

When a final report is received on an incident emails are sent to the OCI and the proponent to indicate this has occured as well as Core and Minespace notifications are triggered.

[MDS-4717](https://bcmines.atlassian.net/browse/MDS-4717)


