### PR TITLE
[MDS-4856] Fix postal code error on NoW pages

### DIFF
--- a/services/core-api/app/api/parties/party/models/address.py
+++ b/services/core-api/app/api/parties/party/models/address.py
@@ -87,17 +87,15 @@ class Address(SoftDeleteMixin, AuditMixin, Base):
         return address
 
     # will be called for both fields, in the order defined in model, 1st call will be missing 2nd value
-    @validates('post_code', 'address_type_code')
-    def validate_address_code(self, key, value):
-        if key == 'address_type_code' and self.post_code is not None:
-            maxLength = 6
-            validPostalCode = re.compile(r"(^[ABCEGHJ-NPRSTVXY]\d[ABCEGHJ-NPRSTV-Z]\d[ABCEGHJ-NPRSTV-Z]\d$)")
-            if value == 'USA':
-                maxLength = 10
-                validPostalCode = re.compile(r"((^\d{5}$)|(^\d{9}$)|(^\d{5}-\d{4}$))")
-            if len(self.post_code) > maxLength:
-                raise AssertionError(f'post_code must not exceed {maxLength} characters.')
-            if not validPostalCode.match(self.post_code):
-                current_app.logger.error(f'Failed post_code validation for address {self.address_id}. post_code: {self.post_code}, address_type_code: {self.address_type_code}, value: {value}',)
-                raise AssertionError(f'Invalid post_code format.')
-        return value
+    @validates('post_code')
+    def validate_address_code(self, key, post_code):
+        if post_code and len(post_code) > 10:
+            raise AssertionError('post_code must not exceed 6 characters.')
+        # regex: CA | US postal codes
+        validCaPostalCode = re.compile(r"(^\d{5}(-\d{4})?$)|(^[abceghjklmnprstvxyABCEGHJKLMNPRSTVXY]{1}\d{1}[a-zA-Z]{1} *\d{1}[a-zA-Z]{1}\d{1}$)")
+        validUsPostalCode = re.compile(r"((^\d{5}$)|(^\d{9}$)|(^\d{5}-\d{4}$))")
+
+        if post_code and not validCaPostalCode.match(post_code) and not validUsPostalCode.match(post_code):
+            current_app.logger.error(f'Failed post_code validation for address {self.address_id}. post_code: {post_code}, address_type_code: {self.address_type_code}')
+
+            raise AssertionError('Invalid post_code format.')

--- a/services/core-api/app/api/parties/party/models/address.py
+++ b/services/core-api/app/api/parties/party/models/address.py
@@ -99,3 +99,4 @@ class Address(SoftDeleteMixin, AuditMixin, Base):
             current_app.logger.error(f'Failed post_code validation for address {self.address_id}. post_code: {post_code}, address_type_code: {self.address_type_code}')
 
             raise AssertionError('Invalid post_code format.')
+        return post_code

--- a/services/core-api/app/api/parties/party/models/address.py
+++ b/services/core-api/app/api/parties/party/models/address.py
@@ -90,7 +90,7 @@ class Address(SoftDeleteMixin, AuditMixin, Base):
     @validates('post_code')
     def validate_address_code(self, key, post_code):
         if post_code and len(post_code) > 10:
-            raise AssertionError('post_code must not exceed 6 characters.')
+            raise AssertionError('post_code must not exceed 10 characters.')
         # regex: CA | US postal codes
         validCaPostalCode = re.compile(r"(^\d{5}(-\d{4})?$)|(^[abceghjklmnprstvxyABCEGHJKLMNPRSTVXY]{1}\d{1}[a-zA-Z]{1} *\d{1}[a-zA-Z]{1}\d{1}$)")
         validUsPostalCode = re.compile(r"((^\d{5}$)|(^\d{9}$)|(^\d{5}-\d{4}$))")

--- a/services/core-api/tests/parties/address/models/test_address_model.py
+++ b/services/core-api/tests/parties/address/models/test_address_model.py
@@ -11,9 +11,9 @@ def test_party_model_validate_post_code():
             address_line_2='Bar',
             city='Baz',
             sub_division_code='AB',
-            post_code='0' * 7,
+            post_code='0' * 11,
             address_type_code='CAN')
-    assert 'post_code must not exceed 6 characters' in str(e.value)
+    assert 'post_code must not exceed 10 characters' in str(e.value)
 
     with pytest.raises(AssertionError) as e:
         Address(


### PR DESCRIPTION
## Objective 

[MDS-4856](https://bcmines.atlassian.net/browse/MDS-4856)

Relaxed the postal code validation of an address to fix errors that have been popping up where the validation fails when you do not know the address_type_code of an address (as in the case of some MMS applications). This still keeps support for both Canadian and US postal codes

_Why are you making this change? Provide a short explanation and/or screenshots_
