### PR TITLE
[MDS-4846] - Core fetch NOD data

### DIFF
--- a/services/core-web/src/components/mine/MineDashboard.js
+++ b/services/core-web/src/components/mine/MineDashboard.js
@@ -264,7 +264,7 @@ export class MineDashboard extends Component {
             actions={[storeMine]}
             listActions={[storeVariances, storePermits]}
             requests={[
-              () => this.props.fetchNoticesOfDeparture({ mineGuid: id }),
+              () => this.props.fetchNoticesOfDeparture(id),
               () => this.props.fetchVariancesByMine({ mineGuid: id }),
               () => this.props.fetchPermits(mine.mine_guid),
               () => this.props.fetchMineRecordById(id),


### PR DESCRIPTION
## Objective 
Fix refreshing of mine data in core from causing an error

[MDS-4846](https://bcmines.atlassian.net/browse/MDS-4846)

- mine_guid was being incorrectly passed within an object to the `fetchNoticesOfDeparture` action creator ( ie. `{mineGuid: id}`).  Updated this to passing the parameter directly.

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/83598933/199841231-35f4d71c-2f84-44c3-99f1-66585cd3aa5b.png">


