### PR TITLE
[CHORE] - Codespaces setup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,49 +1,4 @@
 {
-	"name": "Debian",
-	"image": "mcr.microsoft.com/devcontainers/base:bullseye",
-	"features": {
-		"ghcr.io/devcontainers/features/docker-from-docker:1": {},
-		"ghcr.io/devcontainers/features/docker-in-docker:1": {},
-		"ghcr.io/devcontainers/features/git:1": {},
-		"ghcr.io/devcontainers/features/github-cli:1": {},
-		"ghcr.io/devcontainers/features/python:1": {},
-		"ghcr.io/devcontainers/features/sshd:1": {
-			"version": "latest"
-		},
-		"ghcr.io/devcontainers/features/node:1": {
-			"version": "14.8.0"
-		}
-	},
-	  "forwardPorts": [3000, 3020, 5000, 5432, 5500, 5001],
-	  "portsAttributes": {
-		"3000": {
-		  "label": "Core",
-		  "onAutoForward": "notify"
-		},
-		"3020": {
-		  "label": "Minespace",
-		  "onAutoForward": "notify"
-		},
-		"5000": {
-		  "label": "API",
-		  "onAutoForward": "notify"
-		},
-		"5432": {
-		  "label": "Postgres",
-		  "onAutoForward": "notify"
-		},
-		"5500": {
-		  "label": "NRIS",
-		  "onAutoForward": "notify"
-		},
-		"5001": {
-		  "label": "Document Manager",
-		  "onAutoForward": "notify"
-		}
-	  },
-	  "onCreateCommand": "make INPUT=yes env",
-	  "postCreateCommand": "make be && make seeddb && yarn install"
-=======
   "name": "Debian",
   "image": "mcr.microsoft.com/devcontainers/base:bullseye",
   "features": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,91 @@
+{
+	"name": "Debian",
+	"image": "mcr.microsoft.com/devcontainers/base:bullseye",
+	"features": {
+		"ghcr.io/devcontainers/features/docker-from-docker:1": {},
+		"ghcr.io/devcontainers/features/docker-in-docker:1": {},
+		"ghcr.io/devcontainers/features/git:1": {},
+		"ghcr.io/devcontainers/features/github-cli:1": {},
+		"ghcr.io/devcontainers/features/python:1": {},
+		"ghcr.io/devcontainers/features/sshd:1": {
+			"version": "latest"
+		},
+		"ghcr.io/devcontainers/features/node:1": {
+			"version": "14.8.0"
+		}
+	},
+	  "forwardPorts": [3000, 3020, 5000, 5432, 5500, 5001],
+	  "portsAttributes": {
+		"3000": {
+		  "label": "Core",
+		  "onAutoForward": "notify"
+		},
+		"3020": {
+		  "label": "Minespace",
+		  "onAutoForward": "notify"
+		},
+		"5000": {
+		  "label": "API",
+		  "onAutoForward": "notify"
+		},
+		"5432": {
+		  "label": "Postgres",
+		  "onAutoForward": "notify"
+		},
+		"5500": {
+		  "label": "NRIS",
+		  "onAutoForward": "notify"
+		},
+		"5001": {
+		  "label": "Document Manager",
+		  "onAutoForward": "notify"
+		}
+	  },
+	  "onCreateCommand": "make INPUT=yes env",
+	  "postCreateCommand": "make be && make seeddb && yarn install"
+=======
+  "name": "Debian",
+  "image": "mcr.microsoft.com/devcontainers/base:bullseye",
+  "features": {
+    "ghcr.io/devcontainers/features/docker-from-docker:1": {},
+    "ghcr.io/devcontainers/features/docker-in-docker:1": {},
+    "ghcr.io/devcontainers/features/git:1": {},
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/devcontainers/features/python:1": {},
+    "ghcr.io/devcontainers/features/sshd:1": {
+      "version": "latest"
+    },
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "14.8.0"
+    }
+  },
+  "forwardPorts": [3000, 3020, 5000, 5432, 5500, 5001],
+  "portsAttributes": {
+    "3000": {
+      "label": "Core",
+      "onAutoForward": "notify"
+    },
+    "3020": {
+      "label": "Minespace",
+      "onAutoForward": "notify"
+    },
+    "5000": {
+      "label": "API",
+      "onAutoForward": "notify"
+    },
+    "5432": {
+      "label": "Postgres",
+      "onAutoForward": "notify"
+    },
+    "5500": {
+      "label": "NRIS",
+      "onAutoForward": "notify"
+    },
+    "5001": {
+      "label": "Document Manager",
+      "onAutoForward": "notify"
+    }
+  },
+  "onCreateCommand": "make INPUT=yes env",
+  "postCreateCommand": "make be && make seeddb && yarn install"
+}

--- a/bin/setenv.sh
+++ b/bin/setenv.sh
@@ -15,10 +15,13 @@ filesystem-provider
 minespace-web
 tusd
 "
+if [ -z "$INPUT" ];
+    then
+        echo "This command can be destructive if you have valid .env's in place and run this multiple times!"
+        echo "Continue? (only accepts 'yes')"
+        read INPUT
+fi
 
-echo "This command can be destructive if you have valid .env's in place and run this multiple times!"
-echo "Continue? (only accepts 'yes')"
-read INPUT
 if [ "$INPUT" = "yes" ];
 then
     for S in $SERVICES


### PR DESCRIPTION
## Objective 

Added devcontainer.json file to base folder with project specific setup.

updated setenv.sh file to accept `INPUT` parameter so `make INPUT=true env` can be used to auto run the script and bypass the confirmation check.

With this in place, spinning up a codespace will set up the entire environment and be ready to go.
It will:

- forward all necessary ports to local
- install all requirements for the application to run (node, python etc.)
- On initial creation it will (it will not run these commands again unless the container is rebuilt)
    - run `make env`
    - run `make be`
    - run `make seeddb`
    - run `yarn install`
