### PR TITLE
[MDS-4848] - TSF Operating Status

### DIFF
--- a/services/common/src/constants/strings.js
+++ b/services/common/src/constants/strings.js
@@ -210,7 +210,14 @@ export const TSF_INDEPENDENT_TAILINGS_REVIEW_BOARD = [
   { value: "NO", label: "No" },
 ];
 
-export const TSF_OPERATING_STATUS_CODE = [{ value: "OPT", label: "Operating" }];
+export const TSF_OPERATING_STATUS_CODE = [
+  { value: "CON", label: "Construction" },
+  { value: "OPT", label: "Operation" },
+  { value: "CAM", label: "Care and Maintenance" },
+  { value: "CLT", label: "Closure - Transition" },
+  { value: "CLA", label: "Closure - Active Care" },
+  { value: "CLP", label: "Closure - Passive Care" },
+];
 
 export const CONSEQUENCE_CLASSIFICATION_STATUS_CODE = [
   { value: "LOW", label: "Low" },

--- a/services/core-web/common/components/SteppedForm.js
+++ b/services/core-web/common/components/SteppedForm.js
@@ -44,6 +44,7 @@ const SteppedForm = (props) => {
     cancelText,
     handleCancel,
     cancelConfirmMessage,
+    errors,
   } = props;
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [tabIndex, setTabIndex] = useState(0);
@@ -78,6 +79,8 @@ const SteppedForm = (props) => {
       if (handleSaveData) {
         await handleSaveData(null, tab);
       }
+
+      if (errors.length > 0) return;
 
       setTabIndex(indexOf(tabs, tab));
     } finally {
@@ -152,7 +155,7 @@ const SteppedForm = (props) => {
                   )}
                   <Button
                     type="secondary"
-                    disabled={isSubmitting || props.errors?.length > 0}
+                    disabled={isSubmitting}
                     onClick={(e) => handleNextClick(e, tabs[tabIndex + 1])}
                   >
                     Next <RightOutlined />
@@ -160,11 +163,7 @@ const SteppedForm = (props) => {
                 </div>
               )}
               {isLast && (
-                <Button
-                  type="primary"
-                  disabled={isSubmitting || props.errors?.length > 0}
-                  onClick={handleSaveData}
-                >
+                <Button type="primary" disabled={isSubmitting} onClick={handleSaveData}>
                   {submitText || "Submit"}
                 </Button>
               )}

