### PR TITLE
[MDS-5017] Refresh token- bug fix

### DIFF
--- a/services/core-web/common/reducers/authenticationReducer.js
+++ b/services/core-web/common/reducers/authenticationReducer.js
@@ -11,12 +11,22 @@ const initialState = {
   userInfo: {},
 };
 
+const getUserName = (tokenParsed) => {
+  const {bceid_username} = tokenParsed;
+  if (bceid_username && bceid_username.length > 0) {
+    return `${bceid_username  }@bceid`;
+  }
+  if (tokenParsed.idir_username) {
+    return tokenParsed.idir_username;
+  }
+  return tokenParsed.preferred_username;
+};
+
 export const authenticationReducer = (state = initialState, action) => {
   switch (action.type) {
     case ActionTypes.AUTHENTICATE_USER:
       const tokenParsed = action.payload.userInfo;
-      const preferred_username =
-        tokenParsed.idir_username ?? tokenParsed.bceid_username ?? tokenParsed.preferred_username;
+      const preferred_username = getUserName(tokenParsed);
       return {
         ...state,
         isAuthenticated: true,

--- a/services/minespace-web/common/reducers/authenticationReducer.js
+++ b/services/minespace-web/common/reducers/authenticationReducer.js
@@ -11,12 +11,22 @@ const initialState = {
   userInfo: {},
 };
 
+const getUserName = (tokenParsed) => {
+  const {bceid_username} = tokenParsed;
+  if (bceid_username && bceid_username.length > 0) {
+    return `${bceid_username  }@bceid`;
+  }
+  if (tokenParsed.idir_username) {
+    return tokenParsed.idir_username;
+  }
+  return tokenParsed.preferred_username;
+};
+
 export const authenticationReducer = (state = initialState, action) => {
   switch (action.type) {
     case ActionTypes.AUTHENTICATE_USER:
       const tokenParsed = action.payload.userInfo;
-      const preferred_username =
-        tokenParsed.idir_username ?? tokenParsed.bceid_username ?? tokenParsed.preferred_username;
+      const preferred_username = getUserName(tokenParsed);
       return {
         ...state,
         isAuthenticated: true,

--- a/services/minespace-web/src/reducers/authenticationReducer.js
+++ b/services/minespace-web/src/reducers/authenticationReducer.js
@@ -12,12 +12,22 @@ const initialState = {
   isProponent: undefined,
 };
 
+const getUserName = (tokenParsed) => {
+  const {bceid_username} = tokenParsed;
+  if (bceid_username && bceid_username.length > 0) {
+    return `${bceid_username  }@bceid`;
+  }
+  if (tokenParsed.idir_username) {
+    return tokenParsed.idir_username;
+  }
+  return tokenParsed.preferred_username;
+};
+
 const authenticationReducer = (state = initialState, action) => {
   switch (action.type) {
     case ActionTypes.AUTHENTICATE_USER:
       const tokenParsed = action.payload.userInfo;
-      const preferred_username =
-        tokenParsed.idir_username ?? tokenParsed.bceid_username ?? tokenParsed.preferred_username;
+      const preferred_username = getUserName(tokenParsed);
       return {
         ...state,
         isAuthenticated: true,


### PR DESCRIPTION
## Objective 
No bug ticket has been written yet, but this was bug from 5017 PR. 

Making sure to append `@bceid` to bceid usernames. Notification function in particular broke when it wasn't able to query users properly, with this fix my notifications are back.

[MDS-5017](https://bcmines.atlassian.net/browse/MDS-5017)

_Why are you making this change? Provide a short explanation and/or screenshots_
