### PR TITLE
[MDS-4891] Fix error when running job through celery

### DIFF
--- a/services/core-api/app/api/utils/include/user_info.py
+++ b/services/core-api/app/api/utils/include/user_info.py
@@ -1,5 +1,6 @@
 from app.extensions import jwt
 from jose import jwt as jwt_jose
+from flask import has_request_context
 
 VALID_REALM = ['idir']
 
@@ -30,7 +31,10 @@ class User:
         return raw_info.get('email')
 
     def get_user_username(self):
-        raw_info = self.get_user_raw_info()
-        realms = list(set(VALID_REALM) & set(raw_info['realm_access']['roles']))
-        return realms[0] + '\\' + raw_info['preferred_username'] if realms else raw_info[
-            'preferred_username']
+        if has_request_context():
+            raw_info = self.get_user_raw_info()
+            realms = list(set(VALID_REALM) & set(raw_info['realm_access']['roles']))
+            return realms[0] + '\\' + raw_info['preferred_username'] if realms else raw_info[
+                'preferred_username']
+        else:
+            return 'system'


### PR DESCRIPTION
## Objective 

[MDS-4891](https://bcmines.atlassian.net/browse/MDS-4891)

Fixes an error popping up when running jobs that inserts records into tables that autofills the `updated_by` columns. These cases look up the username of the person form the Auth token, which in the case of Celery jobs will not exist as it is run asynchronously. In this case, we set the `updated_by` to `system`

![image](https://user-images.githubusercontent.com/66635118/206569656-f17b71c3-39a2-4be9-bc5f-61af4b8a70a5.png)


_Why are you making this change? Provide a short explanation and/or screenshots_