--- a/services/core-web/common/components/tailings/BasicInformation.js
+++ b/services/core-web/common/components/tailings/BasicInformation.js
@@ -5,7 +5,7 @@ import {
   TSF_INDEPENDENT_TAILINGS_REVIEW_BOARD,
   TSF_OPERATING_STATUS_CODE,
   TSF_TYPES,
-} from "@common/constants/strings";
+} from "@mds/common";
 import { Col, Row, Typography } from "antd";
 import React, { useEffect, useState } from "react";
 import {
@@ -37,8 +37,13 @@ const defaultProps = {
 };
 
 export const BasicInformation = (props) => {
-  const { permits, renderConfig, viewOnly = false } = props;
+  const { permits, renderConfig, viewOnly = false, tsf } = props;
   const [permitOptions, setPermitOptions] = useState([]);
+
+  const includeClosedStatus =
+    tsf?.tsf_operating_status_code === "CLO"
+      ? [...TSF_OPERATING_STATUS_CODE, { value: "CLO", label: "Closed" }]
+      : TSF_OPERATING_STATUS_CODE;
 
   useEffect(() => {
     if (permits.length > 0) {
@@ -141,10 +146,10 @@ export const BasicInformation = (props) => {
         id="tsf_operating_status_code"
         name="tsf_operating_status_code"
         label="Operating Status"
-        data={TSF_OPERATING_STATUS_CODE}
+        data={includeClosedStatus}
         component={renderConfig.SELECT}
         disabled={viewOnly}
-        validate={[requiredList, validateSelectOptions(TSF_OPERATING_STATUS_CODE)]}
+        validate={[requiredList, validateSelectOptions(includeClosedStatus)]}
       />
       <Field
         id="itrb_exemption_status_code"

--- a/services/core-web/common/components/tailings/BasicInformation.js
+++ b/services/core-web/common/components/tailings/BasicInformation.js
@@ -40,7 +40,7 @@ export const BasicInformation = (props) => {
   const { permits, renderConfig, viewOnly = false, tsf } = props;
   const [permitOptions, setPermitOptions] = useState([]);
 
-  const includeClosedStatus =
+  const statusCodeOptions =
     tsf?.tsf_operating_status_code === "CLO"
       ? [...TSF_OPERATING_STATUS_CODE, { value: "CLO", label: "Closed" }]
       : TSF_OPERATING_STATUS_CODE;
@@ -146,10 +146,10 @@ export const BasicInformation = (props) => {
         id="tsf_operating_status_code"
         name="tsf_operating_status_code"
         label="Operating Status"
-        data={includeClosedStatus}
+        data={statusCodeOptions}
         component={renderConfig.SELECT}
         disabled={viewOnly}
-        validate={[requiredList, validateSelectOptions(includeClosedStatus)]}
+        validate={[requiredList, validateSelectOptions(statusCodeOptions)]}
       />
       <Field
         id="itrb_exemption_status_code"

--- a/services/minespace-web/common/components/SteppedForm.js
+++ b/services/minespace-web/common/components/SteppedForm.js
@@ -44,6 +44,7 @@ const SteppedForm = (props) => {
     cancelText,
     handleCancel,
     cancelConfirmMessage,
+    errors,
   } = props;
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [tabIndex, setTabIndex] = useState(0);
@@ -78,6 +79,8 @@ const SteppedForm = (props) => {
       if (handleSaveData) {
         await handleSaveData(null, tab);
       }
+
+      if (errors.length > 0) return;
 
       setTabIndex(indexOf(tabs, tab));
     } finally {
@@ -152,7 +155,7 @@ const SteppedForm = (props) => {
                   )}
                   <Button
                     type="secondary"
-                    disabled={isSubmitting || props.errors?.length > 0}
+                    disabled={isSubmitting}
                     onClick={(e) => handleNextClick(e, tabs[tabIndex + 1])}
                   >
                     Next <RightOutlined />
@@ -160,11 +163,7 @@ const SteppedForm = (props) => {
                 </div>
               )}
               {isLast && (
-                <Button
-                  type="primary"
-                  disabled={isSubmitting || props.errors?.length > 0}
-                  onClick={handleSaveData}
-                >
+                <Button type="primary" disabled={isSubmitting} onClick={handleSaveData}>
                   {submitText || "Submit"}
                 </Button>
               )}

--- a/services/minespace-web/common/components/tailings/BasicInformation.js
+++ b/services/minespace-web/common/components/tailings/BasicInformation.js
@@ -5,7 +5,7 @@ import {
   TSF_INDEPENDENT_TAILINGS_REVIEW_BOARD,
   TSF_OPERATING_STATUS_CODE,
   TSF_TYPES,
-} from "@common/constants/strings";
+} from "@mds/common";
 import { Col, Row, Typography } from "antd";
 import React, { useEffect, useState } from "react";
 import {
@@ -37,8 +37,13 @@ const defaultProps = {
 };
 
 export const BasicInformation = (props) => {
-  const { permits, renderConfig, viewOnly = false } = props;
+  const { permits, renderConfig, viewOnly = false, tsf } = props;
   const [permitOptions, setPermitOptions] = useState([]);
+
+  const includeClosedStatus =
+    tsf?.tsf_operating_status_code === "CLO"
+      ? [...TSF_OPERATING_STATUS_CODE, { value: "CLO", label: "Closed" }]
+      : TSF_OPERATING_STATUS_CODE;
 
   useEffect(() => {
     if (permits.length > 0) {
@@ -141,10 +146,10 @@ export const BasicInformation = (props) => {
         id="tsf_operating_status_code"
         name="tsf_operating_status_code"
         label="Operating Status"
-        data={TSF_OPERATING_STATUS_CODE}
+        data={includeClosedStatus}
         component={renderConfig.SELECT}
         disabled={viewOnly}
-        validate={[requiredList, validateSelectOptions(TSF_OPERATING_STATUS_CODE)]}
+        validate={[requiredList, validateSelectOptions(includeClosedStatus)]}
       />
       <Field
         id="itrb_exemption_status_code"

--- a/services/minespace-web/common/components/tailings/BasicInformation.js
+++ b/services/minespace-web/common/components/tailings/BasicInformation.js
@@ -40,7 +40,7 @@ export const BasicInformation = (props) => {
   const { permits, renderConfig, viewOnly = false, tsf } = props;
   const [permitOptions, setPermitOptions] = useState([]);
 
-  const includeClosedStatus =
+  const statusCodeOptions =
     tsf?.tsf_operating_status_code === "CLO"
       ? [...TSF_OPERATING_STATUS_CODE, { value: "CLO", label: "Closed" }]
       : TSF_OPERATING_STATUS_CODE;
@@ -146,10 +146,10 @@ export const BasicInformation = (props) => {
         id="tsf_operating_status_code"
         name="tsf_operating_status_code"
         label="Operating Status"
-        data={includeClosedStatus}
+        data={statusCodeOptions}
         component={renderConfig.SELECT}
         disabled={viewOnly}
-        validate={[requiredList, validateSelectOptions(includeClosedStatus)]}
+        validate={[requiredList, validateSelectOptions(statusCodeOptions)]}
       />
       <Field
         id="itrb_exemption_status_code"

--- a/services/minespace-web/src/tests/components/common/__snapshots__/SteppedForm.spec.js.snap
+++ b/services/minespace-web/src/tests/components/common/__snapshots__/SteppedForm.spec.js.snap
@@ -73,7 +73,7 @@ exports[`SteppedForm renders properly 1`] = `
           </Button>
           <Button
             block={false}
-            disabled={true}
+            disabled={false}
             ghost={false}
             htmlType="button"
             loading={false}


### PR DESCRIPTION
## Objective 

[MDS-4848](https://bcmines.atlassian.net/browse/MDS-4848)

The `Closed` operating status no longer exists for TSFs, but previous TSFs may already have this assigned.  Added in logic to add it as an option when it already exists (to avoid showing "CLO" in the dropdown).

Also removed the code disabling the `Next` button in the stepped form if errors in the form validation were present, and instead properly triggered the validation messages on fields without navigating to the next page.

<img width="1018" alt="image" src="https://user-images.githubusercontent.com/83598933/200061302-1b241cb2-5717-48d6-a167-186774a806e2.png">
