### PR TITLE
[MDS-5044] Permit Issuing bug

### DIFF
--- a/migrations/sql/V2023.03.20.03.35__explosives_permit_number_sequence.sql
+++ b/migrations/sql/V2023.03.20.03.35__explosives_permit_number_sequence.sql
@@ -1,5 +1,3 @@
-DROP SEQUENCE IF EXISTS explosives_permit_number_sequence;
-
 CREATE SEQUENCE IF NOT EXISTS explosives_permit_number_sequence
 OWNED BY explosives_permit.permit_number;
 

--- a/migrations/sql/V2023.03.20.03.35__explosives_permit_number_sequence.sql
+++ b/migrations/sql/V2023.03.20.03.35__explosives_permit_number_sequence.sql
@@ -5,7 +5,7 @@ OWNED BY explosives_permit.permit_number;
 
 -- find the highest value matching BC-100XX and start the sequence at the next one, or 10000 if no results
 SELECT setval('explosives_permit_number_sequence', 
-    COALESCE((SELECT 1+(
+    COALESCE((
         SELECT SUBSTRING(permit_number FROM 4)::int FROM explosives_permit WHERE permit_number LIKE '%BC-100%' ORDER BY SUBSTRING(permit_number FROM 4)::int DESC LIMIT 1
-        )), 9999)
+        ), 9999)
 );

--- a/migrations/sql/V2023.03.20.03.35__explosives_permit_number_sequence.sql
+++ b/migrations/sql/V2023.03.20.03.35__explosives_permit_number_sequence.sql
@@ -1,9 +1,18 @@
 CREATE SEQUENCE IF NOT EXISTS explosives_permit_number_sequence
 OWNED BY explosives_permit.permit_number;
 
+CREATE SEQUENCE IF NOT EXISTS explosives_permit_application_number_sequence
+OWNED BY explosives_permit.application_number;
+
 -- find the highest value matching BC-100XX and start the sequence at the next one, or 10000 if no results
 SELECT setval('explosives_permit_number_sequence', 
     COALESCE((
-        SELECT SUBSTRING(permit_number FROM 4)::int FROM explosives_permit WHERE permit_number LIKE '%BC-100%' ORDER BY SUBSTRING(permit_number FROM 4)::int DESC LIMIT 1
-        ), 9999)
+        SELECT SUBSTRING(permit_number FROM 4)::int AS perm_num FROM explosives_permit WHERE permit_number LIKE '%BC-100%' ORDER BY perm_num DESC LIMIT 1
+    ), 9999)
+);
+
+SELECT setval('explosives_permit_application_number_sequence', 
+    COALESCE((
+        SELECT SUBSTRING(application_number FROM 0 FOR 6)::int AS app_num FROM explosives_permit WHERE application_number ~ '[0-9]{5}-[0-9]{4}-[0-9]{2}' ORDER BY app_num DESC LIMIT 1
+    ), 9999)
 );

--- a/migrations/sql/V2023.03.20.03.35__explosives_permit_number_sequence.sql
+++ b/migrations/sql/V2023.03.20.03.35__explosives_permit_number_sequence.sql
@@ -1,0 +1,11 @@
+DROP SEQUENCE IF EXISTS explosives_permit_number_sequence;
+
+CREATE SEQUENCE IF NOT EXISTS explosives_permit_number_sequence
+OWNED BY explosives_permit.permit_number;
+
+-- find the highest value matching BC-100XX and start the sequence at the next one, or 10000 if no results
+SELECT setval('explosives_permit_number_sequence', 
+    COALESCE((SELECT 1+(
+        SELECT SUBSTRING(permit_number FROM 4)::int FROM explosives_permit WHERE permit_number LIKE '%BC-100%' ORDER BY SUBSTRING(permit_number FROM 4)::int DESC LIMIT 1
+        )), 9999)
+);

--- a/services/core-api/app/api/mines/explosives_permit/models/explosives_permit.py
+++ b/services/core-api/app/api/mines/explosives_permit/models/explosives_permit.py
@@ -323,9 +323,10 @@ class ExplosivesPermit(SoftDeleteMixin, AuditMixin, Base):
         now = datetime.now(timezone('US/Pacific'))
         month = now.strftime('%m')
         year = now.strftime('%Y')
-        base = 10000
-        total = cls.query.count()
-        return f'{base + total}-{year}-{month}'
+
+        sequence = Sequence('explosives_permit_application_number_sequence')
+        next_value = sequence.next_value()
+        return func.concat(next_value, f'-{year}-{month}')
 
     @classmethod
     def get_next_permit_number(cls):


### PR DESCRIPTION
## Objective 
There's a bug in issuing permits stemming from the miscalculation of the next permit number value, resulting in a duplicate value attempting to be inserted into a field with a unique constraint. I believe there had been a value deleted from the table which caused it to skip a number and throw off the calculation.

Created a sequence for this field that the python code concatenates the prefix with. Due to differing values in prod, test, and brand new local environments (which may have 0 records in the table), also made a somewhat complicated query to determine where this sequence should start.

After attempting to recreate the data problem on test by deleting an explosives_permit record, noticed that application_number had basically the same issue and triggered an error first, but it wasn't coming up on prod anymore because it also added the month (so after December was over, it was no longer a duplicate). Did similar fix for application_number.

[MDS-5044](https://bcmines.atlassian.net/browse/MDS-5044)

_Why are you making this change? Provide a short explanation and/or screenshots_
