### PR TITLE
[MDS-5037] EOR/QP appointment

### DIFF
--- a/services/core-api/app/api/parties/party/resources/party_resource.py
+++ b/services/core-api/app/api/parties/party/resources/party_resource.py
@@ -14,7 +14,7 @@ from app.api.parties.response_models import PARTY
 from app.api.users.minespace.models.minespace_user import MinespaceUser
 from app.api.utils.access_decorators import MINE_ADMIN
 from app.api.utils.access_decorators import requires_role_view_all, requires_role_mine_admin, \
-    requires_any_of, EDIT_PARTY, MINESPACE_PROPONENT, is_minespace_user, username
+    requires_any_of, EDIT_PARTY, MINESPACE_PROPONENT, is_minespace_user, bceid_username
 from app.api.utils.custom_reqparser import CustomReqparser
 from app.api.utils.resources_mixins import UserMixin
 from app.extensions import api, jwt, cache
@@ -209,7 +209,7 @@ class PartyResource(Resource, UserMixin):
     @api.marshal_with(PARTY, code=200)
     def put(self, party_guid):
         if is_minespace_user():
-            user = username()
+            user = bceid_username()
             minespace_user = MinespaceUser.find_by_email(user + "@bceid")
             if not minespace_user:
                 raise BadRequest('User not found.')

--- a/services/core-api/app/api/parties/party/resources/party_resource.py
+++ b/services/core-api/app/api/parties/party/resources/party_resource.py
@@ -1,23 +1,23 @@
-from flask import request, current_app
-from flask_restplus import Resource
-from sqlalchemy import or_, exc as alch_exceptions
-from sqlalchemy_filters import apply_pagination
-from sqlalchemy.exc import DBAPIError
-from werkzeug.exceptions import NotFound, BadRequest
 from datetime import datetime, timezone
 
-from app.extensions import api, jwt, cache
-from app.api.utils.access_decorators import requires_role_view_all, requires_role_mine_edit, requires_role_mine_admin, requires_role_edit_party
-from app.api.utils.resources_mixins import UserMixin
-from app.api.utils.custom_reqparser import CustomReqparser
-from app.api.utils.access_decorators import MINE_ADMIN
-from app.api.constants import GET_ALL_INSPECTORS_KEY, GET_ALL_PROJECT_LEADS_KEY
+from flask import current_app
+from flask_restplus import Resource
+from sqlalchemy import exc as alch_exceptions
+from werkzeug.exceptions import NotFound, BadRequest
 
-from app.api.parties.party.models.party import Party
+from app.api.constants import GET_ALL_INSPECTORS_KEY, GET_ALL_PROJECT_LEADS_KEY
 from app.api.parties.party.models.address import Address
-from app.api.parties.response_models import PARTY
+from app.api.parties.party.models.party import Party
 from app.api.parties.party_appt.models.mine_party_appt import MinePartyAppointment
 from app.api.parties.party_appt.models.party_business_role_appt import PartyBusinessRoleAppointment
+from app.api.parties.response_models import PARTY
+from app.api.users.minespace.models.minespace_user import MinespaceUser
+from app.api.utils.access_decorators import MINE_ADMIN
+from app.api.utils.access_decorators import requires_role_view_all, requires_role_mine_admin, \
+    requires_any_of, EDIT_PARTY, MINESPACE_PROPONENT, is_minespace_user, username
+from app.api.utils.custom_reqparser import CustomReqparser
+from app.api.utils.resources_mixins import UserMixin
+from app.extensions import api, jwt, cache
 
 
 class PartyResource(Resource, UserMixin):
@@ -205,9 +205,23 @@ class PartyResource(Resource, UserMixin):
     @api.expect(parser)
     @api.doc(
         description='Update a party by guid', params={'party_guid': 'guid of the party to update.'})
-    @requires_role_edit_party
+    @requires_any_of([EDIT_PARTY, MINESPACE_PROPONENT])
     @api.marshal_with(PARTY, code=200)
     def put(self, party_guid):
+        if is_minespace_user():
+            user = username()
+            minespace_user = MinespaceUser.find_by_email(user + "@bceid")
+            if not minespace_user:
+                raise BadRequest('User not found.')
+
+            party_appointments = MinePartyAppointment.find_by_party_guid(party_guid)
+
+            if not party_appointments:
+                raise BadRequest('User does not have access to this party.')
+            if not next((appointment for appointment in party_appointments if
+                         appointment.mine.mine_guid in minespace_user.mines), None):
+                raise BadRequest('User does not have access to this party.')
+
         data = PartyResource.parser.parse_args()
         existing_party = Party.find_by_party_guid(party_guid)
         if not existing_party:
