### PR TITLE
[MDS-4868] Story bugs: validation, category options

### DIFF
--- a/bin/setup_codespaces.sh
+++ b/bin/setup_codespaces.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 yes yes | make env
+nvm install
 yarn
 make be
 make seeddb

--- a/migrations/sql/V2023.03.24.14.47__remake_incident_categories.sql
+++ b/migrations/sql/V2023.03.24.14.47__remake_incident_categories.sql
@@ -1,0 +1,263 @@
+UPDATE mine_incident_category
+    SET display_order = 10
+    WHERE mine_incident_category_code = 'ENV';
+
+UPDATE mine_incident_category
+    SET display_order = 20
+    WHERE mine_incident_category_code = 'GTC';
+
+UPDATE mine_incident_category
+    SET display_order = 30
+    WHERE mine_incident_category_code = 'H&S';
+
+UPDATE mine_incident_category
+    SET display_order = 40
+    WHERE mine_incident_category_code = 'SPI';
+
+
+UPDATE mine_incident_category
+    SET display_order = 50,
+    description = 'Geotechnical',
+    parent_mine_incident_category_code = NULL
+    WHERE mine_incident_category_code = 'GT1';
+UPDATE mine_incident_category
+    SET display_order = 60,
+    description = 'Dam/Dike',
+    parent_mine_incident_category_code = NULL
+    WHERE mine_incident_category_code = 'DMD';
+UPDATE mine_incident_category
+    SET display_order = 70,
+    description = 'Mobile Equipment',
+    parent_mine_incident_category_code = NULL
+    WHERE mine_incident_category_code = 'MBE';
+UPDATE mine_incident_category
+    SET display_order = 80,
+    description = 'Dust, Fumes & Gasses',
+    parent_mine_incident_category_code = NULL
+    WHERE mine_incident_category_code = 'DFG';
+UPDATE mine_incident_category
+    SET display_order = 90,
+    description = 'Blasting',
+    parent_mine_incident_category_code = NULL
+    WHERE mine_incident_category_code = 'BLT';
+UPDATE mine_incident_category
+    SET display_order = 100,
+    description = 'Pressure Vessel or Boiler',
+    parent_mine_incident_category_code = NULL
+    WHERE mine_incident_category_code = 'PVB';
+UPDATE mine_incident_category
+    SET display_order = 110,
+    description = 'Fire (not electrical/mobile equipment)',
+    parent_mine_incident_category_code = NULL
+    WHERE mine_incident_category_code = 'FNE';
+UPDATE mine_incident_category
+    SET display_order = 120,
+    description = 'Electrical',
+    parent_mine_incident_category_code = NULL
+    WHERE mine_incident_category_code = 'ELC';
+UPDATE mine_incident_category
+    SET display_order = 140,
+    description = 'Working at Height (free fall, failed lifts, etc.)',
+    parent_mine_incident_category_code = NULL
+    WHERE mine_incident_category_code = 'WAH';
+UPDATE mine_incident_category
+    SET display_order = 150,
+    description = 'Ventilation',
+    parent_mine_incident_category_code = NULL
+    WHERE mine_incident_category_code = 'VNT';
+UPDATE mine_incident_category
+    SET display_order = 160,
+    description = 'Hoisting Plant',
+    parent_mine_incident_category_code = NULL
+    WHERE mine_incident_category_code = 'HSP';
+UPDATE mine_incident_category
+    SET display_order = 170,
+    description = 'Environmental',
+    parent_mine_incident_category_code = NULL
+    WHERE mine_incident_category_code = 'EV1';
+UPDATE mine_incident_category
+    SET display_order = 180,
+    description = 'Other',
+    parent_mine_incident_category_code = NULL
+    WHERE mine_incident_category_code = 'OTH';
+
+
+UPDATE mine_incident_category
+    SET display_order = 51,
+    description = 'Fall of ground',
+    parent_mine_incident_category_code = 'GT1'
+    WHERE mine_incident_category_code = 'FOG';
+UPDATE mine_incident_category
+    SET display_order = 52,
+    description = 'Slope failure/unstable face',
+    parent_mine_incident_category_code = 'GT1'
+    WHERE mine_incident_category_code = 'USF';
+UPDATE mine_incident_category
+    SET display_order = 53,
+    description = 'In-rush of water, debris, or mud',
+    parent_mine_incident_category_code = 'GT1'
+    WHERE mine_incident_category_code = 'IRD';
+UPDATE mine_incident_category
+    SET display_order = 61,
+    description = 'Cracking or subsidence',
+    parent_mine_incident_category_code = 'DMD'
+    WHERE mine_incident_category_code = 'COS';
+UPDATE mine_incident_category
+    SET display_order = 62,
+    description = 'Unexpected seepage/springs',
+    parent_mine_incident_category_code = 'DMD'
+    WHERE mine_incident_category_code = 'UES';
+UPDATE mine_incident_category
+    SET display_order = 63,
+    description = 'Loss of freeboard',
+    parent_mine_incident_category_code = 'DMD'
+    WHERE mine_incident_category_code = 'LOF';
+UPDATE mine_incident_category
+    SET display_order = 64,
+    description = 'Washout or erosion',
+    parent_mine_incident_category_code = 'DMD'
+    WHERE mine_incident_category_code = 'WOE';
+UPDATE mine_incident_category
+    SET display_order = 71,
+    description = 'Collision',
+    parent_mine_incident_category_code = 'MBE'
+    WHERE mine_incident_category_code = 'CLN';
+UPDATE mine_incident_category
+    SET display_order = 72,
+    description = 'Unexpected movement/out of control',
+    parent_mine_incident_category_code = 'MBE'
+    WHERE mine_incident_category_code = 'OOC';
+UPDATE mine_incident_category
+    SET display_order = 73,
+    description = 'Rollover',
+    parent_mine_incident_category_code = 'MBE'
+    WHERE mine_incident_category_code = 'RLO';
+UPDATE mine_incident_category
+    SET display_order = 74,
+    description = 'Fire',
+    parent_mine_incident_category_code = 'MBE'
+    WHERE mine_incident_category_code = 'FR1';
+UPDATE mine_incident_category
+    SET display_order = 76,
+    description = 'Other vehicle-related incidents',
+    parent_mine_incident_category_code = 'MBE'
+    WHERE mine_incident_category_code = 'OVI';
+UPDATE mine_incident_category
+    SET display_order = 81,
+    description = 'Noxious/explosive/flammable/toxic/other dangerous gas',
+    parent_mine_incident_category_code = 'DFG'
+    WHERE mine_incident_category_code = 'NEG';
+UPDATE mine_incident_category
+    SET display_order = 82,
+    description = 'Chemical exposure',
+    parent_mine_incident_category_code = 'DFG'
+    WHERE mine_incident_category_code = 'CHM';
+UPDATE mine_incident_category
+    SET display_order = 83,
+    description = 'Ignition/explosion of gas or dust',
+    parent_mine_incident_category_code = 'DFG'
+    WHERE mine_incident_category_code = 'EXP';
+UPDATE mine_incident_category
+    SET display_order = 91,
+    description = 'Explosives',
+    parent_mine_incident_category_code = 'BLT'
+    WHERE mine_incident_category_code = 'FEX';
+UPDATE mine_incident_category
+    SET display_order = 92,
+    description = 'Misfires',
+    parent_mine_incident_category_code = 'BLT'
+    WHERE mine_incident_category_code = 'MSF';
+UPDATE mine_incident_category
+    SET display_order = 93,
+    description = 'Uncontrolled Blast (overpressure, fly rock, no signal, blast zone breach)',
+    parent_mine_incident_category_code = 'BLT'
+    WHERE mine_incident_category_code = 'UCB';
+UPDATE mine_incident_category
+    SET display_order = 111,
+    description = 'Underground fire',
+    parent_mine_incident_category_code = 'FNE'
+    WHERE mine_incident_category_code = 'UGF';
+UPDATE mine_incident_category
+    SET display_order = 112,
+    description = 'Fire that threatened persons/equipment',
+    parent_mine_incident_category_code = 'FNE'
+    WHERE mine_incident_category_code = 'FTH';
+UPDATE mine_incident_category
+    SET display_order = 121,
+    description = 'Shock',
+    parent_mine_incident_category_code = 'ELC'
+    WHERE mine_incident_category_code = 'SHK';
+UPDATE mine_incident_category
+    SET display_order = 122,
+    description = 'Fire',
+    parent_mine_incident_category_code = 'ELC'
+    WHERE mine_incident_category_code = 'FR2';
+UPDATE mine_incident_category
+    SET display_order = 123,
+    description = 'Arc Flash',
+    parent_mine_incident_category_code = 'ELC'
+    WHERE mine_incident_category_code = 'AFH';
+UPDATE mine_incident_category
+    SET display_order = 141,
+    description = 'Falling objects',
+    parent_mine_incident_category_code = 'WAH'
+    WHERE mine_incident_category_code = 'FOJ';
+UPDATE mine_incident_category
+    SET display_order = 142,
+    description = 'Falling workers',
+    parent_mine_incident_category_code = 'WAH'
+    WHERE mine_incident_category_code = 'FWK';
+UPDATE mine_incident_category
+    SET display_order = 151,
+    description = 'Stoppage',
+    parent_mine_incident_category_code = 'VNT'
+    WHERE mine_incident_category_code = 'STP';
+UPDATE mine_incident_category
+    SET display_order = 152,
+    description = 'Smoke',
+    parent_mine_incident_category_code = 'VNT'
+    WHERE mine_incident_category_code = 'SMK';
+UPDATE mine_incident_category
+    SET display_order = 153,
+    description = 'Circulation',
+    parent_mine_incident_category_code = 'VNT'
+    WHERE mine_incident_category_code = 'CCL';
+UPDATE mine_incident_category
+    SET display_order = 154,
+    description = 'Stench gas released',
+    parent_mine_incident_category_code = 'VNT'
+    WHERE mine_incident_category_code = 'SGR';
+UPDATE mine_incident_category
+    SET display_order = 171,
+    description = 'Hazardous environmental conditions',
+    parent_mine_incident_category_code = 'EV1'
+    WHERE mine_incident_category_code = 'WTR';
+UPDATE mine_incident_category
+    SET display_order = 172,
+    description = 'Wild animal',
+    parent_mine_incident_category_code = 'EV1'
+    WHERE mine_incident_category_code = 'WAN';
+UPDATE mine_incident_category
+    SET display_order = 173,
+    description = 'Avalanche/snow',
+    parent_mine_incident_category_code = 'EV1'
+    WHERE mine_incident_category_code = 'AOS';
+UPDATE mine_incident_category
+    SET display_order = 174,
+    description = 'Flooding',
+    parent_mine_incident_category_code = 'EV1'
+    WHERE mine_incident_category_code = 'FLD';
+  
+
+INSERT INTO mine_incident_category
+  (mine_incident_category_code, description, active_ind, create_user, update_user, display_order, parent_mine_incident_category_code)
+VALUES
+  ('EQP', 'Equipment', TRUE, 'system-mds', 'system-mds', 130, NULL),
+   ('OSD', 'Any other structural deficiency', TRUE, 'system-mds', 'system-mds', 65, 'DMD'),
+   ('ASA', 'Autonomous or semi-autonomous', TRUE, 'system-mds', 'system-mds', 75, 'MBE'),
+   ('FPB', 'Failure of pressure vessel or boiler', TRUE, 'system-mds', 'system-mds', 101, 'PVB'),
+   ('CDR', 'Contact with drilling or other rotational equipment', TRUE, 'system-mds', 'system-mds', 131, 'EQP'),
+   ('AHP', 'Accident involving a hoisting plant', TRUE, 'system-mds', 'system-mds', 161, 'HSP')
+  ;
+
+  DELETE FROM mine_incident_category WHERE mine_incident_category_code IN ('DST', 'FAC');

