### PR TITLE
[MDS-5061] Bug: can edit fields when in view mode

### DIFF
--- a/services/core-web/src/components/Forms/incidents/IncidentForm.js
+++ b/services/core-web/src/components/Forms/incidents/IncidentForm.js
@@ -7,7 +7,7 @@ import { Field, FieldArray, reduxForm, change, getFormValues, formValueSelector 
 import { LockOutlined, PlusOutlined } from "@ant-design/icons";
 import { Form } from "@ant-design/compatible";
 import "@ant-design/compatible/assets/index.css";
-import { Col, Row, Typography, Divider, Empty, Button, Popconfirm, Alert } from "antd";
+import { Col, Row, Typography, Divider, Empty, Button, Alert } from "antd";
 import {
   required,
   requiredList,
@@ -78,7 +78,7 @@ const documentColumns = [
   uploadDateColumn("upload_date"),
 ];
 
-const alertText = (status, updateUser, updateDate, responsibleInspector, selectedStatusCode) => {
+const alertText = (updateUser, updateDate, responsibleInspector, selectedStatusCode) => {
   let text = "";
 
   if (selectedStatusCode === "UNR" && !responsibleInspector) {
@@ -757,9 +757,7 @@ const renderInternalDocumentsComments = (childProps, isEditMode, handlers, paren
       <Col span={24}>
         <Typography.Title level={3} id="internal-documents">
           <LockOutlined className="violet" />
-          {' '}
-Internal Documents and Comments (Ministry Visible
-          Only)
+          Internal Documents and Comments (Ministry Visible Only)
         </Typography.Title>
         <Divider />
         {!incidentCreated ? (
@@ -846,7 +844,6 @@ const updateIncidentStatus = (childProps, isNewIncident) => {
             <Col xs={24} md={18}>
               <p>
                 {alertText(
-                  childProps.incident?.status_code,
                   childProps.incident?.update_user,
                   childProps.incident?.update_timestamp,
                   responsibleInspector,
@@ -898,29 +895,16 @@ const updateIncidentStatus = (childProps, isNewIncident) => {
 const renderEditSaveControls = (childProps, isEditMode, isNewIncident) => (
   <div className="right center-mobile violet">
     {isEditMode && (
-      <>
-        <Popconfirm
-          placement="topLeft"
-          title="Are you sure you want to cancel this submission? All unsaved changes will be lost."
-          onConfirm={() => childProps.handlers.handleCancelEdit()}
-          okText="Yes"
-          cancelText="No"
-        >
-          <Button className="full-mobile right violet violet-border" type="secondary">
-            Cancel
-          </Button>
-        </Popconfirm>
-        <Button
-          id="mine-incident-submit"
-          className="full-mobile right"
-          type="primary"
-          htmlType="submit"
-          loading={childProps.submitting}
-          disabled={childProps.submitting}
-        >
-          {isNewIncident ? "Create Incident" : "Save Changes"}
-        </Button>
-      </>
+      <Button
+        id="mine-incident-submit"
+        className="full-mobile right"
+        type="primary"
+        htmlType="submit"
+        loading={childProps.submitting}
+        disabled={childProps.submitting}
+      >
+        {isNewIncident ? "Create Incident" : "Save Changes"}
+      </Button>
     )}
   </div>
 );

--- a/services/core-web/src/components/Forms/incidents/IncidentForm.js
+++ b/services/core-web/src/components/Forms/incidents/IncidentForm.js
@@ -819,7 +819,6 @@ const renderInternalDocumentsComments = (childProps, isEditMode, handlers, paren
               <br />
               <MinistryInternalComments
                 mineIncidentGuid={childProps.incident?.mine_incident_guid}
-                isEditMode={isEditMode}
               />
             </Col>
           </Row>

--- a/services/core-web/src/components/Forms/incidents/IncidentForm.js
+++ b/services/core-web/src/components/Forms/incidents/IncidentForm.js
@@ -33,7 +33,6 @@ import {
   getDropdownIncidentStatusCodeOptions,
   getIncidentStatusCodeHash,
 } from "@common/selectors/staticContentSelectors";
-import { EDIT_OUTLINE_VIOLET } from "@/constants/assets";
 import AuthorizationGuard from "@/HOC/AuthorizationGuard";
 import * as FORM from "@/constants/forms";
 import * as Permission from "@/constants/permissions";
@@ -411,20 +410,6 @@ const renderDocumentation = (childProps, isEditMode, handlers, parentHandlers) =
           <Col xs={24} md={12}>
             <h4>Upload Initial Notification Documents</h4>
           </Col>
-          <Col xs={24} md={12}>
-            {!isEditMode && (
-              <div className="right center-mobile">
-                <Button
-                  id="mine-incident-add-documentation"
-                  type="secondary"
-                  onClick={parentHandlers.toggleEditMode}
-                  className="full-mobile violet violet-border"
-                >
-                  + Add Documentation
-                </Button>
-              </div>
-            )}
-          </Col>
         </Row>
         <br />
         <h4>Incident Documents</h4>
@@ -512,9 +497,6 @@ const renderDocumentation = (childProps, isEditMode, handlers, parentHandlers) =
                   within 60 days of the reportable incident. Please add the final report
                   documentation by clicking below.
                 </Typography.Paragraph>
-                <Button type="primary" onClick={parentHandlers.toggleEditMode}>
-                  Add Final Report
-                </Button>
               </div>
             )}
           />
@@ -524,7 +506,7 @@ const renderDocumentation = (childProps, isEditMode, handlers, parentHandlers) =
   );
 };
 
-const renderRecommendations = ({ fields, isEditMode, handlers }) => [
+const renderRecommendations = ({ fields, isEditMode }) => [
   fields.map((recommendation) => (
     <Field
       name={`${recommendation}.recommendation`}
@@ -533,10 +515,12 @@ const renderRecommendations = ({ fields, isEditMode, handlers }) => [
       disabled={!isEditMode}
     />
   )),
-  <Button type="primary" onClick={() => (isEditMode ? fields.push({}) : handlers.toggleEditMode())}>
-    <PlusOutlined />
-    Add Recommendation
-  </Button>,
+  isEditMode ? (
+    <Button type="primary" onClick={() => fields.push({})}>
+      <PlusOutlined />
+      Add Recommendation
+    </Button>
+  ) : null,
 ];
 
 const renderMinistryFollowUp = (childProps, isEditMode) => {
@@ -797,20 +781,6 @@ Internal Documents and Comments (Ministry Visible
                 <Col xs={24} md={12}>
                   <h4>Internal Ministry Documentation</h4>
                 </Col>
-                <Col xs={24} md={12}>
-                  {!isEditMode && (
-                    <div className="right center-mobile">
-                      <Button
-                        id="mine-incident-add-documents"
-                        type="primary"
-                        onClick={parentHandlers.toggleEditMode}
-                        className="full-mobile"
-                      >
-                        + Add Documents
-                      </Button>
-                    </div>
-                  )}
-                </Col>
               </Row>
               <br />
               <Typography.Paragraph strong>
@@ -851,6 +821,7 @@ Internal Documents and Comments (Ministry Visible
               <br />
               <MinistryInternalComments
                 mineIncidentGuid={childProps.incident?.mine_incident_guid}
+                isEditMode={isEditMode}
               />
             </Col>
           </Row>
@@ -926,17 +897,6 @@ const updateIncidentStatus = (childProps, isNewIncident) => {
 
 const renderEditSaveControls = (childProps, isEditMode, isNewIncident) => (
   <div className="right center-mobile violet">
-    {!isEditMode && (
-      <Button
-        id="mine-incident-edit"
-        className="full-mobile violet violet-border"
-        type="secondary"
-        onClick={childProps.handlers.toggleEditMode}
-      >
-        <img alt="pencil" src={EDIT_OUTLINE_VIOLET} />
-        &nbsp;Edit Incident
-      </Button>
-    )}
     {isEditMode && (
       <>
         <Popconfirm

--- a/services/core-web/src/components/common/comments/MinistryCommentPanel.js
+++ b/services/core-web/src/components/common/comments/MinistryCommentPanel.js
@@ -1,21 +1,18 @@
 import React from "react";
-import { connect } from "react-redux";
 import PropTypes from "prop-types";
 import { UserOutlined, LoadingOutlined } from "@ant-design/icons";
 import { Avatar, Divider, Row, Col, Spin, List } from "antd";
 
-import { USER_ROLES } from "@mds/common";
-import { getUserAccessData } from "@common/selectors/authenticationSelectors";
 import CommentEditor from "@/components/common/comments/CommentEditor";
 import MinistryComment from "@/components/common/comments/MinistryComment";
 import * as Style from "@/constants/styles";
 import CustomPropTypes from "@/customPropTypes";
+import AuthorizationWrapper from "../wrappers/AuthorizationWrapper";
 
 const propTypes = {
   loading: PropTypes.bool,
   renderEditor: PropTypes.bool,
   comments: PropTypes.arrayOf(CustomPropTypes.mineComment).isRequired,
-  userRoles: PropTypes.arrayOf(PropTypes.string).isRequired,
   createPermission: PropTypes.string,
   onSubmit: PropTypes.func,
   onChange: PropTypes.func,
@@ -24,33 +21,31 @@ const propTypes = {
 const defaultProps = {
   renderEditor: false,
   loading: false,
-  createPermission: null,
+  createPermission: undefined,
   onChange: () => {},
   onSubmit: () => {},
 };
 
-export const CommentPanel = (props) => {
+export const MinistryCommentPanel = (props) => {
   const { comments, createPermission, renderEditor, loading } = props;
-  const hasCreatePermission = createPermission
-    ? props.userRoles.includes(USER_ROLES[createPermission])
-    : true;
-
   return (
     <>
-      {renderEditor && hasCreatePermission && (
-        <Row>
-          <Col span={2}>
-            <Avatar size="small" icon={<UserOutlined />} />
-          </Col>
-          <Col span={22}>
-            <CommentEditor
-              addCommentPermission={createPermission}
-              onChange={props.onChange}
-              onSubmit={props.onSubmit}
-            />
-            <Divider />
-          </Col>
-        </Row>
+      {renderEditor && (
+        <AuthorizationWrapper permission={createPermission}>
+          <Row>
+            <Col span={2}>
+              <Avatar size="small" icon={<UserOutlined />} />
+            </Col>
+            <Col span={22}>
+              <CommentEditor
+                addCommentPermission={createPermission}
+                onChange={props.onChange}
+                onSubmit={props.onSubmit}
+              />
+              <Divider />
+            </Col>
+          </Row>
+        </AuthorizationWrapper>
       )}
       {!loading ? (
         <List
@@ -94,11 +89,7 @@ export const CommentPanel = (props) => {
   );
 };
 
-const mapStateToProps = (state) => ({
-  userRoles: getUserAccessData(state),
-});
+MinistryCommentPanel.defaultProps = defaultProps;
+MinistryCommentPanel.propTypes = propTypes;
 
-CommentPanel.defaultProps = defaultProps;
-CommentPanel.propTypes = propTypes;
-
-export default connect(mapStateToProps)(CommentPanel);
+export default MinistryCommentPanel;

--- a/services/core-web/src/components/common/comments/MinistryCommentPanel.js
+++ b/services/core-web/src/components/common/comments/MinistryCommentPanel.js
@@ -30,13 +30,14 @@ const defaultProps = {
 };
 
 export const CommentPanel = (props) => {
-  const createPermission = props.userRoles.includes(USER_ROLES[props?.createPermission])
-    ? props.createPermission
-    : null;
+  const { comments, createPermission, renderEditor, loading } = props;
+  const hasCreatePermission = createPermission
+    ? props.userRoles.includes(USER_ROLES[createPermission])
+    : true;
 
   return (
-    <React.Fragment>
-      {props.renderEditor && (
+    <>
+      {renderEditor && hasCreatePermission && (
         <Row>
           <Col span={2}>
             <Avatar size="small" icon={<UserOutlined />} />
@@ -51,12 +52,11 @@ export const CommentPanel = (props) => {
           </Col>
         </Row>
       )}
-
-      {!props.loading ? (
+      {!loading ? (
         <List
           className="comment-list"
           itemLayout="horizontal"
-          dataSource={props.comments}
+          dataSource={comments}
           renderItem={(item) => {
             return (
               <li key={item.key}>
@@ -90,7 +90,7 @@ export const CommentPanel = (props) => {
           />
         </div>
       )}
-    </React.Fragment>
+    </>
   );
 };
 

--- a/services/core-web/src/components/mine/Incidents/MineIncident.js
+++ b/services/core-web/src/components/mine/Incidents/MineIncident.js
@@ -56,7 +56,7 @@ export const MineIncident = (props) => {
     ? new URLSearchParams(search).get("mine_name")
     : incident.mine_name;
 
-  const isEditMode = isEditPage || !mineIncidentGuid;
+  const isEditMode = isEditPage || isNewIncident;
 
   const sideBarRoute = (() => {
     if (isNewIncident) {

--- a/services/core-web/src/components/mine/Incidents/MineIncident.js
+++ b/services/core-web/src/components/mine/Incidents/MineIncident.js
@@ -65,9 +65,11 @@ const propTypes = {
 
 export const MineIncident = (props) => {
   const { formValues, formErrors, match, incident, location } = props;
+  // eslint-disable-next-line react/prop-types
+  const isEditPage = props.location.pathname.endsWith("/edit");
   const mineGuid = match?.params?.mineGuid;
   const mineIncidentGuid = match?.params?.mineIncidentGuid;
-  const [isEditMode, setIsEditMode] = useState(false);
+  const [isEditMode, setIsEditMode] = useState(isEditPage);
   const [isNewIncident, setIsNewIncident] = useState(true);
   const [isLoaded, setIsLoaded] = useState(false);
   const [fixedTop, setIsFixedTop] = useState(false);
@@ -93,7 +95,7 @@ export const MineIncident = (props) => {
     return props
       .createMineIncident(mineGuid, formattedValues)
       .then(({ data: { mine_guid, mine_incident_guid } }) =>
-        props.history.replace(routes.MINE_INCIDENT.dynamicRoute(mine_guid, mine_incident_guid))
+        props.history.replace(routes.EDIT_MINE_INCIDENT.dynamicRoute(mine_guid, mine_incident_guid))
       )
       .then(() => handleFetchData())
       .then(() => setIsLoaded(true));
@@ -201,7 +203,6 @@ export const MineIncident = (props) => {
   useEffect(() => {
     handleFetchData().then(() => {
       setIsLoaded(true);
-      setIsEditMode(location.state?.isEditMode);
 
       return () => {
         window.removeEventListener("scroll", handleScroll);
@@ -252,7 +253,7 @@ export const MineIncident = (props) => {
               { href: "internal-documents", title: "Internal Documents" },
               { href: "internal-ministry-comments", title: "Comments" },
             ]}
-            featureUrlRoute={routes.MINE_INCIDENT.hashRoute}
+            featureUrlRoute={routes.VIEW_MINE_INCIDENT.hashRoute}
             featureUrlRouteArguments={[mineGuid, mineIncidentGuid]}
           />
         </div>

--- a/services/core-web/src/components/mine/Incidents/MineIncidentTable.js
+++ b/services/core-web/src/components/mine/Incidents/MineIncidentTable.js
@@ -319,8 +319,10 @@ const MineIncidentTable = (props) => {
                       record.incident
                     )
                   : props.history.push({
-                      pathname: router.MINE_INCIDENT.dynamicRoute(record.mine_guid, record.key),
-                      state: { isEditMode: true },
+                      pathname: router.EDIT_MINE_INCIDENT.dynamicRoute(
+                        record.mine_guid,
+                        record.key
+                      ),
                     })}
             >
               <img src={EDIT_OUTLINE_VIOLET} alt="Edit Incident" />
@@ -335,8 +337,7 @@ const MineIncidentTable = (props) => {
               IN_PROD()
                 ? record.openViewMineIncidentModal(event, record.incident)
                 : props.history.push({
-                    pathname: router.MINE_INCIDENT.dynamicRoute(record.mine_guid, record.key),
-                    state: { isEditMode: false },
+                    pathname: router.VIEW_MINE_INCIDENT.dynamicRoute(record.mine_guid, record.key),
                   })}
           >
             <EyeOutlined className="icon-lg icon-svg-filter" />

--- a/services/core-web/src/components/mine/Incidents/MineIncidents.js
+++ b/services/core-web/src/components/mine/Incidents/MineIncidents.js
@@ -206,10 +206,7 @@ const MineIncidents = (props) => {
                 ? openMineIncidentModal(event, handleAddMineIncident, true)
                 : props.history.push({
                     pathname: ROUTES.CREATE_MINE_INCIDENT.dynamicRoute(mineGuid),
-                    state: {
-                      mineName: mines[mineGuid]?.mine_name,
-                      isEditMode: true,
-                    },
+                    search: `mine_name=${mines[mineGuid]?.mine_name}`,
                   })}
           >
             Record a Mine Incident

--- a/services/core-web/src/components/mine/Incidents/MinistryInternalComments.js
+++ b/services/core-web/src/components/mine/Incidents/MinistryInternalComments.js
@@ -10,6 +10,7 @@ import {
 import MinistryCommentPanel from "@/components/common/comments/MinistryCommentPanel";
 import CustomPropTypes from "@/customPropTypes";
 import * as Permission from "@/constants/permissions";
+import AuthorizationWrapper from "@/components/common/wrappers/AuthorizationWrapper";
 
 const propTypes = {
   notes: PropTypes.arrayOf(CustomPropTypes.incidentNote).isRequired,
@@ -52,16 +53,18 @@ export const MinistryInternalComments = (props) => {
     <div>
       <h4 id="internal-ministry-comments">Internal Ministry Comments</h4>
       {isEditMode && (
-        <div className="margin-large--top margin-large--bottom">
-          <p>
-            <strong>
-              These comments are for interal staff only and will not be shown to proponents.
-            </strong>
-            {" "}
-            Add comments to this incident for future reference. Anything written in these comments
-            may be requested under FOIPPA. Keep it professional and concise.
-          </p>
-        </div>
+        <AuthorizationWrapper permission={createPermission}>
+          <div className="margin-large--top margin-large--bottom">
+            <p>
+              <strong>
+                These comments are for interal staff only and will not be shown to proponents.
+              </strong>
+              {" "}
+              Add comments to this incident for future reference. Anything written in these comments
+              may be requested under FOIPPA. Keep it professional and concise.
+            </p>
+          </div>
+        </AuthorizationWrapper>
       )}
       <MinistryCommentPanel
         renderEditor={isEditMode}

--- a/services/core-web/src/components/navigation/NotificationDrawer.js
+++ b/services/core-web/src/components/navigation/NotificationDrawer.js
@@ -15,7 +15,7 @@ import { useHistory } from "react-router-dom";
 import { storeActivities } from "@common/actions/activityActions";
 import {
   NOTICE_OF_DEPARTURE,
-  MINE_INCIDENT,
+  VIEW_MINE_INCIDENT,
   PRE_APPLICATIONS,
   INFORMATION_REQUIREMENTS_TABLE,
   PROJECTS,
@@ -103,7 +103,7 @@ const NotificationDrawer = (props) => {
           notification.notification_document.metadata.entity_guid
         );
       case "MineIncident":
-        return MINE_INCIDENT.dynamicRoute(
+        return VIEW_MINE_INCIDENT.dynamicRoute(
           notification.notification_document.metadata.mine.mine_guid,
           notification.notification_document.metadata.entity_guid
         );

--- a/services/core-web/src/constants/routes.js
+++ b/services/core-web/src/constants/routes.js
@@ -1,6 +1,7 @@
 import queryString from "query-string";
 import * as Strings from "@common/constants/strings";
 import { isEmpty } from "lodash";
+import { getEnvironment } from "@common/utils/environmentUtils";
 import Home from "@/components/Home";
 import Logout from "@/components/common/Logout";
 import Dashboard from "@/components/dashboard/minesHomePage/Dashboard";
@@ -53,7 +54,6 @@ import MineIncident from "@/components/mine/Incidents/MineIncident";
 import MineReportTailingsInfo from "@/components/mine/Tailings/MineReportTailingsInfo";
 import MineTailingsDetailsPage from "@/components/mine/Tailings/MineTailingsDetailsPage";
 import DamsDetailsPage from "@/components/mine/Tailings/DamsDetailsPage";
-import { getEnvironment } from "@common/utils/environmentUtils";
 
 const withoutDefaultParams = (params, defaults) => {
   const newParams = JSON.parse(JSON.stringify(params));
@@ -280,7 +280,16 @@ export const MINE_INCIDENTS = {
   component: MineIncidents,
 };
 
-export const MINE_INCIDENT = {
+export const EDIT_MINE_INCIDENT = {
+  route: "/mines/:mineGuid/incidents/:mineIncidentGuid/edit",
+  dynamicRoute: (mineGuid, mineIncidentGuid) =>
+    `/mines/${mineGuid}/incidents/${mineIncidentGuid}/edit`,
+  hashRoute: (mineGuid, mineIncidentGuid, link) =>
+    `/mines/${mineGuid}/incidents/${mineIncidentGuid}/edit${link}`,
+  component: MineIncident,
+};
+
+export const VIEW_MINE_INCIDENT = {
   route: "/mines/:mineGuid/incidents/:mineIncidentGuid",
   dynamicRoute: (mineGuid, mineIncidentGuid) => `/mines/${mineGuid}/incidents/${mineIncidentGuid}`,
   hashRoute: (mineGuid, mineIncidentGuid, link) =>
@@ -464,13 +473,13 @@ export const EDIT_PERMIT_CONDITIONS = {
 };
 
 const MINESPACE_URLS = {
-  'production': "https://minespace.gov.bc.ca/",
-  'development': "https://minespace-dev.apps.silver.devops.gov.bc.ca/",
-  'test': "https://minespace-test.apps.silver.devops.gov.bc.ca/",
+  production: "https://minespace.gov.bc.ca/",
+  development: "https://minespace-dev.apps.silver.devops.gov.bc.ca/",
+  test: "https://minespace-test.apps.silver.devops.gov.bc.ca/",
 };
 
 export const VIEW_MINESPACE = (mineGuid) => {
-  const MINESPACE_URL = MINESPACE_URLS[getEnvironment() ?? 'production'];
+  const MINESPACE_URL = MINESPACE_URLS[getEnvironment() ?? "production"];
   return `${MINESPACE_URL}mines/${mineGuid}/overview?redirectingFromCore=true`;
 };
 

--- a/services/core-web/src/constants/routes.js
+++ b/services/core-web/src/constants/routes.js
@@ -300,7 +300,8 @@ export const VIEW_MINE_INCIDENT = {
 export const CREATE_MINE_INCIDENT = {
   route: "/mines/:mineGuid/new-incident",
   dynamicRoute: (mineGuid) => `/mines/${mineGuid}/new-incident`,
-  hashRoute: (mineGuid, mineIncidentGuid, link) => `/mines/${mineGuid}/new-incident${link}`,
+  hashRoute: (mineGuid, mine_name, link) =>
+    `/mines/${mineGuid}/new-incident?mine_name=${mine_name}${link}`,
   component: MineIncident,
 };
 

--- a/services/core-web/src/constants/routes.js
+++ b/services/core-web/src/constants/routes.js
@@ -300,7 +300,7 @@ export const VIEW_MINE_INCIDENT = {
 export const CREATE_MINE_INCIDENT = {
   route: "/mines/:mineGuid/new-incident",
   dynamicRoute: (mineGuid) => `/mines/${mineGuid}/new-incident`,
-  hashRoute: (mineGuid, link) => `/mines/${mineGuid}/new-incident${link}`,
+  hashRoute: (mineGuid, mineIncidentGuid, link) => `/mines/${mineGuid}/new-incident${link}`,
   component: MineIncident,
 };
 

--- a/services/core-web/src/tests/components/mine/Incidents/MineIncident.spec.js
+++ b/services/core-web/src/tests/components/mine/Incidents/MineIncident.spec.js
@@ -6,6 +6,19 @@ import * as MOCK from "@/tests/mocks/dataMocks";
 const props = {};
 const dispatchProps = {};
 
+function mockFunction() {
+  const original = require.requireActual("react-router-dom");
+  return {
+    ...original,
+    useParams: jest.fn().mockReturnValue({
+      mineGuid: "448014a5-981f-47b8-8687-4963666776b8",
+      mineIncidentGuid: "668014a5-981f-47b8-8687-4963666776b9",
+    }),
+  };
+}
+
+jest.mock("react-router-dom", () => mockFunction());
+
 const setupProps = () => {
   props.incident = MOCK.INCIDENT;
   props.formErrors = {};
@@ -15,23 +28,14 @@ const setupProps = () => {
     internal_ministry_documents: [],
   };
   props.formIsDirty = false;
-  props.match = {
-    params: {
-      mineGuid: "448014a5-981f-47b8-8687-4963666776b8",
-      mineIncidentGuid: "668014a5-981f-47b8-8687-4963666776b9",
-    },
-  };
   props.location = {
-    state: {
-      isEditMode: false,
-      mineName: "Test Mine",
-    },
+    pathname:
+      "/mines/448014a5-981f-47b8-8687-4963666776b8/incidents/668014a5-981f-47b8-8687-4963666776b9",
   };
   props.history = {
     push: jest.fn(),
     replace: jest.fn(),
   };
-  props.reset = jest.fn();
 };
 
 const setupDispatchProps = () => {
@@ -41,7 +45,6 @@ const setupDispatchProps = () => {
   dispatchProps.updateMineIncident = jest.fn(() => Promise.resolve());
   dispatchProps.removeDocumentFromMineIncident = jest.fn(() => Promise.resolve());
   dispatchProps.submit = jest.fn(() => Promise.resolve());
-  dispatchProps.reset = jest.fn(() => Promise.resolve());
   dispatchProps.touch = jest.fn(() => Promise.resolve());
   dispatchProps.change = jest.fn(() => Promise.resolve());
 };

--- a/services/core-web/src/tests/components/mine/Incidents/MineIncident.spec.js
+++ b/services/core-web/src/tests/components/mine/Incidents/MineIncident.spec.js
@@ -14,6 +14,10 @@ function mockFunction() {
       mineGuid: "448014a5-981f-47b8-8687-4963666776b8",
       mineIncidentGuid: "668014a5-981f-47b8-8687-4963666776b9",
     }),
+    useLocation: jest.fn().mockReturnValue({
+      pathname:
+        "/mines/448014a5-981f-47b8-8687-4963666776b8/incidents/668014a5-981f-47b8-8687-4963666776b9",
+    }),
   };
 }
 
@@ -28,10 +32,6 @@ const setupProps = () => {
     internal_ministry_documents: [],
   };
   props.formIsDirty = false;
-  props.location = {
-    pathname:
-      "/mines/448014a5-981f-47b8-8687-4963666776b8/incidents/668014a5-981f-47b8-8687-4963666776b9",
-  };
   props.history = {
     push: jest.fn(),
     replace: jest.fn(),

--- a/services/core-web/src/tests/components/mine/Incidents/__snapshots__/MinistryInternalComments.spec.js.snap
+++ b/services/core-web/src/tests/components/mine/Incidents/__snapshots__/MinistryInternalComments.spec.js.snap
@@ -7,19 +7,26 @@ exports[`MinistryInternalComments renders properly 1`] = `
   >
     Internal Ministry Comments
   </h4>
-  <br />
-  <p>
-    <strong>
-      These comments are for interal staff only and will not be shown to proponents.
-    </strong>
-     
-    Add comments to this incident for future reference. Anything written in these comments may be requested under FOIPPA. Keep it professional and concise.
-  </p>
-  <br />
-  <Connect(CommentPanel)
+  <Connect(AuthorizationWrapper)
+    permission="role_edit_incidents"
+  >
+    <div
+      className="margin-large--top margin-large--bottom"
+    >
+      <p>
+        <strong>
+          These comments are for interal staff only and will not be shown to proponents.
+        </strong>
+         
+        Add comments to this incident for future reference. Anything written in these comments may be requested under FOIPPA. Keep it professional and concise.
+      </p>
+    </div>
+  </Connect(AuthorizationWrapper)>
+  <MinistryCommentPanel
     comments={Array []}
     createPermission="role_edit_incidents"
     loading={true}
+    onChange={[Function]}
     onSubmit={[Function]}
     renderEditor={true}
   />

--- a/services/core-web/src/tests/routes/__snapshots__/DashboardRoutes.spec.js.snap
+++ b/services/core-web/src/tests/routes/__snapshots__/DashboardRoutes.spec.js.snap
@@ -195,6 +195,11 @@ exports[`DashboardRoutes  renders properly 1`] = `
     path="/mine-dashboard/:mineGuid/tailings-storage-facility/:tailingsStorageFacilityGuid/dam/:damGuid"
   />
   <Route
+    component={[Function]}
+    exact={true}
+    path="/mines/:mineGuid/incidents/:mineIncidentGuid/edit"
+  />
+  <Route
     component={
       Object {
         "$$typeof": Symbol(react.memo),
@@ -351,11 +356,6 @@ exports[`DashboardRoutes  renders properly 1`] = `
     }
     exact={true}
     path="/dashboard/mines"
-  />
-  <Route
-    component={[Function]}
-    exact={true}
-    path="/mines/:mineGuid/incidents/:mineIncidentGuid"
   />
   <Route
     component={[Function]}
@@ -665,6 +665,11 @@ exports[`DashboardRoutes  renders properly 1`] = `
   />
   <Route
     exact={true}
+  />
+  <Route
+    component={[Function]}
+    exact={true}
+    path="/mines/:mineGuid/incidents/:mineIncidentGuid"
   />
   <Route
     component={


### PR DESCRIPTION
## Objective 
- fixed some bonus bugs relating to routing as they were disruptive during development
   - refreshing the page won't take the user out of edit mode anymore
   - sidebar menu should always work now! Did not fix that the scroll amount is slightly off, but did fix bugs in create mode: undefined never gets put in the URL and the mine name doesn't go away
   - both isEditMode and the mine name (for new incidents) were being passed along in the state and this was not working very well- now edit has its own route and the mine name is being passed as a query string (maybe not best practice...)
- clarified that the add ministry comments should still be available in view mode
   - there was a major bug with this component/set of components that I also fixed, result was that it was always giving permission on the FE, even if the user did not have the required permission (would still fail in BE)
   - did not get clarification on whether they should be viewable when the user lacks the core_edit_incidents role (required to make a comment) to _view_ the comments, so right now it's still viewable (didn't change). 
- removed the button to switch from view to edit mode
   -  and the Cancel edit button to switch to view mode
   - and the functions required for both buttons

[MDS-5061](https://bcmines.atlassian.net/browse/MDS-5061)

_Why are you making this change? Provide a short explanation and/or screenshots_
