### PR TITLE
[MDS-4989] NOW Consultation page not loading

### DIFF
--- a/services/core-web/common/utils/helpers.js
+++ b/services/core-web/common/utils/helpers.js
@@ -188,7 +188,7 @@ export const normalizeExt = (value) => (value ? value.slice(0, 6) : value);
 
 export const upperCase = (value) => value && value.toUpperCase();
 
-export const truncateFilename = (filename, max = 40) => {
+export const truncateFilename = (filename = "", max = 40) => {
   if (filename.length <= max) {
     return filename;
   }

--- a/services/core-web/src/components/noticeOfWork/applications/referals/NOWApplicationReviewsTable.js
+++ b/services/core-web/src/components/noticeOfWork/applications/referals/NOWApplicationReviewsTable.js
@@ -78,16 +78,18 @@ const columns = (type) => {
       render: (text) => (
         <div title="Documents">
           {text.length > 0
-            ? text.map((doc) => (
-                <li key={doc.mine_document.mine_document_guid}>
-                  <div key={doc.mine_document.mine_document_guid}>
-                    <DocumentLink
-                      documentManagerGuid={doc.mine_document.document_manager_guid}
-                      documentName={doc.mine_document.document_name}
-                    />
-                  </div>
-                </li>
-              ))
+            ? text.map((doc) =>
+                doc && doc.mine_document ? (
+                  <li key={doc.mine_document.mine_document_guid}>
+                    <div key={doc.mine_document.mine_document_guid}>
+                      <DocumentLink
+                        documentManagerGuid={doc.mine_document.document_manager_guid}
+                        documentName={doc.mine_document.document_name}
+                      />
+                    </div>
+                  </li>
+                ) : null
+              )
             : Strings.EMPTY_FIELD}
         </div>
       ),
@@ -120,8 +122,7 @@ const columns = (type) => {
                     record.handleDocumentDelete,
                     record.type,
                     record.categoriesToShow
-                  )
-                }
+                  )}
               >
                 <img src={EDIT_OUTLINE_VIOLET} alt="Edit Review" />
               </Button>

--- a/services/minespace-web/common/utils/helpers.js
+++ b/services/minespace-web/common/utils/helpers.js
@@ -188,7 +188,7 @@ export const normalizeExt = (value) => (value ? value.slice(0, 6) : value);
 
 export const upperCase = (value) => value && value.toUpperCase();
 
-export const truncateFilename = (filename, max = 40) => {
+export const truncateFilename = (filename = "", max = 40) => {
   if (filename.length <= max) {
     return filename;
   }


### PR DESCRIPTION
## Objective 

[MDS-4989](https://bcmines.atlassian.net/browse/MDS-4989)
Bug where specific notice of work consultation & referral pages were not loading. I believe it's related to deleted documents as part of the NoW application. Making front-end not break if bad data comes through, but back-end changes to not send back the data in the first place is probably the next step.

_Why are you making this change? Provide a short explanation and/or screenshots_
