### PR TITLE
[MDS-4891] Fixed expiring / expired notifications sending one day early

### DIFF
--- a/services/core-api/app/api/parties/party_appt/models/mine_party_appt.py
+++ b/services/core-api/app/api/parties/party_appt/models/mine_party_appt.py
@@ -206,7 +206,11 @@ class MinePartyAppointment(SoftDeleteMixin, AuditMixin, Base):
 
     @classmethod
     def find_expiring_appointments(cls, mine_party_appt_type_code, expiring_before_days):
-        expiring_delta = datetime.utcnow() + timedelta(days=expiring_before_days)
+        """
+        Find appointments of the given type that expires within the next expiring_before_days number
+        of days.
+        """
+        expiring_delta = datetime.utcnow() + timedelta(days=expiring_before_days - 1)
         now = datetime.utcnow()
 
         qs = cls.query.filter_by(
@@ -220,7 +224,11 @@ class MinePartyAppointment(SoftDeleteMixin, AuditMixin, Base):
 
     @classmethod
     def find_expired_appointments(cls, mine_party_appt_type_code):
-        now = datetime.utcnow()
+        """
+        Find appointments of the given type that have expired (end date before today)
+        """
+        now = datetime.utcnow() \
+            .replace(hour=0, minute=0, second=0, microsecond=0)
 
         qs = cls.query.filter_by(
             mine_party_appt_type_code=mine_party_appt_type_code,

--- a/services/core-api/tests/parties/party_appt/resources/test_mine_party_appt.py
+++ b/services/core-api/tests/parties/party_appt/resources/test_mine_party_appt.py
@@ -73,7 +73,7 @@ def test_find_expiring_appointments_includes_tomorrow(setup_info):
 def test_find_expiring_appointments_includes_last_day(setup_info):
     eor = setup_info['eor']
 
-    eor.end_date = datetime.utcnow() + timedelta(days=60)
+    eor.end_date = datetime.utcnow() + timedelta(days=59)
     eor.save()
 
     appts = MinePartyAppointment.find_expiring_appointments('EOR', 60)


### PR DESCRIPTION
## Objective 

[MDS-4891](https://bcmines.atlassian.net/browse/MDS-4891)

Fixed an issue where the 60 day expiry / expired alerts for EoRs were triggering one day early compared to the alerts in the app themselves. 

_Why are you making this change? Provide a short explanation and/or screenshots_
