### PR TITLE
[MDS-5125] character limit on mine alerts

### DIFF
--- a/services/core-web/src/components/Forms/mineAlerts/AddMineAlertForm.js
+++ b/services/core-web/src/components/Forms/mineAlerts/AddMineAlertForm.js
@@ -99,6 +99,7 @@ export const AddMineAlertForm = (props) => {
                 label="Message"
                 component={renderConfig.AUTO_SIZE_FIELD}
                 validate={[required, maxLength(300)]}
+                maximumCharacters={300}
               />
             </Form.Item>
           </Col>

--- a/services/core-web/src/components/common/RenderAutoSizeField.js
+++ b/services/core-web/src/components/common/RenderAutoSizeField.js
@@ -61,12 +61,11 @@ const RenderAutoSizeField = (props) => {
         onChange={handleTextAreaChange}
         value={value}
       />
-      {props.maximumCharacters > 0 && (
-        <div className="flex between">
-          <span>{`Maximum ${props.maximumCharacters} characters`}</span>
-          <span className="flex-end">{`${remainingChars} / ${props.maximumCharacters}`}</span>
-        </div>
-      )}
+
+      <div className="flex between">
+        <span>{`Maximum ${props.maximumCharacters} characters`}</span>
+        <span className="flex-end">{`${remainingChars} / ${props.maximumCharacters}`}</span>
+      </div>
     </Form.Item>
   );
 };

