### PR TITLE
[MDS-4894] QP Expiring & Expired Notifications

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,6 +30,7 @@ module.exports = {
     "import/no-named-as-default": 0,
     // TODO: fix unresolved imports for eslint with @common aliases
     "import/no-unresolved": 0,
+    "import/extensions": 0,
     "jsx-a11y/anchor-is-valid": 0,
     "react/destructuring-assignment": "off",
     camelcase: 0,

--- a/services/core-api/app/api/activity/models/activity_notification.py
+++ b/services/core-api/app/api/activity/models/activity_notification.py
@@ -96,6 +96,8 @@ class ActivityType(str, Enum):
     mine = 'mine'
     eor_expiring_60_days = 'eor_expiring_60_days'
     tsf_eor_expired = 'tsf_eor_expired'
+    qp_expiring_60_days = 'qp_expiring_60_days'
+    tsf_qp_expired = 'tsf_qp_expired'
     incident_report_submitted = 'incident_report_submitted'
     mine_incident_created = 'mine_incident_created'
     nod_status_changed = 'nod_status_changed'

--- a/services/core-api/app/api/activity/models/activity_notification.py
+++ b/services/core-api/app/api/activity/models/activity_notification.py
@@ -111,6 +111,13 @@ class ActivityType(str, Enum):
     def __str__(self):
         return self.value
 
+class ActivityRecipients(str, Enum):
+    minespace_users = 'minespace_users'
+    core_users = 'core_users'
+    all_users = 'all_users'
+
+    def __str__(self):
+        return self.value
 
 class ActivityNotification(AuditMixin, Base):
     __tablename__ = 'activity_notification'
@@ -130,17 +137,22 @@ class ActivityNotification(AuditMixin, Base):
         return new_activity.save(commit)
 
     @classmethod
-    def create_many(cls, mine_guid, activity_type, document, idempotency_key=None, commit=True):
+    def create_many(cls, mine_guid, activity_type, document, idempotency_key=None, commit=True, recipients=ActivityRecipients.all_users):
         MinespaceUserMineTable = table(MinespaceUserMine.__tablename__, column('mine_guid'), column('user_id'))
         MinespaceUserTable = table(MinespaceUser.__tablename__, column('email_or_username'), column('user_id'))
         SubscriptionTable = table(Subscription.__tablename__, column('mine_guid'), column('user_name'))
 
-        users = [x[0] for x in (db.session.query(MinespaceUserTable, MinespaceUserMineTable).filter(
-            MinespaceUserMineTable.c.user_id == MinespaceUserTable.c.user_id,
-            MinespaceUserMineTable.c.mine_guid == mine_guid
-        ).all())]
+        users = []
+        if recipients == ActivityRecipients.all_users or recipients == ActivityRecipients.minespace_users:
+            minespace_users = [x[0] for x in (db.session.query(MinespaceUserTable, MinespaceUserMineTable).filter(
+                MinespaceUserMineTable.c.user_id == MinespaceUserTable.c.user_id,
+                MinespaceUserMineTable.c.mine_guid == mine_guid
+            ).all())]
+            users.extend(minespace_users)
 
-        core_users = [x[1] for x in (db.session.query(SubscriptionTable).filter(SubscriptionTable.c.mine_guid == mine_guid).all())]
+        if recipients == ActivityRecipients.all_users or recipients == ActivityRecipients.core_users:
+            core_users = [x[1] for x in (db.session.query(SubscriptionTable).filter(SubscriptionTable.c.mine_guid == mine_guid).all())]
+            users.extend(core_users)
 
         # Look up users that already recieved a notification with the given idempotency key
         # so they will not receive the notification again
@@ -148,8 +160,7 @@ class ActivityNotification(AuditMixin, Base):
             .with_entities(cls.notification_recipient) \
             .filter_by(idempotency_key=idempotency_key) \
             .all()] if idempotency_key else []
-
-        users.extend(core_users)
+        
         notifications = []
 
         for user in users:

--- a/services/core-api/app/api/activity/utils.py
+++ b/services/core-api/app/api/activity/utils.py
@@ -1,7 +1,7 @@
 
-from .models.activity_notification import ActivityNotification
+from .models.activity_notification import ActivityNotification, ActivityRecipients
 