--- a/services/core-web/common/selectors/staticContentSelectors.js
+++ b/services/core-web/common/selectors/staticContentSelectors.js
@@ -283,13 +283,7 @@ export const getDropdownIncidentCategoryCodeOptions = createSelectorWrapper(
         subType: item.parent_mine_incident_category_code ?? null,
       };
     });
-  },
-  [
-    "description",
-    "mine_incident_category_code",
-    "is_historic",
-    "parent_mine_incident_category_code",
-  ]
+  }
 );
 
 export const getIncidentStatusCodeHash = createSelector(

--- a/services/core-web/src/components/Forms/incidents/IncidentCategoryCheckboxGroup.js
+++ b/services/core-web/src/components/Forms/incidents/IncidentCategoryCheckboxGroup.js
@@ -25,12 +25,12 @@ const defaultProps = {
 };
 
 // an item is considered a child of another item when its subType matches the parent's value
-const IncidentCategorySelect = (props) => {
+const IncidentCategoryCheckboxGroup = (props) => {
   const { data, disabled, input, meta } = props;
   const { touched, error = "", initial = [] } = meta;
 
   const [isTouched, setIsTouched] = useState(touched);
-  const showError = isTouched && error;
+  const showError = (isTouched || touched) && error;
   const historicalCategories = data.filter(
     (item) => !item.isActive && initial.includes(item.value)
   );
@@ -123,7 +123,7 @@ const IncidentCategorySelect = (props) => {
   );
 };
 
-IncidentCategorySelect.propTypes = propTypes;
-IncidentCategorySelect.defaultProps = defaultProps;
+IncidentCategoryCheckboxGroup.propTypes = propTypes;
+IncidentCategoryCheckboxGroup.defaultProps = defaultProps;
 
-export default IncidentCategorySelect;
+export default IncidentCategoryCheckboxGroup;

--- a/services/core-web/src/components/Forms/incidents/IncidentForm.js
+++ b/services/core-web/src/components/Forms/incidents/IncidentForm.js
@@ -46,7 +46,7 @@ import { renderConfig } from "@/components/common/config";
 import customPropTypes from "@/customPropTypes";
 import MinistryInternalComments from "@/components/mine/Incidents/MinistryInternalComments";
 import IncidentFileUpload from "./IncidentFileUpload";
-import IncidentCategorySelect from "./IncidentCategorySelect";
+import IncidentCategoryCheckboxGroup from "./IncidentCategoryCheckboxGroup";
 
 const propTypes = {
   // eslint-disable-next-line react/no-unused-prop-types
@@ -226,7 +226,7 @@ const renderInitialReport = (incidentCategoryCodeOptions, isEditMode) => {
               <Field
                 id="categories"
                 name="categories"
-                component={IncidentCategorySelect}
+                component={IncidentCategoryCheckboxGroup}
                 validate={[requiredList]}
                 data={incidentCategoryCodeOptions}
                 disabled={!isEditMode}

--- a/services/minespace-web/common/selectors/staticContentSelectors.js
+++ b/services/minespace-web/common/selectors/staticContentSelectors.js
@@ -283,13 +283,7 @@ export const getDropdownIncidentCategoryCodeOptions = createSelectorWrapper(
         subType: item.parent_mine_incident_category_code ?? null,
       };
     });
-  },
-  [
-    "description",
-    "mine_incident_category_code",
-    "is_historic",
-    "parent_mine_incident_category_code",
-  ]
+  }
 );
 
 export const getIncidentStatusCodeHash = createSelector(


### PR DESCRIPTION
## Objective 
[MDS-4868](https://bcmines.atlassian.net/browse/MDS-4868)

_Why are you making this change? Provide a short explanation and/or screenshots_
- The checkbox group component isn't very good at being able to tell when the form is touched, or setting the state from that (doesn't register as a change?). Now the error message shows up better (ex: go to create an incident, click "save changes" without entering anything, or edit an incident originally created in MS from CORE- by default these will have no categories --> error message displays properly now)
- So many differences between the PDF and existing category options in DB that I just batch updated all of them. I made some very minor changes as discussed with Rebecca. 
- I thought I had renamed the incident category component but evidently not, fixed this
