### PR TITLE
[MDS-4895] Notification when TSF has new EoR or QP

### DIFF
--- a/services/core-api/app/api/parties/party_appt/resources/mine_party_appt_resource.py
+++ b/services/core-api/app/api/parties/party_appt/resources/mine_party_appt_resource.py
@@ -18,6 +18,8 @@ from app.api.parties.party_appt.models.mine_party_appt import MinePartyAppointme
 from app.api.parties.party_appt.models.mine_party_appt_type import MinePartyAppointmentType
 from app.api.mines.tailings.models.tailings import MineTailingsStorageFacility
 from app.api.constants import PERMIT_LINKED_CONTACT_TYPES, TSF_ALLOWED_CONTACT_TYPES
+from app.api.activity.utils import trigger_notifcation
+
 
 class MinePartyApptResource(Resource, UserMixin):
     parser = CustomReqparser()
@@ -117,8 +119,8 @@ class MinePartyApptResource(Resource, UserMixin):
                 raise NotFound('TSF not found')
 
         if not can_edit_mines():
-            # Make sure Minespace users can only assign EORs, associate pre-existing parties for the mine 
-            if mine_party_appt_type_code not in  TSF_ALLOWED_CONTACT_TYPES:
+            # Make sure Minespace users can only assign EORs, associate pre-existing parties for the mine
+            if mine_party_appt_type_code not in TSF_ALLOWED_CONTACT_TYPES:
                 raise Forbidden("Minespace user can only appoint EORs and Qualified Persons")
 
             if not tsf or mine.mine_guid != tsf.mine_guid:
@@ -163,6 +165,11 @@ class MinePartyApptResource(Resource, UserMixin):
                 mpa_type_name = MinePartyAppointmentType.find_by_mine_party_appt_type_code(
                     data.get('mine_party_appt_type_code')).description
                 raise BadRequest(f'Date ranges for {mpa_type_name} must not overlap')
+
+        if mine_party_appt_type_code == "EOR":
+            trigger_notifcation(f'A new Engineer of Record for {mine.mine_name} has been assigned and requires Ministry Acknowledgement to allow for the mine\'s compliance.', mine, "TSF_EngineerOfRecord", tsf.mine_tailings_storage_facility_guid)
+        if mine_party_appt_type_code == "TQP":
+            trigger_notifcation(f'A new Qualified Person for {mine.mine_name} has been assigned.', mine, "TSF_QualifiedPerson", tsf.mine_tailings_storage_facility_guid)
 
         return new_mpa.json()
 

--- a/services/core-api/app/api/parties/party_appt/resources/mine_party_appt_resource.py
+++ b/services/core-api/app/api/parties/party_appt/resources/mine_party_appt_resource.py
@@ -167,9 +167,9 @@ class MinePartyApptResource(Resource, UserMixin):
                 raise BadRequest(f'Date ranges for {mpa_type_name} must not overlap')
 
         if mine_party_appt_type_code == "EOR":
-            trigger_notifcation(f'A new Engineer of Record for {mine.mine_name} has been assigned and requires Ministry Acknowledgement to allow for the mine\'s compliance.', mine, "TSF_EngineerOfRecord", tsf.mine_tailings_storage_facility_guid)
+            trigger_notifcation(f'A new Engineer of Record for {mine.mine_name} has been assigned and requires Ministry Acknowledgement to allow for the mine\'s compliance.', mine, "EngineerOfRecord", tsf.mine_tailings_storage_facility_guid)
         if mine_party_appt_type_code == "TQP":
-            trigger_notifcation(f'A new Qualified Person for {mine.mine_name} has been assigned.', mine, "TSF_QualifiedPerson", tsf.mine_tailings_storage_facility_guid)
+            trigger_notifcation(f'A new Qualified Person for {mine.mine_name} has been assigned.', mine, "QualifiedPerson", tsf.mine_tailings_storage_facility_guid)
 
         return new_mpa.json()
 

--- a/services/core-web/src/components/navigation/NotificationDrawer.js
+++ b/services/core-web/src/components/navigation/NotificationDrawer.js
@@ -13,7 +13,7 @@ import { getActivities } from "@common/selectors/activitySelectors";
 import { getUserInfo } from "@common/selectors/authenticationSelectors";
 import { useHistory } from "react-router-dom";
 import { storeActivities } from "@common/actions/activityActions";
