### PR TITLE
[MDS-5017] Reduce refresh token frequency

### DIFF
--- a/services/minespace-web/src/index.js
+++ b/services/minespace-web/src/index.js
@@ -18,7 +18,7 @@ import { unAuthenticateUser } from "./actionCreators/authenticationActionCreator
 // eslint-disable-next-line import/prefer-default-export
 export const store = configureStore();
 
-// 5 minutees before user is inactive- across tabs
+// 5 minutes before user is inactive- across tabs
 const idleTimeout = 5 * 60_000;
 // seconds before expiry to request new access token
 const refreshTokenBufferSeconds = 60;
@@ -64,11 +64,11 @@ const Index = () => {
   const handleUpdateToken = () => {
     if (keycloak.authenticated && keycloak.tokenParsed) {
       const tokenExpiryTime = keycloak.tokenParsed.exp * 1000;
-      const timeToLive = tokenExpiryTime - Date.now() - (refreshTokenBufferSeconds * 1000);
+      const timeToLive = tokenExpiryTime - Date.now() - refreshTokenBufferSeconds * 1000;
 
       const updateInterval = setInterval(() => {
         if (!isIdle()) {
-          keycloak.updateToken(-1).catch((err = "") => {
+          keycloak.updateToken(refreshTokenBufferSeconds - 1).catch((err = "") => {
             console.log("Failed to refresh token", err);
             handleAuthErrors();
           });
@@ -100,7 +100,7 @@ const Index = () => {
       onAuthLogout={(err = "") => handleAuthErrors(err)}
       onAuthError={(err = "") => handleAuthErrors(err)}
       onAuthRefreshError={(err = "") => handleAuthErrors(err)}
-      onInitError={(err = "") => handleAuthErrors(err)}      
+      onInitError={(err = "") => handleAuthErrors(err)}
     >
       <Provider store={store}>
         <App />


### PR DESCRIPTION
## Objective 
Was using a force refresh (value of -1 in updateToken function) when checking whether to update token. Multiple instances seemed to be getting created and so it was refreshing the token multiple times in quick succession. Put in a value for it to check against before refreshing so that it will only do it once.

[MDS-5017](https://bcmines.atlassian.net/browse/MDS-5017)

_Why are you making this change? Provide a short explanation and/or screenshots_
