### PR TITLE
[MDS-4774] Core add EMLI project lead to Project Contacts in Overview page

### DIFF
--- a/services/core-web/src/components/dashboard/majorProjectHomePage/MajorProjectTable.js
+++ b/services/core-web/src/components/dashboard/majorProjectHomePage/MajorProjectTable.js
@@ -34,7 +34,7 @@ const transformRowData = (projects, mineCommodityHash) =>
     project_title: project.project_title,
     project_id: project.project_id,
     mrc_review_required: project.mrc_review_required ? "Yes" : "No",
-    mine_name: project.mine.mine_name,
+    mine_name: project.mine?.mine_name,
     project_stage: project.stage,
     status_code: project.status_code,
     guid: project.guid,

--- a/services/core-web/src/components/mine/Projects/ProjectOverviewTab.js
+++ b/services/core-web/src/components/mine/Projects/ProjectOverviewTab.js
@@ -55,11 +55,13 @@ export class ProjectOverviewTab extends Component {
                 <>
                   <Typography.Text>{c.name}</Typography.Text>
                   <br />
-                  <Typography.Text>{c.phone_number}</Typography.Text>
+                  <Typography.Text>{c.phone_no || c.phone_number}</Typography.Text>
                   <br />
-                  <Typography.Text>
-                    <a href={`mailto:${c.email}`}>{c.email}</a>
-                  </Typography.Text>
+                  {c.email && (
+                    <Typography.Text>
+                      <a href={`mailto:${c.email}`}>{c.email}</a>
+                    </Typography.Text>
+                  )}
                 </>
               )}
             </Typography.Paragraph>

--- a/services/core-web/src/components/mine/Projects/ProjectOverviewTab.js
+++ b/services/core-web/src/components/mine/Projects/ProjectOverviewTab.js
@@ -87,14 +87,16 @@ export class ProjectOverviewTab extends Component {
       this.props.project.information_requirements_table?.irt_guid
     );
 
-    const project_lead_contact = this.props.projectLeads?.filter((lead) =>
-      lead.party_guid.includes(this.props.project.project_lead_party_guid)
-    );
+    const project_lead_contact =
+      this.props.projectLeads?.filter((lead) =>
+        lead.party_guid.includes(this.props.project.project_lead_party_guid)
+      ) ?? [];
     if (project_lead_contact?.length > 0) {
       project_lead_contact[0].is_project_lead_contact = true;
     } else {
       project_lead_contact.push({ is_project_lead_contact: true });
     }
+
     const contactsAndProjectLead = [...this.props.project.contacts];
     contactsAndProjectLead.push(project_lead_contact[0]);
 

--- a/services/core-web/src/components/mine/Projects/ProjectOverviewTab.js
+++ b/services/core-web/src/components/mine/Projects/ProjectOverviewTab.js
@@ -8,6 +8,7 @@ import {
   getProjectSummaryStatusCodesHash,
   getInformationRequirementsTableStatusCodesHash,
 } from "@common/selectors/staticContentSelectors";
+import { getProjectLeads } from "@common/selectors/partiesSelectors";
 import { formatDate } from "@common/utils/helpers";
 import * as Strings from "@common/constants/strings";
 import { getProject } from "@common/selectors/projectSelectors";
