### PR TITLE
[MDS-4877] Fix sorting of EoRs when they don't have a start date

### DIFF
--- a/services/core-api/app/api/mines/tailings/models/tailings.py
+++ b/services/core-api/app/api/mines/tailings/models/tailings.py
@@ -63,7 +63,7 @@ class MineTailingsStorageFacility(AuditMixin, Base):
         'MineTailingsStorageFacility.mine_tailings_storage_facility_guid, '
         'MinePartyAppointment.mine_party_appt_type_code == "EOR", MinePartyAppointment.deleted_ind == False)',
         order_by=
-        'nullsfirst(desc(MinePartyAppointment.start_date)), nullsfirst(desc(MinePartyAppointment.end_date))'
+        'nullslast(desc(MinePartyAppointment.start_date)), nullsfirst(desc(MinePartyAppointment.end_date))'
     )
     dams = db.relationship(
         'Dam',
@@ -81,7 +81,7 @@ class MineTailingsStorageFacility(AuditMixin, Base):
         primaryjoin=
         'and_(MinePartyAppointment.mine_tailings_storage_facility_guid == MineTailingsStorageFacility.mine_tailings_storage_facility_guid, MinePartyAppointment.mine_party_appt_type_code == "TQP", MinePartyAppointment.deleted_ind == False)',
         order_by=
-        'nullsfirst(desc(MinePartyAppointment.start_date)), nullsfirst(desc(MinePartyAppointment.end_date))'
+        'nullslast(desc(MinePartyAppointment.start_date)), nullsfirst(desc(MinePartyAppointment.end_date))'
     )
 
     @hybrid_property

--- a/services/core-web/common/components/PartyAppointmentTable.js
+++ b/services/core-web/common/components/PartyAppointmentTable.js
@@ -61,7 +61,7 @@ const PartyAppointmentTable = (props) => {
   );
 
   const transformRowData = (partyRelationships) =>
-    partyRelationships.map((r) => {
+    partyRelationships.map((r, ind) => {
       let endDate = r.end_date;
 
       if (!endDate && r.start_date) {
@@ -76,14 +76,15 @@ const PartyAppointmentTable = (props) => {
         startDate: r.start_date || "Unknown",
         endDate,
         letters: r.documents || [],
-        status: moment(r.end_date).isBefore(moment()) || !r.start_date ? "Inactive" : "Active",
+        status: ind === 0? "Active": "Inactive",
         ministryAcknowledged: "N/A",
       };
     });
 
-  const sortedRelationships = props.partyRelationships.sort((a, b) =>
-    moment(a.start_date, "YYYY-MM-DD") >= moment(b.start_date, "YYYY-MM-DD") ? -1 : 1
-  );
+  const sortedRelationships = props.partyRelationships.sort((a, b) => {
+      return moment(a.start_date || '1970-01-01', "YYYY-MM-DD").isAfter(moment(b.start_date || '1970-01-01', "YYYY-MM-DD")) ? -1 : 1
+    }
+  );  
 
   return (
     <Row>

--- a/services/core-web/common/components/PartyAppointmentTable.js
+++ b/services/core-web/common/components/PartyAppointmentTable.js
@@ -76,15 +76,18 @@ const PartyAppointmentTable = (props) => {
         startDate: r.start_date || "Unknown",
         endDate,
         letters: r.documents || [],
-        status: ind === 0? "Active": "Inactive",
+        status: ind === 0 ? "Active" : "Inactive",
         ministryAcknowledged: "N/A",
       };
     });
 
   const sortedRelationships = props.partyRelationships.sort((a, b) => {
-      return moment(a.start_date || '1970-01-01', "YYYY-MM-DD").isAfter(moment(b.start_date || '1970-01-01', "YYYY-MM-DD")) ? -1 : 1
-    }
-  );  
+    return moment(a.start_date || "1970-01-01", "YYYY-MM-DD").isAfter(
+      moment(b.start_date || "1970-01-01", "YYYY-MM-DD")
+    )
+      ? -1
+      : 1;
+  });
 
   return (
     <Row>

--- a/services/minespace-web/common/components/PartyAppointmentTable.js
+++ b/services/minespace-web/common/components/PartyAppointmentTable.js
@@ -61,7 +61,7 @@ const PartyAppointmentTable = (props) => {
   );
 
   const transformRowData = (partyRelationships) =>
-    partyRelationships.map((r) => {
+    partyRelationships.map((r, ind) => {
       let endDate = r.end_date;
 
       if (!endDate && r.start_date) {
@@ -76,14 +76,18 @@ const PartyAppointmentTable = (props) => {
         startDate: r.start_date || "Unknown",
         endDate,
         letters: r.documents || [],
-        status: moment(r.end_date).isBefore(moment()) || !r.start_date ? "Inactive" : "Active",
+        status: ind === 0 ? "Active" : "Inactive",
         ministryAcknowledged: "N/A",
       };
     });
 
-  const sortedRelationships = props.partyRelationships.sort((a, b) =>
-    moment(a.start_date, "YYYY-MM-DD") >= moment(b.start_date, "YYYY-MM-DD") ? -1 : 1
-  );
+  const sortedRelationships = props.partyRelationships.sort((a, b) => {
+    return moment(a.start_date || "1970-01-01", "YYYY-MM-DD").isAfter(
+      moment(b.start_date || "1970-01-01", "YYYY-MM-DD")
+    )
+      ? -1
+      : 1;
+  });
 
   return (
     <Row>


### PR DESCRIPTION
## Objective 

[MDS-4877](https://bcmines.atlassian.net/browse/MDS-4877)

Modified sorting of the EoR list to account for EoRs without a start date - it should not happen, but at least in dev there's some cases where this happens.

_Why are you making this change? Provide a short explanation and/or screenshots_
