### PR TITLE
[MDS-5086] Mine Incident Creation in Core

### DIFF
--- a/services/core-web/src/components/mine/Incidents/MineIncident.js
+++ b/services/core-web/src/components/mine/Incidents/MineIncident.js
@@ -85,7 +85,7 @@ export const MineIncident = (props) => {
       setIsNewIncident(false);
       return props.fetchMineIncident(mineGuid, mineIncidentGuid);
     }
-    return null;
+    return Promise.resolve();
   };
 
   const handleCreateMineIncident = (formattedValues) => {


### PR DESCRIPTION
## Objective 
Bug found in QA
Was unable to create a mine incident in Core because handleFetchData was returning _null_ when there was no mine or incident guid, causing an error when attempting to call .then() on the result. Returned a resolved promise instead. Could have also rejected the promise and modified the callers to catch it and setIsEditMode based on resolve/reject.

[MDS-5086](https://bcmines.atlassian.net/browse/MDS-5086)

_Why are you making this change? Provide a short explanation and/or screenshots_
