### PR TITLE
[MDS-4326] Soft delete now no permit require letter

### DIFF
--- a/services/core-api/app/api/now_applications/models/now_application_document_xref.py
+++ b/services/core-api/app/api/now_applications/models/now_application_document_xref.py
@@ -46,7 +46,9 @@ class NOWApplicationDocumentXref(AuditMixin, Base):
     mine_document = db.relationship(
         'MineDocument',
         lazy='joined',
-        backref=backref('now_application_document_xref', uselist=False))
+        primaryjoin='and_(MineDocument.mine_document_guid == NOWApplicationDocumentXref.mine_document_guid, MineDocument.deleted_ind==False)',
+        backref=backref('now_application_document_xref', uselist=False)
+    )
 
     def __repr__(self):
         return '<ApplicationDocumentXref %r>' % self.now_application_document_xref_guid

--- a/services/core-api/app/api/now_applications/resources/now_application_document_resource.py
+++ b/services/core-api/app/api/now_applications/resources/now_application_document_resource.py
@@ -96,7 +96,8 @@ class NOWApplicationDocumentResource(Resource, UserMixin):
             raise BadRequest(
                 'You cannot remove a document that is a part of the Consultation Package.')
 
-        mine_document.now_application_document_xref.delete()
+        mine_document.deleted_ind = True
+        mine_document.save()
         return None, 204
 
     @api.response(requests.codes.ok, 'Successfully updated document details.')

--- a/services/core-web/src/components/noticeOfWork/applications/administrative/NOWApplicationAdministrative.js
+++ b/services/core-web/src/components/noticeOfWork/applications/administrative/NOWApplicationAdministrative.js
@@ -65,8 +65,8 @@ export const NOWApplicationAdministrative = (props) => {
       >
         <NOWDocuments
           documents={props.noticeOfWork.documents.filter(
-            ({ now_application_document_sub_type_code }) =>
-              now_application_document_sub_type_code === "GDO"
+            ({ mine_document, now_application_document_sub_type_code }) =>
+              mine_document.mine_document_guid && now_application_document_sub_type_code === "GDO"
           )}
           isViewMode={false}
           isAdminView

--- a/services/core-web/src/components/noticeOfWork/applications/administrative/NOWApplicationAdministrative.js
+++ b/services/core-web/src/components/noticeOfWork/applications/administrative/NOWApplicationAdministrative.js
@@ -66,7 +66,7 @@ export const NOWApplicationAdministrative = (props) => {
         <NOWDocuments
           documents={props.noticeOfWork.documents.filter(
             ({ mine_document, now_application_document_sub_type_code }) =>
-              mine_document.mine_document_guid && now_application_document_sub_type_code === "GDO"
+              mine_document?.mine_document_guid && now_application_document_sub_type_code === "GDO"
           )}
           isViewMode={false}
           isAdminView

--- a/services/core-web/src/components/noticeOfWork/applications/manageDocuments/NOWApplicationManageDocuments.js
+++ b/services/core-web/src/components/noticeOfWork/applications/manageDocuments/NOWApplicationManageDocuments.js
@@ -96,8 +96,8 @@ export const NOWApplicationManageDocuments = (props) => {
       >
         <NOWDocuments
           documents={props.noticeOfWork.documents.filter(
-            ({ now_application_document_sub_type_code }) =>
-              now_application_document_sub_type_code === "GDO"
+            ({ mine_document, now_application_document_sub_type_code }) =>
+              mine_document.mine_document_guid && now_application_document_sub_type_code === "GDO"
           )}
           isViewMode={props.isViewMode}
           isAdminView

--- a/services/core-web/src/components/noticeOfWork/applications/manageDocuments/NOWApplicationManageDocuments.js
+++ b/services/core-web/src/components/noticeOfWork/applications/manageDocuments/NOWApplicationManageDocuments.js
@@ -97,7 +97,7 @@ export const NOWApplicationManageDocuments = (props) => {
         <NOWDocuments
           documents={props.noticeOfWork.documents.filter(
             ({ mine_document, now_application_document_sub_type_code }) =>
-              mine_document.mine_document_guid && now_application_document_sub_type_code === "GDO"
+              mine_document?.mine_document_guid && now_application_document_sub_type_code === "GDO"
           )}
           isViewMode={props.isViewMode}
           isAdminView


### PR DESCRIPTION
## Objective 

[MDS-4326-](https://bcmines.atlassian.net/browse/MDS-4326)

- Adding Soft delete to NoW documents

How to test:
- Access Government Documents in Manage Document tab for a Notice of Work:
  http://localhost:3000/dashboard/notice-of-work/app/5cc9856b-08cd-4968-8637-db1b41ebea8b/manage-documents/#government-documents
- Delete document
![image](https://user-images.githubusercontent.com/10526131/197657036-b49daa2f-c741-4a63-811b-7ff32210fadf.png)
- Review the document is soft deleted, `mine_document.deleted_ind` should be updated to True.
- The document is not shown in the UI.

The DELETE request (NOWApplicationDocumentResource) is invoked by deleteNoticeOfWorkApplicationDocument in noticeOfWorkActionCreator when deleting the files in NoW in Core.