### PR TITLE
[MDS-3704] US Postal Codes not accepted

### DIFF
--- a/migrations/sql/V2022.10.26.16.00__add_address_type_code_field_sub_division_code.sql
+++ b/migrations/sql/V2022.10.26.16.00__add_address_type_code_field_sub_division_code.sql
@@ -1,0 +1,5 @@
+ALTER TABLE sub_division_code 
+ADD address_type_code character varying NOT NULL DEFAULT 'CAN'::character varying REFERENCES address_type_code(address_type_code);
+
+UPDATE sub_division_code SET address_type_code = 'USA'
+WHERE display_order > 130;

--- a/services/core-api/app/api/parties/party/models/address.py
+++ b/services/core-api/app/api/parties/party/models/address.py
@@ -94,7 +94,7 @@ class Address(SoftDeleteMixin, AuditMixin, Base):
             if value == 'USA':
                 maxLength = 10
                 validPostalCode = re.compile(r"((^\d{5}$)|(^\d{9}$)|(^\d{5}-\d{4}$))")
-            if len(value) > maxLength:
+            if len(self.post_code) > maxLength:
                 raise AssertionError(f'post_code must not exceed {maxLength} characters.')
             if not validPostalCode.match(self.post_code):
                 raise AssertionError(f'Invalid post_code format.')

--- a/services/core-api/app/api/parties/party/models/address.py
+++ b/services/core-api/app/api/parties/party/models/address.py
@@ -35,7 +35,8 @@ class Address(SoftDeleteMixin, AuditMixin, Base):
             'address_line_2': self.address_line_2,
             'city': self.city,
             'sub_division_code': self.sub_division_code,
-            'post_code': self.post_code
+            'post_code': self.post_code,
+            'address_type_code': self.address_type_code
         }
 
     @hybrid_property
@@ -57,6 +58,8 @@ class Address(SoftDeleteMixin, AuditMixin, Base):
                 full += f' {self.sub_division_code}'
             if self.post_code:
                 full += f' {self.post_code}'
+            if self.address_type_code:
+                full += f' {self.address_type_code}'
 
         return full.strip()
 
@@ -68,6 +71,7 @@ class Address(SoftDeleteMixin, AuditMixin, Base):
                city=None,
                sub_division_code=None,
                post_code=None,
+               address_type_code=None,
                add_to_session=True):
         address = cls(
             suite_no=suite_no,
@@ -75,18 +79,23 @@ class Address(SoftDeleteMixin, AuditMixin, Base):
             address_line_2=address_line_2,
             city=city,
             sub_division_code=sub_division_code,
-            post_code=post_code)
+            post_code=post_code,
+            address_type_code=address_type_code)
         if add_to_session:
             address.save(commit=False)
         return address
 
-    @validates('post_code')
-    def validate_post_code(self, key, post_code):
-        if post_code and len(post_code) > 6:
-            raise AssertionError('post_code must not exceed 6 characters.')
-        validPostalCode = re.compile(
-            r"(^\d{5}(-\d{4})?$)|(^[abceghjklmnprstvxyABCEGHJKLMNPRSTVXY]{1}\d{1}[a-zA-Z]{1} *\d{1}[a-zA-Z]{1}\d{1}$)"
-        )
-        if post_code and not validPostalCode.match(post_code):
-            raise AssertionError('Invalid post_code format.')
-        return post_code
+    # will be called for both fields, in the order defined in model, 1st call will be missing 2nd value
+    @validates('post_code', 'address_type_code')
+    def validate_address_code(self, key, value):
+        if key == 'address_type_code':
+            maxLength = 6
+            validPostalCode = re.compile(r"(^[ABCEGHJ-NPRSTVXY]\d[ABCEGHJ-NPRSTV-Z]\d[ABCEGHJ-NPRSTV-Z]\d$)")
+            if value == 'USA':
+                maxLength = 10
+                validPostalCode = re.compile(r"((^\d{5}$)|(^\d{9}$)|(^\d{5}-\d{4}$))")
+            if len(value) > maxLength:
+                raise AssertionError(f'post_code must not exceed {maxLength} characters.')
+            if not validPostalCode.match(self.post_code):
+                raise AssertionError(f'Invalid post_code format.')
+        return value

