### PR TITLE
[MDS-5044] Permit issue bug migration error fix

### DIFF
--- a/migrations/sql/V2023.03.20.03.35__explosives_permit_number_sequence.sql
+++ b/migrations/sql/V2023.03.20.03.35__explosives_permit_number_sequence.sql
@@ -1,8 +1,6 @@
-CREATE SEQUENCE IF NOT EXISTS explosives_permit_number_sequence
-OWNED BY explosives_permit.permit_number;
+CREATE SEQUENCE IF NOT EXISTS explosives_permit_number_sequence;
 
-CREATE SEQUENCE IF NOT EXISTS explosives_permit_application_number_sequence
-OWNED BY explosives_permit.application_number;
+CREATE SEQUENCE IF NOT EXISTS explosives_permit_application_number_sequence;
 
 -- find the highest value matching BC-100XX and start the sequence at the next one, or 10000 if no results
 SELECT setval('explosives_permit_number_sequence', 


### PR DESCRIPTION
## Objective 
Removing sequence owner from sequences as it is causing migration error. 
As per [postgres documentation](https://www.postgresql.org/docs/current/sql-altersequence.html), "The OWNED BY option causes the sequence to be associated with a specific table column, such that if that column (or its whole table) is dropped, the sequence will be automatically dropped as well." <-- this is really not necessary and if anything could cause additional problems.

[MDS-5044](https://bcmines.atlassian.net/browse/MDS-5044)

_Why are you making this change? Provide a short explanation and/or screenshots_
