### PR TITLE
[MDS-5083] updated mine alert logic and validation

### DIFF
--- a/migrations/sql/V2023.02.22.12.22__remove_constraint_mine_alert_schema.sql
+++ b/migrations/sql/V2023.02.22.12.22__remove_constraint_mine_alert_schema.sql
@@ -1,0 +1,2 @@
+ALTER table mine_alert
+DROP CONSTRAINT mine_guid_date_range_uniq;

--- a/services/core-api/app/api/mines/alerts/resources/mine_alert.py
+++ b/services/core-api/app/api/mines/alerts/resources/mine_alert.py
@@ -1,7 +1,6 @@
 from flask_restplus import Resource, inputs
 from werkzeug.exceptions import NotFound, BadRequest
 from datetime import timedelta, datetime as dt, timezone
-from sqlalchemy.exc import SQLAlchemyError
 
 from app.extensions import api
 from app.api.utils.custom_reqparser import CustomReqparser
@@ -111,7 +110,7 @@ class MineAlertResource(Resource, UserMixin):
         alert = MineAlert.find_by_guid(mine_alert_guid)
         data = self.parser.parse_args()
         all_mine_alerts = MineAlert.find_by_mine_guid(mine_guid)
-        historic_alerts = [_alert for _alert in all_mine_alerts if (str(_alert.mine_alert_guid) != mine_alert_guid and data.get('start_date') >= _alert.start_date)]
+        historic_alerts = [_alert for _alert in all_mine_alerts if _alert.start_date >= data.get('start_date') and str(_alert.mine_alert_guid) != mine_alert_guid]
 
         if not alert:
             raise NotFound('Mine alert with guid "{mine_alert_guid}" not found.')
@@ -135,6 +134,7 @@ class MineAlertResource(Resource, UserMixin):
             raise NotFound('Mine alert with guid "{mine_alert_guid}" not found.')
 
         alert.deleted_ind = True
+        alert.is_active = False
         alert.save()
 
         return ('', 204)

--- a/services/core-web/common/utils/Validate.js
+++ b/services/core-web/common/utils/Validate.js
@@ -161,6 +161,18 @@ export const validateStartDate = memoize(
       : undefined
 );
 
+export const alertStartDateNotBeforeHistoric = memoize((mineAlerts) => (value) => {
+  const isBefore = mineAlerts.some((alert) => new Date(value) < new Date(alert.start_date));
+  return isBefore
+    ? `Start date cannot come before a historic alert. Please check history for more details.`
+    : undefined;
+});
+
+export const alertNotInFutureIfCurrentActive = (value) =>
+  value && new Date(value) >= new Date()
+    ? "Start date cannot be in the future if there is a current active alert.  Please update or remove current alert first"
+    : undefined;
+
 export const dateNotInFuture = (value) =>
   value && new Date(value) >= new Date() ? "Date cannot be in the future" : undefined;
 
@@ -170,7 +182,7 @@ export const dateInFuture = (value) =>
 export const dateNotBeforeOther = memoize(
   (other) => (value) =>
     value && other && new Date(value) <= new Date(other)
-      ? `Date cannot be on or before ${other}`
+      ? `Date cannot be on or before ${new Date(other).toDateString()}`
       : undefined
 );
 
@@ -196,7 +208,7 @@ export const timeNotBeforeOther = memoize(
 export const dateNotAfterOther = memoize(
   (other) => (value) =>
     value && other && new Date(value) >= new Date(other)
-      ? `Date cannot be on or after ${other}`
+      ? `Date cannot be on or after ${new Date(other).toDateString()}`
       : undefined
 );
 

--- a/services/core-web/common/utils/Validate.js
+++ b/services/core-web/common/utils/Validate.js
@@ -168,10 +168,12 @@ export const alertStartDateNotBeforeHistoric = memoize((mineAlerts) => (value) =
     : undefined;
 });
 
-export const alertNotInFutureIfCurrentActive = (value) =>
-  value && new Date(value) >= new Date()
-    ? "Start date cannot be in the future if there is a current active alert.  Please update or remove current alert first"
-    : undefined;
+export const alertNotInFutureIfCurrentActive = memoize(
+  (mineAlert) => (value) =>
+    value && mineAlert.start_date && new Date(value) >= new Date()
+      ? "Start date cannot be in the future if there is a current active alert.  Please update or remove current alert first"
+      : undefined
+);
 
 export const dateNotInFuture = (value) =>
   value && new Date(value) >= new Date() ? "Date cannot be in the future" : undefined;

