### PR TITLE
[MDS-4842] Added FILE_UPLOAD component to core render config

### DIFF
--- a/services/core-web/src/components/common/config.js
+++ b/services/core-web/src/components/common/config.js
@@ -15,6 +15,8 @@ import RenderRadioButtons from "./RenderRadioButtons";
 import RenderGroupedSelect from "./RenderGroupedSelect";
 import RenderMineSelect from "./RenderMineSelect";
 import RenderLabel from "./RenderLabel";
+import FileUpload from "@/components/common/FileUpload";
+
 
 // This file is anticipated to have multiple exports
 // eslint-disable-next-line import/prefer-default-export
@@ -36,4 +38,5 @@ export const renderConfig = {
   GROUPED_SELECT: RenderGroupedSelect,
   MINE_SELECT: RenderMineSelect,
   LABEL: RenderLabel,
+  FILE_UPLOAD: FileUpload,
 };


### PR DESCRIPTION
## Objective 
This fixes the issue where navigating to the EOR tab in core results in a blank screen as the component tries to render the FileUpload component, which did not exist

[MDS-4842](https://bcmines.atlassian.net/browse/MDS-4842)

_Why are you making this change? Provide a short explanation and/or screenshots_
