### PR TITLE
[MDS-4891] Handle TSFs without permit numbers when sending notifications

### DIFF
--- a/services/core-api/app/api/activity/models/activity_notification.py
+++ b/services/core-api/app/api/activity/models/activity_notification.py
@@ -59,7 +59,8 @@ def validate_document(document):
                     'type': 'dict',
                     'schema': {
                         'permit_no': {
-                            'type': 'string'
+                            'type': 'string',
+                            'nullable': True
                         }
                     }
                 },


### PR DESCRIPTION
## Objective 

[MDS-4891](https://bcmines.atlassian.net/browse/MDS-4891)

This fixes an issue where notifications about expiring/expired EORs fail for TSFs without a permit number assign. This is the case for a couple of existing ones - which causes validation of the notification document to fail, and therefore not to be created.
_Why are you making this change? Provide a short explanation and/or screenshots_
