### PR TITLE
[MDS-4905] Tooltip "floating": disable background scroll

### DIFF
--- a/services/core-web/src/components/common/wrappers/ModalWrapper.js
+++ b/services/core-web/src/components/common/wrappers/ModalWrapper.js
@@ -51,6 +51,7 @@ const ModalWrapper = (props) => {
     propCloseModal();
   };
 
+  // listens for browser back || forward button click and invokes function to close the modal
   window.onpopstate = onBrowserButtonEvent;
 
   useEffect(() => {

--- a/services/core-web/src/components/common/wrappers/ModalWrapper.js
+++ b/services/core-web/src/components/common/wrappers/ModalWrapper.js
@@ -39,7 +39,7 @@ const defaultProps = {
 export const ModalWrapper = (props) => {
   const {
     props: childProps,
-    closeModal: propCloseModal,
+    closeModal: handleCloseModal,
     isModalOpen,
     isViewOnly,
     width,
@@ -48,7 +48,7 @@ export const ModalWrapper = (props) => {
   } = props;
 
   const onBrowserButtonEvent = () => {
-    propCloseModal();
+    handleCloseModal();
   };
 
   // listens for browser back || forward button click and invokes function to close the modal
@@ -65,7 +65,7 @@ export const ModalWrapper = (props) => {
 
   const closeModal = (event) => {
     event.preventDefault();
-    propCloseModal();
+    handleCloseModal();
     // default props only shallow merged, may be undefined
     if (childProps.afterClose) {
       childProps.afterClose();
@@ -110,7 +110,7 @@ export const ModalWrapper = (props) => {
       />
       {content && (
         <AddPartyComponentWrapper
-          closeModal={propCloseModal}
+          closeModal={handleCloseModal}
           clearOnSubmit={clearOnSubmit}
           content={content}
           childProps={childProps}

--- a/services/core-web/src/components/common/wrappers/ModalWrapper.js
+++ b/services/core-web/src/components/common/wrappers/ModalWrapper.js
@@ -36,7 +36,7 @@ const defaultProps = {
   content: () => {},
 };
 
-const ModalWrapper = (props) => {
+export const ModalWrapper = (props) => {
   const {
     props: childProps,
     closeModal: propCloseModal,

--- a/services/core-web/src/styles/settings/themeOverride.scss
+++ b/services/core-web/src/styles/settings/themeOverride.scss
@@ -236,7 +236,6 @@
 }
 
 .ant-popover {
-  position: fixed;
   width: 500px;
 }
 


### PR DESCRIPTION
## Objective 

[MDS-4905](https://bcmines.atlassian.net/browse/MDS-4905)

_Why are you making this change? Provide a short explanation and/or screenshots_
- a rule was once added to set popover position to fixed
- this was because tooltips within modals (ex: are you sure you want to close? type popover) would move their positions around a lot without the fixed rule when the background was scrolled, even off of the page
- this problem, and also issues with option lists within select, is resolved when the background is disabled on the <body> when a modal is visible
- enabling me to remove the position:fixed rule that was interfering in non-modal contexts
- the popover on a modal still wiggles a little bit because the modal is a little too tall for the page (same behaviour as before, doesn't affect functionality)