### PR TITLE
[MDS-4894] Qualified Persons notification bug

### DIFF
--- a/services/core-api/app/api/parties/party_appt/resources/mine_party_appt_resource.py
+++ b/services/core-api/app/api/parties/party_appt/resources/mine_party_appt_resource.py
@@ -169,7 +169,7 @@ class MinePartyApptResource(Resource, UserMixin):
         elif mine_party_appt_type_code == 'EOR':
             mine_party_acknowledgement_status = MinePartyAcknowledgedStatus.acknowledged
         
-        if end_current and not is_minespace_user():
+        if end_current and (not is_minespace_user() or mine_party_appt_type_code == 'TQP'):
             new_status = MinePartyAppointmentStatus.active
             MinePartyAppointment.end_current(
                 mine_guid=mine_guid,


### PR DESCRIPTION
## Objective 

Not all TQP notifications working properly. Root cause was appointments made by MineSpace user were being set with NULL status, excluding them from scheduled queries.

Considered changing condition to just "if end_current" but wanted to be careful to avoid breaking other types of appointments. Separate validation or processing for different party appointment types seems like it would make the code easier to read and maintain.

[MDS-4894](https://bcmines.atlassian.net/browse/MDS-4894)

_Why are you making this change? Provide a short explanation and/or screenshots_