@@ -216,7 +230,7 @@ class PartyResource(Resource, UserMixin):
         current_app.logger.info(f'Updating {existing_party} with {data}')
         for key, value in data.items():
             if key in ['party_type_code', 'signature']:
-                continue     # non-editable fields from put
+                continue  # non-editable fields from put
             setattr(existing_party, key, value)
 
         Party.validate_phone_no(existing_party.phone_no)

--- a/services/core-api/app/api/parties/party_appt/resources/mine_party_appt_resource.py
+++ b/services/core-api/app/api/parties/party_appt/resources/mine_party_appt_resource.py
@@ -146,18 +146,19 @@ class MinePartyApptResource(Resource, UserMixin):
 
             if not can_edit_mines():
                 # if this party was not created by the current user, check if they have the correct role
+                if not tsf or mine.mine_guid != tsf.mine_guid:
+                    raise Forbidden("TSF is not associated with the given mine")
+
                 preferred_username = username()
                 if preferred_username not in party.create_user:
                     # Make sure Minespace users can only assign EORs, associate pre-existing parties for the mine
-                    if mine_party_appt_type_code not in TSF_ALLOWED_CONTACT_TYPES:
-                        raise Forbidden("Minespace user can only appoint EORs and Qualified Persons")
-
-                    if not tsf or mine.mine_guid != tsf.mine_guid:
-                        raise Forbidden("TSF is not associated with the given mine")
-
                     if not next((mem for mem in mine.mine_party_appt if party.party_guid == mem.party_guid), None):
                         raise Forbidden("Party is not associated with the given mine")
 
+        if not can_edit_mines():
+            # if this party was not created by the current user, check if they have the correct role
+            if mine_party_appt_type_code not in TSF_ALLOWED_CONTACT_TYPES:
+                raise Forbidden("Minespace user can only appoint EORs and Qualified Persons")
         new_status = None
         mine_party_acknowledgement_status = None
 

--- a/services/core-api/app/api/parties/party_appt/resources/mine_party_appt_resource.py
+++ b/services/core-api/app/api/parties/party_appt/resources/mine_party_appt_resource.py
@@ -7,7 +7,7 @@ from sqlalchemy import and_, exc as alch_exceptions
 from werkzeug.exceptions import BadRequest, NotFound, Forbidden
 
 from app.extensions import api
-from app.api.utils.access_decorators import requires_role_view_all, requires_role_mine_edit, requires_any_of, MINE_EDIT, MINESPACE_PROPONENT, can_edit_mines, username
+from app.api.utils.access_decorators import requires_role_view_all, requires_role_mine_edit, requires_any_of, MINE_EDIT, MINESPACE_PROPONENT, can_edit_mines, bceid_username
 from app.api.utils.resources_mixins import UserMixin
 from app.api.utils.custom_reqparser import CustomReqparser
 
@@ -149,7 +149,7 @@ class MinePartyApptResource(Resource, UserMixin):
                 if not tsf or mine.mine_guid != tsf.mine_guid:
                     raise Forbidden("TSF is not associated with the given mine")
 
-                preferred_username = username()
+                preferred_username = bceid_username()
                 if preferred_username not in party.create_user:
                     # Make sure Minespace users can only assign EORs, associate pre-existing parties for the mine
                     if not next((mem for mem in mine.mine_party_appt if party.party_guid == mem.party_guid), None):

--- a/services/core-api/app/api/parties/party_appt/resources/mine_party_appt_resource.py
+++ b/services/core-api/app/api/parties/party_appt/resources/mine_party_appt_resource.py
@@ -144,19 +144,19 @@ class MinePartyApptResource(Resource, UserMixin):
             if tsf is None:
                 raise NotFound('TSF not found')
 
-        preferred_username = username()
-        # if this party was not created by the current user, check if they have the correct role
-        if preferred_username not in party.create_user:
             if not can_edit_mines():
