### PR TITLE
[MDS-5121] bug fix on on edit alert.

### DIFF
--- a/services/core-web/src/components/common/RenderAutoSizeField.js
+++ b/services/core-web/src/components/common/RenderAutoSizeField.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import PropTypes from "prop-types";
 import { Form } from "@ant-design/compatible";
 import "@ant-design/compatible/assets/index.css";
@@ -29,7 +29,7 @@ const defaultProps = {
 
 const RenderAutoSizeField = (props) => {
   const [remainingChars, setRemainingChars] = useState(props.maximumCharacters);
-  const [value, setValue] = useState("");
+  const [value, setValue] = useState(props.input?.value ?? "");
 
   const handleTextAreaChange = (event) => {
     setValue(event.target.value);
@@ -39,6 +39,14 @@ const RenderAutoSizeField = (props) => {
       setRemainingChars(remaining);
     }
   };
+
+  useEffect(() => {
+    if (props.input) {
+      const input = props.input.value;
+      const remaining = props.maximumCharacters - input.length;
+      setRemainingChars(remaining);
+    }
+  }, []);
 
   return (
     <Form.Item


### PR DESCRIPTION
## Objective 

[MDS-5121](https://bcmines.atlassian.net/browse/MDS-5121)

- There was a bug in the last work I did on this ticket. When you click on edit alert, the value previously entered in the message field was not showing. I have provided screen shots for the fix.

**When Edit alert is clicked**
![edit_alert](https://user-images.githubusercontent.com/72251620/225997502-59788019-f8fb-421d-a40d-18486414c7f4.png)

**When create alert is clicked**
![create_alert_with_typed_text](https://user-images.githubusercontent.com/72251620/225997802-76727e8d-7c72-44dc-ad40-17d95f912e1f.png)
