### PR TITLE
[MDS-4859] Filter out empty mine_documents

### DIFF
--- a/services/core-web/src/components/modalContent/EditFinalPermitDocumentPackage.js
+++ b/services/core-web/src/components/modalContent/EditFinalPermitDocumentPackage.js
@@ -49,7 +49,7 @@ export const EditFinalPermitDocumentPackage = (props) => {
                 now_application_document_type_code,
                 mine_document,
               }) =>
-                applicationFilesTypes.includes(now_application_document_sub_type_code) &&
+                mine_document?.mine_document_guid && applicationFilesTypes.includes(now_application_document_sub_type_code) &&
                 (now_application_document_type_code !== "PMT" ||
                   now_application_document_type_code !== "PMA" ||
                   mine_document.document_name.includes("DRAFT"))

--- a/services/core-web/src/components/noticeOfWork/applications/PermitPackage.js
+++ b/services/core-web/src/components/noticeOfWork/applications/PermitPackage.js
@@ -6,8 +6,6 @@ import { Button, notification } from "antd";
 import { DownloadOutlined } from "@ant-design/icons";
 import { openModal, closeModal } from "@common/actions/modalActions";
 import { getDocumentDownloadToken } from "@common/utils/actionlessNetworkCalls";
-import { modalConfig } from "@/components/modalContent/config";
-import CustomPropTypes from "@/customPropTypes";
 import {
   setNoticeOfWorkApplicationDocumentDownloadState,
   updateNoticeOfWorkApplication,
@@ -18,9 +16,11 @@ import {
   getNoticeOfWork,
   getNOWProgress,
 } from "@common/selectors/noticeOfWorkSelectors";
+import { getDropdownNoticeOfWorkApplicationReviewTypeOptions } from "@common/selectors/staticContentSelectors";
+import { modalConfig } from "@/components/modalContent/config";
+import CustomPropTypes from "@/customPropTypes";
 import { EDIT_OUTLINE_VIOLET, EDIT_OUTLINE } from "@/constants/assets";
 import * as Permission from "@/constants/permissions";
-import { getDropdownNoticeOfWorkApplicationReviewTypeOptions } from "@common/selectors/staticContentSelectors";
 import NOWActionWrapper from "@/components/noticeOfWork/NOWActionWrapper";
 
 /**
@@ -199,7 +199,7 @@ export class PermitPackage extends Component {
         noticeOfWork: this.props.noticeOfWork,
         importNowSubmissionDocumentsJob: this.props.importNowSubmissionDocumentsJob,
         submissionDocuments: this.props.noticeOfWork.filtered_submission_documents,
-        documents: this.props.noticeOfWork.documents,
+        documents: this.props.noticeOfWork.documents.filter(({mine_document}) => mine_document?.mine_document_guid),
         finalDocuments,
         finalSubmissionDocuments,
         onSubmit: this.createFinalDocumentPackage,

--- a/services/core-web/src/components/noticeOfWork/applications/administrative/NOWApplicationAdministrative.js
+++ b/services/core-web/src/components/noticeOfWork/applications/administrative/NOWApplicationAdministrative.js
@@ -47,8 +47,8 @@ export const NOWApplicationAdministrative = (props) => {
         <br />
         <NOWDocuments
           documents={props.noticeOfWork.documents.filter(
-            ({ now_application_document_sub_type_code }) =>
-              now_application_document_sub_type_code === "SDO"
+            ({ mine_document, now_application_document_sub_type_code }) =>
+              mine_document?.mine_document_guid && now_application_document_sub_type_code === "SDO"
           )}
           isViewMode={false}
           isAdminView
@@ -89,6 +89,7 @@ export const NOWApplicationAdministrative = (props) => {
                 now_application_document_type_code,
                 mine_document,
               }) =>
+                mine_document?.mine_document_guid &&
                 now_application_document_sub_type_code === "AEF" &&
                 (now_application_document_type_code !== "PMT" ||
                   now_application_document_type_code !== "PMA" ||

--- a/services/core-web/src/components/noticeOfWork/applications/manageDocuments/NOWApplicationManageDocuments.js
+++ b/services/core-web/src/components/noticeOfWork/applications/manageDocuments/NOWApplicationManageDocuments.js
@@ -54,6 +54,7 @@ export const NOWApplicationManageDocuments = (props) => {
                   now_application_document_type_code,
                   mine_document,
                 }) =>
+                  mine_document?.mine_document_guid &&
                   applicationFilesTypes.includes(now_application_document_sub_type_code) &&
                   (now_application_document_type_code !== "PMT" ||
                     now_application_document_type_code !== "PMA" ||
@@ -119,7 +120,11 @@ export const NOWApplicationManageDocuments = (props) => {
         isLoaded={props.isLoaded}
       >
         <NOWDocuments
-          documents={props.noticeOfWorkReviews.map((r) => r.documents).flat()}
+          documents={props.noticeOfWorkReviews
+            .map((r) =>
+              r.documents.filter(({ mine_document }) => mine_document?.mine_document_guid)
+            )
+            .flat()}
           isViewMode={props.isViewMode}
           isAdminView
           allowAfterProcess


### PR DESCRIPTION
## Objective 

[MDS-4859](https://bcmines.atlassian.net/browse/MDS-4859)

Hide NoW documents that don't have an associated `mine_document_guid`. This happens when a NoW document is soft-deleted. The document reference still exists, and does not respect the deleted flag

_Why are you making this change? Provide a short explanation and/or screenshots_