-                # Make sure Minespace users can only assign EORs, associate pre-existing parties for the mine
-                if mine_party_appt_type_code not in TSF_ALLOWED_CONTACT_TYPES:
-                    raise Forbidden("Minespace user can only appoint EORs and Qualified Persons")
+                # if this party was not created by the current user, check if they have the correct role
+                preferred_username = username()
+                if preferred_username not in party.create_user:
+                    # Make sure Minespace users can only assign EORs, associate pre-existing parties for the mine
+                    if mine_party_appt_type_code not in TSF_ALLOWED_CONTACT_TYPES:
+                        raise Forbidden("Minespace user can only appoint EORs and Qualified Persons")
 
-                if not tsf or mine.mine_guid != tsf.mine_guid:
-                    raise Forbidden("TSF is not associated with the given mine")
+                    if not tsf or mine.mine_guid != tsf.mine_guid:
+                        raise Forbidden("TSF is not associated with the given mine")
 
-                if not next((mem for mem in mine.mine_party_appt if party.party_guid == mem.party_guid), None):
-                    raise Forbidden("Party is not associated with the given mine")
+                    if not next((mem for mem in mine.mine_party_appt if party.party_guid == mem.party_guid), None):
+                        raise Forbidden("Party is not associated with the given mine")
 
         new_status = None
         mine_party_acknowledgement_status = None

--- a/services/core-api/app/api/utils/access_decorators.py
+++ b/services/core-api/app/api/utils/access_decorators.py
@@ -1,8 +1,6 @@
-
 from functools import wraps
 
 from app.extensions import getJwtManager
-from app.api.utils.include.user_info import User
 from app.flask_jwt_oidc_local.exceptions import AuthError
 from werkzeug.exceptions import Forbidden
 
@@ -44,6 +42,10 @@ def can_edit_now_dates():
 
 def can_edit_mines():
     return getJwtManager().validate_roles([MINE_EDIT])
+
+
+def username():
+    return getJwtManager().get_user_name()
 
 
 def requires_role_edit_emli_contacts(func):

--- a/services/core-api/app/api/utils/access_decorators.py
+++ b/services/core-api/app/api/utils/access_decorators.py
@@ -44,8 +44,8 @@ def can_edit_mines():
     return getJwtManager().validate_roles([MINE_EDIT])
 
 
-def username():
-    return getJwtManager().get_user_name()
+def bceid_username():
+    return getJwtManager().get_bceid_user_name()
 
 
 def requires_role_edit_emli_contacts(func):

--- a/services/core-api/app/flask_jwt_oidc_local/jwt_manager.py
+++ b/services/core-api/app/flask_jwt_oidc_local/jwt_manager.py
@@ -166,7 +166,7 @@ class JwtManager:  # pylint: disable=too-many-instance-attributes
             return True
         return False
 
-    def get_user_name(self):
+    def get_bceid_user_name(self):
         """Get the bceid_username from the token."""
         token = self.get_token_auth_header()
         unverified_claims = jwt.get_unverified_claims(token)

--- a/services/core-api/app/flask_jwt_oidc_local/jwt_manager.py
+++ b/services/core-api/app/flask_jwt_oidc_local/jwt_manager.py
@@ -166,6 +166,12 @@ class JwtManager:  # pylint: disable=too-many-instance-attributes
             return True
         return False
 
