### PR TITLE
[MDS-4821] Fixed reloading of TSFs on navigation

### DIFF
--- a/services/core-web/src/components/mine/Tailings/MineTailingsTable.js
+++ b/services/core-web/src/components/mine/Tailings/MineTailingsTable.js
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
+import { withRouter } from "react-router-dom";
 import { EyeOutlined } from "@ant-design/icons";
 import { Button, Tooltip, Typography } from "antd";
 import {
@@ -237,4 +238,4 @@ const mapStateToProps = (state) => ({
   itrmExemptionStatusCodeHash: getITRBExemptionStatusCodeOptionsHash(state),
 });
 
-export default connect(mapStateToProps)(MineTailingsTable);
+export default withRouter(connect(mapStateToProps)(MineTailingsTable));

--- a/services/core-web/src/components/mine/Tailings/TailingsSummaryPage.js
+++ b/services/core-web/src/components/mine/Tailings/TailingsSummaryPage.js
@@ -10,7 +10,7 @@ import { bindActionCreators, compose } from "redux";
 import { storeTsf } from "@common/actions/tailingsActions";
 import { fetchMineRecordById } from "@common/actionCreators/mineActionCreator";
 import { resetForm } from "@common/utils/helpers";
-import { reduxForm, touch } from "redux-form";
+import { getFormValues, reduxForm, touch } from "redux-form";
 import PropTypes from "prop-types";
 
 import Step from "@common/components/Step";
@@ -44,6 +44,7 @@ const propTypes = {
   fetchMineRecordById: PropTypes.func.isRequired,
   storeTsf: PropTypes.func.isRequired,
   initialValues: PropTypes.objectOf(PropTypes.any),
+  formValues: PropTypes.objectOf(PropTypes.any).isRequired,
 };
 
 const defaultProps = {
@@ -73,14 +74,15 @@ export const TailingsSummaryPage = (props) => {
           (tsf) => tsf.mine_tailings_storage_facility_guid === tailingsStorageFacilityGuid
         );
         props.storeTsf(existingTsf);
+        resetForm(FORM.ADD_STORAGE_FACILITY);
       }
     }
     setIsLoaded(true);
   };
 
   useEffect(() => {
-    handleFetchData();
-  }, []);
+    handleFetchData(true);
+  }, [match?.params.tailingsStorageFacilityGuid]);
 
   const mineName = mines[mineGuid]?.mine_name || "";
 
@@ -90,7 +92,7 @@ export const TailingsSummaryPage = (props) => {
         <Row>
           <Col span={24}>
             <Typography.Title>
-              {props.initialValues.mine_tailings_storage_facility_name}
+              {props.formValues.mine_tailings_storage_facility_name}
             </Typography.Title>
           </Col>
         </Row>
@@ -132,6 +134,7 @@ const mapStateToProps = (state) => ({
   mines: getMines(state),
   initialValues: getTsf(state),
   mineGuid: getMineGuid(state),
+  formValues: getFormValues(FORM.ADD_STORAGE_FACILITY)(state),
 });
 
 const mapDispatchToProps = (dispatch) =>

--- a/services/core-web/src/tests/components/mine/Tailings/__snapshots__/MineTailingsInfoTabs.spec.js.snap
+++ b/services/core-web/src/tests/components/mine/Tailings/__snapshots__/MineTailingsInfoTabs.spec.js.snap
@@ -42,7 +42,7 @@ exports[`MineTailingsInfoTabs renders properly 1`] = `
             </AddButton>
           </Connect(AuthorizationWrapper)>
         </div>
-        <Connect(MineTailingsTable)
+        <withRouter(Connect(MineTailingsTable))
           handleEditTailings={[Function]}
           isLoaded={false}
           openEditTailingsModal={[Function]}

--- a/services/core-web/src/tests/components/mine/Tailings/__snapshots__/MineTailingsTable.spec.js.snap
+++ b/services/core-web/src/tests/components/mine/Tailings/__snapshots__/MineTailingsTable.spec.js.snap
@@ -30,7 +30,7 @@ exports[`MineTailingsTable renders properly 1`] = `
     }
   }
 >
-  <Connect(MineTailingsTable)
+  <withRouter(Connect(MineTailingsTable))
     TSFOperatingStatusCodeHash={Object {}}
     consequenceClassificationStatusCodeHash={Object {}}
     isLoaded={true}


### PR DESCRIPTION
## Objective 

[MDS-4821](https://bcmines.atlassian.net/browse/MDS-4821)

Fixed an issue where the TSF page in core would not reload when navigation changed, it would always display info of the first TSF you navigated to

_Why are you making this change? Provide a short explanation and/or screenshots_
