### PR TITLE
[MDS-4559] core edit dams webpack fix

### DIFF
--- a/services/core-web/webpack.config.js
+++ b/services/core-web/webpack.config.js
@@ -147,7 +147,7 @@ const prodConfig = merge([
         quality: 40,
       },
       pngquant: {
-        quality: "50-60",
+        quality: [0.50, 0.60],
         speed: 4,
       },
     },

--- a/services/minespace-web/webpack.config.js
+++ b/services/minespace-web/webpack.config.js
@@ -140,7 +140,7 @@ const prodConfig = merge([
         quality: 40,
       },
       pngquant: {
-        quality: "50-60",
+        quality: [0.50, 0.60],
         speed: 4,
       },
     },


### PR DESCRIPTION
## Objective 

[MDS-4559](https://bcmines.atlassian.net/browse/MDS-4559)

Was receiving this error when attempting to build and deploy to dev:

```Module build failed (from /app/node_modules/image-webpack-loader/index.js):
ArgumentError: Expected `options.quality` to be of type `array` but received type `string`
```

Updated webpack configs in Minespace and core to change options.quality to an array from a string.
