### PR TITLE
[MDS-4748] Added sql script to delete a notice of work

### DIFF
--- a/services/core-api/sql/delete_now_record.sql
+++ b/services/core-api/sql/delete_now_record.sql
@@ -1,0 +1,99 @@
+-- Deletes all objects associated with a notice of work. The tree of objects to delete:
+--
+--	now_application_identity (mine_guid, permit_id)
+--		now_application (now_application_id)
+--			now_party_appointment (now_application_id)
+--			activity_summary (now_application_id)
+--			now_application_review (now_application_id)
+--				now_application_document_xref (now_application_id)
+--			state_of_land (now_application_id)
+--			blasting_operation (now_application_id)
+--			now_application_placer_xref (now_application_id)
+--				placer_operation (activity_summary_id)
+--			now_application_settling_pond_xref (now_application_id)
+--				settling_pond (activity_summary_id)
+--			now_application_progress (now_application_id)
+--
+
+-- Create the function.
+CREATE OR REPLACE FUNCTION delete_now(_now_number varchar) RETURNS VOID AS $$
+
+DECLARE
+    -- Declare the variables.
+    _now_application_id bigint;
+    _now_application_guid uuid;
+	now_application_ids integer[];
+	activity_summary_ids integer[];
+
+BEGIN
+
+-- Get the now_application_id.
+SELECT now_application_id INTO _now_application_id
+      FROM now_application_identity
+      WHERE now_number = _now_number;
+
+-- Get the now_application_guid.
+SELECT now_application_guid INTO _now_application_guid
+    FROM now_application_identity
+    WHERE now_application_id = _now_application_id;
+
+-- Delete the records associated with Notices of Work.
+RAISE NOTICE 'Deleting records associated with Notices of Work';
+
+SELECT array_agg(activity_summary_id) INTO activity_summary_ids
+FROM activity_summary
+WHERE now_application_id = _now_application_id;
+
+DELETE FROM now_party_appointment
+WHERE now_application_id = _now_application_id;
+
+DELETE FROM now_application_placer_xref
+WHERE now_application_id = _now_application_id;
+
+DELETE FROM placer_operation
+WHERE activity_summary_id = ANY(activity_summary_ids);
+
+DELETE FROM now_application_settling_pond_xref
+WHERE now_application_id = _now_application_id;
+
+DELETE FROM settling_pond
+WHERE activity_summary_id = ANY(activity_summary_ids);
+
+DELETE FROM activity_summary
+WHERE activity_summary_id = ANY(activity_summary_ids);
+
+DELETE FROM state_of_land
+WHERE now_application_id = _now_application_id;
+
+DELETE FROM blasting_operation
+WHERE now_application_id = _now_application_id;
+
+DELETE FROM now_application_progress
+WHERE now_application_id = _now_application_id;
+
+DELETE FROM now_application_document_xref
+WHERE now_application_id = _now_application_id;
+
+DELETE FROM now_application_review
+WHERE now_application_id = _now_application_id;
+
+DELETE FROM now_application
+WHERE now_application_id = _now_application_id;
+
+-- Delete the record.
+RAISE NOTICE 'Deleting the record';
+
+DELETE FROM now_application_identity
+WHERE now_application_guid = _now_application_guid;
+
+RAISE NOTICE 'Successfully deleted all records';
+END;
+
+$$ LANGUAGE PLPGSQL;
+
+-- Call the function.
+-- NOTE: Manually check/add the records to delete here before running this script.
+-- SELECT delete_now('1640544-2021-01');
+
+-- Drop the function.
+DROP FUNCTION delete_now(varchar, varchar);

--- a/services/core-api/sql/delete_now_record.sql
+++ b/services/core-api/sql/delete_now_record.sql
@@ -40,6 +40,12 @@ WHERE now_application_id = _now_application_id;
 -- Delete the records associated with Notices of Work.
 RAISE NOTICE 'Deleting records associated with Notices of Work';
 
+delete from now_application_delay
+where now_application_guid = _now_application_guid;
+
+delete from mine_type
+where now_application_guid = _now_application_guid;
+
 SELECT array_agg(activity_summary_id) INTO activity_summary_ids
 FROM activity_summary
 WHERE now_application_id = _now_application_id;
@@ -116,5 +122,7 @@ $$ LANGUAGE PLPGSQL;
 -- NOTE: Manually check/add the records to delete here before running this script.
 -- SELECT delete_now('1640544-2021-01');
 
+SELECT delete_now('1630769-2016-01');
+
 -- Drop the function.
-DROP FUNCTION delete_now(varchar, varchar);
+DROP FUNCTION delete_now(varchar);

