### PR TITLE
[MDS-4610] Fixed loading / refresh of EOR history list

### DIFF
--- a/services/core-api/app/api/parties/party_appt/models/mine_party_appt.py
+++ b/services/core-api/app/api/parties/party_appt/models/mine_party_appt.py
@@ -320,7 +320,7 @@ class MinePartyAppointment(SoftDeleteMixin, AuditMixin, Base):
         if len(current_mpa) != 1:
             raise BAD_REQUEST('There is currently not exactly one active appointment.')
 
-        if validate_new_start_date and current_mpa.start_date and new_start_date < current_mpa.start_date:
+        if validate_new_start_date and current_mpa[0].start_date and new_start_date < current_mpa[0].start_date:
             return False
 
         current_mpa[0].status = MinePartyAppointmentStatus.inactive

--- a/services/core-web/common/actionCreators/partiesActionCreator.js
+++ b/services/core-web/common/actionCreators/partiesActionCreator.js
@@ -139,7 +139,12 @@ export const fetchPartyRelationships = (params) => (dispatch) => {
     )
     .then((response) => {
       dispatch(success(reducerTypes.FETCH_PARTY_RELATIONSHIPS));
-      dispatch(partyActions.storePartyRelationships(response.data, params.mine_tailings_storage_facility_guid));
+      dispatch(
+        partyActions.storePartyRelationships(
+          response.data,
+          params.mine_tailings_storage_facility_guid
+        )
+      );
       return response.data;
     })
     .catch(() => dispatch(error(reducerTypes.FETCH_PARTY_RELATIONSHIPS)))

--- a/services/core-web/common/actionCreators/partiesActionCreator.js
+++ b/services/core-web/common/actionCreators/partiesActionCreator.js
@@ -139,7 +139,7 @@ export const fetchPartyRelationships = (params) => (dispatch) => {
     )
     .then((response) => {
       dispatch(success(reducerTypes.FETCH_PARTY_RELATIONSHIPS));
-      dispatch(partyActions.storePartyRelationships(response.data));
+      dispatch(partyActions.storePartyRelationships(response.data, params.mine_tailings_storage_facility_guid));
       return response.data;
     })
     .catch(() => dispatch(error(reducerTypes.FETCH_PARTY_RELATIONSHIPS)))

--- a/services/core-web/common/actions/partyActions.js
+++ b/services/core-web/common/actions/partyActions.js
@@ -11,9 +11,10 @@ export const storeParty = (payload, id) => ({
   id,
 });
 
-export const storePartyRelationships = (payload) => ({
+export const storePartyRelationships = (payload, mine_tailings_storage_facility_guid=null) => ({
   type: ActionTypes.STORE_PARTY_RELATIONSHIPS,
   payload,
+  mine_tailings_storage_facility_guid,
 });
 
 export const storeAllPartyRelationships = (payload) => ({

--- a/services/core-web/common/actions/partyActions.js
+++ b/services/core-web/common/actions/partyActions.js
@@ -11,7 +11,7 @@ export const storeParty = (payload, id) => ({
   id,
 });
 
-export const storePartyRelationships = (payload, mine_tailings_storage_facility_guid=null) => ({
+export const storePartyRelationships = (payload, mine_tailings_storage_facility_guid = null) => ({
   type: ActionTypes.STORE_PARTY_RELATIONSHIPS,
   payload,
   mine_tailings_storage_facility_guid,

--- a/services/core-web/common/components/tailings/TailingsSummaryPage.js
+++ b/services/core-web/common/components/tailings/TailingsSummaryPage.js
@@ -98,7 +98,7 @@ export const TailingsSummaryPage = (props) => {
           relationships: "party",
           include_permit_contacts: "true",
           mine_tailings_storage_facility_guid: tsfGuid,
-        });  
+        });
       }
     }
     setIsLoaded(true);

--- a/services/core-web/common/components/tailings/TailingsSummaryPage.js
+++ b/services/core-web/common/components/tailings/TailingsSummaryPage.js
@@ -92,14 +92,14 @@ export const TailingsSummaryPage = (props) => {
         );
 
         props.storeTsf(existingTsf);
-      }
 
-      await props.fetchPartyRelationships({
-        mine_guid: mineGuid,
-        relationships: "party",
-        include_permit_contacts: "true",
-        mine_tailings_storage_facility_guid: tsfGuid,
-      });
+        await props.fetchPartyRelationships({
+          mine_guid: mineGuid,
+          relationships: "party",
+          include_permit_contacts: "true",
+          mine_tailings_storage_facility_guid: tsfGuid,
+        });  
+      }
     }
     setIsLoaded(true);
     setIsReloading(false);

