### PR TITLE
[MDS-3704] Allow address_type_code to be nullable in address table (bug fix)

### DIFF
--- a/migrations/sql/V2022.11.03.12.00__alter_address_nullable_address_type_code.sql
+++ b/migrations/sql/V2022.11.03.12.00__alter_address_nullable_address_type_code.sql
@@ -1,0 +1,1 @@
+ALTER TABLE address ALTER column address_type_code DROP NOT NULL;

--- a/migrations/sql/V2022.11.03.12.00__alter_address_nullable_address_type_code.sql
+++ b/migrations/sql/V2022.11.03.12.00__alter_address_nullable_address_type_code.sql
@@ -1,1 +1,0 @@
-ALTER TABLE address ALTER column address_type_code DROP NOT NULL;

--- a/services/core-api/app/api/parties/party/models/address.py
+++ b/services/core-api/app/api/parties/party/models/address.py
@@ -19,7 +19,7 @@ class Address(SoftDeleteMixin, AuditMixin, Base):
     sub_division_code = db.Column(
         db.String, db.ForeignKey('sub_division_code.sub_division_code'), nullable=True)
     post_code = db.Column(db.String, nullable=True)
-    address_type_code = db.Column(db.String, nullable=False, server_default=FetchedValue())
+    address_type_code = db.Column(db.String, nullable=True, server_default=FetchedValue())
 
     party_guid = db.Column(UUID(as_uuid=True), db.ForeignKey('party.party_guid'), nullable=False)
     party = db.relationship('Party', lazy='joined')

--- a/services/core-api/app/api/parties/party/models/address.py
+++ b/services/core-api/app/api/parties/party/models/address.py
@@ -19,7 +19,7 @@ class Address(SoftDeleteMixin, AuditMixin, Base):
     sub_division_code = db.Column(
         db.String, db.ForeignKey('sub_division_code.sub_division_code'), nullable=True)
     post_code = db.Column(db.String, nullable=True)
-    address_type_code = db.Column(db.String, nullable=True, server_default=FetchedValue())
+    address_type_code = db.Column(db.String, nullable=False, server_default=FetchedValue())
 
     party_guid = db.Column(UUID(as_uuid=True), db.ForeignKey('party.party_guid'), nullable=False)
     party = db.relationship('Party', lazy='joined')

--- a/services/core-web/src/components/modalContent/AddPartyModal.js
+++ b/services/core-web/src/components/modalContent/AddPartyModal.js
@@ -88,7 +88,7 @@ export class AddPartyModal extends Component {
     const address_type_code =
       this.props.provinceOptions.find(
         (prov) => prov.value === this.props.addPartyFormValues.sub_division_code
-      )?.subType ?? "";
+      )?.subType ?? null;
     const payload = { party_type_code, address_type_code, ...this.props.addPartyFormValues };
     const party = await this.props
       .createParty(payload)


### PR DESCRIPTION
## Objective 

[MDS-3704](https://bcmines.atlassian.net/browse/MDS-3704)

Bug fix:
- stopped sending empty strings to the BE for address_type_code
- when it's explicitly null, db properly uses default ("CAN") for field