### PR TITLE
[MDS-4038] Drop down styling 2

### DIFF
--- a/services/core-web/src/components/common/RenderLargeSelect.js
+++ b/services/core-web/src/components/common/RenderLargeSelect.js
@@ -64,6 +64,7 @@ const RenderLargeSelect = (props) => (
       notFoundContent="Not Found"
       dropdownMatchSelectWidth
       backfill
+      getPopupContainer={(trigger) => trigger.parentNode}
       style={{ width: "100%" }}
       options={props.dataSource}
       placeholder={props.placeholder}

--- a/services/core-web/src/components/common/RenderSelect.js
+++ b/services/core-web/src/components/common/RenderSelect.js
@@ -57,7 +57,7 @@ const RenderSelect = (props) => {
         dropdownMatchSelectWidth
         getPopupContainer={(trigger) => trigger.parentNode}
         showSearch
-        dropdownStyle={{ zIndex: 100000, position: "relative" }}
+        dropdownStyle={{ position: "relative" }}
         placeholder={props.placeholder}
         optionFilterProp="children"
         filterOption={(input, option) =>
@@ -71,7 +71,7 @@ const RenderSelect = (props) => {
       >
         {props.data.map((opt) => (
           <Select.Option
-            style={{ zIndex: 10000, position: "relative" }}
+            style={{ position: "relative" }}
             disabled={props.usedOptions && props.usedOptions.includes(opt.value)}
             key={opt.value}
             value={opt.value}

--- a/services/core-web/src/styles/components/NoticeOfWork.scss
+++ b/services/core-web/src/styles/components/NoticeOfWork.scss
@@ -92,8 +92,12 @@
       position: fixed;
       width: 100vw;
       background-color: $pure-white;
-      z-index: 50;
+      z-index: 950;
       box-shadow: $default-box-shadow;
+
+      .ant-select-dropdown {
+        z-index: 960;
+      }
     }
     &--content {
       padding: 10px;

--- a/services/core-web/src/styles/settings/themeOverride.scss
+++ b/services/core-web/src/styles/settings/themeOverride.scss
@@ -649,6 +649,10 @@ select {
   margin-top: -12px;
 }
 
+.ant-select-dropdown {
+  z-index: 900;
+}
+
 // update HTML select component to look like the ant design select. This block of code changes the default icon
 select {
   width: inherit;

--- a/services/core-web/src/tests/components/common/__snapshots__/RenderLargeSelect.spec.js.snap
+++ b/services/core-web/src/tests/components/common/__snapshots__/RenderLargeSelect.spec.js.snap
@@ -15,6 +15,7 @@ exports[`RenderLargeSelect renders properly 1`] = `
     disabled={false}
     dropdownMatchSelectWidth={true}
     filterOption={[Function]}
+    getPopupContainer={[Function]}
     id="parties"
     notFoundContent="Not Found"
     onChange={

--- a/services/core-web/src/tests/components/common/__snapshots__/RenderSelect.spec.js.snap
+++ b/services/core-web/src/tests/components/common/__snapshots__/RenderSelect.spec.js.snap
@@ -19,7 +19,6 @@ exports[`RenderSelect renders properly 1`] = `
     dropdownStyle={
       Object {
         "position": "relative",
-        "zIndex": 100000,
       }
     }
     filterOption={[Function]}
@@ -38,7 +37,6 @@ exports[`RenderSelect renders properly 1`] = `
       style={
         Object {
           "position": "relative",
-          "zIndex": 10000,
         }
       }
     />
@@ -47,7 +45,6 @@ exports[`RenderSelect renders properly 1`] = `
       style={
         Object {
           "position": "relative",
-          "zIndex": 10000,
         }
       }
     />

--- a/services/minespace-web/src/components/common/RenderSelect.js
+++ b/services/minespace-web/src/components/common/RenderSelect.js
@@ -57,7 +57,7 @@ const RenderSelect = (props) => {
         dropdownMatchSelectWidth
         getPopupContainer={(trigger) => trigger.parentNode}
         showSearch
-        dropdownStyle={{ zIndex: 100000, position: "relative" }}
+        dropdownStyle={{ position: "relative" }}
         placeholder={props.placeholder}
         optionFilterProp="children"
         filterOption={(input, option) =>
@@ -71,7 +71,7 @@ const RenderSelect = (props) => {
       >
         {props.data.map((opt) => (
           <Select.Option
-            style={{ zIndex: 10000, position: "relative" }}
+            style={{ position: "relative" }}
             disabled={props.usedOptions && props.usedOptions.includes(opt.value)}
             key={opt.value}
             value={opt.value}


### PR DESCRIPTION
## Objective 
Redoing previous PR that has since been reverted.

[MDS-4038](https://bcmines.atlassian.net/browse/MDS-4038)

Fixed additional bug created where certain instances of Select boxes that had their option list rendering outside of the parent were not showing correctly, by attaching the list to its parent.
Otherwise the same as https://github.com/bcgov/mds/pull/2332
