### PR TITLE
[MDS-4980] Codespaces Makefile changes

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -5,13 +5,13 @@
   "recommendations": [
     "aaron-bond.better-comments",
     "editorconfig.editorconfig",
-    "coenraads.bracket-pair-colorizer",
     "eamodio.gitlens",
     "ms-vsliveshare.vsliveshare",
     "christian-kohler.path-intellisense",
     "ms-python.python",
     "ms-vscode-remote.remote-containers",
-    "dbaeumer.vscode-eslint"
+    "dbaeumer.vscode-eslint",
+    "ms-azuretools.vscode-docker"
   ],
   // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
   "unwantedRecommendations": []

--- a/Makefile
+++ b/Makefile
@@ -117,5 +117,15 @@ clean: stop |
 	@docker rmi -f mds_postgres mds_backend mds_frontend mds_flyway
 	@docker volume rm mds_postgres_data -f
 
+# initial project setup for local/codespaces development
+init:
+	@./bin/setup_codespaces.sh
+
+# builds BE & serves up FE in background
+# CODESPACES NOTE: Currently in codespaces, if the containers are running
+# but the CS has been paused, must run `make stop` before `make be` or `make restart`
+restart:
+	@./bin/restart_codespaces.sh
+
 help:
 	@./bin/help.sh

--- a/bin/restart_codespaces.sh
+++ b/bin/restart_codespaces.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+make be &
+cd services/common && yarn watch &
+cd services/core-web && yarn serve &
+cd services/minespace-web && yarn serve

--- a/bin/setup_codespaces.sh
+++ b/bin/setup_codespaces.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+yes yes | make env
+yarn
+make be
+make seeddb


### PR DESCRIPTION
## Objective 
- make running codespaces a little smoother

[MDS-4980](https://bcmines.atlassian.net/browse/MDS-4980)

_Why are you making this change? Provide a short explanation and/or screenshots_
- project has to be re-initialized if you ever make a new codespace, can use "make init" now
- should also work in a regular local environment
- codespaces shuts down more frequently to preserve resources: added "make restart" command to rebuild backend and serve up frontend
   - it "should" work to run ```make be``` while your containers are running to rebuild them, but when the CS automatically pauses, I have found **that this is not the case**. In this scenario, ```make stop``` must be run before ```make be``` (or ```make restart```)
   - in order for the command to also be useful for local dev, I have omitted ```make stop``` from restart