--- a/services/core-api/sql/delete_now_record.sql
+++ b/services/core-api/sql/delete_now_record.sql
@@ -120,9 +120,11 @@ $$ LANGUAGE PLPGSQL;
 
 -- Call the function.
 -- NOTE: Manually check/add the records to delete here before running this script.
--- SELECT delete_now('1640544-2021-01');
+-- SELECT delete_now('e78021f0-28a4-4569-9681-2020e170e6db');
 
-SELECT delete_now('1630769-2016-01');
+-- Ran Oct 20, 2022
+-- SELECT delete_mine_party_appt('e78021f0-28a4-4569-9681-2020e170e6db');
+
 
 -- Drop the function.
 DROP FUNCTION delete_now(varchar);

--- a/services/core-api/sql/delete_now_record.sql
+++ b/services/core-api/sql/delete_now_record.sql
@@ -20,22 +20,22 @@ CREATE OR REPLACE FUNCTION delete_now(_now_number varchar) RETURNS VOID AS $$
 
 DECLARE
     -- Declare the variables.
-    _now_application_id bigint;
+_now_application_id bigint;
     _now_application_guid uuid;
-	now_application_ids integer[];
-	activity_summary_ids integer[];
+    now_application_ids integer[];
+    activity_summary_ids integer[];
 
 BEGIN
 
--- Get the now_application_id.
+    -- Get the now_application_id.
 SELECT now_application_id INTO _now_application_id
-      FROM now_application_identity
-      WHERE now_number = _now_number;
+FROM now_application_identity
+WHERE now_number = _now_number;
 
 -- Get the now_application_guid.
 SELECT now_application_guid INTO _now_application_guid
-    FROM now_application_identity
-    WHERE now_application_id = _now_application_id;
+FROM now_application_identity
+WHERE now_application_id = _now_application_id;
 
 -- Delete the records associated with Notices of Work.
 RAISE NOTICE 'Deleting records associated with Notices of Work';
@@ -59,7 +59,22 @@ WHERE now_application_id = _now_application_id;
 DELETE FROM settling_pond
 WHERE activity_summary_id = ANY(activity_summary_ids);
 
-DELETE FROM activity_summary
+DELETE FROM camp
+WHERE activity_summary_id = ANY(activity_summary_ids);
+
+DELETE FROM exploration_surface_drilling
+WHERE activity_summary_id = ANY(activity_summary_ids);
+
+DELETE FROM exploration_access
+WHERE activity_summary_id = ANY(activity_summary_ids);
+
+DELETE FROM sand_gravel_quarry_operation
+WHERE activity_summary_id = ANY(activity_summary_ids);
+
+DELETE FROM surface_bulk_sample
+WHERE activity_summary_id = ANY(activity_summary_ids);
+
+DELETE FROM underground_exploration
 WHERE activity_summary_id = ANY(activity_summary_ids);
 
 DELETE FROM state_of_land
@@ -77,16 +92,22 @@ WHERE now_application_id = _now_application_id;
 DELETE FROM now_application_review
 WHERE now_application_id = _now_application_id;
 
+DELETE FROM now_application_identity
+WHERE now_application_guid = _now_application_guid;
+
 DELETE FROM now_application
 WHERE now_application_id = _now_application_id;
+
+DELETE FROM activity_summary
+WHERE activity_summary_id = ANY(activity_summary_ids);
+
 
 -- Delete the record.
 RAISE NOTICE 'Deleting the record';
 
-DELETE FROM now_application_identity
-WHERE now_application_guid = _now_application_guid;
 
-RAISE NOTICE 'Successfully deleted all records';
+
+    RAISE NOTICE 'Successfully deleted all records';
 END;
 
 $$ LANGUAGE PLPGSQL;
@@ -94,6 +115,8 @@ $$ LANGUAGE PLPGSQL;
 -- Call the function.
 -- NOTE: Manually check/add the records to delete here before running this script.
 -- SELECT delete_now('1640544-2021-01');
+
+select delete_now('11');
 
 -- Drop the function.
 DROP FUNCTION delete_now(varchar, varchar);

--- a/services/core-api/sql/delete_now_record.sql
+++ b/services/core-api/sql/delete_now_record.sql
@@ -116,7 +116,5 @@ $$ LANGUAGE PLPGSQL;
 -- NOTE: Manually check/add the records to delete here before running this script.
 -- SELECT delete_now('1640544-2021-01');
 
-select delete_now('11');
-
 -- Drop the function.
 DROP FUNCTION delete_now(varchar, varchar);


### PR DESCRIPTION
Create a reusable script to delete a notice of work.

[MDS-4748](https://bcmines.atlassian.net/browse/MDS-4748)

Created an SQL script in the API to delete a notice of work.

Much of this script was pulled from the `delete_mine_permit_xref_record` script since part of that script was to delete notices of work attached to a permit.  Adjustments were made to base the query off a passed in `now_number`.
