### PR TITLE
[MDS-5085] Mine GUID undefined when clicking on Incident link in notification

### DIFF
--- a/services/core-web/src/components/navigation/NotificationDrawer.js
+++ b/services/core-web/src/components/navigation/NotificationDrawer.js
@@ -104,7 +104,7 @@ const NotificationDrawer = (props) => {
         );
       case "MineIncident":
         return MINE_INCIDENT.dynamicRoute(
-          notification.notification_document.metadata.mine_guid,
+          notification.notification_document.metadata.mine.mine_guid,
           notification.notification_document.metadata.entity_guid
         );
       case "ProjectSummary":


### PR DESCRIPTION
## Objective 
Notification drawer bug. Was originally intending to fix 5081 but this one was blocking it.

[MDS-5085](https://bcmines.atlassian.net/browse/MDS-5085)

_Why are you making this change? Provide a short explanation and/or screenshots_