@@ -21,6 +22,7 @@ const propTypes = {
   projectSummaryDocumentTypesHash: PropTypes.objectOf(PropTypes.string).isRequired,
   projectSummaryStatusCodesHash: PropTypes.objectOf(PropTypes.string).isRequired,
   project: CustomPropTypes.project.isRequired,
+  projectLeads: CustomPropTypes.projectContact.isRequired,
 };
 
 export class ProjectOverviewTab extends Component {
@@ -30,8 +32,11 @@ export class ProjectOverviewTab extends Component {
         {contacts.map((c) => {
           const isPrimary = c.is_primary;
           const hasJobTitle = c.job_title;
+          const isProjectLeadContact = c.is_project_lead_contact;
           let title;
-          if (isPrimary) {
+          if (isProjectLeadContact) {
+            title = "EMLI Project Lead";
+          } else if (isPrimary) {
             title = "Primary Contact";
           } else if (hasJobTitle) {
             title = c.job_title;
@@ -44,13 +49,19 @@ export class ProjectOverviewTab extends Component {
                 </Typography.Text>
               )}
               <br />
-              <Typography.Text>{c.name}</Typography.Text>
-              <br />
-              <Typography.Text>{c.phone_number}</Typography.Text>
-              <br />
-              <Typography.Text>
-                <a href={`mailto:${c.email}`}>{c.email}</a>
-              </Typography.Text>
+              {c.is_project_lead_contact && !c.name ? (
+                <Typography.Text>Project Lead has not been assigned</Typography.Text>
+              ) : (
+                <>
+                  <Typography.Text>{c.name}</Typography.Text>
+                  <br />
+                  <Typography.Text>{c.phone_number}</Typography.Text>
+                  <br />
+                  <Typography.Text>
+                    <a href={`mailto:${c.email}`}>{c.email}</a>
+                  </Typography.Text>
+                </>
+              )}
             </Typography.Paragraph>
           );
         })}
@@ -75,6 +86,17 @@ export class ProjectOverviewTab extends Component {
     const hasInformationRequirementsTable = Boolean(
       this.props.project.information_requirements_table?.irt_guid
     );
+
+    const project_lead_contact = this.props.projectLeads?.filter((lead) =>
+      lead.party_guid.includes(this.props.project.project_lead_party_guid)
+    );
+    if (project_lead_contact?.length > 0) {
+      project_lead_contact[0].is_project_lead_contact = true;
+    } else {
+      project_lead_contact.push({ is_project_lead_contact: true });
+    }
+    const contactsAndProjectLead = [...this.props.project.contacts];
+    contactsAndProjectLead.push(project_lead_contact[0]);
 
     const requiredProjectStages = [
       {
@@ -221,7 +243,7 @@ export class ProjectOverviewTab extends Component {
         </Col>
         <Col lg={{ span: 9, offset: 1 }} xl={{ span: 7, offset: 1 }}>
           <Row>
-            <Col span={24}>{this.renderProjectContactsCard(this.props.project.contacts)}</Col>
+            <Col span={24}>{this.renderProjectContactsCard(contactsAndProjectLead)}</Col>
           </Row>
         </Col>
       </Row>
@@ -236,6 +258,7 @@ const mapStateToProps = (state) => ({
   informationRequirementsTableStatusCodesHash: getInformationRequirementsTableStatusCodesHash(
     state
   ),
+  projectLeads: getProjectLeads(state),
 });
 
 ProjectOverviewTab.propTypes = propTypes;

--- a/services/core-web/src/tests/components/mine/Projects/__snapshots__/ProjectOverviewTab.spec.js.snap
+++ b/services/core-web/src/tests/components/mine/Projects/__snapshots__/ProjectOverviewTab.spec.js.snap
@@ -215,7 +215,22 @@ exports[`ProjectOverviewTab renders properly 1`] = `
             }
           }
           title="Project Contacts"
-        />
+        >
+          <Paragraph
+            className="ministry-contact-item"
+          >
+            <Text
+              className="ministry-contact-title"
+              strong={true}
+            >
+              EMLI Project Lead
+            </Text>
+            <br />
+            <Text>
+              Project Lead has not been assigned
+            </Text>
+          </Paragraph>
+        </Card>
       </Col>
     </Row>
   </Col>


### PR DESCRIPTION
## Objective 

[MDS-4774](https://bcmines.atlassian.net/browse/MDS-4774)

- Add EMLI Project Lead to Project Contacts section in Project Overview:
![image](https://user-images.githubusercontent.com/10526131/198145699-ed8c103e-384b-412b-aaaa-aa737173a711.png)

- If EMLI Project Lead is not present, then show a message "Project Lead has not been assigned":
![image](https://user-images.githubusercontent.com/10526131/198145795-404703bc-ba9a-4ef5-8686-9e4e732991c0.png)