--- a/services/core-api/app/api/parties/party/models/sub_division_code.py
+++ b/services/core-api/app/api/parties/party/models/sub_division_code.py
@@ -10,6 +10,7 @@ class SubDivisionCode(AuditMixin, Base):
     description = db.Column(db.String, nullable=False)
     display_order = db.Column(db.Integer, nullable=False)
     active_ind = db.Column(db.Boolean, nullable=False, server_default=FetchedValue())
+    address_type_code = db.Column(db.String, nullable=False, server_default=FetchedValue())
 
     def __repr__(self):
         return '<SubDivisionCode %r>' % self.sub_division_code

--- a/services/core-api/app/api/parties/party/resources/merge_resource.py
+++ b/services/core-api/app/api/parties/party/resources/merge_resource.py
@@ -99,9 +99,10 @@ class MergeResource(Resource, UserMixin):
         city = address_data.get('city')
         sub_division_code = address_data.get('sub_division_code')
         post_code = address_data.get('post_code')
-        if (suite_no or address_line_1 or address_line_2 or city or sub_division_code or post_code):
+        address_type_code = address_data.get('address_type_code')
+        if (suite_no or address_line_1 or address_line_2 or city or sub_division_code or post_code or address_type_code):
             merged_address = Address.create(suite_no, address_line_1, address_line_2, city,
-                                            sub_division_code, post_code)
+                                            sub_division_code, post_code, address_type_code)
             merged_party.address.append(merged_address)
 
         # Delete the addresses of the merged parties.

--- a/services/core-api/app/api/parties/party/resources/party_list_resource.py
+++ b/services/core-api/app/api/parties/party/resources/party_list_resource.py
@@ -80,6 +80,11 @@ class PartyListResource(Resource, UserMixin):
         store_missing=False,
         help='The postal code of the party address. Ex: A0B1C2')
     parser.add_argument(
+        'address_type_code',
+        type=str,
+        store_missing=False,
+        help='The country where the party is located. Ex: CAN')
+    parser.add_argument(
         'job_title',
         type=str,
         store_missing=False,
@@ -190,7 +195,8 @@ class PartyListResource(Resource, UserMixin):
                 address_line_2=data.get('address_line_2'),
                 city=data.get('city'),
                 sub_division_code=data.get('sub_division_code'),
-                post_code=data.get('post_code'))
+                post_code=data.get('post_code'),
+                address_type_code=data.get('address_type_code'))
             party.address.append(address)
 
         party.save()

--- a/services/core-api/app/api/parties/response_models.py
+++ b/services/core-api/app/api/parties/response_models.py
@@ -148,6 +148,7 @@ PAGINATED_PARTY_LIST = api.inherit('PartyList', PAGINATED_LIST, {
 SUB_DIVISION_CODE_MODEL = api.model(
     'SubDivisionCodeModel', {
         'sub_division_code': fields.String,
+        'address_type_code': fields.String,
         'description': fields.String,
         'display_order': fields.Integer,
         'active_ind': fields.Boolean

--- a/services/core-api/tests/parties/address/models/test_address_model.py
+++ b/services/core-api/tests/parties/address/models/test_address_model.py
@@ -11,7 +11,7 @@ def test_party_model_validate_post_code():
             address_line_2='Bar',
             city='Baz',
             sub_division_code='AB',
-            post_code='0' * 7
+            post_code='0' * 7,
             address_type_code='CAN')
     assert 'post_code must not exceed 6 characters' in str(e.value)
 
@@ -22,6 +22,6 @@ def test_party_model_validate_post_code():
             address_line_2='Bar',
             city='Baz',
             sub_division_code='AB',
-            post_code='0' * 6
+            post_code='0' * 6,
             address_type_code='CAN')
     assert 'Invalid post_code format' in str(e.value)

--- a/services/core-api/tests/parties/address/models/test_address_model.py
+++ b/services/core-api/tests/parties/address/models/test_address_model.py
@@ -11,7 +11,8 @@ def test_party_model_validate_post_code():
             address_line_2='Bar',
             city='Baz',
             sub_division_code='AB',
-            post_code='0' * 7)
+            post_code='0' * 7
+            address_type_code='CAN')
     assert 'post_code must not exceed 6 characters' in str(e.value)
 
     with pytest.raises(AssertionError) as e:
