### PR TITLE
[MDS-5086] Text changes on Incidents

### DIFF
--- a/services/minespace-web/src/components/Forms/incidents/IncidentForm.js
+++ b/services/minespace-web/src/components/Forms/incidents/IncidentForm.js
@@ -756,6 +756,12 @@ const renderUploadInitialNotificationDocuments = (
             </Col>
           )}
         </Row>
+        <Row>
+          <Typography.Title level={5}>
+            A final report must be submitted within 60 days of the reportable incident. Please add
+            the final report documentation below.
+          </Typography.Title>
+        </Row>
         {formDisabled && (
           <DocumentTable
             documents={finalReportDocuments}

--- a/services/minespace-web/src/components/Forms/incidents/IncidentForm.js
+++ b/services/minespace-web/src/components/Forms/incidents/IncidentForm.js
@@ -218,7 +218,7 @@ const renderInitialReport = (incidentCategoryCodeOptions, formDisabled) => (
     <Col span={24}>
       <Typography.Title level={3}>Initial Report</Typography.Title>
       <Typography.Paragraph>
-        Select one or more incident types for this submission.
+        <Typography.Text>Select one or more incident types for this submission.</Typography.Text>
       </Typography.Paragraph>
       <Form.Item label="Incident type(s)">
         <Field
@@ -757,10 +757,10 @@ const renderUploadInitialNotificationDocuments = (
           )}
         </Row>
         <Row>
-          <Typography.Title level={5}>
+          <Typography.Paragraph>
             A final report must be submitted within 60 days of the reportable incident. Please add
             the final report documentation below.
-          </Typography.Title>
+          </Typography.Paragraph>
         </Row>
         {formDisabled && (
           <DocumentTable

--- a/services/minespace-web/src/components/dashboard/mine/incidents/Incidents.js
+++ b/services/minespace-web/src/components/dashboard/mine/incidents/Incidents.js
@@ -124,7 +124,6 @@ export const Incidents = (props) => {
           <Typography.Text className="color-primary" strong>
             reported incidents.
           </Typography.Text>
-          .
         </Typography.Paragraph>
         <Typography.Paragraph>
           <a
@@ -134,6 +133,7 @@ export const Incidents = (props) => {
           >
             Click here
           </a>
+          {" "}
           for more information on reportable incidents.
         </Typography.Paragraph>
         <IncidentsTable

--- a/services/minespace-web/src/tests/components/Forms/incidents/__snapshots__/IncidentForm.spec.js.snap
+++ b/services/minespace-web/src/tests/components/Forms/incidents/__snapshots__/IncidentForm.spec.js.snap
@@ -41,7 +41,9 @@ exports[`IncidentForm renders properly 1`] = `
             Initial Report
           </Title>
           <Paragraph>
-            Select one or more incident types for this submission.
+            <Text>
+              Select one or more incident types for this submission.
+            </Text>
           </Paragraph>
           <FormItem
             hasFeedback={false}
@@ -640,11 +642,9 @@ exports[`IncidentForm renders properly 1`] = `
             </Col>
           </Row>
           <Row>
-            <Title
-              level={5}
-            >
+            <Paragraph>
               A final report must be submitted within 60 days of the reportable incident. Please add the final report documentation below.
-            </Title>
+            </Paragraph>
           </Row>
           <DocumentTable
             deletePayload={Object {}}

--- a/services/minespace-web/src/tests/components/Forms/incidents/__snapshots__/IncidentForm.spec.js.snap
+++ b/services/minespace-web/src/tests/components/Forms/incidents/__snapshots__/IncidentForm.spec.js.snap
@@ -639,6 +639,13 @@ exports[`IncidentForm renders properly 1`] = `
               </div>
             </Col>
           </Row>
+          <Row>
+            <Title
+              level={5}
+            >
+              A final report must be submitted within 60 days of the reportable incident. Please add the final report documentation below.
+            </Title>
+          </Row>
           <DocumentTable
             deletePayload={Object {}}
             deletePermission={null}

--- a/services/minespace-web/src/tests/components/dashboard/mine/incidents/__snapshots__/Incidents.spec.js.snap
+++ b/services/minespace-web/src/tests/components/dashboard/mine/incidents/__snapshots__/Incidents.spec.js.snap
@@ -37,7 +37,6 @@ exports[`MineIncidents renders properly 1`] = `
       >
         reported incidents.
       </Text>
-      .
     </Paragraph>
     <Paragraph>
       <a
@@ -47,6 +46,7 @@ exports[`MineIncidents renders properly 1`] = `
       >
         Click here
       </a>
+       
       for more information on reportable incidents.
     </Paragraph>
     <withRouter(Connect(IncidentsTable))


### PR DESCRIPTION
## Objective 
- put a missing space between words
- noticed a sentence that ended like this.. <-- removed the extra one
- add subheading

[MDS-5086](https://bcmines.atlassian.net/browse/MDS-5086)

_Why are you making this change? Provide a short explanation and/or screenshots_
![image](https://user-images.githubusercontent.com/102187683/220457411-3a605f4f-fc71-4346-8507-3cfe5ef111d4.png)
![image](https://user-images.githubusercontent.com/102187683/220450439-1524df0e-a80e-4888-8c70-5bb7917a5727.png)