-import { NOTICE_OF_DEPARTURE, MINE_INCIDENT } from "@/constants/routes";
+import { NOTICE_OF_DEPARTURE, MINE_INCIDENT, MINE_TAILINGS_DETAILS } from "@/constants/routes";
 
 const propTypes = {
   fetchActivities: PropTypes.func.isRequired,
@@ -99,6 +99,18 @@ const NotificationDrawer = (props) => {
         return MINE_INCIDENT.dynamicRoute(
           notification.notification_document.metadata.mine_guid,
           notification.notification_document.metadata.entity_guid
+        );
+      case "TSF_EngineerOfRecord":
+        return MINE_TAILINGS_DETAILS.dynamicRoute(
+          notification.notification_document.metadata.mine.mine_guid,
+          notification.notification_document.metadata.entity_guid,
+          "engineer-of-record"
+        );
+      case "TSF_QualifiedPerson":
+        return MINE_TAILINGS_DETAILS.dynamicRoute(
+          notification.notification_document.metadata.mine.mine_guid,
+          notification.notification_document.metadata.entity_guid,
+          "qualified-person"
         );
       default:
         return null;

--- a/services/core-web/src/components/navigation/NotificationDrawer.js
+++ b/services/core-web/src/components/navigation/NotificationDrawer.js
@@ -102,14 +102,14 @@ const NotificationDrawer = (props) => {
         );
       case "TSF_EngineerOfRecord":
         return MINE_TAILINGS_DETAILS.dynamicRoute(
-          notification.notification_document.metadata.mine.mine_guid,
           notification.notification_document.metadata.entity_guid,
+          notification.notification_document.metadata.mine.mine_guid,
           "engineer-of-record"
         );
       case "TSF_QualifiedPerson":
         return MINE_TAILINGS_DETAILS.dynamicRoute(
-          notification.notification_document.metadata.mine.mine_guid,
           notification.notification_document.metadata.entity_guid,
+          notification.notification_document.metadata.mine.mine_guid,
           "qualified-person"
         );
       default:

--- a/services/core-web/src/components/navigation/NotificationDrawer.js
+++ b/services/core-web/src/components/navigation/NotificationDrawer.js
@@ -100,13 +100,13 @@ const NotificationDrawer = (props) => {
           notification.notification_document.metadata.mine_guid,
           notification.notification_document.metadata.entity_guid
         );
-      case "TSF_EngineerOfRecord":
+      case "EngineerOfRecord":
         return MINE_TAILINGS_DETAILS.dynamicRoute(
           notification.notification_document.metadata.entity_guid,
           notification.notification_document.metadata.mine.mine_guid,
           "engineer-of-record"
         );
-      case "TSF_QualifiedPerson":
+      case "QualifiedPerson":
         return MINE_TAILINGS_DETAILS.dynamicRoute(
           notification.notification_document.metadata.entity_guid,
           notification.notification_document.metadata.mine.mine_guid,

--- a/services/minespace-web/src/components/layout/NotificationDrawer.js
+++ b/services/minespace-web/src/components/layout/NotificationDrawer.js
@@ -13,7 +13,11 @@ import { getActivities } from "@common/selectors/activitySelectors";
 import { getUserInfo } from "@common/selectors/authenticationSelectors";
 import { storeActivities } from "@common/actions/activityActions";
 import { useHistory } from "react-router-dom";
-import { MINE_DASHBOARD, EDIT_MINE_INCIDENT } from "@/constants/routes";
+import {
+  MINE_DASHBOARD,
+  EDIT_MINE_INCIDENT,
+  EDIT_TAILINGS_STORAGE_FACILITY,
+} from "@/constants/routes";
 
 const propTypes = {
   fetchActivities: PropTypes.func.isRequired,
@@ -102,6 +106,18 @@ const NotificationDrawer = (props) => {
         return EDIT_MINE_INCIDENT.dynamicRoute(
           notification.notification_document.metadata.mine.mine_guid,
           notification.notification_document.metadata.entity_guid
+        );
+      case "EngineerOfRecord":
+        return EDIT_TAILINGS_STORAGE_FACILITY.dynamicRoute(
+          notification.notification_document.metadata.entity_guid,
+          notification.notification_document.metadata.mine.mine_guid,
+          "engineer-of-record"
+        );
+      case "QualifiedPerson":
+        return EDIT_TAILINGS_STORAGE_FACILITY.dynamicRoute(
+          notification.notification_document.metadata.entity_guid,
+          notification.notification_document.metadata.mine.mine_guid,
+          "qualified-person"
         );
       default:
         return null;


### PR DESCRIPTION
## Objective 

[MDS-4895](https://bcmines.atlassian.net/browse/MDS-4895)

- when a TSF has a new EoR or QP, notify users subscribed to the mine
- clicking on the notification directs user to view the TSF, and the tab of the new person

- should be resolved first:
  - my current user has the permissions to view the page the notification directs them to, but they _do not_ have the permissions to navigate to the same page through the UI
  - my suggestion is to change the condition that shows the "View" button for the TSF on the mine page