@@ -21,5 +22,6 @@ def test_party_model_validate_post_code():
             address_line_2='Bar',
             city='Baz',
             sub_division_code='AB',
-            post_code='0' * 6)
+            post_code='0' * 6
+            address_type_code='CAN')
     assert 'Invalid post_code format' in str(e.value)

--- a/services/core-web/common/selectors/staticContentSelectors.js
+++ b/services/core-web/common/selectors/staticContentSelectors.js
@@ -210,7 +210,7 @@ export const getDropdownCommodityOptions = createSelectorWrapper(
 export const getDropdownProvinceOptions = createSelectorWrapper(
   getProvinceOptions,
   createDropDownList,
-  ["sub_division_code", "sub_division_code", "active_ind"]
+  ["sub_division_code", "sub_division_code", "active_ind", "address_type_code"]
 );
 
 // no need for wrapper, does not have a 'active_ind'

--- a/services/core-web/common/utils/Validate.js
+++ b/services/core-web/common/utils/Validate.js
@@ -60,9 +60,8 @@ class Validator {
   checkPostalCode(code, country = "CAN") {
     if (country === "USA") {
       return this.US_POSTAL_CODE_REGEX.test(code);
-    } 
-      return this.CAN_POSTAL_CODE_REGEX.test(code);
-    
+    }
+    return this.CAN_POSTAL_CODE_REGEX.test(code);
   }
 
   checkCurrency(number) {

--- a/services/core-web/common/utils/Validate.js
+++ b/services/core-web/common/utils/Validate.js
@@ -58,15 +58,11 @@ class Validator {
   }
 
   checkPostalCode(code, country = "CAN") {
-    switch (country) {
-      case "CAN":
-        return this.CAN_POSTAL_CODE_REGEX.test(code);
-      case "USA":
-        return this.US_POSTAL_CODE_REGEX.test(code);
-      default:
-        // international/not entered
-        return true;
-    }
+    if (country === "USA") {
+      return this.US_POSTAL_CODE_REGEX.test(code);
+    } 
+      return this.CAN_POSTAL_CODE_REGEX.test(code);
+    
   }
 
   checkCurrency(number) {
@@ -137,7 +133,7 @@ export const postalCode = (value, allValues, formProps) => {
   const { sub_division_code } = allValues;
   const country = formProps.provinceOptions.find((prov) => prov.value === sub_division_code)
     ?.subType;
-  return value && country && !Validate.checkPostalCode(value, country)
+  return value && !Validate.checkPostalCode(value, country)
     ? "Invalid postal code or zip code"
     : undefined;
 };

--- a/services/core-web/common/utils/Validate.js
+++ b/services/core-web/common/utils/Validate.js
@@ -9,7 +9,9 @@ import moment from "moment";
 class Validator {
   ASCII_REGEX = /^[\x0-\x7F\s]*$/;
 
-  CAN_POSTAL_CODE_REGEX = /(^\d{5}(-\d{4})?$)|(^[abceghjklmnprstvxyABCEGHJKLMNPRSTVXY]{1}\d{1}[a-zA-Z]{1} *\d{1}[a-zA-Z]{1}\d{1}$)/;
+  CAN_POSTAL_CODE_REGEX = /^[ABCEGHJ-NPRSTVXY]\d[ABCEGHJ-NPRSTV-Z]\d[ABCEGHJ-NPRSTV-Z]\d$/;
+
+  US_POSTAL_CODE_REGEX = /(^\d{5}$)|(^\d{9}$)|(^\d{5}-\d{4}$)/;
 
   EMAIL_REGEX = /^[a-zA-Z0-9`'’._%+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$/;
 
@@ -55,8 +57,16 @@ class Validator {
     return this.EMAIL_REGEX.test(email);
   }
 
-  checkPostalCode(code) {
-    return this.CAN_POSTAL_CODE_REGEX.test(code);
+  checkPostalCode(code, country = "CAN") {
+    switch (country) {
+      case "CAN":
+        return this.CAN_POSTAL_CODE_REGEX.test(code);
+      case "USA":
+        return this.US_POSTAL_CODE_REGEX.test(code);
+      default:
+        // international/not entered
+        return true;
+    }
   }
 
   checkCurrency(number) {
@@ -123,8 +133,14 @@ export const lonNegative = (value) =>
 export const phoneNumber = (value) =>
   value && !Validate.checkPhone(value) ? "Invalid phone number e.g. xxx-xxx-xxxx" : undefined;
 
-export const postalCode = (value) =>
-  value && !Validate.checkPostalCode(value) ? "Invalid postal code or zip code" : undefined;
+export const postalCode = (value, allValues, formProps) => {
+  const { sub_division_code } = allValues;
+  const country = formProps.provinceOptions.find((prov) => prov.value === sub_division_code)
+    ?.subType;
+  return value && country && !Validate.checkPostalCode(value, country)
+    ? "Invalid postal code or zip code"
+    : undefined;
+};
 
 export const protocol = (value) =>
   value && !Validate.checkProtocol(value) ? "Invalid. Url must contain https://" : undefined;

--- a/services/core-web/src/components/modalContent/AddPartyModal.js
+++ b/services/core-web/src/components/modalContent/AddPartyModal.js
@@ -85,7 +85,11 @@ export class AddPartyModal extends Component {
     event.preventDefault();
     this.setState({ submitting: true });
     const party_type_code = this.state.isPerson ? "PER" : "ORG";
-    const payload = { party_type_code, ...this.props.addPartyFormValues };
+    const selectedProvince = this.props.provinceOptions.find(
+      (prov) => prov.value === this.props.addPartyFormValues.sub_division_code
+    );
+    const address_type_code = selectedProvince.subType;
+    const payload = { party_type_code, address_type_code, ...this.props.addPartyFormValues };
     const party = await this.props
       .createParty(payload)
       .then(({ data }) => {

--- a/services/core-web/src/components/modalContent/AddPartyModal.js
+++ b/services/core-web/src/components/modalContent/AddPartyModal.js
@@ -85,10 +85,10 @@ export class AddPartyModal extends Component {
     event.preventDefault();
     this.setState({ submitting: true });
     const party_type_code = this.state.isPerson ? "PER" : "ORG";
-    const selectedProvince = this.props.provinceOptions.find(
-      (prov) => prov.value === this.props.addPartyFormValues.sub_division_code
-    );
-    const address_type_code = selectedProvince.subType;
+    const address_type_code =
+      this.props.provinceOptions.find(
+        (prov) => prov.value === this.props.addPartyFormValues.sub_division_code
+      )?.subType ?? "";
     const payload = { party_type_code, address_type_code, ...this.props.addPartyFormValues };
     const party = await this.props
       .createParty(payload)

--- a/services/core-web/src/tests/components/Forms/Securities/__snapshots__/BondForm.spec.js.snap
+++ b/services/core-web/src/tests/components/Forms/Securities/__snapshots__/BondForm.spec.js.snap
@@ -248,13 +248,13 @@ exports[`BondForm renders properly 1`] = `
               Object {
                 "isActive": true,
                 "label": "AB",
-                "subType": null,
+                "subType": "CAN",
                 "value": "AB",
               },
               Object {
                 "isActive": true,
                 "label": "BC",
-                "subType": null,
+                "subType": "CAN",
                 "value": "BC",
               },
             ]

--- a/services/core-web/src/tests/components/Forms/parties/__snapshots__/AddFullPartyForm.spec.js.snap
+++ b/services/core-web/src/tests/components/Forms/parties/__snapshots__/AddFullPartyForm.spec.js.snap
@@ -349,13 +349,13 @@ exports[`AddFullPartyForm renders properly 1`] = `
                     Object {
                       "isActive": true,
                       "label": "AB",
-                      "subType": null,
+                      "subType": "CAN",
                       "value": "AB",
                     },
                     Object {
                       "isActive": true,
                       "label": "BC",
-                      "subType": null,
+                      "subType": "CAN",
                       "value": "BC",
                     },
                   ]

--- a/services/core-web/src/tests/components/Forms/parties/__snapshots__/EditFullPartyForm.spec.js.snap
+++ b/services/core-web/src/tests/components/Forms/parties/__snapshots__/EditFullPartyForm.spec.js.snap
@@ -345,13 +345,13 @@ exports[`EditFullPartyForm renders properly 1`] = `
                     Object {
                       "isActive": true,
                       "label": "AB",
-                      "subType": null,
+                      "subType": "CAN",
                       "value": "AB",
                     },
                     Object {
                       "isActive": true,
                       "label": "BC",
-                      "subType": null,
+                      "subType": "CAN",
                       "value": "BC",
                     },
                   ]

--- a/services/core-web/src/tests/components/Forms/parties/__snapshots__/MergePartyConfirmationForm.spec.js.snap
+++ b/services/core-web/src/tests/components/Forms/parties/__snapshots__/MergePartyConfirmationForm.spec.js.snap
@@ -186,13 +186,13 @@ exports[`MergePartyConfirmationForm renders properly 1`] = `
                       Object {
                         "isActive": true,
                         "label": "AB",
-                        "subType": null,
+                        "subType": "CAN",
                         "value": "AB",
                       },
                       Object {
                         "isActive": true,
                         "label": "BC",
-                        "subType": null,
+                        "subType": "CAN",
                         "value": "BC",
                       },
                     ]

--- a/services/core-web/src/tests/components/modalContent/__snapshots__/AddBondModal.spec.js.snap
+++ b/services/core-web/src/tests/components/modalContent/__snapshots__/AddBondModal.spec.js.snap
@@ -62,13 +62,13 @@ exports[`AddBondModal renders properly 1`] = `
         Object {
           "isActive": true,
           "label": "AB",
-          "subType": null,
+          "subType": "CAN",
           "value": "AB",
         },
         Object {
           "isActive": true,
           "label": "BC",
-          "subType": null,
+          "subType": "CAN",
           "value": "BC",
         },
       ]

--- a/services/core-web/src/tests/components/modalContent/__snapshots__/EditPartyModal.spec.js.snap
+++ b/services/core-web/src/tests/components/modalContent/__snapshots__/EditPartyModal.spec.js.snap
@@ -43,13 +43,13 @@ exports[`EditPartyModal renders properly 1`] = `
       Object {
         "isActive": true,
         "label": "AB",
-        "subType": null,
+        "subType": "CAN",
         "value": "AB",
       },
       Object {
         "isActive": true,
         "label": "BC",
-        "subType": null,
+        "subType": "CAN",
         "value": "BC",
       },
     ]

--- a/services/core-web/src/tests/mocks/dataMocks.js
+++ b/services/core-web/src/tests/mocks/dataMocks.js
@@ -1254,21 +1254,31 @@ export const DROPDOWN_PROVINCE_OPTIONS = [
   {
     value: "AB",
     label: "AB",
-    subType: null,
+    subType: "CAN",
     isActive: true,
   },
   {
     value: "BC",
     label: "BC",
-    subType: null,
+    subType: "CAN",
     isActive: true,
   },
 ];
 
 export const PROVINCE_OPTIONS = {
   records: [
-    { description: "British Columbia", display_order: 10, sub_division_code: "BC" },
-    { description: "Alberta", display_order: 10, sub_division_code: "AB" },
+    {
+      description: "British Columbia",
+      display_order: 10,
+      sub_division_code: "BC",
+      address_type_code: "CAN",
+    },
+    {
+      description: "Alberta",
+      display_order: 10,
+      sub_division_code: "AB",
+      address_type_code: "CAN",
+    },
   ],
 };
 
@@ -3324,7 +3334,10 @@ export const BULK_STATIC_CONTENT_RESPONSE = {
   ],
   incidentDeterminationOptions: [
     { mine_incident_determination_type_code: "PEN", description: "Pending determination" },
-    { mine_incident_determination_type_code: "DO", description: "This was a dangerous occurrence" },
+    {
+      mine_incident_determination_type_code: "DO",
+      description: "This was a dangerous occurrence",
+    },
     {
       mine_incident_determination_type_code: "NDO",
       description: "This was not a dangerous occurrence",
@@ -3368,12 +3381,19 @@ export const BULK_STATIC_CONTENT_RESPONSE = {
   ],
   exemptionFeeStatusOptions: [],
   provinceOptions: [
-    { sub_division_code: "AB", description: "Alberta", display_order: 10, active_ind: true },
+    {
+      sub_division_code: "AB",
+      description: "Alberta",
+      display_order: 10,
+      active_ind: true,
+      address_type_code: "CAN",
+    },
     {
       sub_division_code: "BC",
       description: "British Columbia",
       display_order: 20,
       active_ind: true,
+      address_type_code: "CAN",
     },
   ],
   complianceCodes: [
@@ -3410,13 +3430,21 @@ export const BULK_STATIC_CONTENT_RESPONSE = {
     },
     { variance_application_status_code: "WIT", description: "Withdrawn", active_ind: true },
     { variance_application_status_code: "REV", description: "In Review", active_ind: true },
-    { variance_application_status_code: "NAP", description: "Not Applicable", active_ind: true },
+    {
+      variance_application_status_code: "NAP",
+      description: "Not Applicable",
+      active_ind: true,
+    },
     { variance_application_status_code: "APP", description: "Approved", active_ind: true },
     { variance_application_status_code: "DEN", description: "Denied", active_ind: true },
   ],
   varianceDocumentCategoryOptions: [
     { variance_document_category_code: "REQ", description: "Request", active_ind: true },
-    { variance_document_category_code: "REC", description: "Recommendation", active_ind: true },
+    {
+      variance_document_category_code: "REC",
+      description: "Recommendation",
+      active_ind: true,
+    },
     { variance_document_category_code: "DEC", description: "Decision", active_ind: true },
   ],
   projectSummaryStatusCodes: [
@@ -3830,7 +3858,12 @@ export const BULK_STATIC_CONTENT_RESPONSE = {
     { activity_type_code: "water_supply", description: "Water Supply", active_ind: true },
   ],
   noticeOfWorkUnitTypeOptions: [
-    { short_description: "km", unit_type_code: "KMT", description: "Kilometer ", active_ind: true },
+    {
+      short_description: "km",
+      unit_type_code: "KMT",
+      description: "Kilometer ",
+      active_ind: true,
+    },
     {
       short_description: "t",
       unit_type_code: "MTN",
@@ -3843,15 +3876,30 @@ export const BULK_STATIC_CONTENT_RESPONSE = {
       description: "Meters cubed",
       active_ind: true,
     },
-    { short_description: "ha", unit_type_code: "HA", description: "Hectares", active_ind: true },
-    { short_description: "deg", unit_type_code: "DEG", description: "Degrees", active_ind: true },
+    {
+      short_description: "ha",
+      unit_type_code: "HA",
+      description: "Hectares",
+      active_ind: true,
+    },
+    {
+      short_description: "deg",
+      unit_type_code: "DEG",
+      description: "Degrees",
+      active_ind: true,
+    },
     {
       short_description: "%",
       unit_type_code: "PER",
       description: "Grade (Percent)",
       active_ind: true,
     },
-    { short_description: "m", unit_type_code: "MTR", description: "Meters", active_ind: true },
+    {
+      short_description: "m",
+      unit_type_code: "MTR",
+      description: "Meters",
+      active_ind: true,
+    },
   ],
   noticeOfWorkApplicationTypeOptions: [
     {
@@ -3872,11 +3920,23 @@ export const BULK_STATIC_CONTENT_RESPONSE = {
   noticeOfWorkApplicationStatusOptions: [
     { now_application_status_code: "SUB", description: "Submitted", active_ind: true },
     { now_application_status_code: "REF", description: "Referred", active_ind: true },
-    { now_application_status_code: "CDI", description: "Client Delay Info", active_ind: true },
-    { now_application_status_code: "CDB", description: "Client Delay Bond", active_ind: true },
+    {
+      now_application_status_code: "CDI",
+      description: "Client Delay Info",
+      active_ind: true,
+    },
+    {
+      now_application_status_code: "CDB",
+      description: "Client Delay Bond",
+      active_ind: true,
+    },
     { now_application_status_code: "GVD", description: "Govt Delay", active_ind: true },
     { now_application_status_code: "CON", description: "Consultation", active_ind: true },
-    { now_application_status_code: "AIA", description: "Active/Issued/Approved", active_ind: true },
+    {
+      now_application_status_code: "AIA",
+      description: "Active/Issued/Approved",
+      active_ind: true,
+    },
     { now_application_status_code: "WDN", description: "Withdrawn", active_ind: true },
     { now_application_status_code: "REJ", description: "Rejected", active_ind: true },
     { now_application_status_code: "CLO", description: "Closed", active_ind: true },
@@ -5001,7 +5061,11 @@ export const BULK_STATIC_CONTENT_RESPONSE = {
   ],
   noticeOfWorkUndergroundExplorationTypeOptions: [
     { underground_exploration_type_code: "NEW", description: "New", active_ind: true },
-    { underground_exploration_type_code: "RHB", description: "Rehabilitation", active_ind: true },
+    {
+      underground_exploration_type_code: "RHB",
+      description: "Rehabilitation",
+      active_ind: true,
+    },
     { underground_exploration_type_code: "SUR", description: "Surface", active_ind: true },
   ],
   noticeOfWorkApplicationProgressStatusCodeOptions: [
@@ -5016,8 +5080,16 @@ export const BULK_STATIC_CONTENT_RESPONSE = {
       description: "Multi-Year, Area-Based Permit",
       active_ind: true,
     },
-    { now_application_permit_type_code: "OYP", description: "One-Year Permit", active_ind: true },
-    { now_application_permit_type_code: "MYP", description: "Multi-Year Permit", active_ind: true },
+    {
+      now_application_permit_type_code: "OYP",
+      description: "One-Year Permit",
+      active_ind: true,
+    },
+    {
+      now_application_permit_type_code: "MYP",
+      description: "Multi-Year Permit",
+      active_ind: true,
+    },
   ],
   noticeOfWorkApplicationReviewOptions: [
     { now_application_review_type_code: "REF", description: "Referral" },
@@ -5044,8 +5116,16 @@ export const BULK_STATIC_CONTENT_RESPONSE = {
       description: "Scan of Reclamation Security Bond",
       active_ind: true,
     },
-    { bond_document_type_code: "RSF", description: "Release of Security Form", active_ind: true },
-    { bond_document_type_code: "RSL", description: "Release of Security Letter", active_ind: true },
+    {
+      bond_document_type_code: "RSF",
+      description: "Release of Security Form",
+      active_ind: true,
+    },
+    {
+      bond_document_type_code: "RSL",
+      description: "Release of Security Letter",
+      active_ind: true,
+    },
     {
       bond_document_type_code: "CSF",
       description: "Confiscation of Security Form",
@@ -5057,7 +5137,11 @@ export const BULK_STATIC_CONTENT_RESPONSE = {
       active_ind: true,
     },
     { bond_document_type_code: "REL", description: "Reminder Letter", active_ind: true },
-    { bond_document_type_code: "AKL", description: "Acknowledgement Letter", active_ind: true },
+    {
+      bond_document_type_code: "AKL",
+      description: "Acknowledgement Letter",
+      active_ind: true,
+    },
   ],
   permitConditionTypeOptions: [
     {

--- a/services/minespace-web/common/selectors/staticContentSelectors.js
+++ b/services/minespace-web/common/selectors/staticContentSelectors.js
@@ -210,7 +210,7 @@ export const getDropdownCommodityOptions = createSelectorWrapper(
 export const getDropdownProvinceOptions = createSelectorWrapper(
   getProvinceOptions,
   createDropDownList,
-  ["sub_division_code", "sub_division_code", "active_ind"]
+  ["sub_division_code", "sub_division_code", "active_ind", "address_type_code"]
 );
 
 // no need for wrapper, does not have a 'active_ind'

--- a/services/minespace-web/common/utils/Validate.js
+++ b/services/minespace-web/common/utils/Validate.js
@@ -9,7 +9,9 @@ import moment from "moment";
 class Validator {
   ASCII_REGEX = /^[\x0-\x7F\s]*$/;
 
-  CAN_POSTAL_CODE_REGEX = /(^\d{5}(-\d{4})?$)|(^[abceghjklmnprstvxyABCEGHJKLMNPRSTVXY]{1}\d{1}[a-zA-Z]{1} *\d{1}[a-zA-Z]{1}\d{1}$)/;
+  CAN_POSTAL_CODE_REGEX = /^[ABCEGHJ-NPRSTVXY]\d[ABCEGHJ-NPRSTV-Z]\d[ABCEGHJ-NPRSTV-Z]\d$/;
+
+  US_POSTAL_CODE_REGEX = /(^\d{5}$)|(^\d{9}$)|(^\d{5}-\d{4}$)/;
 
   EMAIL_REGEX = /^[a-zA-Z0-9`'’._%+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$/;
 
@@ -55,7 +57,10 @@ class Validator {
     return this.EMAIL_REGEX.test(email);
   }
 
-  checkPostalCode(code) {
+  checkPostalCode(code, country = "CAN") {
+    if (country === "USA") {
+      return this.US_POSTAL_CODE_REGEX.test(code);
+    }
     return this.CAN_POSTAL_CODE_REGEX.test(code);
   }
 
@@ -123,8 +128,14 @@ export const lonNegative = (value) =>
 export const phoneNumber = (value) =>
   value && !Validate.checkPhone(value) ? "Invalid phone number e.g. xxx-xxx-xxxx" : undefined;
 
-export const postalCode = (value) =>
-  value && !Validate.checkPostalCode(value) ? "Invalid postal code or zip code" : undefined;
+export const postalCode = (value, allValues, formProps) => {
+  const { sub_division_code } = allValues;
+  const country = formProps.provinceOptions.find((prov) => prov.value === sub_division_code)
+    ?.subType;
+  return value && !Validate.checkPostalCode(value, country)
+    ? "Invalid postal code or zip code"
+    : undefined;
+};
 
 export const protocol = (value) =>
   value && !Validate.checkProtocol(value) ? "Invalid. Url must contain https://" : undefined;


### PR DESCRIPTION
## Use appropriate validation for postal code depending on country (CAN/USA)

[MDS-3704](https://bcmines.atlassian.net/browse/MDS-3704)

- five-four zip codes were not accepted at all
- validation did not catch when US zip code entered for address with Canadian province or Canadian postal code for US state
- backend validation differed from frontend validation, making some validation errors show as a toast

Summary of changes:
- db migration: added address_type_code field to sub_division_code table to link prov/state to its country, linked existing entries to CAN/USA (ex: Alberta has address type code of CAN, California has USA)
- modified the return of of province dropdown options to include the country code as subType
- found/created separate US/CAN postal code regex patterns- put on both FE & BE
   - US pattern accepts formats: 12345, 123451234, 12345-1234
   - Canadian pattern accepts: A1A1A1, does not accept A1A-1A1 or A1A 1A1
- modified FE & BE to validate postal code based on country
- added address_type_code to data being parsed before creating address
- when there is no prov/state (and therefore country) entered: both BE & FE will assume Canadian and apply Canadian rules
- merge_resource functionality: include country in address merge

Didn't include:
- clean up of address_type_code field in address table- debatable if this field is still necessary
- modification to address_etl function
- did not change error message to specify correct postal code field name depending on country (this would be easy- is it desired? ex "invalid _zip_ code format" or "invalid _postal_ code format")