### PR TITLE
[MDS-4895] Disable sending of eor/qfp notification in production

### DIFF
--- a/services/core-api/app/api/parties/party_appt/resources/mine_party_appt_resource.py
+++ b/services/core-api/app/api/parties/party_appt/resources/mine_party_appt_resource.py
@@ -19,7 +19,7 @@ from app.api.parties.party_appt.models.mine_party_appt_type import MinePartyAppo
 from app.api.mines.tailings.models.tailings import MineTailingsStorageFacility
 from app.api.constants import PERMIT_LINKED_CONTACT_TYPES, TSF_ALLOWED_CONTACT_TYPES
 from app.api.activity.utils import trigger_notifcation
-
+from app.config import Config
 
 class MinePartyApptResource(Resource, UserMixin):
     parser = CustomReqparser()
@@ -166,10 +166,12 @@ class MinePartyApptResource(Resource, UserMixin):
                     data.get('mine_party_appt_type_code')).description
                 raise BadRequest(f'Date ranges for {mpa_type_name} must not overlap')
 
-        if mine_party_appt_type_code == "EOR":
-            trigger_notifcation(f'A new Engineer of Record for {mine.mine_name} has been assigned and requires Ministry Acknowledgement to allow for the mine\'s compliance.', mine, "EngineerOfRecord", tsf.mine_tailings_storage_facility_guid)
-        if mine_party_appt_type_code == "TQP":
-            trigger_notifcation(f'A new Qualified Person for {mine.mine_name} has been assigned.', mine, "QualifiedPerson", tsf.mine_tailings_storage_facility_guid)
+        if Config.ENVIRONMENT_NAME != 'prod':
+            # TODO: Remove this once TSF functionality is ready to go live
+            if mine_party_appt_type_code == "EOR":
+                trigger_notifcation(f'A new Engineer of Record for {mine.mine_name} has been assigned and requires Ministry Acknowledgement to allow for the mine\'s compliance.', mine, "EngineerOfRecord", tsf.mine_tailings_storage_facility_guid)
+            if mine_party_appt_type_code == "TQP":
+                trigger_notifcation(f'A new Qualified Person for {mine.mine_name} has been assigned.', mine, "QualifiedPerson", tsf.mine_tailings_storage_facility_guid)
 
         return new_mpa.json()
 


### PR DESCRIPTION
## Objective 

[MDS-4895](https://bcmines.atlassian.net/browse/MDS-4895)

Disable sending of EOR/QFP notification in production, as those pages are currently feature flagged.

_Why are you making this change? Provide a short explanation and/or screenshots_