--- a/services/core-web/src/components/common/RenderAutoSizeField.js
+++ b/services/core-web/src/components/common/RenderAutoSizeField.js
@@ -24,7 +24,7 @@ const defaultProps = {
   label: "",
   disabled: false,
   minRows: 3,
-  maximumCharacters: 300,
+  maximumCharacters: 0,
 };
 
 const RenderAutoSizeField = (props) => {
@@ -33,10 +33,11 @@ const RenderAutoSizeField = (props) => {
 
   const handleTextAreaChange = (event) => {
     setValue(event.target.value);
-
-    const input = event.target.value;
-    const remaining = props.maximumCharacters - input.length;
-    setRemainingChars(remaining);
+    if (props.maximumCharacters > 0) {
+      const input = event.target.value;
+      const remaining = props.maximumCharacters - input.length;
+      setRemainingChars(remaining);
+    }
   };
 
   return (
@@ -61,11 +62,12 @@ const RenderAutoSizeField = (props) => {
         onChange={handleTextAreaChange}
         value={value}
       />
-
-      <div className="flex between">
-        <span>{`Maximum ${props.maximumCharacters} characters`}</span>
-        <span className="flex-end">{`${remainingChars} / ${props.maximumCharacters}`}</span>
-      </div>
+      {props.maximumCharacters > 0 && (
+        <div className="flex between">
+          <span>{`Maximum ${props.maximumCharacters} characters`}</span>
+          <span className="flex-end">{`${remainingChars} / ${props.maximumCharacters}`}</span>
+        </div>
+      )}
     </Form.Item>
   );
 };

--- a/services/core-web/src/components/common/RenderAutoSizeField.js
+++ b/services/core-web/src/components/common/RenderAutoSizeField.js
@@ -16,7 +16,6 @@ const propTypes = {
   meta: PropTypes.objectOf(PropTypes.any).isRequired,
   disabled: PropTypes.bool,
   minRows: PropTypes.number,
-  displayMaximumCharacters: PropTypes.bool,
   maximumCharacters: PropTypes.number,
 };
 
@@ -25,7 +24,6 @@ const defaultProps = {
   label: "",
   disabled: false,
   minRows: 3,
-  displayMaximumCharacters: false,
   maximumCharacters: 300,
 };
 

--- a/services/core-web/src/components/common/RenderAutoSizeField.js
+++ b/services/core-web/src/components/common/RenderAutoSizeField.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import PropTypes from "prop-types";
 import { Form } from "@ant-design/compatible";
 import "@ant-design/compatible/assets/index.css";
@@ -16,6 +16,8 @@ const propTypes = {
   meta: PropTypes.objectOf(PropTypes.any).isRequired,
   disabled: PropTypes.bool,
   minRows: PropTypes.number,
+  displayMaximumCharacters: PropTypes.bool,
+  maximumCharacters: PropTypes.number,
 };
 
 const defaultProps = {
@@ -23,30 +25,53 @@ const defaultProps = {
   label: "",
   disabled: false,
   minRows: 3,
+  displayMaximumCharacters: false,
+  maximumCharacters: 300,
 };
 
-const RenderAutoSizeField = (props) => (
-  <Form.Item
-    label={props.label}
-    placeholder={props.placeholder}
-    validateStatus={
-      props.meta.touched ? (props.meta.error && "error") || (props.meta.warning && "warning") : ""
-    }
-    help={
-      props.meta.touched &&
-      ((props.meta.error && <span>{props.meta.error}</span>) ||
-        (props.meta.warning && <span>{props.meta.warning}</span>))
-    }
-  >
-    <Input.TextArea
-      disabled={props.disabled}
-      id={props.id}
-      {...props.input}
-      autoSize={{ minRows: props.minRows }}
+const RenderAutoSizeField = (props) => {
+  const [remainingChars, setRemainingChars] = useState(props.maximumCharacters);
+  const [value, setValue] = useState("");
+
+  const handleTextAreaChange = (event) => {
+    setValue(event.target.value);
+
+    const input = event.target.value;
+    const remaining = props.maximumCharacters - input.length;
+    setRemainingChars(remaining);
+  };
+
+  return (
+    <Form.Item
+      label={props.label}
       placeholder={props.placeholder}
-    />
-  </Form.Item>
-);
+      validateStatus={
+        props.meta.touched ? (props.meta.error && "error") || (props.meta.warning && "warning") : ""
+      }
+      help={
+        props.meta.touched &&
+        ((props.meta.error && <span>{props.meta.error}</span>) ||
+          (props.meta.warning && <span>{props.meta.warning}</span>))
+      }
+    >
+      <Input.TextArea
+        disabled={props.disabled}
+        id={props.id}
+        {...props.input}
+        autoSize={{ minRows: props.minRows }}
+        placeholder={props.placeholder}
+        onChange={handleTextAreaChange}
+        value={value}
+      />
+      {props.maximumCharacters > 0 && (
+        <div className="flex between">
+          <span>{`Maximum ${props.maximumCharacters} characters`}</span>
+          <span className="flex-end">{`${remainingChars} / ${props.maximumCharacters}`}</span>
+        </div>
+      )}
+    </Form.Item>
+  );
+};
 
 RenderAutoSizeField.propTypes = propTypes;
 RenderAutoSizeField.defaultProps = defaultProps;

--- a/services/core-web/src/tests/components/common/RenderAutoSizeField.spec.js
+++ b/services/core-web/src/tests/components/common/RenderAutoSizeField.spec.js
@@ -15,7 +15,7 @@ const setupProps = () => {
       error: false,
       warning: false,
     },
-    maximumCharacters: 0,
+    maximumCharacters: 300,
   };
 };
 

--- a/services/core-web/src/tests/components/common/RenderAutoSizeField.spec.js
+++ b/services/core-web/src/tests/components/common/RenderAutoSizeField.spec.js
@@ -1,29 +1,30 @@
-import React from 'react';
-import { shallow } from 'enzyme';
-import RenderAutoSizeField from '@/components/common/RenderAutoSizeField';
+import React from "react";
+import { shallow } from "enzyme";
+import RenderAutoSizeField from "@/components/common/RenderAutoSizeField";
 
 let props = {};
 
 const setupProps = () => {
   props = {
     id: 1,
-    input: '',
-    label: '',
-    type: '',
+    input: "",
+    label: "",
+    type: "",
     meta: {
       touched: false,
       error: false,
       warning: false,
     },
+    maximumCharacters: 0,
   };
-}
+};
 
 beforeEach(() => {
   setupProps();
 });
 
-describe('RenderAutoSizeField', () => {
-  it('renders properly', () => {
+describe("RenderAutoSizeField", () => {
+  it("renders properly", () => {
     const wrapper = shallow(<RenderAutoSizeField {...props} />);
     expect(wrapper).toMatchSnapshot();
   });

--- a/services/core-web/src/tests/components/common/__snapshots__/RenderAutoSizeField.spec.js.snap
+++ b/services/core-web/src/tests/components/common/__snapshots__/RenderAutoSizeField.spec.js.snap
@@ -16,7 +16,21 @@ exports[`RenderAutoSizeField renders properly 1`] = `
     }
     disabled={false}
     id={1}
+    onChange={[Function]}
     placeholder=""
+    value=""
   />
+  <div
+    className="flex between"
+  >
+    <span>
+      Maximum 300 characters
+    </span>
+    <span
+      className="flex-end"
+    >
+      300 / 300
+    </span>
+  </div>
 </FormItem>
 `;


### PR DESCRIPTION
## Objective 

[[MDS-5121](https://bcmines.atlassian.net/browse/MDS-5121)]

- Display the number of characters that are already input (as a fraction of the total number allowed) - to match the design.

 - The input shouldn’t allow more characters than what is allowed.
 
![image](https://user-images.githubusercontent.com/72251620/225051386-7dbafa0a-dc51-49a9-a359-933c4a66513d.png)