+    def get_user_name(self):
+        """Get the bceid_username from the token."""
+        token = self.get_token_auth_header()
+        unverified_claims = jwt.get_unverified_claims(token)
+        return unverified_claims['bceid_username']
+
     def has_one_of_roles(self, roles):
         """Check that at least one of the roles are in the token using the registered callback.
 

--- a/services/core-api/tests/auth/test_expected_auth.py
+++ b/services/core-api/tests/auth/test_expected_auth.py
@@ -90,7 +90,7 @@ from app.api.projects.project_decision_package.resources.project_decision_packag
      (MineVarianceResource, "put", [EDIT_VARIANCE, MINESPACE_PROPONENT]),
      (PartyListResource, "get", [VIEW_ALL, MINESPACE_PROPONENT]),
      (PartyListResource, "post", [EDIT_PARTY, MINESPACE_PROPONENT]), (PartyResource, "get", [VIEW_ALL]),
-     (PartyResource, "put", [EDIT_PARTY]), (PartyResource, "delete", [MINE_ADMIN]),
+     (PartyResource, "put", [EDIT_PARTY, MINESPACE_PROPONENT]), (PartyResource, "delete", [MINE_ADMIN]),
      (PermitResource, "get", [VIEW_ALL]), (PermitListResource, "post", [EDIT_PERMIT]),
      (PermitResource, "put", [EDIT_SECURITIES]),
      (PermitAmendmentListResource, "post", [EDIT_PERMIT]),

--- a/services/core-api/tests/constants.py
+++ b/services/core-api/tests/constants.py
@@ -89,7 +89,8 @@ PROPONENT_ONLY_AUTH_CLAIMS = {
     "preferred_username": "test-proponent",
     "username": "test-proponent",
     "email": "test-proponent-email@minespace.ca",
-    "client_roles": ["mds_minespace_proponents"]
+    "client_roles": ["mds_minespace_proponents"],
+    "bceid_username": "test-proponent"
 }
 
 NROS_VFCBC_AUTH_CLAIMS = {

--- a/services/core-api/tests/factories.py
+++ b/services/core-api/tests/factories.py
@@ -554,6 +554,7 @@ class PartyFactory(BaseFactory):
             party_name=factory.Faker('last_name'),
             email=factory.LazyAttribute(lambda o: f'{o.first_name}.{o.party_name}@example.com'),
             party_type_code='PER',
+            create_user='test-proponent'
         )
 
         company = factory.Trait(

--- a/services/core-api/tests/parties/party_appt/resources/test_mine_party_appt_resource.py
+++ b/services/core-api/tests/parties/party_appt/resources/test_mine_party_appt_resource.py
@@ -1,11 +1,12 @@
 import json, uuid, pytest
 
-from tests.factories import MineFactory, PartyFactory, MinePartyAppointmentFactory
+from tests.factories import MineFactory, PartyFactory, MinePartyAppointmentFactory, MineTailingsStorageFacilityFactory
 
 
 @pytest.fixture(scope="function")
 def setup_info(db_session):
     mine = MineFactory()
+    mine_b = MineFactory()
     eor = MinePartyAppointmentFactory(mine=mine, mine_party_appt_type_code='EOR')
     mine_manager = MinePartyAppointmentFactory(mine=mine, mine_party_appt_type_code='MMG')
     qp = MinePartyAppointmentFactory(mine=mine, mine_party_appt_type_code='TQP')
@@ -17,7 +18,8 @@ def setup_info(db_session):
         mine_manager_appt_guid=str(mine_manager.mine_party_appt_guid),
         mine_manager_guid=str(mine_manager.party.party_guid),
         qp_guid=str(qp.party.party_guid),
-        tsf_guid=str(mine.mine_tailings_storage_facilities[0].mine_tailings_storage_facility_guid))
+        tsf_guid=str(mine.mine_tailings_storage_facilities[0].mine_tailings_storage_facility_guid),
+        unrelated_tsf_guid=str(mine_b.mine_tailings_storage_facilities[0].mine_tailings_storage_facility_guid),)
 
 
 # GET
@@ -222,7 +224,7 @@ def test_post_mine_party_appt_EOR_as_ms_user_not_associated_with_mine_fail(test_
         'mine_guid': setup_info['mine_guid'],
         'party_guid': str(party_guid),
         'mine_party_appt_type_code': 'EOR',
-        'related_guid': setup_info['tsf_guid'],
+        'related_guid': setup_info['unrelated_tsf_guid'],
     }
     post_resp = test_client.post(
         '/parties/mines', data=test_data, headers=auth_headers['proponent_only_auth_header'])
@@ -236,7 +238,7 @@ def test_post_mine_party_appt_TQP_as_ms_user_not_associated_with_mine_fail(test_
         'mine_guid': setup_info['mine_guid'],
         'party_guid': str(party_guid),
         'mine_party_appt_type_code': 'TQP',
-        'related_guid': setup_info['tsf_guid'],
+        'related_guid': setup_info['unrelated_tsf_guid'],
     }
     post_resp = test_client.post(
         '/parties/mines', data=test_data, headers=auth_headers['proponent_only_auth_header'])


### PR DESCRIPTION
[MDS-5037](https://bcmines.atlassian.net/browse/MDS-5037)

A check was in place in the API before making a mine party appointment to make sure that if the user was a Minespace user the `party` was already assigned to that mine somewhere else.  This was designed to prevent Minespace user access to the entire user base.  This didn't work though for a newly created user, so I added a check before this to see if the creating user of the party was the same as the current user.

Also fixed the updating of Info on already assigned EORs and QPs.  Permission to edit these was lost with new SSO, so created logic to check if the current user has access to any mines that the party is appointed to.