--- a/services/core-web/src/components/Forms/mineAlerts/AddMineAlertForm.js
+++ b/services/core-web/src/components/Forms/mineAlerts/AddMineAlertForm.js
@@ -37,7 +37,23 @@ const defaultProps = {
 };
 
 export const AddMineAlertForm = (props) => {
-  const { title, text, activeMineAlert, mineAlerts } = props;
+  const { title, text, activeMineAlert, mineAlerts, formValues } = props;
+
+  const startDateValidation = () => {
+    return formValues?.mine_alert_guid
+      ? [
+          required,
+          dateNotAfterOther(props.formValues.stop_date),
+          alertStartDateNotBeforeHistoric(mineAlerts),
+        ]
+      : [
+          required,
+          dateNotAfterOther(props.formValues.stop_date),
+          alertStartDateNotBeforeHistoric(mineAlerts),
+          dateNotBeforeOther(activeMineAlert.start_date),
+          alertNotInFutureIfCurrentActive(activeMineAlert),
+        ];
+  };
 
   return (
     <div>
@@ -96,13 +112,7 @@ export const AddMineAlertForm = (props) => {
                 label="Start Date"
                 placeholder="Select Date"
                 component={renderConfig.DATE}
-                validate={[
-                  required,
-                  dateNotAfterOther(props.formValues.stop_date),
-                  alertStartDateNotBeforeHistoric(mineAlerts),
-                  dateNotBeforeOther(activeMineAlert.start_date),
-                  activeMineAlert?.start_date ? alertNotInFutureIfCurrentActive : null,
-                ]}
+                validate={startDateValidation()}
                 format={null}
               />
             </Form.Item>

--- a/services/core-web/src/components/Forms/mineAlerts/AddMineAlertForm.js
+++ b/services/core-web/src/components/Forms/mineAlerts/AddMineAlertForm.js
@@ -11,10 +11,13 @@ import {
   dateNotAfterOther,
   maxLength,
   phoneNumber,
+  alertStartDateNotBeforeHistoric,
+  alertNotInFutureIfCurrentActive,
 } from "@common/utils/Validate";
 import { resetForm, normalizePhone } from "@common/utils/helpers";
 import * as FORM from "@/constants/forms";
 import { renderConfig } from "@/components/common/config";
+import CustomPropTypes from "@/customPropTypes";
 
 const propTypes = {
   handleSubmit: PropTypes.func.isRequired,
@@ -23,14 +26,19 @@ const propTypes = {
   formValues: PropTypes.objectOf(PropTypes.any),
   title: PropTypes.string.isRequired,
   text: PropTypes.string.isRequired,
+  activeMineAlert: CustomPropTypes.mineAlert,
+  mineAlerts: PropTypes.arrayOf(CustomPropTypes.mineAlert),
 };
 
 const defaultProps = {
   formValues: {},
+  activeMineAlert: {},
+  mineAlerts: [],
 };
 
 export const AddMineAlertForm = (props) => {
-  const { title, text } = props;
+  const { title, text, activeMineAlert, mineAlerts } = props;
+
   return (
     <div>
       <Form layout="vertical" onSubmit={props.handleSubmit}>
@@ -88,7 +96,13 @@ export const AddMineAlertForm = (props) => {
                 label="Start Date"
                 placeholder="Select Date"
                 component={renderConfig.DATE}
-                validate={[required, dateNotAfterOther(props.formValues.stop_date)]}
+                validate={[
+                  required,
+                  dateNotAfterOther(props.formValues.stop_date),
+                  alertStartDateNotBeforeHistoric(mineAlerts),
+                  dateNotBeforeOther(activeMineAlert.start_date),
+                  activeMineAlert?.start_date ? alertNotInFutureIfCurrentActive : null,
+                ]}
                 format={null}
               />
             </Form.Item>

--- a/services/core-web/src/components/mine/MineAlert.js
+++ b/services/core-web/src/components/mine/MineAlert.js
@@ -92,7 +92,7 @@ export class MineAlert extends Component {
     return null;
   };
 
-  openCreateMineAlertModal = () => {
+  openCreateMineAlertModal = (activeMineAlert, mineAlerts) => {
     return this.props.openModal({
       props: {
         title: ModalContent.CREATE_MINE_ALERT_RECORD,
@@ -100,12 +100,14 @@ export class MineAlert extends Component {
         mineAlertGuid: this.state.activeMineAlert?.mine_alert_guid,
         closeModal: this.props.closeModal,
         onSubmit: this.submitCreateMineAlarmForm(this.state.activeMineAlert?.mine_alert_guid),
+        activeMineAlert,
+        mineAlerts,
       },
       content: modalConfig.ADD_MINE_ALERT,
     });
   };
 
-  openUpdateMineAlertModal = () => {
+  openUpdateMineAlertModal = (activeMineAlert, mineAlerts) => {
     return this.props.openModal({
       props: {
         title: ModalContent.EDIT_MINE_ALERT_RECORD,
@@ -114,6 +116,8 @@ export class MineAlert extends Component {
         mineAlertGuid: this.state.activeMineAlert?.mine_alert_guid,
         closeModal: this.props.closeModal,
         onSubmit: this.submitUpdateMineAlarmForm(this.state.activeMineAlert?.mine_alert_guid),
+        activeMineAlert,
+        mineAlerts,
       },
       content: modalConfig.ADD_MINE_ALERT,
     });
@@ -149,7 +153,8 @@ export class MineAlert extends Component {
           <button
             type="button"
             className="full add-permit-dropdown-button"
-            onClick={() => this.openCreateMineAlertModal()}
+            onClick={() =>
+              this.openCreateMineAlertModal(this.state.activeMineAlert, this.props.mineAlerts)}
           >
             Create New Alert
           </button>
@@ -159,7 +164,8 @@ export class MineAlert extends Component {
             <button
               type="button"
               className="full add-permit-dropdown-button"
-              onClick={() => this.openUpdateMineAlertModal()}
+              onClick={() =>
+                this.openUpdateMineAlertModal(this.state.activeMineAlert, this.props.mineAlerts)}
             >
               Edit Active Alert
             </button>
@@ -238,19 +244,12 @@ export class MineAlert extends Component {
                   <p>
                     {this.state.activeMineAlert.end_date ? (
                       <b>
-                        Active Alert: 
-                        {' '}
-                        {formatDate(this.state.activeMineAlert.start_date)}
-                        {' '}
--
-                        {" "}
-                        {formatDate(this.state.activeMineAlert.end_date)}
+                        {`Active Alert: ${formatDate(
+                          this.state.activeMineAlert.start_date
+                        )} - ${formatDate(this.state.activeMineAlert.end_date)}`}
                       </b>
                     ) : (
-                      <b>
-Active Alert:
-                        {formatDate(this.state.activeMineAlert.start_date)}
-                      </b>
+                      <b>{`Active Alert: ${formatDate(this.state.activeMineAlert.start_date)}`}</b>
                     )}
                   </p>
                   <p>

--- a/services/core-web/src/components/mine/MineAlert.js
+++ b/services/core-web/src/components/mine/MineAlert.js
@@ -154,7 +154,7 @@ export class MineAlert extends Component {
             type="button"
             className="full add-permit-dropdown-button"
             onClick={() =>
-              this.openCreateMineAlertModal(this.state.activeMineAlert, this.props.mineAlerts)}
+              this.openCreateMineAlertModal(this.state.activeMineAlert, this.state.pastMineAlerts)}
           >
             Create New Alert
           </button>
@@ -165,7 +165,7 @@ export class MineAlert extends Component {
               type="button"
               className="full add-permit-dropdown-button"
               onClick={() =>
-                this.openUpdateMineAlertModal(this.state.activeMineAlert, this.props.mineAlerts)}
+                this.openUpdateMineAlertModal(this.state.activeMineAlert, this.state.pastMineAlerts)}
             >
               Edit Active Alert
             </button>

--- a/services/core-web/src/components/mine/PastMineAlert.js
+++ b/services/core-web/src/components/mine/PastMineAlert.js
@@ -15,28 +15,36 @@ export const PastMineAlert = (props) => {
   return (
     <div>
       <Alert
-        description={
+        description={(
           <Row>
             <Col xs={24} md={18}>
               <>
                 <p>
                   {props.end_date ? (
                     <b>
-                      Active Alert: {formatDate(props.start_date)} - {formatDate(props.end_date)}
+                      {`Active Alert: ${formatDate(props.start_date)} - ${formatDate(
+                        props.end_date
+                      )}`}
                     </b>
                   ) : (
-                    <b>Active Alert: {formatDate(props.start_date)}</b>
+                    <b>{`Active Alert: ${formatDate(props.start_date)}`}</b>
                   )}
                 </p>
                 <p>
                   {props.message}
                   <br />
-                  For more information contact: {props.contact_name} - {props.contact_phone}
+                  For more information contact: 
+                  {' '}
+                  {props.contact_name}
+                  {' '}
+- 
+                  {' '}
+                  {props.contact_phone}
                 </p>
               </>
             </Col>
           </Row>
-        }
+        )}
         type="warning"
         showIcon
         style={{ backgroundColor: "#FFF2F0", border: "1.5px solid #FF0000" }}

--- a/services/minespace-web/common/utils/Validate.js
+++ b/services/minespace-web/common/utils/Validate.js
@@ -161,6 +161,18 @@ export const validateStartDate = memoize(
       : undefined
 );
 
+export const alertStartDateNotBeforeHistoric = memoize((mineAlerts) => (value) => {
+  const isBefore = mineAlerts.some((alert) => new Date(value) < new Date(alert.start_date));
+  return isBefore
+    ? `Start date cannot come before a historic alert. Please check history for more details.`
+    : undefined;
+});
+
+export const alertNotInFutureIfCurrentActive = (value) =>
+  value && new Date(value) >= new Date()
+    ? "Start date cannot be in the future if there is a current active alert.  Please update or remove current alert first"
+    : undefined;
+
 export const dateNotInFuture = (value) =>
   value && new Date(value) >= new Date() ? "Date cannot be in the future" : undefined;
 
@@ -170,7 +182,7 @@ export const dateInFuture = (value) =>
 export const dateNotBeforeOther = memoize(
   (other) => (value) =>
     value && other && new Date(value) <= new Date(other)
-      ? `Date cannot be on or before ${other}`
+      ? `Date cannot be on or before ${new Date(other).toDateString()}`
       : undefined
 );
 
@@ -196,7 +208,7 @@ export const timeNotBeforeOther = memoize(
 export const dateNotAfterOther = memoize(
   (other) => (value) =>
     value && other && new Date(value) >= new Date(other)
-      ? `Date cannot be on or after ${other}`
+      ? `Date cannot be on or after ${new Date(other).toDateString()}`
       : undefined
 );
 

--- a/services/minespace-web/common/utils/Validate.js
+++ b/services/minespace-web/common/utils/Validate.js
@@ -168,10 +168,12 @@ export const alertStartDateNotBeforeHistoric = memoize((mineAlerts) => (value) =
     : undefined;
 });
 
-export const alertNotInFutureIfCurrentActive = (value) =>
-  value && new Date(value) >= new Date()
-    ? "Start date cannot be in the future if there is a current active alert.  Please update or remove current alert first"
-    : undefined;
+export const alertNotInFutureIfCurrentActive = memoize(
+  (mineAlert) => (value) =>
+    value && mineAlert.start_date && new Date(value) >= new Date()
+      ? "Start date cannot be in the future if there is a current active alert.  Please update or remove current alert first"
+      : undefined
+);
 
 export const dateNotInFuture = (value) =>
   value && new Date(value) >= new Date() ? "Date cannot be in the future" : undefined;


### PR DESCRIPTION
## Objective 

[MDS-5083](https://bcmines.atlassian.net/browse/MDS-5083)

- Added frontend validation to match backend for alert form
- Removed database constraint preventing users from creating new alerts that overlap with previous inactive alerts (this is the requested behaviour, and the constraint wasn't properly ignoring records with `deleted_ind=true`

_Why are you making this change? Provide a short explanation and/or screenshots_

<img width="661" alt="image" src="https://user-images.githubusercontent.com/83598933/220752075-c248c34d-d04c-478d-87ff-46dec1a57756.png">