-def trigger_notification(message, activity_type, mine, entity_name, entity_guid, extra_data=None, idempotency_key=None, commit=True):
+def trigger_notification(message, activity_type, mine, entity_name, entity_guid, extra_data=None, idempotency_key=None, recipients=ActivityRecipients.all_users, commit=True):
     """
     Triggers a notification for MS and Core users subscribed to the given mine
     
@@ -12,6 +12,7 @@ def trigger_notification(message, activity_type, mine, entity_name, entity_guid,
     :param entity_guid: GUID of the entity the notification relates to
     :param extra_data: Additional data that should be included in the notification e.g. to enable the frontend to route the user on click
     :param idempotency_key: String that should determine whether or not a user has already received the given notifciation. If triggering a notification for the same user with the same idempotency_key, the second notification will not be sent.
+    :param recipients: Send notification to all user types, or only recipients on Minespace or Core - ActivityRecipients
     :param commit: Whether or not to commit the transaction on success, or leave it up to the caller
     """
     document = {
@@ -34,5 +35,6 @@ def trigger_notification(message, activity_type, mine, entity_name, entity_guid,
         activity_type,
         document,
         idempotency_key,
-        commit=commit
+        commit=commit,
+        recipients=recipients
     )

--- a/services/core-api/app/api/parties/party_appt/tasks.py
+++ b/services/core-api/app/api/parties/party_appt/tasks.py
@@ -8,17 +8,25 @@ from app.tasks.celery import celery
 
 @celery.task()
 def notify_expiring_party_appointments():
-    expiring_parties = MinePartyAppointment.find_expiring_appointments('EOR', 60)
-    message = lambda party: f'60 days notice Engineer of Record expiry for {party.mine_tailings_storage_facility.mine_tailings_storage_facility_name} at {party.mine.mine_name}'
+    expiring_eors = MinePartyAppointment.find_expiring_appointments('EOR', 60)
+    expiring_qps = MinePartyAppointment.find_expiring_appointments('TQP', 60)
+    
+    eor_message = lambda party: f'60 days notice Engineer of Record expiry for {party.mine_tailings_storage_facility.mine_tailings_storage_facility_name} at {party.mine.mine_name}'
+    qp_message = lambda party: f'60 days notice Qualified Person expiry for {party.mine_tailings_storage_facility.mine_tailings_storage_facility_name} at {party.mine.mine_name}'
 
-    notifications = list(_notify_party_appointments(expiring_parties, message, ActivityType.eor_expiring_60_days))
+    eor_notifications = list(_notify_party_appointments(expiring_eors, eor_message, ActivityType.eor_expiring_60_days))
+    qp_notifications = list(_notify_party_appointments(expiring_qps, qp_message, ActivityType.qp_expiring_60_days))
+    notifications = eor_notifications + qp_notifications
+
     db.session.commit()
 
     return notifications
 
 @celery.task()
 def notify_and_update_expired_party_appointments():
-    expired_parties = MinePartyAppointment.find_expired_appointments('EOR')
+    expired_eors = MinePartyAppointment.find_expired_appointments('EOR')
+    expired_qps = MinePartyAppointment.find_expired_appointments('TQP')
+    expired_parties = expired_eors + expired_qps
 
     MinePartyAppointment.update_status_many(
         [p.mine_party_appt_id for p in expired_parties],
@@ -26,23 +34,24 @@ def notify_and_update_expired_party_appointments():
         commit=False
     )
 
-    notifications = list(notify_expired_party_appointments(expired_parties))
+    eor_message = lambda party: f'Engineer of Record expired on {party.mine_tailings_storage_facility.mine_tailings_storage_facility_name} at {party.mine.mine_name}.'
+    qp_message = lambda party: f'The term date has elapsed with the Qualified Person for {party.mine_tailings_storage_facility.mine_tailings_storage_facility_name} at {party.mine.mine_name}.'
+
+    eor_notifications = list(_notify_party_appointments(expired_eors, eor_message, ActivityType.tsf_eor_expired))
+    qp_notifications = list(_notify_party_appointments(expired_qps, qp_message, ActivityType.tsf_qp_expired))
+    
+    notifications = eor_notifications + qp_notifications
 
     db.session.commit()
 
     return list(notifications)
-
-def notify_expired_party_appointments(expired_parties):
-    message = lambda party: f'Engineer of Record expired on {party.mine_tailings_storage_facility.mine_tailings_storage_facility_name} at {party.mine.mine_name}'
-
-    return list(_notify_party_appointments(expired_parties, message, ActivityType.tsf_eor_expired))
 
 def _notify_party_appointments(parties, message, activity_type):
     created_notifications = [] 
     for party in parties:
         idempotency_key = f'{activity_type}_{party.mine_party_appt_guid}_{party.end_date.strftime("%Y-%m-%d")}'
 
-        nots = trigger_notification(message(party), activity_type, party.mine, 'EngineerOfRecord', party.mine_party_appt_guid,
+        nots = trigger_notification(message(party), activity_type, party.mine, _get_party_name(party), party.mine_party_appt_guid,
             {
                 'mine_tailings_storage_facility': {
                     'mine_tailings_storage_facility_guid': str(party.mine_tailings_storage_facility_guid),
@@ -57,3 +66,10 @@ def _notify_party_appointments(parties, message, activity_type):
 
         created_notifications.extend(nots)
     return created_notifications
+
+def _get_party_name(party):
+    party_names = {
+        'EOR': 'EngineerOfRecord',
+        'TQP': 'QualifiedPerson'
+    }
+    return party_names.get(party.mine_party_appt_type_code)

--- a/services/core-api/app/api/parties/party_appt/tasks.py
+++ b/services/core-api/app/api/parties/party_appt/tasks.py
@@ -3,13 +3,11 @@ from app.api.activity.utils import trigger_notification
 from app.api.parties.party_appt.models.mine_party_appt import MinePartyAppointment, MinePartyAppointmentStatus
 from app.extensions import db
 from app.tasks.celery import celery
-from flask import current_app
 
 
 
 @celery.task()
 def notify_expiring_party_appointments():
-    #minespace only, not on core
     expiring_eors = MinePartyAppointment.find_expiring_appointments('EOR', 60)
     expiring_qps = MinePartyAppointment.find_expiring_appointments('TQP', 60)
     

--- a/services/core-api/tests/factories.py
+++ b/services/core-api/tests/factories.py
@@ -35,6 +35,7 @@ from app.api.securities.models.bond import Bond
 from app.api.securities.models.reclamation_invoice import ReclamationInvoice
 from app.api.users.core.models.core_user import CoreUser, IdirUserDetail
 from app.api.users.minespace.models.minespace_user import MinespaceUser
+from app.api.users.minespace.models.minespace_user_mine import MinespaceUserMine
 from app.api.variances.models.variance import Variance
 from app.api.variances.models.variance_document_xref import VarianceDocumentXref
 from app.api.parties.party_appt.models.party_business_role_appt import PartyBusinessRoleAppointment
@@ -674,7 +675,7 @@ class MinespaceUserFactory(BaseFactory):
     keycloak_guid = GUID
     email_or_username = factory.Faker('email')
 
-
+# Core subscriptions
 class SubscriptionFactory(BaseFactory):
     class Meta:
         model = Subscription
@@ -685,6 +686,17 @@ class SubscriptionFactory(BaseFactory):
     mine_guid = factory.SelfAttribute('mine.mine_guid')
     user_name = factory.Faker('last_name')
 
+# Minespace subscriptions/access
+class MinespaceSubscriptionFactory(BaseFactory):
+    class Meta:
+        model = MinespaceUserMine
+
+    class Params:
+        mine = factory.SubFactory('tests.factories.MineFactory', minimal=True)
+        minespace_user = factory.SubFactory(MinespaceUserFactory)
+
+    mine_guid = factory.SelfAttribute('mine.mine_guid')
+    user_id = factory.SelfAttribute('minespace_user.user_id')
 
 class MineFactory(BaseFactory):
     class Meta:

--- a/services/core-web/src/components/navigation/NotificationDrawer.js
+++ b/services/core-web/src/components/navigation/NotificationDrawer.js
@@ -124,13 +124,15 @@ const NotificationDrawer = (props) => {
         );
       case "EngineerOfRecord":
         return MINE_TAILINGS_DETAILS.dynamicRoute(
-          notification.notification_document.metadata.entity_guid,
+          notification.notification_document.metadata.mine_tailings_storage_facility
+            .mine_tailings_storage_facility_guid,
           notification.notification_document.metadata.mine.mine_guid,
           "engineer-of-record"
         );
       case "QualifiedPerson":
         return MINE_TAILINGS_DETAILS.dynamicRoute(
-          notification.notification_document.metadata.entity_guid,
+          notification.notification_document.metadata.mine_tailings_storage_facility
+            .mine_tailings_storage_facility_guid,
           notification.notification_document.metadata.mine.mine_guid,
           "qualified-person"
         );
@@ -161,14 +163,14 @@ const NotificationDrawer = (props) => {
         onClick={handleCollapse}
         type="text"
         className={`notification-button ${open ? "notification-button-open" : ""}`}
-        icon={
+        icon={(
           <Badge
             className="notification-badge"
             count={props.activities?.filter((act) => !act?.notification_read).length || 0}
           >
             <BellOutlined className="notification-icon" />
           </Badge>
-        }
+        )}
       />
       <div className={`notification-drawer ${open ? "notification-drawer-open" : ""}`}>
         <Tabs

--- a/services/minespace-web/src/components/layout/NotificationDrawer.js
+++ b/services/minespace-web/src/components/layout/NotificationDrawer.js
@@ -143,7 +143,8 @@ const NotificationDrawer = (props) => {
       case "EngineerOfRecord":
         return {
           route: EDIT_TAILINGS_STORAGE_FACILITY.dynamicRoute(
-            notification.notification_document.metadata.entity_guid,
+            notification.notification_document.metadata.mine_tailings_storage_facility
+              .mine_tailings_storage_facility_guid,
             notification.notification_document.metadata.mine.mine_guid,
             "engineer-of-record"
           ),
@@ -152,7 +153,8 @@ const NotificationDrawer = (props) => {
       case "QualifiedPerson":
         return {
           route: EDIT_TAILINGS_STORAGE_FACILITY.dynamicRoute(
-            notification.notification_document.metadata.entity_guid,
+            notification.notification_document.metadata.mine_tailings_storage_facility
+              .mine_tailings_storage_facility_guid,
             notification.notification_document.metadata.mine.mine_guid,
             "qualified-person"
           ),
@@ -186,14 +188,14 @@ const NotificationDrawer = (props) => {
         onClick={handleCollapse}
         type="text"
         className={`notification-button ${open ? "notification-button-open" : ""}`}
-        icon={
+        icon={(
           <Badge
             className="notification-badge"
             count={props.activities?.filter((act) => !act?.notification_read).length || 0}
           >
             <BellOutlined className="notification-icon" />
           </Badge>
-        }
+        )}
       />
       <div className={`notification-drawer ${open ? "notification-drawer-open" : ""}`}>
         <Tabs
@@ -203,11 +205,11 @@ const NotificationDrawer = (props) => {
         >
           <Tabs.TabPane
             className="notification-tab-pane"
-            tab={
+            tab={(
               <Typography.Title level={5} className="notification-tab-header">
                 Mine Activity
               </Typography.Title>
-            }
+            )}
             key="1"
           >
             <div className="notification-button-all-container">


### PR DESCRIPTION
## Objective 

[MDS-4894](https://bcmines.atlassian.net/browse/MDS-4894)
[MDS-4893](https://bcmines.atlassian.net/browse/MDS-4893)

- adding the notification for QP expiring in 60 days and notification for already expired to scheduled celery tasks
- noticed that expiring in 60 days notification is for Minespace only (not Core), added some logic to be able to specify this, made same adjustment for EoR

_Why are you making this change? Provide a short explanation and/or screenshots_
With 1 expiring QP, 1 expiring EoR, and one expired QP, generates the following notifications:
Core: (ignore the 2- I cropped out an unrelated notification)
![image](https://user-images.githubusercontent.com/102187683/209411401-226c98bf-2c73-466c-9434-6db70bc36903.png)
MineSpace:
![image](https://user-images.githubusercontent.com/102187683/209411438-c7c037c0-e41f-4001-a9f5-0a658b1ac84b.png)