--- a/services/core-web/common/reducers/partiesReducer.js
+++ b/services/core-web/common/reducers/partiesReducer.js
@@ -41,6 +41,7 @@ export const partiesReducer = (state = initialState, action) => {
         partyIds: createItemIdsArray([action.payload], "party_guid"),
       };
     case actionTypes.STORE_PARTY_RELATIONSHIPS:
+      const tsfGuid = action.mine_tailings_storage_facility_guid;
       const eors = action.payload
         .filter((p) => p.mine_party_appt_type_code === "EOR")
         .map((p) => ({
@@ -48,26 +49,26 @@ export const partiesReducer = (state = initialState, action) => {
           label: p.party.name,
         }));
 
-      const eorRecords = state.tsf
+      const eorRecords = tsfGuid
         ? action.payload.filter(
             (p) =>
               p.mine_party_appt_type_code === "EOR" &&
-              p.related_guid === state.tsf.mine_tailings_storage_facility_guid
+              p.related_guid === tsfGuid
           )
         : [];
-      const qfpRecords = state.tsf
+      const qfpRecords = tsfGuid
         ? action.payload.filter(
             (p) =>
               p.mine_party_appt_type_code === "QFP" &&
-              p.related_guid === state.tsf.mine_tailings_storage_facility_guid
+              p.related_guid === tsfGuid
           )
         : [];
 
       return {
         ...state,
         partyRelationships: action.payload,
-        engineersOfRecord: eorRecords,
-        qualifiedPersons: qfpRecords,
+        engineersOfRecord: tsfGuid? eorRecords: state.engineersOfRecord,
+        qualifiedPersons: tsfGuid? qfpRecords: state.qualifiedPersons,
         engineersOfRecordOptions: uniqBy(eors, "value"),
       };
     case actionTypes.STORE_ALL_PARTY_RELATIONSHIPS:

--- a/services/core-web/common/reducers/partiesReducer.js
+++ b/services/core-web/common/reducers/partiesReducer.js
@@ -51,24 +51,20 @@ export const partiesReducer = (state = initialState, action) => {
 
       const eorRecords = tsfGuid
         ? action.payload.filter(
-            (p) =>
-              p.mine_party_appt_type_code === "EOR" &&
-              p.related_guid === tsfGuid
+            (p) => p.mine_party_appt_type_code === "EOR" && p.related_guid === tsfGuid
           )
         : [];
       const qfpRecords = tsfGuid
         ? action.payload.filter(
-            (p) =>
-              p.mine_party_appt_type_code === "QFP" &&
-              p.related_guid === tsfGuid
+            (p) => p.mine_party_appt_type_code === "QFP" && p.related_guid === tsfGuid
           )
         : [];
 
       return {
         ...state,
         partyRelationships: action.payload,
-        engineersOfRecord: tsfGuid? eorRecords: state.engineersOfRecord,
-        qualifiedPersons: tsfGuid? qfpRecords: state.qualifiedPersons,
+        engineersOfRecord: tsfGuid ? eorRecords : state.engineersOfRecord,
+        qualifiedPersons: tsfGuid ? qfpRecords : state.qualifiedPersons,
         engineersOfRecordOptions: uniqBy(eors, "value"),
       };
     case actionTypes.STORE_ALL_PARTY_RELATIONSHIPS:

--- a/services/core-web/src/components/mine/Tailings/TailingsSummaryPageWrapper.js
+++ b/services/core-web/src/components/mine/Tailings/TailingsSummaryPageWrapper.js
@@ -43,6 +43,7 @@ export const TailingsSummaryPageWrapper = (props) => {
       renderConfig={renderConfig}
       addContactModalConfig={modalConfig.ADD_PARTY_RELATIONSHIP}
       tsfFormName={FORM.ADD_STORAGE_FACILITY}
+      tsfGuid={match.params.tailingsStorageFacilityGuid}
       showUpdateTimestamp
       routes={routes}
       eorHistoryColumns={['name', 'status', 'dates', 'letters', 'ministryAcknowledged']}

--- a/services/minespace-web/common/actionCreators/partiesActionCreator.js
+++ b/services/minespace-web/common/actionCreators/partiesActionCreator.js
@@ -139,7 +139,12 @@ export const fetchPartyRelationships = (params) => (dispatch) => {
     )
     .then((response) => {
       dispatch(success(reducerTypes.FETCH_PARTY_RELATIONSHIPS));
-      dispatch(partyActions.storePartyRelationships(response.data));
+      dispatch(
+        partyActions.storePartyRelationships(
+          response.data,
+          params.mine_tailings_storage_facility_guid
+        )
+      );
       return response.data;
     })
     .catch(() => dispatch(error(reducerTypes.FETCH_PARTY_RELATIONSHIPS)))

--- a/services/minespace-web/common/actions/partyActions.js
+++ b/services/minespace-web/common/actions/partyActions.js
@@ -11,9 +11,10 @@ export const storeParty = (payload, id) => ({
   id,
 });
 
-export const storePartyRelationships = (payload) => ({
+export const storePartyRelationships = (payload, mine_tailings_storage_facility_guid = null) => ({
   type: ActionTypes.STORE_PARTY_RELATIONSHIPS,
   payload,
+  mine_tailings_storage_facility_guid,
 });
 
 export const storeAllPartyRelationships = (payload) => ({

--- a/services/minespace-web/common/components/tailings/TailingsSummaryPage.js
+++ b/services/minespace-web/common/components/tailings/TailingsSummaryPage.js
@@ -92,14 +92,14 @@ export const TailingsSummaryPage = (props) => {
         );
 
         props.storeTsf(existingTsf);
-      }
 
-      await props.fetchPartyRelationships({
-        mine_guid: mineGuid,
-        relationships: "party",
-        include_permit_contacts: "true",
-        mine_tailings_storage_facility_guid: tsfGuid,
-      });
+        await props.fetchPartyRelationships({
+          mine_guid: mineGuid,
+          relationships: "party",
+          include_permit_contacts: "true",
+          mine_tailings_storage_facility_guid: tsfGuid,
+        });
+      }
     }
     setIsLoaded(true);
     setIsReloading(false);

--- a/services/minespace-web/common/reducers/partiesReducer.js
+++ b/services/minespace-web/common/reducers/partiesReducer.js
@@ -41,6 +41,7 @@ export const partiesReducer = (state = initialState, action) => {
         partyIds: createItemIdsArray([action.payload], "party_guid"),
       };
     case actionTypes.STORE_PARTY_RELATIONSHIPS:
+      const tsfGuid = action.mine_tailings_storage_facility_guid;
       const eors = action.payload
         .filter((p) => p.mine_party_appt_type_code === "EOR")
         .map((p) => ({
@@ -48,26 +49,22 @@ export const partiesReducer = (state = initialState, action) => {
           label: p.party.name,
         }));
 
-      const eorRecords = state.tsf
+      const eorRecords = tsfGuid
         ? action.payload.filter(
-            (p) =>
-              p.mine_party_appt_type_code === "EOR" &&
-              p.related_guid === state.tsf.mine_tailings_storage_facility_guid
+            (p) => p.mine_party_appt_type_code === "EOR" && p.related_guid === tsfGuid
           )
         : [];
-      const qfpRecords = state.tsf
+      const qfpRecords = tsfGuid
         ? action.payload.filter(
-            (p) =>
-              p.mine_party_appt_type_code === "QFP" &&
-              p.related_guid === state.tsf.mine_tailings_storage_facility_guid
+            (p) => p.mine_party_appt_type_code === "QFP" && p.related_guid === tsfGuid
           )
         : [];
 
       return {
         ...state,
         partyRelationships: action.payload,
-        engineersOfRecord: eorRecords,
-        qualifiedPersons: qfpRecords,
+        engineersOfRecord: tsfGuid ? eorRecords : state.engineersOfRecord,
+        qualifiedPersons: tsfGuid ? qfpRecords : state.qualifiedPersons,
         engineersOfRecordOptions: uniqBy(eors, "value"),
       };
     case actionTypes.STORE_ALL_PARTY_RELATIONSHIPS:

--- a/services/minespace-web/src/components/pages/Tailings/TailingsSummaryPageWrapper.js
+++ b/services/minespace-web/src/components/pages/Tailings/TailingsSummaryPageWrapper.js
@@ -3,6 +3,7 @@ import React from "react";
 import TailingsProvider from "@common/components/tailings/TailingsProvider";
 import ContactDetails from "@common/components/ContactDetails";
 import TailingsSummaryPage from "@common/components/tailings/TailingsSummaryPage";
+import PropTypes from "prop-types";
 import { renderConfig } from "@/components/common/config";
 import LinkButton from "@/components/common/LinkButton";
 import { modalConfig } from "@/components/modalContent/config";
@@ -13,17 +14,17 @@ import {
   EDIT_TAILINGS_STORAGE_FACILITY,
   MINE_DASHBOARD,
 } from "@/constants/routes";
-import PropTypes from "prop-types";
 
 const propTypes = {
   match: PropTypes.shape({
     params: PropTypes.shape({
       id: PropTypes.string,
+      mineGuid: PropTypes.string,
       tailingsStorageFacilityGuid: PropTypes.string,
       tab: PropTypes.string,
     }),
   }).isRequired,
-}
+};
 
 export const TailingsSummaryPageWrapper = (props) => {
   const { match } = props;
@@ -45,15 +46,16 @@ export const TailingsSummaryPageWrapper = (props) => {
       renderConfig={renderConfig}
       addContactModalConfig={modalConfig.ADD_CONTACT}
       tsfFormName={FORM.ADD_TAILINGS_STORAGE_FACILITY}
+      tsfGuid={match.params.tailingsStorageFacilityGuid}
       canAssignEor
       routes={routes}
       eorHistoryColumns={["name", "status", "dates", "letters"]}
     >
       <TailingsSummaryPage
-          form={FORM.ADD_TAILINGS_STORAGE_FACILITY}
-          mineGuid={match.params.mineGuid}
-          tsfGuid={match.params.tailingsStorageFacilityGuid}
-          tab={match.params.tab}
+        form={FORM.ADD_TAILINGS_STORAGE_FACILITY}
+        mineGuid={match.params.mineGuid}
+        tsfGuid={match.params.tailingsStorageFacilityGuid}
+        tab={match.params.tab}
       />
     </TailingsProvider>
   );


### PR DESCRIPTION
## Objective 

[MDS-4610](https://bcmines.atlassian.net/browse/MDS-4610)

- Fixes an issue that prevents the EOR history table from loading, and when loading properly, from being refreshed when you acknowledge /change the status of an EOR
- Fixes an error that pops up when trying to assign a new EOR to a tsf

_Why are you making this change? Provide a short explanation and/or screenshots_
