### PR TITLE
[MDS-5000] Celery - redbeat lock key

### DIFF
--- a/services/core-api/app/__init__.py
+++ b/services/core-api/app/__init__.py
@@ -87,7 +87,8 @@ def make_celery(app):
         # Register beat schedule (for triggering scheduled tasks)
         beat_schedule = Config.CELERY_BEAT_SCHEDULE,
         beat_scheduler = 'redbeat.RedBeatScheduler',
-        redbeat_redis_url = Config.CELERY_READBEAT_BROKER_URL
+        redbeat_redis_url = Config.CELERY_READBEAT_BROKER_URL,
+        redbeat_lock_key = 'core-api'
     )
 
     return celery


### PR DESCRIPTION
## Objective 

[MDS-5000](https://bcmines.atlassian.net/browse/MDS-5000)

_Why are you making this change? Provide a short explanation and/or screenshots_
I think they're both trying to acquire the same lock- adding in a lock prefix that should be different from the default (redbeat).