### PR TITLE
[MDS-4859] Added soft-delete support for now_document_xref

### DIFF
--- a/migrations/sql/V2022.11.14.12.00__add_now_document_xref_delete_ind.sql
+++ b/migrations/sql/V2022.11.14.12.00__add_now_document_xref_delete_ind.sql
@@ -1,0 +1,11 @@
+ALTER TABLE
+    now_application_document_xref
+ADD
+    COLUMN IF NOT EXISTS deleted_ind boolean DEFAULT false NOT NULL;
+
+UPDATE
+    now_application_document_xref as x
+SET deleted_ind = d.deleted_ind
+FROM mine_document d
+WHERE
+    d.mine_document_guid = x.mine_document_guid;

--- a/services/core-api/app/api/now_applications/models/now_application.py
+++ b/services/core-api/app/api/now_applications/models/now_application.py
@@ -161,7 +161,7 @@ class NOWApplication(Base, AuditMixin):
         'NOWApplicationDocumentXref',
         lazy='selectin',
         primaryjoin=
-        'and_(NOWApplicationDocumentXref.now_application_id==NOWApplication.now_application_id, NOWApplicationDocumentXref.now_application_review_id==None)',
+        'and_(NOWApplicationDocumentXref.now_application_id==NOWApplication.now_application_id, NOWApplicationDocumentXref.now_application_review_id==None, NOWApplicationDocumentXref.deleted_ind==False)',
         order_by='desc(NOWApplicationDocumentXref.create_timestamp)')
 
     application_reason_codes = db.relationship(

--- a/services/core-api/app/api/now_applications/models/now_application_document_xref.py
+++ b/services/core-api/app/api/now_applications/models/now_application_document_xref.py
@@ -1,3 +1,4 @@
+from app.api.utils.models_mixins import SoftDeleteMixin
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.schema import FetchedValue
 from sqlalchemy.ext.associationproxy import association_proxy
@@ -8,7 +9,7 @@ from app.extensions import db
 from app.api.constants import NOW_APPLICATION_EDIT_GROUP
 
 
-class NOWApplicationDocumentXref(AuditMixin, Base):
+class NOWApplicationDocumentXref(SoftDeleteMixin, AuditMixin, Base):
     __tablename__ = 'now_application_document_xref'
 
     _edit_groups = [NOW_APPLICATION_EDIT_GROUP]
@@ -56,3 +57,7 @@ class NOWApplicationDocumentXref(AuditMixin, Base):
     @classmethod
     def find_by_guid(cls, guid):
         return cls.query.filter_by(now_application_document_xref_guid=guid).one_or_none()
+
+    def delete(self, commit=True):
+        self.mine_document.delete(commit)
+        super(NOWApplicationDocumentXref, self).delete(commit)

--- a/services/core-api/app/api/now_applications/resources/now_application_document_resource.py
+++ b/services/core-api/app/api/now_applications/resources/now_application_document_resource.py
@@ -96,8 +96,8 @@ class NOWApplicationDocumentResource(Resource, UserMixin):
             raise BadRequest(
                 'You cannot remove a document that is a part of the Consultation Package.')
 
-        mine_document.deleted_ind = True
-        mine_document.save()
+        mine_document.now_application_document_xref.delete(True)
+
         return None, 204
 
     @api.response(requests.codes.ok, 'Successfully updated document details.')


### PR DESCRIPTION
## Objective 

[MDS-4859](https://bcmines.atlassian.net/browse/MDS-4859)
This PR fixes the issue where deleted documents causes errors when modifying consultation packages/permit packages in core. 
Added soft delete functionality to the document xref to match the document itself so we can properly exclude it when deleted

_Why are you making this change? Provide a short explanation and/or screenshots_
