### PR TITLE
[MDS-5032] Missing Incident status banners

### DIFF
--- a/services/minespace-web/src/components/Forms/incidents/IncidentForm.js
+++ b/services/minespace-web/src/components/Forms/incidents/IncidentForm.js
@@ -126,7 +126,7 @@ const incidentStatusCalloutContent = (statusCode) => {
     case "FRS":
       return {
         message:
-          "This incident has not yet been reviewed by ministry staff. You will be notified if further clarification is required.",
+          "This incident has not yet been reviewed by Ministry staff. You will be notified if further clarification is required.",
         title: "This Incident is Pending Ministry Review",
         severity: Strings.CALLOUT_SEVERITY.warning,
       };
@@ -134,41 +134,41 @@ const incidentStatusCalloutContent = (statusCode) => {
       return {
         message:
           "This incident has been reviewed and is currently under investigation. You will be notified if further clarification is required.",
-        title: "This Incident is under investigation",
+        title: "This Incident is Under Investigation",
         severity: Strings.CALLOUT_SEVERITY.warning,
       };
     case "UNR":
       return {
         message:
           "This incident has been reviewed and is currently under investigation. You will be notified if further clarification is required.",
-        title: "This Incident is under investigation",
+        title: "This Incident is Under Investigation",
         severity: Strings.CALLOUT_SEVERITY.warning,
       };
     case "MIU":
       return {
         message:
           "This incident has been reviewed and is currently under investigation. You will be notified if further clarification is required.",
-        title: "This Incident is under investigation",
+        title: "This Incident is Under Investigation",
         severity: Strings.CALLOUT_SEVERITY.warning,
       };
     case "CLD":
       return {
         message: "This incident has been reviewed and has been closed.",
-        title: "This Incident Has been closed",
+        title: "This Incident Has Been Closed",
         severity: Strings.CALLOUT_SEVERITY.warning,
       };
     case "RSS":
       return {
         message:
-          "The severity of this incident's status is currently under review by ministry staff. You will be notified if further information is required.",
+          "The severity of this incident's status is currently under review by Ministry staff. You will be notified if further information is required.",
         title: "This Incident's Severity Status is being Reviewed",
         severity: Strings.CALLOUT_SEVERITY.warning,
       };
     case "IMS":
       return {
         message:
-          "This incident is missing critical information, please refer to your communications with ministry staff and resubmit with additional information.",
-        title: "This Incident is missing information",
+          "This incident is missing critical information, please refer to your communications with Ministry staff and resubmit with additional information.",
+        title: "This Incident is Missing Information",
         severity: Strings.CALLOUT_SEVERITY.warning,
       };
     default:

--- a/services/minespace-web/src/components/Forms/incidents/IncidentForm.js
+++ b/services/minespace-web/src/components/Forms/incidents/IncidentForm.js
@@ -157,6 +157,20 @@ const incidentStatusCalloutContent = (statusCode) => {
         title: "This Incident Has been closed",
         severity: Strings.CALLOUT_SEVERITY.warning,
       };
+    case "RSS":
+      return {
+        message:
+          "The severity of this incident's status is currently under review by ministry staff. You will be notified if further information is required.",
+        title: "This Incident's Severity Status is being Reviewed",
+        severity: Strings.CALLOUT_SEVERITY.warning,
+      };
+    case "IMS":
+      return {
+        message:
+          "This incident is missing critical information, please refer to your communications with ministry staff and resubmit with additional information.",
+        title: "This Incident is missing information",
+        severity: Strings.CALLOUT_SEVERITY.warning,
+      };
     default:
       return {
         message: null,
@@ -857,7 +871,7 @@ export const IncidentForm = (props) => {
     <Form layout="vertical" onSubmit={props.handleSubmit}>
       <Row>
         <Col {...parentColumnProps}>
-          {props.isFinalReviewStage && renderIncidentStatusCallout(props)}
+          {renderIncidentStatusCallout(props)}
           {renderInitialReport(props, formDisabled)}
           <br />
           {renderReporterDetails(props, formDisabled)}

--- a/services/minespace-web/src/tests/components/Forms/incidents/__snapshots__/IncidentForm.spec.js.snap
+++ b/services/minespace-web/src/tests/components/Forms/incidents/__snapshots__/IncidentForm.spec.js.snap
@@ -12,6 +12,27 @@ exports[`IncidentForm renders properly 1`] = `
       offset={4}
       span={16}
     >
+      <Callout
+        message={
+          <div>
+            <h4
+              style={
+                Object {
+                  "color": "#313132",
+                  "fontWeight": 700,
+                }
+              }
+            >
+              This Incident Has been closed
+            </h4>
+            <p>
+              This incident has been reviewed and has been closed.
+            </p>
+          </div>
+        }
+        severity="warning"
+        style={Object {}}
+      />
       <Row>
         <Col
           span={24}

--- a/services/minespace-web/src/tests/components/Forms/incidents/__snapshots__/IncidentForm.spec.js.snap
+++ b/services/minespace-web/src/tests/components/Forms/incidents/__snapshots__/IncidentForm.spec.js.snap
@@ -23,7 +23,7 @@ exports[`IncidentForm renders properly 1`] = `
                 }
               }
             >
-              This Incident Has been closed
+              This Incident Has Been Closed
             </h4>
             <p>
               This incident has been reviewed and has been closed.


### PR DESCRIPTION
## Objective 
Add banners for RSS and IMS statuses. I removed the condition that only displayed the callout if "is final review stage"- verified that the default in the switch-case returning null didn't render something strange.


[MDS-5032](https://bcmines.atlassian.net/browse/MDS-5032)

_Why are you making this change? Provide a short explanation and/or screenshots_

Used https://titlecaseconverter.com/ for consistency in headings, APA style.
