### PR TITLE
[MDS-5164] Resource Monitoring Metrics

### DIFF
--- a/sysdig/dashboards/api_troubleshooting.json
+++ b/sysdig/dashboards/api_troubleshooting.json
@@ -1,0 +1,983 @@
+{
+  "dashboard": {
+    "id": 393141,
+    "teamId": 35635,
+    "name": "API Troubleshooting",
+    "panels": [
+      {
+        "id": 6,
+        "type": "basicTimechart",
+        "name": "Average and Max Request Time",
+        "description": "",
+        "nullValueDisplayText": null,
+        "links": null,
+        "basicQueries": [
+          {
+            "enabled": true,
+            "displayInfo": {
+              "displayName": "",
+              "timeSeriesDisplayNameTemplate": "",
+              "type": "lines"
+            },
+            "format": {
+              "unit": "number",
+              "inputFormat": "1",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullGap",
+              "minInterval": null
+            },
+            "scope": {
+              "expressions": [],
+              "extendsDashboardScope": true
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "hour"
+            },
+            "metrics": [
+              {
+                "id": "sysdig_container_net_http_request_time",
+                "timeAggregation": "avg",
+                "groupAggregation": "avg",
+                "descriptor": null,
+                "sorting": null
+              }
+            ],
+            "displayedValue": null,
+            "segmentation": {
+              "labels": [],
+              "limit": 10,
+              "direction": "desc"
+            }
+          },
+          {
+            "enabled": true,
+            "displayInfo": {
+              "displayName": "",
+              "timeSeriesDisplayNameTemplate": "",
+              "type": "lines"
+            },
+            "format": {
+              "unit": "relativeTime",
+              "inputFormat": "ns",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullGap",
+              "minInterval": null
+            },
+            "scope": {
+              "expressions": [],
+              "extendsDashboardScope": true
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "hour"
+            },
+            "metrics": [
+              {
+                "id": "sysdig_container_net_http_request_time",
+                "timeAggregation": "max",
+                "groupAggregation": "max",
+                "descriptor": null,
+                "sorting": null
+              }
+            ],
+            "displayedValue": null,
+            "segmentation": {
+              "labels": [],
+              "limit": 10,
+              "direction": "desc"
+            }
+          }
+        ],
+        "applyScopeToAll": true,
+        "applySegmentationToAll": false,
+        "legendConfiguration": {
+          "enabled": true,
+          "position": "right",
+          "layout": "table",
+          "showCurrent": true,
+          "width": null,
+          "height": null
+        },
+        "axesConfiguration": {
+          "bottom": {
+            "enabled": true
+          },
+          "left": {
+            "enabled": true,
+            "displayName": "",
+            "unit": "auto",
+            "displayFormat": "auto",
+            "decimals": null,
+            "minValue": 0.0,
+            "maxValue": null,
+            "minInputFormat": "1",
+            "maxInputFormat": "1",
+            "scale": "linear"
+          },
+          "right": {
+            "enabled": true,
+            "displayName": "",
+            "unit": "auto",
+            "displayFormat": "auto",
+            "decimals": null,
+            "minValue": 0.0,
+            "maxValue": null,
+            "minInputFormat": "ns",
+            "maxInputFormat": "ns",
+            "scale": "linear"
+          }
+        }
+      },
+      {
+        "id": 9,
+        "type": "basicTimechart",
+        "name": "Status Codes Over Time",
+        "description": "",
+        "nullValueDisplayText": null,
+        "links": null,
+        "basicQueries": [
+          {
+            "enabled": true,
+            "displayInfo": {
+              "displayName": "",
+              "timeSeriesDisplayNameTemplate": "",
+              "type": "lines"
+            },
+            "format": {
+              "unit": "number",
+              "inputFormat": "1",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullGap",
+              "minInterval": null
+            },
+            "scope": {
+              "expressions": [],
+              "extendsDashboardScope": true
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "hour"
+            },
+            "metrics": [
+              {
+                "id": "sysdig_container_net_http_statuscode_request_count",
+                "timeAggregation": "timeAvg",
+                "groupAggregation": "avg",
+                "descriptor": null,
+                "sorting": null
+              }
+            ],
+            "displayedValue": null,
+            "segmentation": {
+              "labels": [
+                {
+                  "id": "net.http.statusCode",
+                  "descriptor": {
+                    "segmentations": [],
+                    "documentId": "net.http.statusCode",
+                    "id": "net.http.statusCode",
+                    "metricType": "tag",
+                    "type": "string",
+                    "scale": 1.0,
+                    "name": "HTTP status code",
+                    "description": "HTTP response status code",
+                    "category": "network",
+                    "namespaces": ["host.net"],
+                    "scopes": ["host", "container"],
+                    "timeAggregations": ["concat", "distinct", "count"],
+                    "groupAggregations": ["concat", "distinct", "count"],
+                    "aggregationForGroup": "none",
+                    "createdAt": 1648212882000,
+                    "hidden": false,
+                    "experimental": false,
+                    "deferred": false,
+                    "identity": false,
+                    "canMonitor": false,
+                    "canGroupBy": false,
+                    "canFilter": true,
+                    "generatedFrom": "com.draios.model.metrics.http.HttpStatusCode",
+                    "publicId": "net_http_statuscode",
+                    "segment": false,
+                    "documentTimestamp": 1648212882000,
+                    "heuristic": false,
+                    "documentType": "metric"
+                  },
+                  "displayName": null,
+                  "sorting": null
+                }
+              ],
+              "limit": 10,
+              "direction": "desc"
+            }
+          }
+        ],
+        "applyScopeToAll": true,
+        "applySegmentationToAll": false,
+        "legendConfiguration": {
+          "enabled": true,
+          "position": "right",
+          "layout": "table",
+          "showCurrent": true,
+          "width": null,
+          "height": null
+        },
+        "axesConfiguration": {
+          "bottom": {
+            "enabled": true
+          },
+          "left": {
+            "enabled": true,
+            "displayName": "",
+            "unit": "auto",
+            "displayFormat": "auto",
+            "decimals": null,
+            "minValue": 0.0,
+            "maxValue": null,
+            "minInputFormat": "1",
+            "maxInputFormat": "1",
+            "scale": "linear"
+          },
+          "right": {
+            "enabled": true,
+            "displayName": "",
+            "unit": "auto",
+            "displayFormat": "auto",
+            "decimals": null,
+            "minValue": 0.0,
+            "maxValue": null,
+            "minInputFormat": "1",
+            "maxInputFormat": "1",
+            "scale": "linear"
+          }
+        }
+      },
+      {
+        "id": 10,
+        "type": "basicTimechart",
+        "name": "Request Types Over Time",
+        "description": "",
+        "nullValueDisplayText": null,
+        "links": null,
+        "basicQueries": [
+          {
+            "enabled": true,
+            "displayInfo": {
+              "displayName": "",
+              "timeSeriesDisplayNameTemplate": "",
+              "type": "lines"
+            },
+            "format": {
+              "unit": "number",
+              "inputFormat": "1",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullGap",
+              "minInterval": null
+            },
+            "scope": {
+              "expressions": [],
+              "extendsDashboardScope": true
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "hour"
+            },
+            "metrics": [
+              {
+                "id": "sysdig_container_net_http_url_request_count",
+                "timeAggregation": "timeAvg",
+                "groupAggregation": "avg",
+                "descriptor": null,
+                "sorting": null
+              }
+            ],
+            "displayedValue": null,
+            "segmentation": {
+              "labels": [
+                {
+                  "id": "net.http.method",
+                  "descriptor": {
+                    "segmentations": [],
+                    "documentId": "net.http.method",
+                    "id": "net.http.method",
+                    "metricType": "tag",
+                    "type": "string",
+                    "scale": 1.0,
+                    "name": "Method",
+                    "description": "HTTP request method",
+                    "category": "network",
+                    "namespaces": ["host.net"],
+                    "scopes": ["host", "container"],
+                    "timeAggregations": ["concat", "distinct", "count"],
+                    "groupAggregations": ["concat", "distinct", "count"],
+                    "aggregationForGroup": "none",
+                    "createdAt": 1648212882000,
+                    "hidden": false,
+                    "experimental": false,
+                    "deferred": false,
+                    "identity": false,
+                    "canMonitor": false,
+                    "canGroupBy": false,
+                    "canFilter": true,
+                    "generatedFrom": "com.draios.model.metrics.http.HttpMethod",
+                    "publicId": "net_http_method",
+                    "segment": false,
+                    "documentTimestamp": 1648212882000,
+                    "heuristic": false,
+                    "documentType": "metric"
+                  },
+                  "displayName": null,
+                  "sorting": null
+                }
+              ],
+              "limit": 10,
+              "direction": "desc"
+            }
+          }
+        ],
+        "applyScopeToAll": true,
+        "applySegmentationToAll": false,
+        "legendConfiguration": {
+          "enabled": true,
+          "position": "right",
+          "layout": "table",
+          "showCurrent": true,
+          "width": null,
+          "height": null
+        },
+        "axesConfiguration": {
+          "bottom": {
+            "enabled": true
+          },
+          "left": {
+            "enabled": true,
+            "displayName": "",
+            "unit": "auto",
+            "displayFormat": "auto",
+            "decimals": null,
+            "minValue": 0.0,
+            "maxValue": null,
+            "minInputFormat": "1",
+            "maxInputFormat": "1",
+            "scale": "linear"
+          },
+          "right": {
+            "enabled": true,
+            "displayName": "",
+            "unit": "auto",
+            "displayFormat": "auto",
+            "decimals": null,
+            "minValue": 0.0,
+            "maxValue": null,
+            "minInputFormat": "1",
+            "maxInputFormat": "1",
+            "scale": "linear"
+          }
+        }
+      },
+      {
+        "id": 11,
+        "type": "basicTable",
+        "name": "Slowest Endpoints by average request time",
+        "description": "Average request time, unlike total request time, is not biased towards endpoints without GUIDs. However, endpoints that are called infrequently may be listed higher.",
+        "nullValueDisplayText": null,
+        "links": null,
+        "basicQueries": [
+          {
+            "enabled": true,
+            "displayInfo": {
+              "displayName": "Avg Request Time",
+              "timeSeriesDisplayNameTemplate": "",
+              "type": "lines"
+            },
+            "format": {
+              "unit": "relativeTime",
+              "inputFormat": "ns",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullGap",
+              "minInterval": null
+            },
+            "scope": {
+              "expressions": [],
+              "extendsDashboardScope": true
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "day"
+            },
+            "metrics": [
+              {
+                "id": "sysdig_container_net_http_url_request_time",
+                "timeAggregation": "avg",
+                "groupAggregation": "avg",
+                "descriptor": null,
+                "sorting": null
+              }
+            ],
+            "displayedValue": "entireRange",
+            "segmentation": {
+              "labels": [
+                {
+                  "id": "net.http.url",
+                  "descriptor": {
+                    "segmentations": [],
+                    "documentId": "net.http.url",
+                    "id": "net.http.url",
+                    "metricType": "tag",
+                    "type": "string",
+                    "scale": 1.0,
+                    "name": "URL",
+                    "description": "HTTP request URL",
+                    "category": "network",
+                    "namespaces": ["host.net"],
+                    "scopes": ["host", "container"],
+                    "timeAggregations": ["concat", "distinct", "count"],
+                    "groupAggregations": ["concat", "distinct", "count"],
+                    "aggregationForGroup": "none",
+                    "createdAt": 1648212882000,
+                    "hidden": false,
+                    "experimental": false,
+                    "deferred": false,
+                    "identity": false,
+                    "canMonitor": false,
+                    "canGroupBy": false,
+                    "canFilter": true,
+                    "generatedFrom": "com.draios.model.metrics.http.HttpUrl",
+                    "publicId": "net_http_url",
+                    "segment": false,
+                    "documentTimestamp": 1648212882000,
+                    "heuristic": false,
+                    "documentType": "metric"
+                  },
+                  "displayName": "Request URL",
+                  "sorting": null
+                }
+              ],
+              "limit": 10,
+              "direction": "desc"
+            }
+          },
+          {
+            "enabled": true,
+            "displayInfo": {
+              "displayName": "Request Count",
+              "timeSeriesDisplayNameTemplate": "",
+              "type": "lines"
+            },
+            "format": {
+              "unit": "number",
+              "inputFormat": "1",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullGap",
+              "minInterval": null
+            },
+            "scope": {
+              "expressions": [],
+              "extendsDashboardScope": true
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "day"
+            },
+            "metrics": [
+              {
+                "id": "sysdig_container_net_http_url_request_count",
+                "timeAggregation": "sum",
+                "groupAggregation": "sum",
+                "descriptor": null,
+                "sorting": null
+              }
+            ],
+            "displayedValue": "latest",
+            "segmentation": {
+              "labels": [],
+              "limit": 10,
+              "direction": "desc"
+            }
+          }
+        ]
+      },
+      {
+        "id": 12,
+        "type": "advancedTable",
+        "name": "Requests with \"null\" or \"undefined\" in them",
+        "description": "Bad requests that are generated by errors on the front-end.",
+        "nullValueDisplayText": "Hurray! No results!",
+        "links": null,
+        "advancedQueries": [
+          {
+            "query": "sum(sum_over_time(sysdig_container_net_http_url_request_count{$__scope,net_http_url=~\".*(undefined|null).*\"}[$__range])) by (net_http_url)",
+            "enabled": true,
+            "displayInfo": {
+              "displayName": "Number of Requests Made",
+              "timeSeriesDisplayNameTemplate": "{{net_http_url}} ",
+              "type": "lines"
+            },
+            "format": {
+              "unit": "number",
+              "inputFormat": "1",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullGap",
+              "minInterval": null
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "day"
+            }
+          }
+        ]
+      },
+      {
+        "id": 13,
+        "type": "basicTable",
+        "name": "Endpoints that generate the most errors",
+        "description": "",
+        "nullValueDisplayText": null,
+        "links": null,
+        "basicQueries": [
+          {
+            "enabled": true,
+            "displayInfo": {
+              "displayName": "Errors Returned",
+              "timeSeriesDisplayNameTemplate": "",
+              "type": "lines"
+            },
+            "format": {
+              "unit": "number",
+              "inputFormat": "1",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullGap",
+              "minInterval": null
+            },
+            "scope": {
+              "expressions": [],
+              "extendsDashboardScope": true
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "day"
+            },
+            "metrics": [
+              {
+                "id": "sysdig_container_net_http_url_error_count",
+                "timeAggregation": "sum",
+                "groupAggregation": "sum",
+                "descriptor": null,
+                "sorting": null
+              }
+            ],
+            "displayedValue": "entireRange",
+            "segmentation": {
+              "labels": [
+                {
+                  "id": "net.http.url",
+                  "descriptor": {
+                    "segmentations": [],
+                    "documentId": "net.http.url",
+                    "id": "net.http.url",
+                    "metricType": "tag",
+                    "type": "string",
+                    "scale": 1.0,
+                    "name": "URL",
+                    "description": "HTTP request URL",
+                    "category": "network",
+                    "namespaces": ["host.net"],
+                    "scopes": ["host", "container"],
+                    "timeAggregations": ["concat", "distinct", "count"],
+                    "groupAggregations": ["concat", "distinct", "count"],
+                    "aggregationForGroup": "none",
+                    "createdAt": 1648212882000,
+                    "hidden": false,
+                    "experimental": false,
+                    "deferred": false,
+                    "identity": false,
+                    "canMonitor": false,
+                    "canGroupBy": false,
+                    "canFilter": true,
+                    "generatedFrom": "com.draios.model.metrics.http.HttpUrl",
+                    "publicId": "net_http_url",
+                    "segment": false,
+                    "documentTimestamp": 1648212882000,
+                    "heuristic": false,
+                    "documentType": "metric"
+                  },
+                  "displayName": "Request URL",
+                  "sorting": null
+                }
+              ],
+              "limit": 10,
+              "direction": "desc"
+            }
+          },
+          {
+            "enabled": true,
+            "displayInfo": {
+              "displayName": "Total Requests made",
+              "timeSeriesDisplayNameTemplate": "",
+              "type": "lines"
+            },
+            "format": {
+              "unit": "number",
+              "inputFormat": "1",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullGap",
+              "minInterval": null
+            },
+            "scope": {
+              "expressions": [],
+              "extendsDashboardScope": true
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "day"
+            },
+            "metrics": [
+              {
+                "id": "sysdig_container_net_http_url_request_count",
+                "timeAggregation": "sum",
+                "groupAggregation": "sum",
+                "descriptor": null,
+                "sorting": null
+              }
+            ],
+            "displayedValue": "latest",
+            "segmentation": {
+              "labels": [],
+              "limit": 10,
+              "direction": "desc"
+            }
+          }
+        ]
+      },
+      {
+        "id": 14,
+        "type": "basicTable",
+        "name": "Slowest Endpoints by total request time",
+        "description": "Which endpoints take the most total time (ie: number of requests * average request time). Focusing on these endpoints should result in the most performance gains, but requests containing GUIDS will be listed separately by GUID.",
+        "nullValueDisplayText": null,
+        "links": null,
+        "basicQueries": [
+          {
+            "enabled": true,
+            "displayInfo": {
+              "displayName": "Total Request Time",
+              "timeSeriesDisplayNameTemplate": "",
+              "type": "lines"
+            },
+            "format": {
+              "unit": "relativeTime",
+              "inputFormat": "ns",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullGap",
+              "minInterval": null
+            },
+            "scope": {
+              "expressions": [],
+              "extendsDashboardScope": true
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "day"
+            },
+            "metrics": [
+              {
+                "id": "sysdig_container_net_http_url_request_time",
+                "timeAggregation": "sum",
+                "groupAggregation": "sum",
+                "descriptor": null,
+                "sorting": null
+              }
+            ],
+            "displayedValue": "entireRange",
+            "segmentation": {
+              "labels": [
+                {
+                  "id": "net.http.url",
+                  "descriptor": {
+                    "segmentations": [],
+                    "documentId": "net.http.url",
+                    "id": "net.http.url",
+                    "metricType": "tag",
+                    "type": "string",
+                    "scale": 1.0,
+                    "name": "URL",
+                    "description": "HTTP request URL",
+                    "category": "network",
+                    "namespaces": ["host.net"],
+                    "scopes": ["host", "container"],
+                    "timeAggregations": ["concat", "distinct", "count"],
+                    "groupAggregations": ["concat", "distinct", "count"],
+                    "aggregationForGroup": "none",
+                    "createdAt": 1648212882000,
+                    "hidden": false,
+                    "experimental": false,
+                    "deferred": false,
+                    "identity": false,
+                    "canMonitor": false,
+                    "canGroupBy": false,
+                    "canFilter": true,
+                    "generatedFrom": "com.draios.model.metrics.http.HttpUrl",
+                    "publicId": "net_http_url",
+                    "segment": false,
+                    "documentTimestamp": 1648212882000,
+                    "heuristic": false,
+                    "documentType": "metric"
+                  },
+                  "displayName": "Request URL",
+                  "sorting": null
+                }
+              ],
+              "limit": 10,
+              "direction": "desc"
+            }
+          },
+          {
+            "enabled": true,
+            "displayInfo": {
+              "displayName": "Request Count",
+              "timeSeriesDisplayNameTemplate": "",
+              "type": "lines"
+            },
+            "format": {
+              "unit": "number",
+              "inputFormat": "1",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullGap",
+              "minInterval": null
+            },
+            "scope": {
+              "expressions": [],
+              "extendsDashboardScope": true
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "day"
+            },
+            "metrics": [
+              {
+                "id": "sysdig_container_net_http_url_request_count",
+                "timeAggregation": "sum",
+                "groupAggregation": "sum",
+                "descriptor": null,
+                "sorting": null
+              }
+            ],
+            "displayedValue": "latest",
+            "segmentation": {
+              "labels": [],
+              "limit": 10,
+              "direction": "desc"
+            }
+          }
+        ]
+      }
+    ],
+    "scopeExpressionList": [
+      {
+        "operand": "kubernetes.namespace.name",
+        "operator": "in",
+        "displayName": "",
+        "value": ["4c2ba9-prod"],
+        "descriptor": {
+          "documentId": "kubernetes.namespace.name",
+          "id": "kubernetes.namespace.name",
+          "metricType": "tag",
+          "type": "string",
+          "scale": 0.0,
+          "name": "kubernetes.namespace.name",
+          "description": "kubernetes.namespace.name",
+          "namespaces": ["kubernetes.namespace"],
+          "scopes": [],
+          "timeAggregations": ["concat", "distinct", "count"],
+          "groupAggregations": ["concat", "distinct", "count"],
+          "aggregationForGroup": "none",
+          "hidden": false,
+          "experimental": false,
+          "deferred": false,
+          "identity": false,
+          "canMonitor": false,
+          "canGroupBy": true,
+          "canFilter": true,
+          "generatedFrom": "com.draios.model.metrics.custom.CustomMetric$Tag",
+          "publicId": "kube_namespace_name",
+          "segment": false,
+          "documentTimestamp": 1680300699743,
+          "heuristic": false,
+          "documentType": "metric"
+        },
+        "variable": true,
+        "isVariable": true
+      },
+      {
+        "operand": "kubernetes.workload.name",
+        "operator": "in",
+        "displayName": "",
+        "value": ["core-api"],
+        "descriptor": {
+          "documentId": "kubernetes.workload.name",
+          "id": "kubernetes.workload.name",
+          "metricType": "tag",
+          "type": "string",
+          "scale": 0.0,
+          "name": "kubernetes.workload.name",
+          "description": "kubernetes.workload.name",
+          "namespaces": [
+            "cloudProvider",
+            "host.container",
+            "ecs",
+            "host.fs",
+            "host.file",
+            "host",
+            "kubernetes",
+            "kubernetes.cluster",
+            "kubernetes.daemonSet",
+            "kubernetes.deployment",
+            "kubernetes.job",
+            "kubernetes.namespace",
+            "kubernetes.node",
+            "kubernetes.pod",
+            "kubernetes.replicaSet",
+            "kubernetes.service",
+            "kubernetes.statefulSet",
+            "kubernetes.resourcequota",
+            "kubernetes.hpa",
+            "link",
+            "mesos",
+            "host.net",
+            "host.process",
+            "prometheus",
+            "swarm",
+            "prombeacon"
+          ],
+          "scopes": [],
+          "timeAggregations": ["concat", "distinct", "count"],
+          "groupAggregations": ["concat", "distinct", "count"],
+          "aggregationForGroup": "none",
+          "hidden": false,
+          "experimental": false,
+          "deferred": false,
+          "identity": false,
+          "canMonitor": false,
+          "canGroupBy": true,
+          "canFilter": true,
+          "generatedFrom": "com.draios.model.metrics.custom.CustomMetric$Tag",
+          "publicId": "kube_workload_name",
+          "segment": false,
+          "documentTimestamp": 1680300699743,
+          "heuristic": false,
+          "documentType": "metric"
+        },
+        "variable": true,
+        "isVariable": true
+      }
+    ],
+    "eventDisplaySettings": {
+      "enabled": true,
+      "queryParams": {
+        "severities": [],
+        "alertStatuses": [],
+        "categories": [],
+        "filter": null,
+        "teamScope": false
+      }
+    },
+    "version": 40,
+    "description": "Highlighting bad and slow requests",
+    "layout": [
+      {
+        "panelId": 9,
+        "x": 0,
+        "y": 0,
+        "w": 12,
+        "h": 4
+      },
+      {
+        "panelId": 6,
+        "x": 12,
+        "y": 0,
+        "w": 12,
+        "h": 4
+      },
+      {
+        "panelId": 11,
+        "x": 0,
+        "y": 4,
+        "w": 12,
+        "h": 4
+      },
+      {
+        "panelId": 13,
+        "x": 12,
+        "y": 8,
+        "w": 12,
+        "h": 4
+      },
+      {
+        "panelId": 12,
+        "x": 0,
+        "y": 8,
+        "w": 12,
+        "h": 4
+      },
+      {
+        "panelId": 10,
+        "x": 12,
+        "y": 12,
+        "w": 12,
+        "h": 4
+      },
+      {
+        "panelId": 14,
+        "x": 12,
+        "y": 4,
+        "w": 12,
+        "h": 4
+      }
+    ],
+    "sharingSettings": [
+      {
+        "role": "ROLE_RESOURCE_EDIT",
+        "member": {
+          "type": "TEAM",
+          "id": 35635,
+          "name": "4c2ba9-team",
+          "teamTheme": "#73A1F7"
+        }
+      }
+    ],
+    "schema": 3
+  }
+}

--- a/sysdig/dashboards/api_troubleshooting.json
+++ b/sysdig/dashboards/api_troubleshooting.json
@@ -834,7 +834,7 @@
           "generatedFrom": "com.draios.model.metrics.custom.CustomMetric$Tag",
           "publicId": "kube_namespace_name",
           "segment": false,
-          "documentTimestamp": 1680300699743,
+          "documentTimestamp": 1680553268156,
           "heuristic": false,
           "documentType": "metric"
         },
@@ -896,7 +896,7 @@
           "generatedFrom": "com.draios.model.metrics.custom.CustomMetric$Tag",
           "publicId": "kube_workload_name",
           "segment": false,
-          "documentTimestamp": 1680300699743,
+          "documentTimestamp": 1680553268156,
           "heuristic": false,
           "documentType": "metric"
         },
@@ -914,7 +914,7 @@
         "teamScope": false
       }
     },
-    "version": 40,
+    "version": 45,
     "description": "Highlighting bad and slow requests",
     "layout": [
       {
@@ -939,9 +939,9 @@
         "h": 4
       },
       {
-        "panelId": 13,
+        "panelId": 14,
         "x": 12,
-        "y": 8,
+        "y": 4,
         "w": 12,
         "h": 4
       },
@@ -953,16 +953,16 @@
         "h": 4
       },
       {
-        "panelId": 10,
+        "panelId": 13,
         "x": 12,
-        "y": 12,
+        "y": 8,
         "w": 12,
         "h": 4
       },
       {
-        "panelId": 14,
+        "panelId": 10,
         "x": 12,
-        "y": 4,
+        "y": 12,
         "w": 12,
         "h": 4
       }

--- a/sysdig/dashboards/resource_allocation.json
+++ b/sysdig/dashboards/resource_allocation.json
@@ -1,0 +1,2127 @@
+{
+  "dashboard": {
+    "id": 391772,
+    "teamId": 35635,
+    "name": "Resource Allocation Dashboard",
+    "panels": [
+      {
+        "id": 1,
+        "type": "basicTimechart",
+        "name": "CPU Usage vs Request vs Limit",
+        "description": "",
+        "nullValueDisplayText": null,
+        "links": null,
+        "basicQueries": [
+          {
+            "enabled": true,
+            "displayInfo": {
+              "displayName": "CPU Used",
+              "timeSeriesDisplayNameTemplate": "",
+              "type": "lines"
+            },
+            "format": {
+              "unit": "number",
+              "inputFormat": "1",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullGap",
+              "minInterval": null
+            },
+            "scope": {
+              "expressions": [],
+              "extendsDashboardScope": true
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "hour"
+            },
+            "metrics": [
+              {
+                "id": "sysdig_container_cpu_cores_used",
+                "timeAggregation": "avg",
+                "groupAggregation": "sum",
+                "descriptor": null,
+                "sorting": null
+              }
+            ],
+            "displayedValue": null,
+            "segmentation": {
+              "labels": [],
+              "limit": 10,
+              "direction": "desc"
+            }
+          },
+          {
+            "enabled": true,
+            "displayInfo": {
+              "displayName": "Max CPU Used",
+              "timeSeriesDisplayNameTemplate": "",
+              "type": "lines"
+            },
+            "format": {
+              "unit": "number",
+              "inputFormat": "1",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullGap",
+              "minInterval": null
+            },
+            "scope": {
+              "expressions": [],
+              "extendsDashboardScope": true
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "hour"
+            },
+            "metrics": [
+              {
+                "id": "sysdig_container_cpu_cores_used",
+                "timeAggregation": "max",
+                "groupAggregation": "sum",
+                "descriptor": null,
+                "sorting": null
+              }
+            ],
+            "displayedValue": null,
+            "segmentation": {
+              "labels": [],
+              "limit": 10,
+              "direction": "desc"
+            }
+          },
+          {
+            "enabled": true,
+            "displayInfo": {
+              "displayName": "CPU Request Quota Used",
+              "timeSeriesDisplayNameTemplate": "",
+              "type": "lines"
+            },
+            "format": {
+              "unit": "number",
+              "inputFormat": "1",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullGap",
+              "minInterval": null
+            },
+            "scope": {
+              "expressions": [],
+              "extendsDashboardScope": true
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "hour"
+            },
+            "metrics": [
+              {
+                "id": "kube_resourcequota_sysdig_requests_cpu_used",
+                "timeAggregation": "avg",
+                "groupAggregation": "sum",
+                "descriptor": null,
+                "sorting": null
+              }
+            ],
+            "displayedValue": null,
+            "segmentation": {
+              "labels": [],
+              "limit": 10,
+              "direction": "desc"
+            }
+          },
+          {
+            "enabled": true,
+            "displayInfo": {
+              "displayName": "CPU Limit Quota Used",
+              "timeSeriesDisplayNameTemplate": "",
+              "type": "lines"
+            },
+            "format": {
+              "unit": "number",
+              "inputFormat": "1",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullGap",
+              "minInterval": null
+            },
+            "scope": {
+              "expressions": [],
+              "extendsDashboardScope": true
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "hour"
+            },
+            "metrics": [
+              {
+                "id": "kube_resourcequota_sysdig_limits_cpu_used",
+                "timeAggregation": "avg",
+                "groupAggregation": "sum",
+                "descriptor": null,
+                "sorting": null
+              }
+            ],
+            "displayedValue": null,
+            "segmentation": {
+              "labels": [],
+              "limit": 10,
+              "direction": "desc"
+            }
+          }
+        ],
+        "applyScopeToAll": true,
+        "applySegmentationToAll": false,
+        "legendConfiguration": {
+          "enabled": true,
+          "position": "right",
+          "layout": "table",
+          "showCurrent": true,
+          "width": null,
+          "height": null
+        },
+        "axesConfiguration": {
+          "bottom": {
+            "enabled": true
+          },
+          "left": {
+            "enabled": true,
+            "displayName": "",
+            "unit": "auto",
+            "displayFormat": "auto",
+            "decimals": null,
+            "minValue": 0.0,
+            "maxValue": null,
+            "minInputFormat": "1",
+            "maxInputFormat": "1",
+            "scale": "linear"
+          },
+          "right": {
+            "enabled": true,
+            "displayName": "",
+            "unit": "auto",
+            "displayFormat": "auto",
+            "decimals": null,
+            "minValue": 0.0,
+            "maxValue": null,
+            "minInputFormat": "1",
+            "maxInputFormat": "1",
+            "scale": "linear"
+          }
+        }
+      },
+      {
+        "id": 2,
+        "type": "basicNumber",
+        "name": "Quota - CPU Limit",
+        "description": "",
+        "nullValueDisplayText": null,
+        "links": null,
+        "basicQueries": [
+          {
+            "enabled": true,
+            "displayInfo": {
+              "displayName": "",
+              "timeSeriesDisplayNameTemplate": "",
+              "type": "lines"
+            },
+            "format": {
+              "unit": "number",
+              "inputFormat": "1",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullGap",
+              "minInterval": null
+            },
+            "scope": {
+              "expressions": [],
+              "extendsDashboardScope": true
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "hour"
+            },
+            "displayedValue": "entireRange",
+            "metrics": [
+              {
+                "id": "kube_resourcequota_sysdig_limits_cpu_hard",
+                "timeAggregation": "avg",
+                "groupAggregation": "avg",
+                "descriptor": null,
+                "sorting": null
+              }
+            ]
+          }
+        ],
+        "numberThresholds": {
+          "values": [],
+          "base": {
+            "severity": "none",
+            "displayText": ""
+          },
+          "useDefaults": true
+        }
+      },
+      {
+        "id": 3,
+        "type": "basicNumber",
+        "name": "CPU Used",
+        "description": "",
+        "nullValueDisplayText": null,
+        "links": null,
+        "basicQueries": [
+          {
+            "enabled": true,
+            "displayInfo": {
+              "displayName": "",
+              "timeSeriesDisplayNameTemplate": "",
+              "type": "lines"
+            },
+            "format": {
+              "unit": "number",
+              "inputFormat": "1",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullGap",
+              "minInterval": null
+            },
+            "scope": {
+              "expressions": [],
+              "extendsDashboardScope": true
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "hour"
+            },
+            "displayedValue": "entireRange",
+            "metrics": [
+              {
+                "id": "sysdig_container_cpu_cores_used",
+                "timeAggregation": "avg",
+                "groupAggregation": "sum",
+                "descriptor": null,
+                "sorting": null
+              }
+            ]
+          }
+        ],
+        "numberThresholds": {
+          "values": [],
+          "base": {
+            "severity": "none",
+            "displayText": ""
+          },
+          "useDefaults": true
+        }
+      },
+      {
+        "id": 6,
+        "type": "basicTimechart",
+        "name": "Memory Usage vs. Requests vs Limits Over Time",
+        "description": "",
+        "nullValueDisplayText": null,
+        "links": null,
+        "basicQueries": [
+          {
+            "enabled": true,
+            "displayInfo": {
+              "displayName": "Memory Usage",
+              "timeSeriesDisplayNameTemplate": "",
+              "type": "lines"
+            },
+            "format": {
+              "unit": "byte",
+              "inputFormat": "B",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullGap",
+              "minInterval": null
+            },
+            "scope": {
+              "expressions": [],
+              "extendsDashboardScope": true
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "hour"
+            },
+            "metrics": [
+              {
+                "id": "sysdig_container_memory_used_bytes",
+                "timeAggregation": "avg",
+                "groupAggregation": "sum",
+                "descriptor": null,
+                "sorting": null
+              }
+            ],
+            "displayedValue": null,
+            "segmentation": {
+              "labels": [],
+              "limit": 10,
+              "direction": "desc"
+            }
+          },
+          {
+            "enabled": true,
+            "displayInfo": {
+              "displayName": "Max Memory Usage",
+              "timeSeriesDisplayNameTemplate": "",
+              "type": "lines"
+            },
+            "format": {
+              "unit": "byte",
+              "inputFormat": "B",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullGap",
+              "minInterval": null
+            },
+            "scope": {
+              "expressions": [],
+              "extendsDashboardScope": true
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "hour"
+            },
+            "metrics": [
+              {
+                "id": "sysdig_container_memory_used_bytes",
+                "timeAggregation": "max",
+                "groupAggregation": "sum",
+                "descriptor": null,
+                "sorting": null
+              }
+            ],
+            "displayedValue": null,
+            "segmentation": {
+              "labels": [],
+              "limit": 10,
+              "direction": "desc"
+            }
+          },
+          {
+            "enabled": true,
+            "displayInfo": {
+              "displayName": "Memory Request Quota Used",
+              "timeSeriesDisplayNameTemplate": "",
+              "type": "lines"
+            },
+            "format": {
+              "unit": "number",
+              "inputFormat": "1",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullGap",
+              "minInterval": null
+            },
+            "scope": {
+              "expressions": [],
+              "extendsDashboardScope": true
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "hour"
+            },
+            "metrics": [
+              {
+                "id": "kube_resourcequota_sysdig_requests_memory_used",
+                "timeAggregation": "avg",
+                "groupAggregation": "sum",
+                "descriptor": null,
+                "sorting": null
+              }
+            ],
+            "displayedValue": null,
+            "segmentation": {
+              "labels": [],
+              "limit": 10,
+              "direction": "desc"
+            }
+          },
+          {
+            "enabled": true,
+            "displayInfo": {
+              "displayName": "Memory Limit Quota Used",
+              "timeSeriesDisplayNameTemplate": "",
+              "type": "lines"
+            },
+            "format": {
+              "unit": "number",
+              "inputFormat": "1",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullGap",
+              "minInterval": null
+            },
+            "scope": {
+              "expressions": [],
+              "extendsDashboardScope": true
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "hour"
+            },
+            "metrics": [
+              {
+                "id": "kube_resourcequota_sysdig_limits_memory_used",
+                "timeAggregation": "avg",
+                "groupAggregation": "sum",
+                "descriptor": null,
+                "sorting": null
+              }
+            ],
+            "displayedValue": null,
+            "segmentation": {
+              "labels": [],
+              "limit": 10,
+              "direction": "desc"
+            }
+          }
+        ],
+        "applyScopeToAll": true,
+        "applySegmentationToAll": false,
+        "legendConfiguration": {
+          "enabled": true,
+          "position": "right",
+          "layout": "table",
+          "showCurrent": true,
+          "width": null,
+          "height": null
+        },
+        "axesConfiguration": {
+          "bottom": {
+            "enabled": true
+          },
+          "left": {
+            "enabled": true,
+            "displayName": "",
+            "unit": "auto",
+            "displayFormat": "auto",
+            "decimals": null,
+            "minValue": 0.0,
+            "maxValue": null,
+            "minInputFormat": "B",
+            "maxInputFormat": "B",
+            "scale": "linear"
+          },
+          "right": {
+            "enabled": true,
+            "displayName": "",
+            "unit": "auto",
+            "displayFormat": "auto",
+            "decimals": null,
+            "minValue": 0.0,
+            "maxValue": null,
+            "minInputFormat": "1",
+            "maxInputFormat": "1",
+            "scale": "linear"
+          }
+        }
+      },
+      {
+        "id": 7,
+        "type": "basicNumber",
+        "name": "Memory Usage",
+        "description": "",
+        "nullValueDisplayText": null,
+        "links": null,
+        "basicQueries": [
+          {
+            "enabled": true,
+            "displayInfo": {
+              "displayName": "",
+              "timeSeriesDisplayNameTemplate": "",
+              "type": "lines"
+            },
+            "format": {
+              "unit": "byte",
+              "inputFormat": "B",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullGap",
+              "minInterval": null
+            },
+            "scope": {
+              "expressions": [],
+              "extendsDashboardScope": true
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "hour"
+            },
+            "displayedValue": "latest",
+            "metrics": [
+              {
+                "id": "sysdig_container_memory_used_bytes",
+                "timeAggregation": "avg",
+                "groupAggregation": "sum",
+                "descriptor": null,
+                "sorting": null
+              }
+            ]
+          }
+        ],
+        "numberThresholds": {
+          "values": [],
+          "base": {
+            "severity": "none",
+            "displayText": ""
+          },
+          "useDefaults": true
+        }
+      },
+      {
+        "id": 10,
+        "type": "advancedNumber",
+        "name": "Memory Used vs Requested",
+        "description": "",
+        "nullValueDisplayText": null,
+        "links": null,
+        "advancedQueries": [
+          {
+            "query": "sum(last_over_time(sysdig_container_memory_used_bytes{kube_cluster_name=~$Cluster,kube_namespace_name=~$Namespace}[$__interval])) / (sum(last_over_time(kube_resourcequota_sysdig_requests_memory_used{kube_cluster_name=~$Cluster,kube_namespace_name=~$Namespace}[$__interval]))) * 100",
+            "enabled": true,
+            "displayInfo": {
+              "displayName": "",
+              "timeSeriesDisplayNameTemplate": "",
+              "type": "lines"
+            },
+            "format": {
+              "unit": "%",
+              "inputFormat": "0-100",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullGap",
+              "minInterval": null
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "day"
+            }
+          }
+        ],
+        "numberThresholds": {
+          "values": [
+            {
+              "severity": "ok",
+              "value": 100.0,
+              "inputFormat": "0-100",
+              "displayText": ""
+            },
+            {
+              "severity": "low",
+              "value": 80.0,
+              "inputFormat": "0-100",
+              "displayText": ""
+            },
+            {
+              "severity": "medium",
+              "value": 50.0,
+              "inputFormat": "0-100",
+              "displayText": ""
+            }
+          ],
+          "base": {
+            "severity": "high",
+            "displayText": ""
+          }
+        }
+      },
+      {
+        "id": 11,
+        "type": "text",
+        "name": "CPU Title",
+        "description": "",
+        "nullValueDisplayText": null,
+        "links": null,
+        "markdownSource": "CPU Resource Allocation",
+        "transparentBackground": true,
+        "panelTitleVisible": false,
+        "textAutosized": true
+      },
+      {
+        "id": 12,
+        "type": "text",
+        "name": "Memory Title",
+        "description": "",
+        "nullValueDisplayText": null,
+        "links": null,
+        "markdownSource": "Memory Resource Allocation",
+        "transparentBackground": true,
+        "panelTitleVisible": false,
+        "textAutosized": true
+      },
+      {
+        "id": 13,
+        "type": "basicTable",
+        "name": "Resource Configuration and Utilization by Pod",
+        "description": "",
+        "nullValueDisplayText": null,
+        "links": null,
+        "basicQueries": [
+          {
+            "enabled": true,
+            "displayInfo": {
+              "displayName": "CPU Cores Used",
+              "timeSeriesDisplayNameTemplate": "",
+              "type": "lines"
+            },
+            "format": {
+              "unit": "number",
+              "inputFormat": "1",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullGap",
+              "minInterval": null
+            },
+            "scope": {
+              "expressions": [],
+              "extendsDashboardScope": true
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "day"
+            },
+            "metrics": [
+              {
+                "id": "sysdig_container_cpu_cores_used",
+                "timeAggregation": "avg",
+                "groupAggregation": "avg",
+                "descriptor": null,
+                "sorting": null
+              }
+            ],
+            "displayedValue": null,
+            "segmentation": {
+              "labels": [
+                {
+                  "id": "kubernetes.pod.name",
+                  "descriptor": {
+                    "documentId": "kubernetes.pod.name",
+                    "id": "kubernetes.pod.name",
+                    "metricType": "tag",
+                    "type": "string",
+                    "scale": 0.0,
+                    "name": "kubernetes.pod.name",
+                    "description": "kubernetes.pod.name",
+                    "namespaces": [
+                      "cloudProvider",
+                      "host.container",
+                      "ecs",
+                      "host.fs",
+                      "host.file",
+                      "host",
+                      "kubernetes",
+                      "kubernetes.cluster",
+                      "kubernetes.daemonSet",
+                      "kubernetes.deployment",
+                      "kubernetes.job",
+                      "kubernetes.namespace",
+                      "kubernetes.node",
+                      "kubernetes.pod",
+                      "kubernetes.replicaSet",
+                      "kubernetes.service",
+                      "kubernetes.statefulSet",
+                      "kubernetes.resourcequota",
+                      "kubernetes.hpa",
+                      "link",
+                      "mesos",
+                      "host.net",
+                      "host.process",
+                      "prometheus",
+                      "swarm",
+                      "prombeacon"
+                    ],
+                    "scopes": [],
+                    "timeAggregations": ["concat", "distinct", "count"],
+                    "groupAggregations": ["concat", "distinct", "count"],
+                    "aggregationForGroup": "none",
+                    "hidden": false,
+                    "experimental": false,
+                    "deferred": false,
+                    "identity": false,
+                    "canMonitor": false,
+                    "canGroupBy": true,
+                    "canFilter": true,
+                    "generatedFrom": "com.draios.model.metrics.custom.CustomMetric$Tag",
+                    "publicId": "kube_pod_name",
+                    "segment": false,
+                    "documentTimestamp": 1680305292774,
+                    "heuristic": false,
+                    "documentType": "metric"
+                  },
+                  "displayName": "Pod Name",
+                  "sorting": null
+                },
+                {
+                  "id": "kubernetes.namespace.name",
+                  "descriptor": {
+                    "documentId": "kubernetes.namespace.name",
+                    "id": "kubernetes.namespace.name",
+                    "metricType": "tag",
+                    "type": "string",
+                    "scale": 0.0,
+                    "name": "kubernetes.namespace.name",
+                    "description": "kubernetes.namespace.name",
+                    "namespaces": ["kubernetes.namespace"],
+                    "scopes": [],
+                    "timeAggregations": ["concat", "distinct", "count"],
+                    "groupAggregations": ["concat", "distinct", "count"],
+                    "aggregationForGroup": "none",
+                    "hidden": false,
+                    "experimental": false,
+                    "deferred": false,
+                    "identity": false,
+                    "canMonitor": false,
+                    "canGroupBy": true,
+                    "canFilter": true,
+                    "generatedFrom": "com.draios.model.metrics.custom.CustomMetric$Tag",
+                    "publicId": "kube_namespace_name",
+                    "segment": false,
+                    "documentTimestamp": 1680305292774,
+                    "heuristic": false,
+                    "documentType": "metric"
+                  },
+                  "displayName": "Namespace",
+                  "sorting": null
+                }
+              ],
+              "limit": 10,
+              "direction": "desc"
+            }
+          },
+          {
+            "enabled": true,
+            "displayInfo": {
+              "displayName": "CPU Requests",
+              "timeSeriesDisplayNameTemplate": "",
+              "type": "lines"
+            },
+            "format": {
+              "unit": "number",
+              "inputFormat": "1",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullGap",
+              "minInterval": null
+            },
+            "scope": {
+              "expressions": [],
+              "extendsDashboardScope": true
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "day"
+            },
+            "metrics": [
+              {
+                "id": "kube_pod_sysdig_resource_requests_cpu_cores",
+                "timeAggregation": "avg",
+                "groupAggregation": "avg",
+                "descriptor": null,
+                "sorting": null
+              }
+            ],
+            "displayedValue": null,
+            "segmentation": {
+              "labels": [],
+              "limit": 10,
+              "direction": "desc"
+            }
+          },
+          {
+            "enabled": true,
+            "displayInfo": {
+              "displayName": "CPU Limits",
+              "timeSeriesDisplayNameTemplate": "",
+              "type": "lines"
+            },
+            "format": {
+              "unit": "number",
+              "inputFormat": "1",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullGap",
+              "minInterval": null
+            },
+            "scope": {
+              "expressions": [],
+              "extendsDashboardScope": true
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "day"
+            },
+            "metrics": [
+              {
+                "id": "kube_pod_sysdig_resource_limits_cpu_cores",
+                "timeAggregation": "avg",
+                "groupAggregation": "avg",
+                "descriptor": null,
+                "sorting": null
+              }
+            ],
+            "displayedValue": null,
+            "segmentation": {
+              "labels": [],
+              "limit": 10,
+              "direction": "desc"
+            }
+          },
+          {
+            "enabled": true,
+            "displayInfo": {
+              "displayName": "Memory Used",
+              "timeSeriesDisplayNameTemplate": "",
+              "type": "lines"
+            },
+            "format": {
+              "unit": "byte",
+              "inputFormat": "B",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullGap",
+              "minInterval": null
+            },
+            "scope": {
+              "expressions": [],
+              "extendsDashboardScope": true
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "day"
+            },
+            "metrics": [
+              {
+                "id": "sysdig_container_memory_used_bytes",
+                "timeAggregation": "avg",
+                "groupAggregation": "avg",
+                "descriptor": null,
+                "sorting": null
+              }
+            ],
+            "displayedValue": null,
+            "segmentation": {
+              "labels": [],
+              "limit": 10,
+              "direction": "desc"
+            }
+          },
+          {
+            "enabled": true,
+            "displayInfo": {
+              "displayName": "Memory Request",
+              "timeSeriesDisplayNameTemplate": "",
+              "type": "lines"
+            },
+            "format": {
+              "unit": "byte",
+              "inputFormat": "B",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullGap",
+              "minInterval": null
+            },
+            "scope": {
+              "expressions": [],
+              "extendsDashboardScope": true
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "day"
+            },
+            "metrics": [
+              {
+                "id": "kube_pod_sysdig_resource_requests_memory_bytes",
+                "timeAggregation": "avg",
+                "groupAggregation": "avg",
+                "descriptor": null,
+                "sorting": null
+              }
+            ],
+            "displayedValue": null,
+            "segmentation": {
+              "labels": [],
+              "limit": 10,
+              "direction": "desc"
+            }
+          },
+          {
+            "enabled": true,
+            "displayInfo": {
+              "displayName": "Memory Limits",
+              "timeSeriesDisplayNameTemplate": "",
+              "type": "lines"
+            },
+            "format": {
+              "unit": "byte",
+              "inputFormat": "B",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullGap",
+              "minInterval": null
+            },
+            "scope": {
+              "expressions": [],
+              "extendsDashboardScope": true
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "day"
+            },
+            "metrics": [
+              {
+                "id": "kube_pod_sysdig_resource_limits_memory_bytes",
+                "timeAggregation": "avg",
+                "groupAggregation": "avg",
+                "descriptor": null,
+                "sorting": null
+              }
+            ],
+            "displayedValue": null,
+            "segmentation": {
+              "labels": [],
+              "limit": 10,
+              "direction": "desc"
+            }
+          }
+        ]
+      },
+      {
+        "id": 15,
+        "type": "text",
+        "name": "Storage Title",
+        "description": "",
+        "nullValueDisplayText": null,
+        "links": null,
+        "markdownSource": "Storage Resource Allocation",
+        "transparentBackground": true,
+        "panelTitleVisible": false,
+        "textAutosized": true
+      },
+      {
+        "id": 16,
+        "type": "advancedNumber",
+        "name": "Storage Used Capacity",
+        "description": "",
+        "nullValueDisplayText": null,
+        "links": null,
+        "advancedQueries": [
+          {
+            "query": "sum(kubelet_volume_stats_used_bytes{namespace=~$Namespace})",
+            "enabled": true,
+            "displayInfo": {
+              "displayName": "",
+              "timeSeriesDisplayNameTemplate": "",
+              "type": "lines"
+            },
+            "format": {
+              "unit": "byte",
+              "inputFormat": "B",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullGap",
+              "minInterval": null
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "day"
+            }
+          }
+        ],
+        "numberThresholds": {
+          "values": [],
+          "base": {
+            "severity": "none",
+            "displayText": ""
+          }
+        }
+      },
+      {
+        "id": 17,
+        "type": "basicNumber",
+        "name": "PVC Count - Quota",
+        "description": "",
+        "nullValueDisplayText": null,
+        "links": null,
+        "basicQueries": [
+          {
+            "enabled": true,
+            "displayInfo": {
+              "displayName": "",
+              "timeSeriesDisplayNameTemplate": "",
+              "type": "lines"
+            },
+            "format": {
+              "unit": "number",
+              "inputFormat": "1",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullGap",
+              "minInterval": null
+            },
+            "scope": {
+              "expressions": [],
+              "extendsDashboardScope": false
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "day"
+            },
+            "displayedValue": "latest",
+            "metrics": [
+              {
+                "id": "kube_resourcequota_sysdig_persistentvolumeclaims_hard",
+                "timeAggregation": "avg",
+                "groupAggregation": "avg",
+                "descriptor": null,
+                "sorting": null
+              }
+            ]
+          }
+        ],
+        "numberThresholds": {
+          "values": [],
+          "base": {
+            "severity": "none",
+            "displayText": ""
+          },
+          "useDefaults": null
+        }
+      },
+      {
+        "id": 18,
+        "type": "advancedTimechart",
+        "name": "Persistent Volume Claims Utilization",
+        "description": "",
+        "nullValueDisplayText": null,
+        "links": null,
+        "advancedQueries": [
+          {
+            "query": "avg(kubelet_volume_stats_used_bytes{namespace=~$Namespace} / kubelet_volume_stats_capacity_bytes{namespace=~$Namespace}) by (persistentvolumeclaim)",
+            "enabled": true,
+            "displayInfo": {
+              "displayName": "PVC Used Percentage",
+              "timeSeriesDisplayNameTemplate": "",
+              "type": "lines"
+            },
+            "format": {
+              "unit": "%",
+              "inputFormat": "0-1",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullGap",
+              "minInterval": null
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "day"
+            }
+          }
+        ],
+        "legendConfiguration": {
+          "enabled": true,
+          "position": "right",
+          "layout": "table",
+          "showCurrent": true,
+          "width": null,
+          "height": null
+        },
+        "axesConfiguration": {
+          "bottom": {
+            "enabled": true
+          },
+          "left": {
+            "enabled": true,
+            "displayName": null,
+            "unit": "auto",
+            "displayFormat": "auto",
+            "decimals": null,
+            "minValue": 0.0,
+            "maxValue": null,
+            "minInputFormat": "0-100",
+            "maxInputFormat": "0-100",
+            "scale": "linear"
+          },
+          "right": {
+            "enabled": true,
+            "displayName": null,
+            "unit": "auto",
+            "displayFormat": "auto",
+            "decimals": null,
+            "minValue": 0.0,
+            "maxValue": null,
+            "minInputFormat": "1",
+            "maxInputFormat": "1",
+            "scale": "linear"
+          }
+        }
+      },
+      {
+        "id": 19,
+        "type": "basicTable",
+        "name": "Storage Utilization by PVC",
+        "description": "",
+        "nullValueDisplayText": null,
+        "links": null,
+        "basicQueries": [
+          {
+            "enabled": true,
+            "displayInfo": {
+              "displayName": "Total Capacity",
+              "timeSeriesDisplayNameTemplate": "",
+              "type": "lines"
+            },
+            "format": {
+              "unit": "byte",
+              "inputFormat": "B",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullGap",
+              "minInterval": null
+            },
+            "scope": {
+              "expressions": [],
+              "extendsDashboardScope": false
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "day"
+            },
+            "metrics": [
+              {
+                "id": "kubelet_volume_stats_capacity_bytes",
+                "timeAggregation": "avg",
+                "groupAggregation": "sum",
+                "descriptor": {
+                  "documentId": "prometheus.kubelet_volume_stats_capacity_bytes",
+                  "id": "kubelet_volume_stats_capacity_bytes",
+                  "metricType": "gauge",
+                  "type": "byte",
+                  "scale": 1.0,
+                  "name": "kubelet_volume_stats_capacity_bytes",
+                  "description": "",
+                  "category": "prometheus",
+                  "namespaces": [
+                    "host",
+                    "host.process",
+                    "host.container",
+                    "cloudProvider",
+                    "mesos",
+                    "ecs",
+                    "kubernetes.cluster",
+                    "kubernetes.namespace",
+                    "kubernetes.deployment",
+                    "kubernetes.job",
+                    "kubernetes.daemonSet",
+                    "kubernetes.service",
+                    "kubernetes.node",
+                    "kubernetes.replicaSet",
+                    "kubernetes.statefulSet",
+                    "kubernetes.resourcequota",
+                    "kubernetes.persistentvolume",
+                    "kubernetes.persistentvolumeclaim",
+                    "kubernetes.pod"
+                  ],
+                  "scopes": [],
+                  "timeAggregations": ["avg", "min", "max"],
+                  "groupAggregations": ["avg", "sum", "min", "max"],
+                  "aggregationForGroup": "avg",
+                  "lastSeen": 1680304823000,
+                  "hidden": false,
+                  "experimental": false,
+                  "deferred": false,
+                  "identity": false,
+                  "canMonitor": false,
+                  "canGroupBy": false,
+                  "canFilter": false,
+                  "generatedFrom": "com.draios.model.metrics.custom.PrometheusRawMetric",
+                  "publicId": "kubelet_volume_stats_capacity_bytes",
+                  "legacyId": "kubelet_volume_stats_capacity_bytes",
+                  "segment": false,
+                  "documentTimestamp": 1680305292774,
+                  "heuristic": false,
+                  "documentType": "metric"
+                },
+                "sorting": null
+              }
+            ],
+            "displayedValue": "latest",
+            "segmentation": {
+              "labels": [
+                {
+                  "id": "persistentvolumeclaim",
+                  "descriptor": null,
+                  "displayName": "PVC Name",
+                  "sorting": null
+                },
+                {
+                  "id": "kubernetes.namespace.name",
+                  "descriptor": {
+                    "documentId": "kubernetes.namespace.name",
+                    "id": "kubernetes.namespace.name",
+                    "metricType": "tag",
+                    "type": "string",
+                    "scale": 0.0,
+                    "name": "kubernetes.namespace.name",
+                    "description": "kubernetes.namespace.name",
+                    "namespaces": ["kubernetes.namespace"],
+                    "scopes": [],
+                    "timeAggregations": ["concat", "distinct", "count"],
+                    "groupAggregations": ["concat", "distinct", "count"],
+                    "aggregationForGroup": "none",
+                    "hidden": false,
+                    "experimental": false,
+                    "deferred": false,
+                    "identity": false,
+                    "canMonitor": false,
+                    "canGroupBy": true,
+                    "canFilter": true,
+                    "generatedFrom": "com.draios.model.metrics.custom.CustomMetric$Tag",
+                    "publicId": "kube_namespace_name",
+                    "segment": false,
+                    "documentTimestamp": 1680305292774,
+                    "heuristic": false,
+                    "documentType": "metric"
+                  },
+                  "displayName": "Namespace",
+                  "sorting": null
+                }
+              ],
+              "limit": 10,
+              "direction": "desc"
+            }
+          },
+          {
+            "enabled": true,
+            "displayInfo": {
+              "displayName": "Used Capacity",
+              "timeSeriesDisplayNameTemplate": "",
+              "type": "lines"
+            },
+            "format": {
+              "unit": "byte",
+              "inputFormat": "B",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullGap",
+              "minInterval": null
+            },
+            "scope": {
+              "expressions": [],
+              "extendsDashboardScope": false
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "day"
+            },
+            "metrics": [
+              {
+                "id": "kubelet_volume_stats_used_bytes",
+                "timeAggregation": "avg",
+                "groupAggregation": "sum",
+                "descriptor": {
+                  "documentId": "prometheus.kubelet_volume_stats_used_bytes",
+                  "id": "kubelet_volume_stats_used_bytes",
+                  "metricType": "gauge",
+                  "type": "byte",
+                  "scale": 1.0,
+                  "name": "kubelet_volume_stats_used_bytes",
+                  "description": "",
+                  "category": "prometheus",
+                  "namespaces": [
+                    "host",
+                    "host.process",
+                    "host.container",
+                    "cloudProvider",
+                    "mesos",
+                    "ecs",
+                    "kubernetes.cluster",
+                    "kubernetes.namespace",
+                    "kubernetes.deployment",
+                    "kubernetes.job",
+                    "kubernetes.daemonSet",
+                    "kubernetes.service",
+                    "kubernetes.node",
+                    "kubernetes.replicaSet",
+                    "kubernetes.statefulSet",
+                    "kubernetes.resourcequota",
+                    "kubernetes.persistentvolume",
+                    "kubernetes.persistentvolumeclaim",
+                    "kubernetes.pod"
+                  ],
+                  "scopes": [],
+                  "timeAggregations": ["avg", "min", "max"],
+                  "groupAggregations": ["avg", "sum", "min", "max"],
+                  "aggregationForGroup": "avg",
+                  "lastSeen": 1680304823000,
+                  "hidden": false,
+                  "experimental": false,
+                  "deferred": false,
+                  "identity": false,
+                  "canMonitor": false,
+                  "canGroupBy": false,
+                  "canFilter": false,
+                  "generatedFrom": "com.draios.model.metrics.custom.PrometheusRawMetric",
+                  "publicId": "kubelet_volume_stats_used_bytes",
+                  "legacyId": "kubelet_volume_stats_used_bytes",
+                  "segment": false,
+                  "documentTimestamp": 1680305292774,
+                  "heuristic": false,
+                  "documentType": "metric"
+                },
+                "sorting": null
+              }
+            ],
+            "displayedValue": "latest",
+            "segmentation": {
+              "labels": [],
+              "limit": 10,
+              "direction": "desc"
+            }
+          }
+        ]
+      },
+      {
+        "id": 20,
+        "type": "basicNumber",
+        "name": "Quota - CPU Request",
+        "description": "",
+        "nullValueDisplayText": null,
+        "links": null,
+        "basicQueries": [
+          {
+            "enabled": true,
+            "displayInfo": {
+              "displayName": "",
+              "timeSeriesDisplayNameTemplate": "",
+              "type": "lines"
+            },
+            "format": {
+              "unit": "number",
+              "inputFormat": "1",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullGap",
+              "minInterval": null
+            },
+            "scope": {
+              "expressions": [],
+              "extendsDashboardScope": true
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "hour"
+            },
+            "displayedValue": "entireRange",
+            "metrics": [
+              {
+                "id": "kube_resourcequota_sysdig_requests_cpu_hard",
+                "timeAggregation": "avg",
+                "groupAggregation": "avg",
+                "descriptor": null,
+                "sorting": null
+              }
+            ]
+          }
+        ],
+        "numberThresholds": {
+          "values": [],
+          "base": {
+            "severity": "none",
+            "displayText": ""
+          },
+          "useDefaults": true
+        }
+      },
+      {
+        "id": 21,
+        "type": "advancedNumber",
+        "name": "CPU Used vs Requested",
+        "description": "",
+        "nullValueDisplayText": null,
+        "links": null,
+        "advancedQueries": [
+          {
+            "query": "sum(last_over_time(sysdig_container_cpu_cores_used{kube_cluster_name=~$Cluster,kube_namespace_name=~$Namespace}[$__interval])) / (sum(last_over_time(sysdig_container_cpu_shares_count{kube_cluster_name=~$Cluster,kube_namespace_name=~$Namespace}[$__interval])) / 1024) * 100",
+            "enabled": true,
+            "displayInfo": {
+              "displayName": "",
+              "timeSeriesDisplayNameTemplate": "",
+              "type": "lines"
+            },
+            "format": {
+              "unit": "%",
+              "inputFormat": "0-100",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullGap",
+              "minInterval": null
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "day"
+            }
+          }
+        ],
+        "numberThresholds": {
+          "values": [
+            {
+              "severity": "ok",
+              "value": 100.0,
+              "inputFormat": "0-100",
+              "displayText": ""
+            },
+            {
+              "severity": "low",
+              "value": 80.0,
+              "inputFormat": "0-100",
+              "displayText": ""
+            },
+            {
+              "severity": "medium",
+              "value": 50.0,
+              "inputFormat": "0-100",
+              "displayText": ""
+            }
+          ],
+          "base": {
+            "severity": "high",
+            "displayText": ""
+          }
+        }
+      },
+      {
+        "id": 9,
+        "type": "basicNumber",
+        "name": "Quota - Memory Request",
+        "description": "",
+        "nullValueDisplayText": null,
+        "links": null,
+        "basicQueries": [
+          {
+            "enabled": true,
+            "displayInfo": {
+              "displayName": "",
+              "timeSeriesDisplayNameTemplate": "",
+              "type": "lines"
+            },
+            "format": {
+              "unit": "byte",
+              "inputFormat": "B",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullGap",
+              "minInterval": null
+            },
+            "scope": {
+              "expressions": [],
+              "extendsDashboardScope": true
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "hour"
+            },
+            "displayedValue": "latest",
+            "metrics": [
+              {
+                "id": "kube_resourcequota_sysdig_requests_memory_hard",
+                "timeAggregation": "avg",
+                "groupAggregation": "avg",
+                "descriptor": null,
+                "sorting": null
+              }
+            ]
+          }
+        ],
+        "numberThresholds": {
+          "values": [],
+          "base": {
+            "severity": "none",
+            "displayText": ""
+          },
+          "useDefaults": true
+        }
+      },
+      {
+        "id": 8,
+        "type": "basicNumber",
+        "name": "Quota - Memory Limit",
+        "description": "",
+        "nullValueDisplayText": null,
+        "links": null,
+        "basicQueries": [
+          {
+            "enabled": true,
+            "displayInfo": {
+              "displayName": "",
+              "timeSeriesDisplayNameTemplate": "",
+              "type": "lines"
+            },
+            "format": {
+              "unit": "byte",
+              "inputFormat": "B",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullGap",
+              "minInterval": null
+            },
+            "scope": {
+              "expressions": [],
+              "extendsDashboardScope": true
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "hour"
+            },
+            "displayedValue": "latest",
+            "metrics": [
+              {
+                "id": "kube_resourcequota_sysdig_limits_memory_hard",
+                "timeAggregation": "avg",
+                "groupAggregation": "avg",
+                "descriptor": null,
+                "sorting": null
+              }
+            ]
+          }
+        ],
+        "numberThresholds": {
+          "values": [],
+          "base": {
+            "severity": "none",
+            "displayText": ""
+          },
+          "useDefaults": true
+        }
+      },
+      {
+        "id": 22,
+        "type": "text",
+        "name": "Resource Usage Overview Title",
+        "description": "",
+        "nullValueDisplayText": null,
+        "links": null,
+        "markdownSource": "Resource Usage List Overview",
+        "transparentBackground": true,
+        "panelTitleVisible": false,
+        "textAutosized": true
+      },
+      {
+        "id": 23,
+        "type": "basicNumber",
+        "name": "PVC Count - Used",
+        "description": "",
+        "nullValueDisplayText": null,
+        "links": null,
+        "basicQueries": [
+          {
+            "enabled": true,
+            "displayInfo": {
+              "displayName": "",
+              "timeSeriesDisplayNameTemplate": "",
+              "type": "lines"
+            },
+            "format": {
+              "unit": "number",
+              "inputFormat": "1",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullGap",
+              "minInterval": null
+            },
+            "scope": {
+              "expressions": [],
+              "extendsDashboardScope": true
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "day"
+            },
+            "displayedValue": "latest",
+            "metrics": [
+              {
+                "id": "kube_resourcequota_sysdig_persistentvolumeclaims_used",
+                "timeAggregation": "avg",
+                "groupAggregation": "avg",
+                "descriptor": null,
+                "sorting": null
+              }
+            ]
+          }
+        ],
+        "numberThresholds": {
+          "values": [],
+          "base": {
+            "severity": "none",
+            "displayText": ""
+          },
+          "useDefaults": null
+        }
+      },
+      {
+        "id": 24,
+        "type": "basicNumber",
+        "name": "CPU Requested",
+        "description": "",
+        "nullValueDisplayText": null,
+        "links": null,
+        "basicQueries": [
+          {
+            "enabled": true,
+            "displayInfo": {
+              "displayName": "",
+              "timeSeriesDisplayNameTemplate": "",
+              "type": "lines"
+            },
+            "format": {
+              "unit": "number",
+              "inputFormat": "1",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullGap",
+              "minInterval": null
+            },
+            "scope": {
+              "expressions": [],
+              "extendsDashboardScope": true
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "hour"
+            },
+            "displayedValue": "entireRange",
+            "metrics": [
+              {
+                "id": "kube_resourcequota_sysdig_requests_cpu_used",
+                "timeAggregation": "avg",
+                "groupAggregation": "sum",
+                "descriptor": null,
+                "sorting": null
+              }
+            ]
+          }
+        ],
+        "numberThresholds": {
+          "values": [],
+          "base": {
+            "severity": "none",
+            "displayText": ""
+          },
+          "useDefaults": true
+        }
+      },
+      {
+        "id": 25,
+        "type": "basicNumber",
+        "name": "Memory Requested",
+        "description": "",
+        "nullValueDisplayText": null,
+        "links": null,
+        "basicQueries": [
+          {
+            "enabled": true,
+            "displayInfo": {
+              "displayName": "",
+              "timeSeriesDisplayNameTemplate": "",
+              "type": "lines"
+            },
+            "format": {
+              "unit": "number",
+              "inputFormat": "1",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullGap",
+              "minInterval": null
+            },
+            "scope": {
+              "expressions": [],
+              "extendsDashboardScope": true
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "hour"
+            },
+            "displayedValue": "latest",
+            "metrics": [
+              {
+                "id": "kube_resourcequota_sysdig_requests_memory_used",
+                "timeAggregation": "avg",
+                "groupAggregation": "sum",
+                "descriptor": null,
+                "sorting": null
+              }
+            ]
+          }
+        ],
+        "numberThresholds": {
+          "values": [],
+          "base": {
+            "severity": "none",
+            "displayText": ""
+          },
+          "useDefaults": true
+        }
+      },
+      {
+        "id": 28,
+        "type": "advancedNumber",
+        "name": "Storage Total Capacity",
+        "description": "",
+        "nullValueDisplayText": null,
+        "links": null,
+        "advancedQueries": [
+          {
+            "query": "sum(kubelet_volume_stats_capacity_bytes{namespace=~$Namespace})",
+            "enabled": true,
+            "displayInfo": {
+              "displayName": "",
+              "timeSeriesDisplayNameTemplate": "",
+              "type": "lines"
+            },
+            "format": {
+              "unit": "byte",
+              "inputFormat": "B",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullGap",
+              "minInterval": null
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "day"
+            }
+          }
+        ],
+        "numberThresholds": {
+          "values": [],
+          "base": {
+            "severity": "none",
+            "displayText": ""
+          }
+        }
+      }
+    ],
+    "scopeExpressionList": [
+      {
+        "operand": "kubernetes.namespace.name",
+        "operator": "in",
+        "displayName": "Namespace",
+        "value": ["4c2ba9-prod"],
+        "descriptor": {
+          "documentId": "kubernetes.namespace.name",
+          "id": "kubernetes.namespace.name",
+          "metricType": "tag",
+          "type": "string",
+          "scale": 0.0,
+          "name": "kubernetes.namespace.name",
+          "description": "kubernetes.namespace.name",
+          "namespaces": ["kubernetes.namespace"],
+          "scopes": [],
+          "timeAggregations": ["concat", "distinct", "count"],
+          "groupAggregations": ["concat", "distinct", "count"],
+          "aggregationForGroup": "none",
+          "hidden": false,
+          "experimental": false,
+          "deferred": false,
+          "identity": false,
+          "canMonitor": false,
+          "canGroupBy": true,
+          "canFilter": true,
+          "generatedFrom": "com.draios.model.metrics.custom.CustomMetric$Tag",
+          "publicId": "kube_namespace_name",
+          "segment": false,
+          "documentTimestamp": 1680305292774,
+          "heuristic": false,
+          "documentType": "metric"
+        },
+        "variable": true,
+        "isVariable": true
+      },
+      {
+        "operand": "kubernetes.cluster.name",
+        "operator": "in",
+        "displayName": "Cluster",
+        "value": ["silver"],
+        "descriptor": {
+          "documentId": "kubernetes.cluster.name",
+          "id": "kubernetes.cluster.name",
+          "metricType": "tag",
+          "type": "string",
+          "scale": 0.0,
+          "name": "kubernetes.cluster.name",
+          "description": "kubernetes.cluster.name",
+          "namespaces": ["kubernetes.cluster"],
+          "scopes": [],
+          "timeAggregations": ["concat", "distinct", "count"],
+          "groupAggregations": ["concat", "distinct", "count"],
+          "aggregationForGroup": "none",
+          "hidden": false,
+          "experimental": false,
+          "deferred": false,
+          "identity": false,
+          "canMonitor": false,
+          "canGroupBy": true,
+          "canFilter": true,
+          "generatedFrom": "com.draios.model.metrics.custom.CustomMetric$Tag",
+          "publicId": "kube_cluster_name",
+          "segment": false,
+          "documentTimestamp": 1680305292774,
+          "heuristic": false,
+          "documentType": "metric"
+        },
+        "variable": true,
+        "isVariable": true
+      }
+    ],
+    "eventDisplaySettings": {
+      "enabled": true,
+      "queryParams": {
+        "severities": [],
+        "alertStatuses": [],
+        "categories": [],
+        "filter": "",
+        "teamScope": false
+      }
+    },
+    "version": 3,
+    "description": "From the BCGov resource allocation template\nCompare requests and limits to quota set by BCGov to see where we can afford to give more resources or where we should scale back.",
+    "layout": [
+      {
+        "panelId": 11,
+        "x": 0,
+        "y": 0,
+        "w": 24,
+        "h": 2
+      },
+      {
+        "panelId": 1,
+        "x": 0,
+        "y": 2,
+        "w": 12,
+        "h": 5
+      },
+      {
+        "panelId": 2,
+        "x": 12,
+        "y": 2,
+        "w": 4,
+        "h": 2
+      },
+      {
+        "panelId": 3,
+        "x": 16,
+        "y": 2,
+        "w": 4,
+        "h": 2
+      },
+      {
+        "panelId": 21,
+        "x": 20,
+        "y": 2,
+        "w": 4,
+        "h": 4
+      },
+      {
+        "panelId": 20,
+        "x": 12,
+        "y": 4,
+        "w": 4,
+        "h": 2
+      },
+      {
+        "panelId": 24,
+        "x": 16,
+        "y": 4,
+        "w": 4,
+        "h": 2
+      },
+      {
+        "panelId": 12,
+        "x": 0,
+        "y": 7,
+        "w": 24,
+        "h": 2
+      },
+      {
+        "panelId": 6,
+        "x": 0,
+        "y": 9,
+        "w": 12,
+        "h": 5
+      },
+      {
+        "panelId": 8,
+        "x": 12,
+        "y": 9,
+        "w": 4,
+        "h": 2
+      },
+      {
+        "panelId": 7,
+        "x": 16,
+        "y": 9,
+        "w": 4,
+        "h": 2
+      },
+      {
+        "panelId": 10,
+        "x": 20,
+        "y": 9,
+        "w": 4,
+        "h": 4
+      },
+      {
+        "panelId": 9,
+        "x": 12,
+        "y": 11,
+        "w": 4,
+        "h": 2
+      },
+      {
+        "panelId": 25,
+        "x": 16,
+        "y": 11,
+        "w": 4,
+        "h": 2
+      },
+      {
+        "panelId": 15,
+        "x": 0,
+        "y": 14,
+        "w": 24,
+        "h": 2
+      },
+      {
+        "panelId": 18,
+        "x": 0,
+        "y": 16,
+        "w": 16,
+        "h": 5
+      },
+      {
+        "panelId": 16,
+        "x": 16,
+        "y": 16,
+        "w": 4,
+        "h": 2
+      },
+      {
+        "panelId": 23,
+        "x": 20,
+        "y": 16,
+        "w": 4,
+        "h": 2
+      },
+      {
+        "panelId": 28,
+        "x": 16,
+        "y": 18,
+        "w": 4,
+        "h": 2
+      },
+      {
+        "panelId": 17,
+        "x": 20,
+        "y": 18,
+        "w": 4,
+        "h": 2
+      },
+      {
+        "panelId": 22,
+        "x": 0,
+        "y": 21,
+        "w": 24,
+        "h": 2
+      },
+      {
+        "panelId": 13,
+        "x": 0,
+        "y": 23,
+        "w": 24,
+        "h": 6
+      },
+      {
+        "panelId": 19,
+        "x": 0,
+        "y": 29,
+        "w": 24,
+        "h": 6
+      }
+    ],
+    "sharingSettings": [
+      {
+        "role": "ROLE_RESOURCE_EDIT",
+        "member": {
+          "type": "TEAM",
+          "id": 35635,
+          "name": "4c2ba9-team",
+          "teamTheme": "#73A1F7"
+        }
+      }
+    ],
+    "schema": 3
+  }
+}

--- a/sysdig/dashboards/sql_statistics.json
+++ b/sysdig/dashboards/sql_statistics.json
@@ -1,76 +1,7 @@
 {
   "dashboard": {
-    "teamId": 35635,
-    "description": "Statistics for production environment",
-    "eventDisplaySettings": {
-      "enabled": true,
-      "queryParams": {
-        "severities": [],
-        "alertStatuses": [],
-        "categories": [],
-        "filter": null,
-        "teamScope": false
-      }
-    },
     "id": 391840,
-    "layout": [
-      {
-        "panelId": 5,
-        "x": 0,
-        "y": 0,
-        "w": 12,
-        "h": 4
-      },
-      {
-        "panelId": 6,
-        "x": 12,
-        "y": 0,
-        "w": 12,
-        "h": 4
-      },
-      {
-        "panelId": 7,
-        "x": 0,
-        "y": 4,
-        "w": 12,
-        "h": 4
-      },
-      {
-        "panelId": 8,
-        "x": 12,
-        "y": 4,
-        "w": 12,
-        "h": 4
-      },
-      {
-        "panelId": 9,
-        "x": 0,
-        "y": 8,
-        "w": 12,
-        "h": 4
-      },
-      {
-        "panelId": 10,
-        "x": 12,
-        "y": 8,
-        "w": 12,
-        "h": 4
-      },
-      {
-        "panelId": 11,
-        "x": 0,
-        "y": 12,
-        "w": 12,
-        "h": 4
-      },
-      {
-        "panelId": 12,
-        "x": 12,
-        "y": 12,
-        "w": 12,
-        "h": 4
-      }
-    ],
+    "teamId": 35635,
     "name": "SQL Statistics",
     "panels": [
       {
@@ -84,8 +15,8 @@
           {
             "enabled": true,
             "displayInfo": {
-              "displayName": "",
-              "timeSeriesDisplayNameTemplate": "",
+              "displayName": "Request Rate (req/s)",
+              "timeSeriesDisplayNameTemplate": "Request Rate",
               "type": "lines"
             },
             "format": {
@@ -125,8 +56,8 @@
           {
             "enabled": true,
             "displayInfo": {
-              "displayName": "",
-              "timeSeriesDisplayNameTemplate": "",
+              "displayName": "Error Rate (err/s)",
+              "timeSeriesDisplayNameTemplate": "Error Rate",
               "type": "lines"
             },
             "format": {
@@ -256,14 +187,14 @@
           {
             "enabled": true,
             "displayInfo": {
-              "displayName": "",
-              "timeSeriesDisplayNameTemplate": "",
+              "displayName": "Max Request Time",
+              "timeSeriesDisplayNameTemplate": "Max Request Time",
               "type": "lines"
             },
             "format": {
               "unit": "relativeTime",
               "inputFormat": "ns",
-              "displayFormat": "auto",
+              "displayFormat": "ms",
               "decimals": null,
               "yAxis": "auto",
               "nullValueDisplayMode": "nullGap",
@@ -337,17 +268,17 @@
       },
       {
         "id": 7,
-        "type": "advancedToplist",
+        "type": "advancedTable",
         "name": "Top Queries by Number of Requests",
         "description": "",
         "nullValueDisplayText": null,
         "links": null,
         "advancedQueries": [
           {
-            "query": "topk(10,max(sum_over_time(sysdig_container_net_sql_query_request_count{$__scope}[$__range])) by (net_sql_query))",
+            "query": "max(sum_over_time(sysdig_container_net_sql_query_request_count{$__scope}[$__range])) by (net_sql_query)",
             "enabled": true,
             "displayInfo": {
-              "displayName": null,
+              "displayName": "Number of Requests",
               "timeSeriesDisplayNameTemplate": "{{net_sql_query}} ",
               "type": "lines"
             },
@@ -370,17 +301,17 @@
       },
       {
         "id": 8,
-        "type": "advancedToplist",
+        "type": "advancedTable",
         "name": "Top Tables by Number of Requests",
         "description": "",
         "nullValueDisplayText": null,
         "links": null,
         "advancedQueries": [
           {
-            "query": "topk(10,max(sum_over_time(sysdig_container_net_sql_table_request_count{$__scope}[$__range])) by (net_sql_table))",
+            "query": "max(sum_over_time(sysdig_container_net_sql_table_request_count{$__scope}[$__range])) by (net_sql_table)",
             "enabled": true,
             "displayInfo": {
-              "displayName": null,
+              "displayName": "Number of Requests",
               "timeSeriesDisplayNameTemplate": "{{net_sql_table}} ",
               "type": "lines"
             },
@@ -403,7 +334,7 @@
       },
       {
         "id": 9,
-        "type": "basicToplist",
+        "type": "basicTable",
         "name": "Slowest Queries by average request time",
         "description": "",
         "nullValueDisplayText": null,
@@ -412,7 +343,7 @@
           {
             "enabled": true,
             "displayInfo": {
-              "displayName": "",
+              "displayName": "Average Request Time",
               "timeSeriesDisplayNameTemplate": "",
               "type": "lines"
             },
@@ -478,7 +409,7 @@
                     "heuristic": false,
                     "documentType": "metric"
                   },
-                  "displayName": null,
+                  "displayName": "Query",
                   "sorting": null
                 }
               ],
@@ -486,13 +417,11 @@
               "direction": "desc"
             }
           }
-        ],
-        "applyScopeToAll": false,
-        "applySegmentationToAll": false
+        ]
       },
       {
         "id": 10,
-        "type": "basicToplist",
+        "type": "basicTable",
         "name": "Slowest Tables by average request time",
         "description": "",
         "nullValueDisplayText": null,
@@ -501,7 +430,7 @@
           {
             "enabled": true,
             "displayInfo": {
-              "displayName": "",
+              "displayName": "Average Request Time",
               "timeSeriesDisplayNameTemplate": "",
               "type": "lines"
             },
@@ -567,7 +496,7 @@
                     "heuristic": false,
                     "documentType": "metric"
                   },
-                  "displayName": null,
+                  "displayName": "Table Name",
                   "sorting": null
                 }
               ],
@@ -575,9 +504,7 @@
               "direction": "desc"
             }
           }
-        ],
-        "applyScopeToAll": false,
-        "applySegmentationToAll": false
+        ]
       },
       {
         "id": 11,
@@ -707,17 +634,17 @@
       },
       {
         "id": 12,
-        "type": "advancedToplist",
+        "type": "advancedTable",
         "name": "Slowest Queries by sum of all request times",
         "description": "",
         "nullValueDisplayText": null,
         "links": null,
         "advancedQueries": [
           {
-            "query": "topk(10,max(sum_over_time(sysdig_container_net_sql_query_request_time{$__scope}[$__range])) by (net_sql_query))",
+            "query": "max(sum_over_time(sysdig_container_net_sql_query_request_time{$__scope}[$__range])) by (net_sql_query)",
             "enabled": true,
             "displayInfo": {
-              "displayName": null,
+              "displayName": "Sum of All Request Times",
               "timeSeriesDisplayNameTemplate": "{{net_sql_query}} ",
               "type": "lines"
             },
@@ -739,7 +666,6 @@
         ]
       }
     ],
-    "schema": 3,
     "scopeExpressionList": [
       {
         "operand": "kubernetes.namespace.name",
@@ -769,7 +695,7 @@
           "generatedFrom": "com.draios.model.metrics.custom.CustomMetric$Tag",
           "publicId": "kube_namespace_name",
           "segment": false,
-          "documentTimestamp": 1680220716924,
+          "documentTimestamp": 1680553247448,
           "heuristic": false,
           "documentType": "metric"
         },
@@ -831,7 +757,7 @@
           "generatedFrom": "com.draios.model.metrics.custom.CustomMetric$Tag",
           "publicId": "kube_workload_name",
           "segment": false,
-          "documentTimestamp": 1680220716924,
+          "documentTimestamp": 1680553247448,
           "heuristic": false,
           "documentType": "metric"
         },
@@ -839,7 +765,76 @@
         "isVariable": true
       }
     ],
-    "version": 32,
+    "eventDisplaySettings": {
+      "enabled": true,
+      "queryParams": {
+        "severities": [],
+        "alertStatuses": [],
+        "categories": [],
+        "filter": null,
+        "teamScope": false
+      }
+    },
+    "version": 43,
+    "description": "Statistics for production environment",
+    "layout": [
+      {
+        "panelId": 5,
+        "x": 0,
+        "y": 0,
+        "w": 12,
+        "h": 4
+      },
+      {
+        "panelId": 6,
+        "x": 12,
+        "y": 0,
+        "w": 12,
+        "h": 4
+      },
+      {
+        "panelId": 7,
+        "x": 0,
+        "y": 4,
+        "w": 12,
+        "h": 4
+      },
+      {
+        "panelId": 8,
+        "x": 12,
+        "y": 4,
+        "w": 12,
+        "h": 4
+      },
+      {
+        "panelId": 9,
+        "x": 0,
+        "y": 8,
+        "w": 12,
+        "h": 4
+      },
+      {
+        "panelId": 10,
+        "x": 12,
+        "y": 8,
+        "w": 12,
+        "h": 4
+      },
+      {
+        "panelId": 11,
+        "x": 0,
+        "y": 12,
+        "w": 12,
+        "h": 4
+      },
+      {
+        "panelId": 12,
+        "x": 12,
+        "y": 12,
+        "w": 12,
+        "h": 4
+      }
+    ],
     "sharingSettings": [
       {
         "role": "ROLE_RESOURCE_EDIT",
@@ -850,6 +845,7 @@
           "teamTheme": "#73A1F7"
         }
       }
-    ]
+    ],
+    "schema": 3
   }
 }

--- a/sysdig/dashboards/sql_statistics.json
+++ b/sysdig/dashboards/sql_statistics.json
@@ -1,0 +1,855 @@
+{
+  "dashboard": {
+    "teamId": 35635,
+    "description": "Statistics for production environment",
+    "eventDisplaySettings": {
+      "enabled": true,
+      "queryParams": {
+        "severities": [],
+        "alertStatuses": [],
+        "categories": [],
+        "filter": null,
+        "teamScope": false
+      }
+    },
+    "id": 391840,
+    "layout": [
+      {
+        "panelId": 5,
+        "x": 0,
+        "y": 0,
+        "w": 12,
+        "h": 4
+      },
+      {
+        "panelId": 6,
+        "x": 12,
+        "y": 0,
+        "w": 12,
+        "h": 4
+      },
+      {
+        "panelId": 7,
+        "x": 0,
+        "y": 4,
+        "w": 12,
+        "h": 4
+      },
+      {
+        "panelId": 8,
+        "x": 12,
+        "y": 4,
+        "w": 12,
+        "h": 4
+      },
+      {
+        "panelId": 9,
+        "x": 0,
+        "y": 8,
+        "w": 12,
+        "h": 4
+      },
+      {
+        "panelId": 10,
+        "x": 12,
+        "y": 8,
+        "w": 12,
+        "h": 4
+      },
+      {
+        "panelId": 11,
+        "x": 0,
+        "y": 12,
+        "w": 12,
+        "h": 4
+      },
+      {
+        "panelId": 12,
+        "x": 12,
+        "y": 12,
+        "w": 12,
+        "h": 4
+      }
+    ],
+    "name": "SQL Statistics",
+    "panels": [
+      {
+        "id": 5,
+        "type": "basicTimechart",
+        "name": "Number of Requests vs Errors",
+        "description": "",
+        "nullValueDisplayText": null,
+        "links": null,
+        "basicQueries": [
+          {
+            "enabled": true,
+            "displayInfo": {
+              "displayName": "",
+              "timeSeriesDisplayNameTemplate": "",
+              "type": "lines"
+            },
+            "format": {
+              "unit": "number",
+              "inputFormat": "1",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullGap",
+              "minInterval": null
+            },
+            "scope": {
+              "expressions": [],
+              "extendsDashboardScope": true
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "hour"
+            },
+            "metrics": [
+              {
+                "id": "sysdig_container_net_sql_request_count",
+                "timeAggregation": "timeAvg",
+                "groupAggregation": "avg",
+                "descriptor": null,
+                "sorting": null
+              }
+            ],
+            "displayedValue": null,
+            "segmentation": {
+              "labels": [],
+              "limit": 10,
+              "direction": "desc"
+            }
+          },
+          {
+            "enabled": true,
+            "displayInfo": {
+              "displayName": "",
+              "timeSeriesDisplayNameTemplate": "",
+              "type": "lines"
+            },
+            "format": {
+              "unit": "number",
+              "inputFormat": "1",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullGap",
+              "minInterval": null
+            },
+            "scope": {
+              "expressions": [],
+              "extendsDashboardScope": true
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "hour"
+            },
+            "metrics": [
+              {
+                "id": "sysdig_container_net_sql_error_count",
+                "timeAggregation": "timeAvg",
+                "groupAggregation": "avg",
+                "descriptor": null,
+                "sorting": null
+              }
+            ],
+            "displayedValue": null,
+            "segmentation": {
+              "labels": [],
+              "limit": 10,
+              "direction": "desc"
+            }
+          }
+        ],
+        "applyScopeToAll": true,
+        "applySegmentationToAll": false,
+        "legendConfiguration": {
+          "enabled": true,
+          "position": "right",
+          "layout": "table",
+          "showCurrent": true,
+          "width": null,
+          "height": null
+        },
+        "axesConfiguration": {
+          "bottom": {
+            "enabled": true
+          },
+          "left": {
+            "enabled": true,
+            "displayName": "",
+            "unit": "auto",
+            "displayFormat": "auto",
+            "decimals": null,
+            "minValue": 0.0,
+            "maxValue": null,
+            "minInputFormat": "1",
+            "maxInputFormat": "1",
+            "scale": "linear"
+          },
+          "right": {
+            "enabled": true,
+            "displayName": "",
+            "unit": "auto",
+            "displayFormat": "auto",
+            "decimals": null,
+            "minValue": 0.0,
+            "maxValue": null,
+            "minInputFormat": "1",
+            "maxInputFormat": "1",
+            "scale": "linear"
+          }
+        }
+      },
+      {
+        "id": 6,
+        "type": "basicTimechart",
+        "name": "Average and Max Request Time",
+        "description": "",
+        "nullValueDisplayText": null,
+        "links": null,
+        "basicQueries": [
+          {
+            "enabled": true,
+            "displayInfo": {
+              "displayName": "",
+              "timeSeriesDisplayNameTemplate": "",
+              "type": "lines"
+            },
+            "format": {
+              "unit": "number",
+              "inputFormat": "1",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullGap",
+              "minInterval": null
+            },
+            "scope": {
+              "expressions": [],
+              "extendsDashboardScope": true
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "hour"
+            },
+            "metrics": [
+              {
+                "id": "sysdig_container_net_sql_request_time",
+                "timeAggregation": "avg",
+                "groupAggregation": "avg",
+                "descriptor": null,
+                "sorting": null
+              }
+            ],
+            "displayedValue": null,
+            "segmentation": {
+              "labels": [],
+              "limit": 10,
+              "direction": "desc"
+            }
+          },
+          {
+            "enabled": true,
+            "displayInfo": {
+              "displayName": "",
+              "timeSeriesDisplayNameTemplate": "",
+              "type": "lines"
+            },
+            "format": {
+              "unit": "relativeTime",
+              "inputFormat": "ns",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullGap",
+              "minInterval": null
+            },
+            "scope": {
+              "expressions": [],
+              "extendsDashboardScope": true
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "hour"
+            },
+            "metrics": [
+              {
+                "id": "sysdig_container_net_sql_request_time",
+                "timeAggregation": "max",
+                "groupAggregation": "max",
+                "descriptor": null,
+                "sorting": null
+              }
+            ],
+            "displayedValue": null,
+            "segmentation": {
+              "labels": [],
+              "limit": 10,
+              "direction": "desc"
+            }
+          }
+        ],
+        "applyScopeToAll": true,
+        "applySegmentationToAll": false,
+        "legendConfiguration": {
+          "enabled": true,
+          "position": "right",
+          "layout": "table",
+          "showCurrent": true,
+          "width": null,
+          "height": null
+        },
+        "axesConfiguration": {
+          "bottom": {
+            "enabled": true
+          },
+          "left": {
+            "enabled": true,
+            "displayName": "",
+            "unit": "auto",
+            "displayFormat": "auto",
+            "decimals": null,
+            "minValue": 0.0,
+            "maxValue": null,
+            "minInputFormat": "1",
+            "maxInputFormat": "1",
+            "scale": "linear"
+          },
+          "right": {
+            "enabled": true,
+            "displayName": "",
+            "unit": "auto",
+            "displayFormat": "auto",
+            "decimals": null,
+            "minValue": 0.0,
+            "maxValue": null,
+            "minInputFormat": "ns",
+            "maxInputFormat": "ns",
+            "scale": "linear"
+          }
+        }
+      },
+      {
+        "id": 7,
+        "type": "advancedToplist",
+        "name": "Top Queries by Number of Requests",
+        "description": "",
+        "nullValueDisplayText": null,
+        "links": null,
+        "advancedQueries": [
+          {
+            "query": "topk(10,max(sum_over_time(sysdig_container_net_sql_query_request_count{$__scope}[$__range])) by (net_sql_query))",
+            "enabled": true,
+            "displayInfo": {
+              "displayName": null,
+              "timeSeriesDisplayNameTemplate": "{{net_sql_query}} ",
+              "type": "lines"
+            },
+            "format": {
+              "unit": "number",
+              "inputFormat": "1",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullGap",
+              "minInterval": null
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "day"
+            }
+          }
+        ]
+      },
+      {
+        "id": 8,
+        "type": "advancedToplist",
+        "name": "Top Tables by Number of Requests",
+        "description": "",
+        "nullValueDisplayText": null,
+        "links": null,
+        "advancedQueries": [
+          {
+            "query": "topk(10,max(sum_over_time(sysdig_container_net_sql_table_request_count{$__scope}[$__range])) by (net_sql_table))",
+            "enabled": true,
+            "displayInfo": {
+              "displayName": null,
+              "timeSeriesDisplayNameTemplate": "{{net_sql_table}} ",
+              "type": "lines"
+            },
+            "format": {
+              "unit": "number",
+              "inputFormat": "1",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullGap",
+              "minInterval": null
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "day"
+            }
+          }
+        ]
+      },
+      {
+        "id": 9,
+        "type": "basicToplist",
+        "name": "Slowest Queries by average request time",
+        "description": "",
+        "nullValueDisplayText": null,
+        "links": null,
+        "basicQueries": [
+          {
+            "enabled": true,
+            "displayInfo": {
+              "displayName": "",
+              "timeSeriesDisplayNameTemplate": "",
+              "type": "lines"
+            },
+            "format": {
+              "unit": "relativeTime",
+              "inputFormat": "ns",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullGap",
+              "minInterval": null
+            },
+            "scope": {
+              "expressions": [],
+              "extendsDashboardScope": true
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "day"
+            },
+            "metrics": [
+              {
+                "id": "sysdig_container_net_sql_query_request_time",
+                "timeAggregation": "avg",
+                "groupAggregation": "max",
+                "descriptor": null,
+                "sorting": null
+              }
+            ],
+            "displayedValue": "entireRange",
+            "segmentation": {
+              "labels": [
+                {
+                  "id": "net.sql.query",
+                  "descriptor": {
+                    "segmentations": [],
+                    "documentId": "net.sql.query",
+                    "id": "net.sql.query",
+                    "metricType": "tag",
+                    "type": "string",
+                    "scale": 1.0,
+                    "name": "sql query",
+                    "description": "sql full query",
+                    "category": "network",
+                    "namespaces": ["host.net"],
+                    "scopes": ["host", "container"],
+                    "timeAggregations": ["concat", "distinct", "count"],
+                    "groupAggregations": ["concat", "distinct", "count"],
+                    "aggregationForGroup": "none",
+                    "createdAt": 1648212882000,
+                    "hidden": false,
+                    "experimental": false,
+                    "deferred": false,
+                    "identity": false,
+                    "canMonitor": false,
+                    "canGroupBy": false,
+                    "canFilter": true,
+                    "generatedFrom": "com.draios.model.metrics.sql.SqlQuery",
+                    "publicId": "net_sql_query",
+                    "segment": false,
+                    "documentTimestamp": 1648212882000,
+                    "heuristic": false,
+                    "documentType": "metric"
+                  },
+                  "displayName": null,
+                  "sorting": null
+                }
+              ],
+              "limit": 10,
+              "direction": "desc"
+            }
+          }
+        ],
+        "applyScopeToAll": false,
+        "applySegmentationToAll": false
+      },
+      {
+        "id": 10,
+        "type": "basicToplist",
+        "name": "Slowest Tables by average request time",
+        "description": "",
+        "nullValueDisplayText": null,
+        "links": null,
+        "basicQueries": [
+          {
+            "enabled": true,
+            "displayInfo": {
+              "displayName": "",
+              "timeSeriesDisplayNameTemplate": "",
+              "type": "lines"
+            },
+            "format": {
+              "unit": "relativeTime",
+              "inputFormat": "ns",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullGap",
+              "minInterval": null
+            },
+            "scope": {
+              "expressions": [],
+              "extendsDashboardScope": true
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "day"
+            },
+            "metrics": [
+              {
+                "id": "sysdig_container_net_sql_table_request_time",
+                "timeAggregation": "avg",
+                "groupAggregation": "max",
+                "descriptor": null,
+                "sorting": null
+              }
+            ],
+            "displayedValue": "entireRange",
+            "segmentation": {
+              "labels": [
+                {
+                  "id": "net.sql.table",
+                  "descriptor": {
+                    "segmentations": [],
+                    "documentId": "net.sql.table",
+                    "id": "net.sql.table",
+                    "metricType": "tag",
+                    "type": "string",
+                    "scale": 1.0,
+                    "name": "sql table",
+                    "description": "sql query table",
+                    "category": "network",
+                    "namespaces": ["host.net"],
+                    "scopes": ["host", "container"],
+                    "timeAggregations": ["concat", "distinct", "count"],
+                    "groupAggregations": ["concat", "distinct", "count"],
+                    "aggregationForGroup": "none",
+                    "createdAt": 1648212882000,
+                    "hidden": false,
+                    "experimental": false,
+                    "deferred": false,
+                    "identity": false,
+                    "canMonitor": false,
+                    "canGroupBy": false,
+                    "canFilter": true,
+                    "generatedFrom": "com.draios.model.metrics.sql.SqlTable",
+                    "publicId": "net_sql_table",
+                    "segment": false,
+                    "documentTimestamp": 1648212882000,
+                    "heuristic": false,
+                    "documentType": "metric"
+                  },
+                  "displayName": null,
+                  "sorting": null
+                }
+              ],
+              "limit": 10,
+              "direction": "desc"
+            }
+          }
+        ],
+        "applyScopeToAll": false,
+        "applySegmentationToAll": false
+      },
+      {
+        "id": 11,
+        "type": "basicTimechart",
+        "name": "Request Types Over Time",
+        "description": "",
+        "nullValueDisplayText": null,
+        "links": null,
+        "basicQueries": [
+          {
+            "enabled": true,
+            "displayInfo": {
+              "displayName": "",
+              "timeSeriesDisplayNameTemplate": "",
+              "type": "lines"
+            },
+            "format": {
+              "unit": "number",
+              "inputFormat": "1",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullGap",
+              "minInterval": null
+            },
+            "scope": {
+              "expressions": [],
+              "extendsDashboardScope": true
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "hour"
+            },
+            "metrics": [
+              {
+                "id": "sysdig_container_net_sql_querytype_request_count",
+                "timeAggregation": "timeAvg",
+                "groupAggregation": "avg",
+                "descriptor": null,
+                "sorting": null
+              }
+            ],
+            "displayedValue": null,
+            "segmentation": {
+              "labels": [
+                {
+                  "id": "net.sql.query.type",
+                  "descriptor": {
+                    "segmentations": [],
+                    "documentId": "net.sql.query.type",
+                    "id": "net.sql.query.type",
+                    "metricType": "tag",
+                    "type": "string",
+                    "scale": 1.0,
+                    "name": "sql query type",
+                    "description": "sql query type (SELECT, INSERT?)",
+                    "category": "network",
+                    "namespaces": ["host.net"],
+                    "scopes": ["host", "container"],
+                    "timeAggregations": ["concat", "distinct", "count"],
+                    "groupAggregations": ["concat", "distinct", "count"],
+                    "aggregationForGroup": "none",
+                    "createdAt": 1648212882000,
+                    "hidden": false,
+                    "experimental": false,
+                    "deferred": false,
+                    "identity": false,
+                    "canMonitor": false,
+                    "canGroupBy": false,
+                    "canFilter": true,
+                    "generatedFrom": "com.draios.model.metrics.sql.SqlQueryType",
+                    "publicId": "net_sql_querytype",
+                    "segment": false,
+                    "documentTimestamp": 1648212882000,
+                    "heuristic": false,
+                    "documentType": "metric"
+                  },
+                  "displayName": null,
+                  "sorting": null
+                }
+              ],
+              "limit": 10,
+              "direction": "desc"
+            }
+          }
+        ],
+        "applyScopeToAll": true,
+        "applySegmentationToAll": false,
+        "legendConfiguration": {
+          "enabled": true,
+          "position": "right",
+          "layout": "table",
+          "showCurrent": true,
+          "width": null,
+          "height": null
+        },
+        "axesConfiguration": {
+          "bottom": {
+            "enabled": true
+          },
+          "left": {
+            "enabled": true,
+            "displayName": "",
+            "unit": "auto",
+            "displayFormat": "auto",
+            "decimals": null,
+            "minValue": 0.0,
+            "maxValue": null,
+            "minInputFormat": "1",
+            "maxInputFormat": "1",
+            "scale": "linear"
+          },
+          "right": {
+            "enabled": true,
+            "displayName": "",
+            "unit": "auto",
+            "displayFormat": "auto",
+            "decimals": null,
+            "minValue": 0.0,
+            "maxValue": null,
+            "minInputFormat": "1",
+            "maxInputFormat": "1",
+            "scale": "linear"
+          }
+        }
+      },
+      {
+        "id": 12,
+        "type": "advancedToplist",
+        "name": "Slowest Queries by sum of all request times",
+        "description": "",
+        "nullValueDisplayText": null,
+        "links": null,
+        "advancedQueries": [
+          {
+            "query": "topk(10,max(sum_over_time(sysdig_container_net_sql_query_request_time{$__scope}[$__range])) by (net_sql_query))",
+            "enabled": true,
+            "displayInfo": {
+              "displayName": null,
+              "timeSeriesDisplayNameTemplate": "{{net_sql_query}} ",
+              "type": "lines"
+            },
+            "format": {
+              "unit": "relativeTime",
+              "inputFormat": "ns",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullGap",
+              "minInterval": null
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "day"
+            }
+          }
+        ]
+      }
+    ],
+    "schema": 3,
+    "scopeExpressionList": [
+      {
+        "operand": "kubernetes.namespace.name",
+        "operator": "in",
+        "displayName": "",
+        "value": ["4c2ba9-prod"],
+        "descriptor": {
+          "documentId": "kubernetes.namespace.name",
+          "id": "kubernetes.namespace.name",
+          "metricType": "tag",
+          "type": "string",
+          "scale": 0.0,
+          "name": "kubernetes.namespace.name",
+          "description": "kubernetes.namespace.name",
+          "namespaces": ["kubernetes.namespace"],
+          "scopes": [],
+          "timeAggregations": ["concat", "distinct", "count"],
+          "groupAggregations": ["concat", "distinct", "count"],
+          "aggregationForGroup": "none",
+          "hidden": false,
+          "experimental": false,
+          "deferred": false,
+          "identity": false,
+          "canMonitor": false,
+          "canGroupBy": true,
+          "canFilter": true,
+          "generatedFrom": "com.draios.model.metrics.custom.CustomMetric$Tag",
+          "publicId": "kube_namespace_name",
+          "segment": false,
+          "documentTimestamp": 1680220716924,
+          "heuristic": false,
+          "documentType": "metric"
+        },
+        "variable": true,
+        "isVariable": true
+      },
+      {
+        "operand": "kubernetes.workload.name",
+        "operator": "in",
+        "displayName": "",
+        "value": ["postgres13"],
+        "descriptor": {
+          "documentId": "kubernetes.workload.name",
+          "id": "kubernetes.workload.name",
+          "metricType": "tag",
+          "type": "string",
+          "scale": 0.0,
+          "name": "kubernetes.workload.name",
+          "description": "kubernetes.workload.name",
+          "namespaces": [
+            "cloudProvider",
+            "host.container",
+            "ecs",
+            "host.fs",
+            "host.file",
+            "host",
+            "kubernetes",
+            "kubernetes.cluster",
+            "kubernetes.daemonSet",
+            "kubernetes.deployment",
+            "kubernetes.job",
+            "kubernetes.namespace",
+            "kubernetes.node",
+            "kubernetes.pod",
+            "kubernetes.replicaSet",
+            "kubernetes.service",
+            "kubernetes.statefulSet",
+            "kubernetes.resourcequota",
+            "kubernetes.hpa",
+            "link",
+            "mesos",
+            "host.net",
+            "host.process",
+            "prometheus",
+            "swarm",
+            "prombeacon"
+          ],
+          "scopes": [],
+          "timeAggregations": ["concat", "distinct", "count"],
+          "groupAggregations": ["concat", "distinct", "count"],
+          "aggregationForGroup": "none",
+          "hidden": false,
+          "experimental": false,
+          "deferred": false,
+          "identity": false,
+          "canMonitor": false,
+          "canGroupBy": true,
+          "canFilter": true,
+          "generatedFrom": "com.draios.model.metrics.custom.CustomMetric$Tag",
+          "publicId": "kube_workload_name",
+          "segment": false,
+          "documentTimestamp": 1680220716924,
+          "heuristic": false,
+          "documentType": "metric"
+        },
+        "variable": true,
+        "isVariable": true
+      }
+    ],
+    "version": 32,
+    "sharingSettings": [
+      {
+        "role": "ROLE_RESOURCE_EDIT",
+        "member": {
+          "type": "TEAM",
+          "id": 35635,
+          "name": "4c2ba9-team",
+          "teamTheme": "#73A1F7"
+        }
+      }
+    ]
+  }
+}

--- a/sysdig/dashboards/workload_status_performance.json
+++ b/sysdig/dashboards/workload_status_performance.json
@@ -1,0 +1,4522 @@
+{
+  "dashboard": {
+    "id": 393233,
+    "teamId": 35635,
+    "name": "Workload Status & Performance",
+    "panels": [
+      {
+        "id": 1,
+        "type": "advancedTimechart",
+        "name": "CPU usage per Workload",
+        "description": "",
+        "nullValueDisplayText": null,
+        "links": null,
+        "advancedQueries": [
+          {
+            "query": "sum by(kube_cluster_name,kube_namespace_name,kube_workload_name) (rate(sysdig_container_cpu_cores_used{kube_workload_name=~$workload,kube_cluster_name=~$cluster,kube_namespace_name=~$namespace,kube_workload_type=~$type}[$__interval]))",
+            "enabled": true,
+            "displayInfo": {
+              "displayName": "Workload < Namespace < Cluster",
+              "timeSeriesDisplayNameTemplate": "{{kube_workload_name}} < {{kube_namespace_name}} < {{kube_cluster_name}}",
+              "type": "lines"
+            },
+            "format": {
+              "unit": "number",
+              "inputFormat": "1",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullGap",
+              "minInterval": null
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "day"
+            }
+          }
+        ],
+        "legendConfiguration": {
+          "enabled": true,
+          "position": "bottom",
+          "layout": "table",
+          "showCurrent": true,
+          "width": null,
+          "height": null
+        },
+        "axesConfiguration": {
+          "bottom": {
+            "enabled": true
+          },
+          "left": {
+            "enabled": true,
+            "displayName": null,
+            "unit": "auto",
+            "displayFormat": "auto",
+            "decimals": null,
+            "minValue": null,
+            "maxValue": null,
+            "minInputFormat": "1",
+            "maxInputFormat": "1",
+            "scale": "linear"
+          },
+          "right": {
+            "enabled": true,
+            "displayName": null,
+            "unit": "auto",
+            "displayFormat": "auto",
+            "decimals": null,
+            "minValue": 0.0,
+            "maxValue": null,
+            "minInputFormat": "1",
+            "maxInputFormat": "1",
+            "scale": "linear"
+          }
+        }
+      },
+      {
+        "id": 4,
+        "type": "advancedNumber",
+        "name": "% Pods available",
+        "description": "",
+        "nullValueDisplayText": null,
+        "links": null,
+        "advancedQueries": [
+          {
+            "query": "(\n  (\n    sum(kube_workload_status_ready{cluster=~$cluster,namespace=~$namespace,kube_workload_name=~$workload,kube_workload_type=~$type})\n  )\n/  \n  (\n    sum(kube_workload_status_desired{cluster=~$cluster,namespace=~$namespace,kube_workload_name=~$workload,kube_workload_type=~$type})\n  )\n)\n*100",
+            "enabled": true,
+            "displayInfo": {
+              "displayName": "",
+              "timeSeriesDisplayNameTemplate": "",
+              "type": "lines"
+            },
+            "format": {
+              "unit": "%",
+              "inputFormat": "0-100",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullGap",
+              "minInterval": null
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "day"
+            }
+          }
+        ],
+        "numberThresholds": {
+          "values": [
+            {
+              "severity": "ok",
+              "value": 90.0,
+              "inputFormat": "0-100",
+              "displayText": ""
+            },
+            {
+              "severity": "low",
+              "value": 60.0,
+              "inputFormat": "0-100",
+              "displayText": ""
+            },
+            {
+              "severity": "high",
+              "value": 0.0,
+              "inputFormat": "0-100",
+              "displayText": ""
+            }
+          ],
+          "base": {
+            "severity": "high",
+            "displayText": "Unknown"
+          }
+        }
+      },
+      {
+        "id": 5,
+        "type": "advancedNumber",
+        "name": "# Pods desired",
+        "description": "",
+        "nullValueDisplayText": null,
+        "links": null,
+        "advancedQueries": [
+          {
+            "query": "sum(kube_workload_status_desired{cluster=~$cluster,namespace=~$namespace,kube_workload_name=~$workload,kube_workload_type=~$type}) or vector(0)",
+            "enabled": true,
+            "displayInfo": {
+              "displayName": "",
+              "timeSeriesDisplayNameTemplate": "",
+              "type": "lines"
+            },
+            "format": {
+              "unit": "number",
+              "inputFormat": "1",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullGap",
+              "minInterval": null
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "day"
+            }
+          }
+        ],
+        "numberThresholds": {
+          "values": [],
+          "base": {
+            "severity": "none",
+            "displayText": ""
+          }
+        }
+      },
+      {
+        "id": 6,
+        "type": "advancedNumber",
+        "name": "# Pods available",
+        "description": "",
+        "nullValueDisplayText": null,
+        "links": null,
+        "advancedQueries": [
+          {
+            "query": "sum(kube_workload_status_ready{cluster=~$cluster,namespace=~$namespace,kube_workload_name=~$workload,kube_workload_type=~$type})",
+            "enabled": true,
+            "displayInfo": {
+              "displayName": "",
+              "timeSeriesDisplayNameTemplate": "",
+              "type": "lines"
+            },
+            "format": {
+              "unit": "number",
+              "inputFormat": "1",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullGap",
+              "minInterval": null
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "day"
+            }
+          }
+        ],
+        "numberThresholds": {
+          "values": [
+            {
+              "severity": "none",
+              "value": 1.0,
+              "inputFormat": "1",
+              "displayText": ""
+            }
+          ],
+          "base": {
+            "severity": "high",
+            "displayText": ""
+          }
+        }
+      },
+      {
+        "id": 8,
+        "type": "advancedTimechart",
+        "name": "Pods Available",
+        "description": "",
+        "nullValueDisplayText": null,
+        "links": null,
+        "advancedQueries": [
+          {
+            "query": "kube_workload_status_ready{cluster=~$cluster,namespace=~$namespace,kube_workload_name=~$workload,kube_workload_type=~$type}",
+            "enabled": true,
+            "displayInfo": {
+              "displayName": "Workload < Namespace < Cluster",
+              "timeSeriesDisplayNameTemplate": "{{kube_workload_name}} < {{kube_namespace_name}} < {{kube_cluster_name}}",
+              "type": "lines"
+            },
+            "format": {
+              "unit": "number",
+              "inputFormat": "1",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullGap",
+              "minInterval": null
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "day"
+            }
+          }
+        ],
+        "legendConfiguration": {
+          "enabled": true,
+          "position": "bottom",
+          "layout": "table",
+          "showCurrent": true,
+          "width": null,
+          "height": null
+        },
+        "axesConfiguration": {
+          "bottom": {
+            "enabled": true
+          },
+          "left": {
+            "enabled": true,
+            "displayName": null,
+            "unit": "auto",
+            "displayFormat": "auto",
+            "decimals": 2,
+            "minValue": null,
+            "maxValue": null,
+            "minInputFormat": "1",
+            "maxInputFormat": "1",
+            "scale": "linear"
+          },
+          "right": {
+            "enabled": true,
+            "displayName": null,
+            "unit": "auto",
+            "displayFormat": "auto",
+            "decimals": null,
+            "minValue": 0.0,
+            "maxValue": null,
+            "minInputFormat": "1",
+            "maxInputFormat": "1",
+            "scale": "linear"
+          }
+        }
+      },
+      {
+        "id": 10,
+        "type": "advancedTimechart",
+        "name": "☠️ Pods Unavailable ",
+        "description": "",
+        "nullValueDisplayText": null,
+        "links": null,
+        "advancedQueries": [
+          {
+            "query": "(\n  sum by(kube_cluster_name,kube_namespace_name,kube_workload_name)(kube_workload_status_desired{cluster=~$cluster,namespace=~$namespace,kube_workload_name=~$workload,kube_workload_type=~$type})\n)\n-\n(\n  sum by(kube_cluster_name,kube_namespace_name,kube_workload_name)(kube_workload_status_ready{cluster=~$cluster,namespace=~$namespace,kube_workload_name=~$workload,kube_workload_type=~$type, kube_workload_type!=\"daemonset\"} or kube_daemonset_status_number_ready{cluster=~$cluster,namespace=~$namespace,kube_workload_name=~$workload}) or vector(0)\n)\n > 0 or vector(0)",
+            "enabled": true,
+            "displayInfo": {
+              "displayName": "☠️ Workload < Namespace < Cluster",
+              "timeSeriesDisplayNameTemplate": "☠️ {{kube_workload_name}} < {{kube_namespace_name}} < {{kube_cluster_name}}",
+              "type": "lines"
+            },
+            "format": {
+              "unit": "number",
+              "inputFormat": "1",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullGap",
+              "minInterval": null
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "day"
+            }
+          }
+        ],
+        "legendConfiguration": {
+          "enabled": true,
+          "position": "bottom",
+          "layout": "table",
+          "showCurrent": true,
+          "width": null,
+          "height": null
+        },
+        "axesConfiguration": {
+          "bottom": {
+            "enabled": true
+          },
+          "left": {
+            "enabled": true,
+            "displayName": null,
+            "unit": "auto",
+            "displayFormat": "auto",
+            "decimals": null,
+            "minValue": 0.0,
+            "maxValue": null,
+            "minInputFormat": "1",
+            "maxInputFormat": "1",
+            "scale": "linear"
+          },
+          "right": {
+            "enabled": true,
+            "displayName": null,
+            "unit": "auto",
+            "displayFormat": "auto",
+            "decimals": null,
+            "minValue": 0.0,
+            "maxValue": null,
+            "minInputFormat": "1",
+            "maxInputFormat": "1",
+            "scale": "linear"
+          }
+        }
+      },
+      {
+        "id": 11,
+        "type": "advancedNumber",
+        "name": "# Pods ready",
+        "description": "",
+        "nullValueDisplayText": null,
+        "links": null,
+        "advancedQueries": [
+          {
+            "query": "sum (kube_pod_status_ready{condition=\"true\",kube_cluster_name=~$cluster,kube_namespace_name=~$namespace,kube_workload_name=~$workload,kube_workload_type=~$type})",
+            "enabled": true,
+            "displayInfo": {
+              "displayName": "",
+              "timeSeriesDisplayNameTemplate": "",
+              "type": "lines"
+            },
+            "format": {
+              "unit": "number",
+              "inputFormat": "1",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullGap",
+              "minInterval": null
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "day"
+            }
+          }
+        ],
+        "numberThresholds": {
+          "values": [
+            {
+              "severity": "none",
+              "value": 1.0,
+              "inputFormat": "1",
+              "displayText": ""
+            }
+          ],
+          "base": {
+            "severity": "high",
+            "displayText": ""
+          }
+        }
+      },
+      {
+        "id": 12,
+        "type": "advancedNumber",
+        "name": "# Pods not ready",
+        "description": "",
+        "nullValueDisplayText": null,
+        "links": null,
+        "advancedQueries": [
+          {
+            "query": "sum (kube_pod_status_ready{condition=\"false\",kube_cluster_name=~$cluster,kube_namespace_name=~$namespace,kube_workload_name=~$workload,kube_workload_type=~$type, kube_workload_type!=\"job\"})",
+            "enabled": true,
+            "displayInfo": {
+              "displayName": "",
+              "timeSeriesDisplayNameTemplate": "",
+              "type": "lines"
+            },
+            "format": {
+              "unit": "number",
+              "inputFormat": "1",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullGap",
+              "minInterval": null
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "day"
+            }
+          }
+        ],
+        "numberThresholds": {
+          "values": [
+            {
+              "severity": "high",
+              "value": 1.0,
+              "inputFormat": "1",
+              "displayText": ""
+            }
+          ],
+          "base": {
+            "severity": "ok",
+            "displayText": ""
+          }
+        }
+      },
+      {
+        "id": 14,
+        "type": "text",
+        "name": "Pod health",
+        "description": "",
+        "nullValueDisplayText": null,
+        "links": null,
+        "markdownSource": "## Pods health",
+        "transparentBackground": false,
+        "panelTitleVisible": false,
+        "textAutosized": false
+      },
+      {
+        "id": 15,
+        "type": "text",
+        "name": "Resource usage",
+        "description": "",
+        "nullValueDisplayText": null,
+        "links": null,
+        "markdownSource": "## Resource usage by Workload",
+        "transparentBackground": false,
+        "panelTitleVisible": false,
+        "textAutosized": false
+      },
+      {
+        "id": 16,
+        "type": "text",
+        "name": "Pod health info",
+        "description": "",
+        "nullValueDisplayText": null,
+        "links": null,
+        "markdownSource": "⛳️ A pod will be in the **Not Available** state or have **too many restarts** for several reasons:\n\n✅ Check if the rest of the pods in the deployment are also unavailable.\n- This specific case indicates a problem with the resource quota of the namespace or the capacity of the nodes.\n  * 👉 See the **[Cluster Capacity](#/dashboard-template/view.kubernetes.cluster.capacityPlanning)** dashboard to check if both cluster and namespace have enough resources to allocate to the pods.\n  * 👉 If the namespace and the nodes have sufficient resources, the problem could be related to the runtime of one of the pod's containers. See the **[Pod Overview](#/dashboard-template/view.kubernetes.pod.status)** dashboard to identify the problems in the pod's containers.\n\n- Ensure that all the containers in the deployment are using the same image.\n  * 👉 See the **Images by Deployment** section below.\n\n✅ Check if the rest of the pods in the deployment are also unavailable. If this is the case, it could be a configuration or container issue.\n*  👉 See the **[Pod Overview](#/dashboard-template/view.kubernetes.pod.status)** dashboard to identify the problems in the pod's containers.\n\n\n✅ Check if the problematic pod was in any of the following states to narrow down the potential issue:\n- The percentage of pod available is not 100%\n- The desired pods are not the same as the pods ready\n- The number of pods in the pods not ready status is more than 0\n- The number of pods status unknown is more than 0\n\n**⭐️Tip**:  To locate the deployment with these potential problems, filter by cluster and namespace and check the **Pods available** status.\n\n\n\n",
+        "transparentBackground": false,
+        "panelTitleVisible": false,
+        "textAutosized": false
+      },
+      {
+        "id": 17,
+        "type": "text",
+        "name": "Resource usage pod",
+        "description": "",
+        "nullValueDisplayText": null,
+        "links": null,
+        "markdownSource": "## Resource usage by Pod",
+        "transparentBackground": false,
+        "panelTitleVisible": false,
+        "textAutosized": false
+      },
+      {
+        "id": 18,
+        "type": "advancedTimechart",
+        "name": "CPU usage per pod",
+        "description": "",
+        "nullValueDisplayText": null,
+        "links": null,
+        "advancedQueries": [
+          {
+            "query": "sum by (kube_pod_name,kube_namespace_name,kube_cluster_name,kube_workload_name)(sysdig_container_cpu_cores_used {kube_workload_name=~$workload,kube_workload_type=~$type,kube_cluster_name=~$cluster,kube_namespace_name=~$namespace})",
+            "enabled": true,
+            "displayInfo": {
+              "displayName": "Pod < Workload < Namespace < Cluster",
+              "timeSeriesDisplayNameTemplate": "{{kube_pod_name}} < {{kube_workload_name}} < {{kube_namespace_name}} < {{kube_cluster_name}}",
+              "type": "lines"
+            },
+            "format": {
+              "unit": "number",
+              "inputFormat": "1",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullGap",
+              "minInterval": null
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "day"
+            }
+          }
+        ],
+        "legendConfiguration": {
+          "enabled": true,
+          "position": "bottom",
+          "layout": "table",
+          "showCurrent": true,
+          "width": null,
+          "height": null
+        },
+        "axesConfiguration": {
+          "bottom": {
+            "enabled": true
+          },
+          "left": {
+            "enabled": true,
+            "displayName": null,
+            "unit": "auto",
+            "displayFormat": "auto",
+            "decimals": null,
+            "minValue": null,
+            "maxValue": null,
+            "minInputFormat": "1",
+            "maxInputFormat": "1",
+            "scale": "linear"
+          },
+          "right": {
+            "enabled": true,
+            "displayName": null,
+            "unit": "auto",
+            "displayFormat": "auto",
+            "decimals": null,
+            "minValue": null,
+            "maxValue": null,
+            "minInputFormat": "1",
+            "maxInputFormat": "1",
+            "scale": "linear"
+          }
+        }
+      },
+      {
+        "id": 19,
+        "type": "advancedTimechart",
+        "name": "Memory usage by Pod",
+        "description": "",
+        "nullValueDisplayText": null,
+        "links": null,
+        "advancedQueries": [
+          {
+            "query": "sum by(kube_workload_name,kube_cluster_name,kube_namespace_name,kube_pod_name) (sysdig_container_memory_used_bytes{kube_workload_name=~$workload,kube_cluster_name=~$cluster,kube_namespace_name=~$namespace,kube_workload_type=~$type})",
+            "enabled": true,
+            "displayInfo": {
+              "displayName": "Pod < Workload < Namespace < Cluster",
+              "timeSeriesDisplayNameTemplate": "{{kube_pod_name}} < {{kube_workload_name}} < {{kube_namespace_name}} < {{kube_cluster_name}}",
+              "type": "lines"
+            },
+            "format": {
+              "unit": "byte",
+              "inputFormat": "B",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullGap",
+              "minInterval": null
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "day"
+            }
+          }
+        ],
+        "legendConfiguration": {
+          "enabled": true,
+          "position": "bottom",
+          "layout": "table",
+          "showCurrent": true,
+          "width": null,
+          "height": null
+        },
+        "axesConfiguration": {
+          "bottom": {
+            "enabled": true
+          },
+          "left": {
+            "enabled": true,
+            "displayName": null,
+            "unit": "auto",
+            "displayFormat": "auto",
+            "decimals": null,
+            "minValue": 0.0,
+            "maxValue": null,
+            "minInputFormat": "B",
+            "maxInputFormat": "B",
+            "scale": "linear"
+          },
+          "right": {
+            "enabled": true,
+            "displayName": null,
+            "unit": "auto",
+            "displayFormat": "auto",
+            "decimals": null,
+            "minValue": 0.0,
+            "maxValue": null,
+            "minInputFormat": "1",
+            "maxInputFormat": "1",
+            "scale": "linear"
+          }
+        }
+      },
+      {
+        "id": 24,
+        "type": "advancedTimechart",
+        "name": "♻️ Pod Restarts",
+        "description": "",
+        "nullValueDisplayText": "No pods restarted on the selected workloads",
+        "links": null,
+        "advancedQueries": [
+          {
+            "query": "topk(15,sum by(kube_cluster_name,kube_namespace_name,kube_workload_name)(changes(kube_pod_status_ready{condition=\"true\",kube_cluster_name=~$cluster,kube_workload_type=~$type,kube_namespace_name=~$namespace,kube_workload_name=~$workload,kube_workload_type=~$type}[$__interval])))",
+            "enabled": false,
+            "displayInfo": {
+              "displayName": "♻️ Workload Restarts [workload < namespace < cluster]",
+              "timeSeriesDisplayNameTemplate": "♻️ {{kube_workload_name}} < {{kube_namespace_name}} < {{kube_cluster_name}}",
+              "type": "lines"
+            },
+            "format": {
+              "unit": "number",
+              "inputFormat": "1",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullZero",
+              "minInterval": null
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "day"
+            }
+          },
+          {
+            "query": "rate(kube_pod_container_status_restarts_total{kube_cluster_name=~$cluster,kube_workload_type=~$type,kube_namespace_name=~$namespace,kube_workload_name=~$workload}[$__interval])>0",
+            "enabled": true,
+            "displayInfo": {
+              "displayName": "♻️ Workload Restarts [workload < namespace < cluster]",
+              "timeSeriesDisplayNameTemplate": "♻️ {{kube_workload_name}} < {{kube_namespace_name}} < {{kube_cluster_name}}",
+              "type": "lines"
+            },
+            "format": {
+              "unit": "numberRate",
+              "inputFormat": "/s",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullZero",
+              "minInterval": null
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "day"
+            }
+          }
+        ],
+        "legendConfiguration": {
+          "enabled": true,
+          "position": "bottom",
+          "layout": "table",
+          "showCurrent": true,
+          "width": null,
+          "height": null
+        },
+        "axesConfiguration": {
+          "bottom": {
+            "enabled": true
+          },
+          "left": {
+            "enabled": true,
+            "displayName": null,
+            "unit": "auto",
+            "displayFormat": "auto",
+            "decimals": null,
+            "minValue": 0.0,
+            "maxValue": null,
+            "minInputFormat": "1",
+            "maxInputFormat": "1",
+            "scale": "linear"
+          },
+          "right": {
+            "enabled": true,
+            "displayName": null,
+            "unit": "auto",
+            "displayFormat": "auto",
+            "decimals": null,
+            "minValue": 0.0,
+            "maxValue": null,
+            "minInputFormat": "/s",
+            "maxInputFormat": "/s",
+            "scale": "linear"
+          }
+        }
+      },
+      {
+        "id": 25,
+        "type": "text",
+        "name": "Resource usage (2)",
+        "description": "",
+        "nullValueDisplayText": null,
+        "links": null,
+        "markdownSource": "## Workload Golden Signals",
+        "transparentBackground": false,
+        "panelTitleVisible": false,
+        "textAutosized": false
+      },
+      {
+        "id": 27,
+        "type": "basicTimechart",
+        "name": "AVG Network Latency per Workload",
+        "description": "",
+        "nullValueDisplayText": null,
+        "links": null,
+        "basicQueries": [
+          {
+            "enabled": true,
+            "displayInfo": {
+              "displayName": "Workload < Namespace < Cluster",
+              "timeSeriesDisplayNameTemplate": "{{kube_workload_name}} < {{kube_namespace_name}} < {{kube_cluster_name}}",
+              "type": "lines"
+            },
+            "format": {
+              "unit": "relativeTime",
+              "inputFormat": "ns",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullZero",
+              "minInterval": null
+            },
+            "scope": {
+              "expressions": [],
+              "extendsDashboardScope": true
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "day"
+            },
+            "metrics": [
+              {
+                "id": "sysdig_container_net_request_time",
+                "timeAggregation": "avg",
+                "groupAggregation": "avg",
+                "descriptor": null,
+                "sorting": null
+              }
+            ],
+            "displayedValue": null,
+            "segmentation": {
+              "labels": [
+                {
+                  "id": "kubernetes.cluster.name",
+                  "descriptor": {
+                    "documentId": "kubernetes.cluster.name",
+                    "id": "kubernetes.cluster.name",
+                    "metricType": "tag",
+                    "type": "string",
+                    "scale": 0.0,
+                    "name": "kubernetes.cluster.name",
+                    "description": "kubernetes.cluster.name",
+                    "namespaces": ["kubernetes.cluster"],
+                    "scopes": [],
+                    "timeAggregations": ["concat", "distinct", "count"],
+                    "groupAggregations": ["concat", "distinct", "count"],
+                    "aggregationForGroup": "none",
+                    "hidden": false,
+                    "experimental": false,
+                    "deferred": false,
+                    "identity": false,
+                    "canMonitor": false,
+                    "canGroupBy": true,
+                    "canFilter": true,
+                    "generatedFrom": "com.draios.model.metrics.custom.CustomMetric$Tag",
+                    "publicId": "kube_cluster_name",
+                    "segment": false,
+                    "documentTimestamp": 1680305324247,
+                    "heuristic": false,
+                    "documentType": "metric"
+                  },
+                  "displayName": null,
+                  "sorting": null
+                },
+                {
+                  "id": "kubernetes.namespace.name",
+                  "descriptor": {
+                    "documentId": "kubernetes.namespace.name",
+                    "id": "kubernetes.namespace.name",
+                    "metricType": "tag",
+                    "type": "string",
+                    "scale": 0.0,
+                    "name": "kubernetes.namespace.name",
+                    "description": "kubernetes.namespace.name",
+                    "namespaces": ["kubernetes.namespace"],
+                    "scopes": [],
+                    "timeAggregations": ["concat", "distinct", "count"],
+                    "groupAggregations": ["concat", "distinct", "count"],
+                    "aggregationForGroup": "none",
+                    "hidden": false,
+                    "experimental": false,
+                    "deferred": false,
+                    "identity": false,
+                    "canMonitor": false,
+                    "canGroupBy": true,
+                    "canFilter": true,
+                    "generatedFrom": "com.draios.model.metrics.custom.CustomMetric$Tag",
+                    "publicId": "kube_namespace_name",
+                    "segment": false,
+                    "documentTimestamp": 1680305324247,
+                    "heuristic": false,
+                    "documentType": "metric"
+                  },
+                  "displayName": null,
+                  "sorting": null
+                },
+                {
+                  "id": "kubernetes.workload.type",
+                  "descriptor": {
+                    "documentId": "kubernetes.workload.type",
+                    "id": "kubernetes.workload.type",
+                    "metricType": "tag",
+                    "type": "string",
+                    "scale": 0.0,
+                    "name": "kubernetes.workload.type",
+                    "description": "kubernetes.workload.type",
+                    "namespaces": [
+                      "cloudProvider",
+                      "host.container",
+                      "ecs",
+                      "host.fs",
+                      "host.file",
+                      "host",
+                      "kubernetes",
+                      "kubernetes.cluster",
+                      "kubernetes.daemonSet",
+                      "kubernetes.deployment",
+                      "kubernetes.job",
+                      "kubernetes.namespace",
+                      "kubernetes.node",
+                      "kubernetes.pod",
+                      "kubernetes.replicaSet",
+                      "kubernetes.service",
+                      "kubernetes.statefulSet",
+                      "kubernetes.resourcequota",
+                      "kubernetes.hpa",
+                      "link",
+                      "mesos",
+                      "host.net",
+                      "host.process",
+                      "prometheus",
+                      "swarm",
+                      "prombeacon"
+                    ],
+                    "scopes": [],
+                    "timeAggregations": ["concat", "distinct", "count"],
+                    "groupAggregations": ["concat", "distinct", "count"],
+                    "aggregationForGroup": "none",
+                    "hidden": false,
+                    "experimental": false,
+                    "deferred": false,
+                    "identity": false,
+                    "canMonitor": false,
+                    "canGroupBy": true,
+                    "canFilter": true,
+                    "generatedFrom": "com.draios.model.metrics.custom.CustomMetric$Tag",
+                    "publicId": "kube_workload_type",
+                    "segment": false,
+                    "documentTimestamp": 1680305324247,
+                    "heuristic": false,
+                    "documentType": "metric"
+                  },
+                  "displayName": null,
+                  "sorting": null
+                },
+                {
+                  "id": "kubernetes.workload.name",
+                  "descriptor": {
+                    "documentId": "kubernetes.workload.name",
+                    "id": "kubernetes.workload.name",
+                    "metricType": "tag",
+                    "type": "string",
+                    "scale": 0.0,
+                    "name": "kubernetes.workload.name",
+                    "description": "kubernetes.workload.name",
+                    "namespaces": [
+                      "cloudProvider",
+                      "host.container",
+                      "ecs",
+                      "host.fs",
+                      "host.file",
+                      "host",
+                      "kubernetes",
+                      "kubernetes.cluster",
+                      "kubernetes.daemonSet",
+                      "kubernetes.deployment",
+                      "kubernetes.job",
+                      "kubernetes.namespace",
+                      "kubernetes.node",
+                      "kubernetes.pod",
+                      "kubernetes.replicaSet",
+                      "kubernetes.service",
+                      "kubernetes.statefulSet",
+                      "kubernetes.resourcequota",
+                      "kubernetes.hpa",
+                      "link",
+                      "mesos",
+                      "host.net",
+                      "host.process",
+                      "prometheus",
+                      "swarm",
+                      "prombeacon"
+                    ],
+                    "scopes": [],
+                    "timeAggregations": ["concat", "distinct", "count"],
+                    "groupAggregations": ["concat", "distinct", "count"],
+                    "aggregationForGroup": "none",
+                    "hidden": false,
+                    "experimental": false,
+                    "deferred": false,
+                    "identity": false,
+                    "canMonitor": false,
+                    "canGroupBy": true,
+                    "canFilter": true,
+                    "generatedFrom": "com.draios.model.metrics.custom.CustomMetric$Tag",
+                    "publicId": "kube_workload_name",
+                    "segment": false,
+                    "documentTimestamp": 1680305324247,
+                    "heuristic": false,
+                    "documentType": "metric"
+                  },
+                  "displayName": null,
+                  "sorting": null
+                }
+              ],
+              "limit": 10,
+              "direction": "desc"
+            }
+          }
+        ],
+        "applyScopeToAll": false,
+        "applySegmentationToAll": false,
+        "legendConfiguration": {
+          "enabled": true,
+          "position": "bottom",
+          "layout": "table",
+          "showCurrent": true,
+          "width": null,
+          "height": null
+        },
+        "axesConfiguration": {
+          "bottom": {
+            "enabled": true
+          },
+          "left": {
+            "enabled": true,
+            "displayName": null,
+            "unit": "auto",
+            "displayFormat": "auto",
+            "decimals": null,
+            "minValue": 0.0,
+            "maxValue": null,
+            "minInputFormat": "ns",
+            "maxInputFormat": "ns",
+            "scale": "linear"
+          },
+          "right": {
+            "enabled": true,
+            "displayName": null,
+            "unit": "auto",
+            "displayFormat": "auto",
+            "decimals": null,
+            "minValue": 0.0,
+            "maxValue": null,
+            "minInputFormat": "1",
+            "maxInputFormat": "1",
+            "scale": "linear"
+          }
+        }
+      },
+      {
+        "id": 28,
+        "type": "basicTimechart",
+        "name": "Network Requests per Workload",
+        "description": "",
+        "nullValueDisplayText": null,
+        "links": null,
+        "basicQueries": [
+          {
+            "enabled": true,
+            "displayInfo": {
+              "displayName": "Workload < Namespace < Cluster",
+              "timeSeriesDisplayNameTemplate": "{{kube_workload_name}} < {{kube_namespace_name}} < {{kube_cluster_name}}",
+              "type": "lines"
+            },
+            "format": {
+              "unit": "numberRate",
+              "inputFormat": "/s",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullZero",
+              "minInterval": null
+            },
+            "scope": {
+              "expressions": [],
+              "extendsDashboardScope": true
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "day"
+            },
+            "metrics": [
+              {
+                "id": "sysdig_container_net_request_count",
+                "timeAggregation": "timeAvg",
+                "groupAggregation": "sum",
+                "descriptor": null,
+                "sorting": null
+              }
+            ],
+            "displayedValue": null,
+            "segmentation": {
+              "labels": [
+                {
+                  "id": "kubernetes.cluster.name",
+                  "descriptor": {
+                    "documentId": "kubernetes.cluster.name",
+                    "id": "kubernetes.cluster.name",
+                    "metricType": "tag",
+                    "type": "string",
+                    "scale": 0.0,
+                    "name": "kubernetes.cluster.name",
+                    "description": "kubernetes.cluster.name",
+                    "namespaces": ["kubernetes.cluster"],
+                    "scopes": [],
+                    "timeAggregations": ["concat", "distinct", "count"],
+                    "groupAggregations": ["concat", "distinct", "count"],
+                    "aggregationForGroup": "none",
+                    "hidden": false,
+                    "experimental": false,
+                    "deferred": false,
+                    "identity": false,
+                    "canMonitor": false,
+                    "canGroupBy": true,
+                    "canFilter": true,
+                    "generatedFrom": "com.draios.model.metrics.custom.CustomMetric$Tag",
+                    "publicId": "kube_cluster_name",
+                    "segment": false,
+                    "documentTimestamp": 1680305324247,
+                    "heuristic": false,
+                    "documentType": "metric"
+                  },
+                  "displayName": null,
+                  "sorting": null
+                },
+                {
+                  "id": "kubernetes.namespace.name",
+                  "descriptor": {
+                    "documentId": "kubernetes.namespace.name",
+                    "id": "kubernetes.namespace.name",
+                    "metricType": "tag",
+                    "type": "string",
+                    "scale": 0.0,
+                    "name": "kubernetes.namespace.name",
+                    "description": "kubernetes.namespace.name",
+                    "namespaces": ["kubernetes.namespace"],
+                    "scopes": [],
+                    "timeAggregations": ["concat", "distinct", "count"],
+                    "groupAggregations": ["concat", "distinct", "count"],
+                    "aggregationForGroup": "none",
+                    "hidden": false,
+                    "experimental": false,
+                    "deferred": false,
+                    "identity": false,
+                    "canMonitor": false,
+                    "canGroupBy": true,
+                    "canFilter": true,
+                    "generatedFrom": "com.draios.model.metrics.custom.CustomMetric$Tag",
+                    "publicId": "kube_namespace_name",
+                    "segment": false,
+                    "documentTimestamp": 1680305324247,
+                    "heuristic": false,
+                    "documentType": "metric"
+                  },
+                  "displayName": null,
+                  "sorting": null
+                },
+                {
+                  "id": "kubernetes.workload.type",
+                  "descriptor": {
+                    "documentId": "kubernetes.workload.type",
+                    "id": "kubernetes.workload.type",
+                    "metricType": "tag",
+                    "type": "string",
+                    "scale": 0.0,
+                    "name": "kubernetes.workload.type",
+                    "description": "kubernetes.workload.type",
+                    "namespaces": [
+                      "cloudProvider",
+                      "host.container",
+                      "ecs",
+                      "host.fs",
+                      "host.file",
+                      "host",
+                      "kubernetes",
+                      "kubernetes.cluster",
+                      "kubernetes.daemonSet",
+                      "kubernetes.deployment",
+                      "kubernetes.job",
+                      "kubernetes.namespace",
+                      "kubernetes.node",
+                      "kubernetes.pod",
+                      "kubernetes.replicaSet",
+                      "kubernetes.service",
+                      "kubernetes.statefulSet",
+                      "kubernetes.resourcequota",
+                      "kubernetes.hpa",
+                      "link",
+                      "mesos",
+                      "host.net",
+                      "host.process",
+                      "prometheus",
+                      "swarm",
+                      "prombeacon"
+                    ],
+                    "scopes": [],
+                    "timeAggregations": ["concat", "distinct", "count"],
+                    "groupAggregations": ["concat", "distinct", "count"],
+                    "aggregationForGroup": "none",
+                    "hidden": false,
+                    "experimental": false,
+                    "deferred": false,
+                    "identity": false,
+                    "canMonitor": false,
+                    "canGroupBy": true,
+                    "canFilter": true,
+                    "generatedFrom": "com.draios.model.metrics.custom.CustomMetric$Tag",
+                    "publicId": "kube_workload_type",
+                    "segment": false,
+                    "documentTimestamp": 1680305324247,
+                    "heuristic": false,
+                    "documentType": "metric"
+                  },
+                  "displayName": null,
+                  "sorting": null
+                },
+                {
+                  "id": "kubernetes.workload.name",
+                  "descriptor": {
+                    "documentId": "kubernetes.workload.name",
+                    "id": "kubernetes.workload.name",
+                    "metricType": "tag",
+                    "type": "string",
+                    "scale": 0.0,
+                    "name": "kubernetes.workload.name",
+                    "description": "kubernetes.workload.name",
+                    "namespaces": [
+                      "cloudProvider",
+                      "host.container",
+                      "ecs",
+                      "host.fs",
+                      "host.file",
+                      "host",
+                      "kubernetes",
+                      "kubernetes.cluster",
+                      "kubernetes.daemonSet",
+                      "kubernetes.deployment",
+                      "kubernetes.job",
+                      "kubernetes.namespace",
+                      "kubernetes.node",
+                      "kubernetes.pod",
+                      "kubernetes.replicaSet",
+                      "kubernetes.service",
+                      "kubernetes.statefulSet",
+                      "kubernetes.resourcequota",
+                      "kubernetes.hpa",
+                      "link",
+                      "mesos",
+                      "host.net",
+                      "host.process",
+                      "prometheus",
+                      "swarm",
+                      "prombeacon"
+                    ],
+                    "scopes": [],
+                    "timeAggregations": ["concat", "distinct", "count"],
+                    "groupAggregations": ["concat", "distinct", "count"],
+                    "aggregationForGroup": "none",
+                    "hidden": false,
+                    "experimental": false,
+                    "deferred": false,
+                    "identity": false,
+                    "canMonitor": false,
+                    "canGroupBy": true,
+                    "canFilter": true,
+                    "generatedFrom": "com.draios.model.metrics.custom.CustomMetric$Tag",
+                    "publicId": "kube_workload_name",
+                    "segment": false,
+                    "documentTimestamp": 1680305324247,
+                    "heuristic": false,
+                    "documentType": "metric"
+                  },
+                  "displayName": null,
+                  "sorting": null
+                }
+              ],
+              "limit": 10,
+              "direction": "desc"
+            }
+          }
+        ],
+        "applyScopeToAll": false,
+        "applySegmentationToAll": false,
+        "legendConfiguration": {
+          "enabled": true,
+          "position": "bottom",
+          "layout": "table",
+          "showCurrent": true,
+          "width": null,
+          "height": null
+        },
+        "axesConfiguration": {
+          "bottom": {
+            "enabled": true
+          },
+          "left": {
+            "enabled": true,
+            "displayName": null,
+            "unit": "auto",
+            "displayFormat": "auto",
+            "decimals": null,
+            "minValue": 0.0,
+            "maxValue": null,
+            "minInputFormat": "/s",
+            "maxInputFormat": "/s",
+            "scale": "linear"
+          },
+          "right": {
+            "enabled": true,
+            "displayName": null,
+            "unit": "auto",
+            "displayFormat": "auto",
+            "decimals": null,
+            "minValue": 0.0,
+            "maxValue": null,
+            "minInputFormat": "1",
+            "maxInputFormat": "1",
+            "scale": "linear"
+          }
+        }
+      },
+      {
+        "id": 29,
+        "type": "basicTimechart",
+        "name": "Network Traffic per Workload",
+        "description": "",
+        "nullValueDisplayText": null,
+        "links": null,
+        "basicQueries": [
+          {
+            "enabled": true,
+            "displayInfo": {
+              "displayName": "↘ Inbound: Workload < Namespace < Cluster",
+              "timeSeriesDisplayNameTemplate": "↘ {{kube_workload_name}} < {{kube_namespace_name}} < {{kube_cluster_name}}",
+              "type": "lines"
+            },
+            "format": {
+              "unit": "byteRate",
+              "inputFormat": "B/s",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullZero",
+              "minInterval": null
+            },
+            "scope": {
+              "expressions": [],
+              "extendsDashboardScope": true
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "day"
+            },
+            "metrics": [
+              {
+                "id": "sysdig_container_net_in_bytes",
+                "timeAggregation": "timeAvg",
+                "groupAggregation": "sum",
+                "descriptor": null,
+                "sorting": null
+              }
+            ],
+            "displayedValue": null,
+            "segmentation": {
+              "labels": [
+                {
+                  "id": "kubernetes.cluster.name",
+                  "descriptor": {
+                    "documentId": "kubernetes.cluster.name",
+                    "id": "kubernetes.cluster.name",
+                    "metricType": "tag",
+                    "type": "string",
+                    "scale": 0.0,
+                    "name": "kubernetes.cluster.name",
+                    "description": "kubernetes.cluster.name",
+                    "namespaces": ["kubernetes.cluster"],
+                    "scopes": [],
+                    "timeAggregations": ["concat", "distinct", "count"],
+                    "groupAggregations": ["concat", "distinct", "count"],
+                    "aggregationForGroup": "none",
+                    "hidden": false,
+                    "experimental": false,
+                    "deferred": false,
+                    "identity": false,
+                    "canMonitor": false,
+                    "canGroupBy": true,
+                    "canFilter": true,
+                    "generatedFrom": "com.draios.model.metrics.custom.CustomMetric$Tag",
+                    "publicId": "kube_cluster_name",
+                    "segment": false,
+                    "documentTimestamp": 1680305324247,
+                    "heuristic": false,
+                    "documentType": "metric"
+                  },
+                  "displayName": null,
+                  "sorting": null
+                },
+                {
+                  "id": "kubernetes.namespace.name",
+                  "descriptor": {
+                    "documentId": "kubernetes.namespace.name",
+                    "id": "kubernetes.namespace.name",
+                    "metricType": "tag",
+                    "type": "string",
+                    "scale": 0.0,
+                    "name": "kubernetes.namespace.name",
+                    "description": "kubernetes.namespace.name",
+                    "namespaces": ["kubernetes.namespace"],
+                    "scopes": [],
+                    "timeAggregations": ["concat", "distinct", "count"],
+                    "groupAggregations": ["concat", "distinct", "count"],
+                    "aggregationForGroup": "none",
+                    "hidden": false,
+                    "experimental": false,
+                    "deferred": false,
+                    "identity": false,
+                    "canMonitor": false,
+                    "canGroupBy": true,
+                    "canFilter": true,
+                    "generatedFrom": "com.draios.model.metrics.custom.CustomMetric$Tag",
+                    "publicId": "kube_namespace_name",
+                    "segment": false,
+                    "documentTimestamp": 1680305324247,
+                    "heuristic": false,
+                    "documentType": "metric"
+                  },
+                  "displayName": null,
+                  "sorting": null
+                },
+                {
+                  "id": "kubernetes.workload.type",
+                  "descriptor": {
+                    "documentId": "kubernetes.workload.type",
+                    "id": "kubernetes.workload.type",
+                    "metricType": "tag",
+                    "type": "string",
+                    "scale": 0.0,
+                    "name": "kubernetes.workload.type",
+                    "description": "kubernetes.workload.type",
+                    "namespaces": [
+                      "cloudProvider",
+                      "host.container",
+                      "ecs",
+                      "host.fs",
+                      "host.file",
+                      "host",
+                      "kubernetes",
+                      "kubernetes.cluster",
+                      "kubernetes.daemonSet",
+                      "kubernetes.deployment",
+                      "kubernetes.job",
+                      "kubernetes.namespace",
+                      "kubernetes.node",
+                      "kubernetes.pod",
+                      "kubernetes.replicaSet",
+                      "kubernetes.service",
+                      "kubernetes.statefulSet",
+                      "kubernetes.resourcequota",
+                      "kubernetes.hpa",
+                      "link",
+                      "mesos",
+                      "host.net",
+                      "host.process",
+                      "prometheus",
+                      "swarm",
+                      "prombeacon"
+                    ],
+                    "scopes": [],
+                    "timeAggregations": ["concat", "distinct", "count"],
+                    "groupAggregations": ["concat", "distinct", "count"],
+                    "aggregationForGroup": "none",
+                    "hidden": false,
+                    "experimental": false,
+                    "deferred": false,
+                    "identity": false,
+                    "canMonitor": false,
+                    "canGroupBy": true,
+                    "canFilter": true,
+                    "generatedFrom": "com.draios.model.metrics.custom.CustomMetric$Tag",
+                    "publicId": "kube_workload_type",
+                    "segment": false,
+                    "documentTimestamp": 1680305324248,
+                    "heuristic": false,
+                    "documentType": "metric"
+                  },
+                  "displayName": null,
+                  "sorting": null
+                },
+                {
+                  "id": "kubernetes.workload.name",
+                  "descriptor": {
+                    "documentId": "kubernetes.workload.name",
+                    "id": "kubernetes.workload.name",
+                    "metricType": "tag",
+                    "type": "string",
+                    "scale": 0.0,
+                    "name": "kubernetes.workload.name",
+                    "description": "kubernetes.workload.name",
+                    "namespaces": [
+                      "cloudProvider",
+                      "host.container",
+                      "ecs",
+                      "host.fs",
+                      "host.file",
+                      "host",
+                      "kubernetes",
+                      "kubernetes.cluster",
+                      "kubernetes.daemonSet",
+                      "kubernetes.deployment",
+                      "kubernetes.job",
+                      "kubernetes.namespace",
+                      "kubernetes.node",
+                      "kubernetes.pod",
+                      "kubernetes.replicaSet",
+                      "kubernetes.service",
+                      "kubernetes.statefulSet",
+                      "kubernetes.resourcequota",
+                      "kubernetes.hpa",
+                      "link",
+                      "mesos",
+                      "host.net",
+                      "host.process",
+                      "prometheus",
+                      "swarm",
+                      "prombeacon"
+                    ],
+                    "scopes": [],
+                    "timeAggregations": ["concat", "distinct", "count"],
+                    "groupAggregations": ["concat", "distinct", "count"],
+                    "aggregationForGroup": "none",
+                    "hidden": false,
+                    "experimental": false,
+                    "deferred": false,
+                    "identity": false,
+                    "canMonitor": false,
+                    "canGroupBy": true,
+                    "canFilter": true,
+                    "generatedFrom": "com.draios.model.metrics.custom.CustomMetric$Tag",
+                    "publicId": "kube_workload_name",
+                    "segment": false,
+                    "documentTimestamp": 1680305324248,
+                    "heuristic": false,
+                    "documentType": "metric"
+                  },
+                  "displayName": null,
+                  "sorting": null
+                }
+              ],
+              "limit": 10,
+              "direction": "desc"
+            }
+          },
+          {
+            "enabled": true,
+            "displayInfo": {
+              "displayName": "↗ Outbound: Workload < Namespace < Cluster",
+              "timeSeriesDisplayNameTemplate": "↗ {{kube_workload_name}} < {{kube_namespace_name}} < {{kube_cluster_name}}",
+              "type": "lines"
+            },
+            "format": {
+              "unit": "byteRate",
+              "inputFormat": "B/s",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullZero",
+              "minInterval": null
+            },
+            "scope": {
+              "expressions": [],
+              "extendsDashboardScope": true
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "day"
+            },
+            "metrics": [
+              {
+                "id": "sysdig_container_net_out_bytes",
+                "timeAggregation": "timeAvg",
+                "groupAggregation": "sum",
+                "descriptor": null,
+                "sorting": null
+              }
+            ],
+            "displayedValue": null,
+            "segmentation": {
+              "labels": [
+                {
+                  "id": "kubernetes.cluster.name",
+                  "descriptor": {
+                    "documentId": "kubernetes.cluster.name",
+                    "id": "kubernetes.cluster.name",
+                    "metricType": "tag",
+                    "type": "string",
+                    "scale": 0.0,
+                    "name": "kubernetes.cluster.name",
+                    "description": "kubernetes.cluster.name",
+                    "namespaces": ["kubernetes.cluster"],
+                    "scopes": [],
+                    "timeAggregations": ["concat", "distinct", "count"],
+                    "groupAggregations": ["concat", "distinct", "count"],
+                    "aggregationForGroup": "none",
+                    "hidden": false,
+                    "experimental": false,
+                    "deferred": false,
+                    "identity": false,
+                    "canMonitor": false,
+                    "canGroupBy": true,
+                    "canFilter": true,
+                    "generatedFrom": "com.draios.model.metrics.custom.CustomMetric$Tag",
+                    "publicId": "kube_cluster_name",
+                    "segment": false,
+                    "documentTimestamp": 1680305324248,
+                    "heuristic": false,
+                    "documentType": "metric"
+                  },
+                  "displayName": null,
+                  "sorting": null
+                },
+                {
+                  "id": "kubernetes.namespace.name",
+                  "descriptor": {
+                    "documentId": "kubernetes.namespace.name",
+                    "id": "kubernetes.namespace.name",
+                    "metricType": "tag",
+                    "type": "string",
+                    "scale": 0.0,
+                    "name": "kubernetes.namespace.name",
+                    "description": "kubernetes.namespace.name",
+                    "namespaces": ["kubernetes.namespace"],
+                    "scopes": [],
+                    "timeAggregations": ["concat", "distinct", "count"],
+                    "groupAggregations": ["concat", "distinct", "count"],
+                    "aggregationForGroup": "none",
+                    "hidden": false,
+                    "experimental": false,
+                    "deferred": false,
+                    "identity": false,
+                    "canMonitor": false,
+                    "canGroupBy": true,
+                    "canFilter": true,
+                    "generatedFrom": "com.draios.model.metrics.custom.CustomMetric$Tag",
+                    "publicId": "kube_namespace_name",
+                    "segment": false,
+                    "documentTimestamp": 1680305324248,
+                    "heuristic": false,
+                    "documentType": "metric"
+                  },
+                  "displayName": null,
+                  "sorting": null
+                },
+                {
+                  "id": "kubernetes.workload.type",
+                  "descriptor": {
+                    "documentId": "kubernetes.workload.type",
+                    "id": "kubernetes.workload.type",
+                    "metricType": "tag",
+                    "type": "string",
+                    "scale": 0.0,
+                    "name": "kubernetes.workload.type",
+                    "description": "kubernetes.workload.type",
+                    "namespaces": [
+                      "cloudProvider",
+                      "host.container",
+                      "ecs",
+                      "host.fs",
+                      "host.file",
+                      "host",
+                      "kubernetes",
+                      "kubernetes.cluster",
+                      "kubernetes.daemonSet",
+                      "kubernetes.deployment",
+                      "kubernetes.job",
+                      "kubernetes.namespace",
+                      "kubernetes.node",
+                      "kubernetes.pod",
+                      "kubernetes.replicaSet",
+                      "kubernetes.service",
+                      "kubernetes.statefulSet",
+                      "kubernetes.resourcequota",
+                      "kubernetes.hpa",
+                      "link",
+                      "mesos",
+                      "host.net",
+                      "host.process",
+                      "prometheus",
+                      "swarm",
+                      "prombeacon"
+                    ],
+                    "scopes": [],
+                    "timeAggregations": ["concat", "distinct", "count"],
+                    "groupAggregations": ["concat", "distinct", "count"],
+                    "aggregationForGroup": "none",
+                    "hidden": false,
+                    "experimental": false,
+                    "deferred": false,
+                    "identity": false,
+                    "canMonitor": false,
+                    "canGroupBy": true,
+                    "canFilter": true,
+                    "generatedFrom": "com.draios.model.metrics.custom.CustomMetric$Tag",
+                    "publicId": "kube_workload_type",
+                    "segment": false,
+                    "documentTimestamp": 1680305324248,
+                    "heuristic": false,
+                    "documentType": "metric"
+                  },
+                  "displayName": null,
+                  "sorting": null
+                },
+                {
+                  "id": "kubernetes.workload.name",
+                  "descriptor": {
+                    "documentId": "kubernetes.workload.name",
+                    "id": "kubernetes.workload.name",
+                    "metricType": "tag",
+                    "type": "string",
+                    "scale": 0.0,
+                    "name": "kubernetes.workload.name",
+                    "description": "kubernetes.workload.name",
+                    "namespaces": [
+                      "cloudProvider",
+                      "host.container",
+                      "ecs",
+                      "host.fs",
+                      "host.file",
+                      "host",
+                      "kubernetes",
+                      "kubernetes.cluster",
+                      "kubernetes.daemonSet",
+                      "kubernetes.deployment",
+                      "kubernetes.job",
+                      "kubernetes.namespace",
+                      "kubernetes.node",
+                      "kubernetes.pod",
+                      "kubernetes.replicaSet",
+                      "kubernetes.service",
+                      "kubernetes.statefulSet",
+                      "kubernetes.resourcequota",
+                      "kubernetes.hpa",
+                      "link",
+                      "mesos",
+                      "host.net",
+                      "host.process",
+                      "prometheus",
+                      "swarm",
+                      "prombeacon"
+                    ],
+                    "scopes": [],
+                    "timeAggregations": ["concat", "distinct", "count"],
+                    "groupAggregations": ["concat", "distinct", "count"],
+                    "aggregationForGroup": "none",
+                    "hidden": false,
+                    "experimental": false,
+                    "deferred": false,
+                    "identity": false,
+                    "canMonitor": false,
+                    "canGroupBy": true,
+                    "canFilter": true,
+                    "generatedFrom": "com.draios.model.metrics.custom.CustomMetric$Tag",
+                    "publicId": "kube_workload_name",
+                    "segment": false,
+                    "documentTimestamp": 1680305324248,
+                    "heuristic": false,
+                    "documentType": "metric"
+                  },
+                  "displayName": null,
+                  "sorting": null
+                }
+              ],
+              "limit": 10,
+              "direction": "desc"
+            }
+          }
+        ],
+        "applyScopeToAll": false,
+        "applySegmentationToAll": false,
+        "legendConfiguration": {
+          "enabled": true,
+          "position": "bottom",
+          "layout": "table",
+          "showCurrent": true,
+          "width": null,
+          "height": null
+        },
+        "axesConfiguration": {
+          "bottom": {
+            "enabled": true
+          },
+          "left": {
+            "enabled": true,
+            "displayName": null,
+            "unit": "auto",
+            "displayFormat": "auto",
+            "decimals": null,
+            "minValue": 0.0,
+            "maxValue": null,
+            "minInputFormat": "B/s",
+            "maxInputFormat": "B/s",
+            "scale": "linear"
+          },
+          "right": {
+            "enabled": true,
+            "displayName": null,
+            "unit": "auto",
+            "displayFormat": "auto",
+            "decimals": null,
+            "minValue": 0.0,
+            "maxValue": null,
+            "minInputFormat": "1",
+            "maxInputFormat": "1",
+            "scale": "linear"
+          }
+        }
+      },
+      {
+        "id": 34,
+        "type": "basicTimechart",
+        "name": "Network Errors per Workload",
+        "description": "",
+        "nullValueDisplayText": null,
+        "links": null,
+        "basicQueries": [
+          {
+            "enabled": true,
+            "displayInfo": {
+              "displayName": "Workload < Namespace < Cluster",
+              "timeSeriesDisplayNameTemplate": "{{kube_workload_name}} < {{kube_namespace_name}} < {{kube_cluster_name}}",
+              "type": "lines"
+            },
+            "format": {
+              "unit": "numberRate",
+              "inputFormat": "/s",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullZero",
+              "minInterval": null
+            },
+            "scope": {
+              "expressions": [],
+              "extendsDashboardScope": true
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "day"
+            },
+            "metrics": [
+              {
+                "id": "sysdig_container_net_error_count",
+                "timeAggregation": "timeAvg",
+                "groupAggregation": "sum",
+                "descriptor": null,
+                "sorting": null
+              }
+            ],
+            "displayedValue": null,
+            "segmentation": {
+              "labels": [
+                {
+                  "id": "kubernetes.cluster.name",
+                  "descriptor": {
+                    "documentId": "kubernetes.cluster.name",
+                    "id": "kubernetes.cluster.name",
+                    "metricType": "tag",
+                    "type": "string",
+                    "scale": 0.0,
+                    "name": "kubernetes.cluster.name",
+                    "description": "kubernetes.cluster.name",
+                    "namespaces": ["kubernetes.cluster"],
+                    "scopes": [],
+                    "timeAggregations": ["concat", "distinct", "count"],
+                    "groupAggregations": ["concat", "distinct", "count"],
+                    "aggregationForGroup": "none",
+                    "hidden": false,
+                    "experimental": false,
+                    "deferred": false,
+                    "identity": false,
+                    "canMonitor": false,
+                    "canGroupBy": true,
+                    "canFilter": true,
+                    "generatedFrom": "com.draios.model.metrics.custom.CustomMetric$Tag",
+                    "publicId": "kube_cluster_name",
+                    "segment": false,
+                    "documentTimestamp": 1680305324248,
+                    "heuristic": false,
+                    "documentType": "metric"
+                  },
+                  "displayName": null,
+                  "sorting": null
+                },
+                {
+                  "id": "kubernetes.namespace.name",
+                  "descriptor": {
+                    "documentId": "kubernetes.namespace.name",
+                    "id": "kubernetes.namespace.name",
+                    "metricType": "tag",
+                    "type": "string",
+                    "scale": 0.0,
+                    "name": "kubernetes.namespace.name",
+                    "description": "kubernetes.namespace.name",
+                    "namespaces": ["kubernetes.namespace"],
+                    "scopes": [],
+                    "timeAggregations": ["concat", "distinct", "count"],
+                    "groupAggregations": ["concat", "distinct", "count"],
+                    "aggregationForGroup": "none",
+                    "hidden": false,
+                    "experimental": false,
+                    "deferred": false,
+                    "identity": false,
+                    "canMonitor": false,
+                    "canGroupBy": true,
+                    "canFilter": true,
+                    "generatedFrom": "com.draios.model.metrics.custom.CustomMetric$Tag",
+                    "publicId": "kube_namespace_name",
+                    "segment": false,
+                    "documentTimestamp": 1680305324248,
+                    "heuristic": false,
+                    "documentType": "metric"
+                  },
+                  "displayName": null,
+                  "sorting": null
+                },
+                {
+                  "id": "kubernetes.workload.type",
+                  "descriptor": {
+                    "documentId": "kubernetes.workload.type",
+                    "id": "kubernetes.workload.type",
+                    "metricType": "tag",
+                    "type": "string",
+                    "scale": 0.0,
+                    "name": "kubernetes.workload.type",
+                    "description": "kubernetes.workload.type",
+                    "namespaces": [
+                      "cloudProvider",
+                      "host.container",
+                      "ecs",
+                      "host.fs",
+                      "host.file",
+                      "host",
+                      "kubernetes",
+                      "kubernetes.cluster",
+                      "kubernetes.daemonSet",
+                      "kubernetes.deployment",
+                      "kubernetes.job",
+                      "kubernetes.namespace",
+                      "kubernetes.node",
+                      "kubernetes.pod",
+                      "kubernetes.replicaSet",
+                      "kubernetes.service",
+                      "kubernetes.statefulSet",
+                      "kubernetes.resourcequota",
+                      "kubernetes.hpa",
+                      "link",
+                      "mesos",
+                      "host.net",
+                      "host.process",
+                      "prometheus",
+                      "swarm",
+                      "prombeacon"
+                    ],
+                    "scopes": [],
+                    "timeAggregations": ["concat", "distinct", "count"],
+                    "groupAggregations": ["concat", "distinct", "count"],
+                    "aggregationForGroup": "none",
+                    "hidden": false,
+                    "experimental": false,
+                    "deferred": false,
+                    "identity": false,
+                    "canMonitor": false,
+                    "canGroupBy": true,
+                    "canFilter": true,
+                    "generatedFrom": "com.draios.model.metrics.custom.CustomMetric$Tag",
+                    "publicId": "kube_workload_type",
+                    "segment": false,
+                    "documentTimestamp": 1680305324248,
+                    "heuristic": false,
+                    "documentType": "metric"
+                  },
+                  "displayName": null,
+                  "sorting": null
+                },
+                {
+                  "id": "kubernetes.workload.name",
+                  "descriptor": {
+                    "documentId": "kubernetes.workload.name",
+                    "id": "kubernetes.workload.name",
+                    "metricType": "tag",
+                    "type": "string",
+                    "scale": 0.0,
+                    "name": "kubernetes.workload.name",
+                    "description": "kubernetes.workload.name",
+                    "namespaces": [
+                      "cloudProvider",
+                      "host.container",
+                      "ecs",
+                      "host.fs",
+                      "host.file",
+                      "host",
+                      "kubernetes",
+                      "kubernetes.cluster",
+                      "kubernetes.daemonSet",
+                      "kubernetes.deployment",
+                      "kubernetes.job",
+                      "kubernetes.namespace",
+                      "kubernetes.node",
+                      "kubernetes.pod",
+                      "kubernetes.replicaSet",
+                      "kubernetes.service",
+                      "kubernetes.statefulSet",
+                      "kubernetes.resourcequota",
+                      "kubernetes.hpa",
+                      "link",
+                      "mesos",
+                      "host.net",
+                      "host.process",
+                      "prometheus",
+                      "swarm",
+                      "prombeacon"
+                    ],
+                    "scopes": [],
+                    "timeAggregations": ["concat", "distinct", "count"],
+                    "groupAggregations": ["concat", "distinct", "count"],
+                    "aggregationForGroup": "none",
+                    "hidden": false,
+                    "experimental": false,
+                    "deferred": false,
+                    "identity": false,
+                    "canMonitor": false,
+                    "canGroupBy": true,
+                    "canFilter": true,
+                    "generatedFrom": "com.draios.model.metrics.custom.CustomMetric$Tag",
+                    "publicId": "kube_workload_name",
+                    "segment": false,
+                    "documentTimestamp": 1680305324248,
+                    "heuristic": false,
+                    "documentType": "metric"
+                  },
+                  "displayName": null,
+                  "sorting": null
+                }
+              ],
+              "limit": 10,
+              "direction": "desc"
+            }
+          }
+        ],
+        "applyScopeToAll": false,
+        "applySegmentationToAll": false,
+        "legendConfiguration": {
+          "enabled": true,
+          "position": "bottom",
+          "layout": "table",
+          "showCurrent": true,
+          "width": null,
+          "height": null
+        },
+        "axesConfiguration": {
+          "bottom": {
+            "enabled": true
+          },
+          "left": {
+            "enabled": true,
+            "displayName": null,
+            "unit": "auto",
+            "displayFormat": "auto",
+            "decimals": null,
+            "minValue": 0.0,
+            "maxValue": null,
+            "minInputFormat": "/s",
+            "maxInputFormat": "/s",
+            "scale": "linear"
+          },
+          "right": {
+            "enabled": true,
+            "displayName": null,
+            "unit": "auto",
+            "displayFormat": "auto",
+            "decimals": null,
+            "minValue": 0.0,
+            "maxValue": null,
+            "minInputFormat": "1",
+            "maxInputFormat": "1",
+            "scale": "linear"
+          }
+        }
+      },
+      {
+        "id": 35,
+        "type": "basicTimechart",
+        "name": "HTTP Requests Count per Workload",
+        "description": "",
+        "nullValueDisplayText": null,
+        "links": null,
+        "basicQueries": [
+          {
+            "enabled": true,
+            "displayInfo": {
+              "displayName": "Status: Workload < Namespace < Cluster",
+              "timeSeriesDisplayNameTemplate": "{{net_http_statuscode}}: {{kube_workload_name}} < {{kube_namespace_name}} < {{kube_cluster_name}}",
+              "type": "lines"
+            },
+            "format": {
+              "unit": "numberRate",
+              "inputFormat": "/s",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullZero",
+              "minInterval": null
+            },
+            "scope": {
+              "expressions": [],
+              "extendsDashboardScope": true
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "day"
+            },
+            "metrics": [
+              {
+                "id": "sysdig_container_net_http_statuscode_request_count",
+                "timeAggregation": "timeAvg",
+                "groupAggregation": "sum",
+                "descriptor": null,
+                "sorting": null
+              }
+            ],
+            "displayedValue": null,
+            "segmentation": {
+              "labels": [
+                {
+                  "id": "kubernetes.cluster.name",
+                  "descriptor": {
+                    "documentId": "kubernetes.cluster.name",
+                    "id": "kubernetes.cluster.name",
+                    "metricType": "tag",
+                    "type": "string",
+                    "scale": 0.0,
+                    "name": "kubernetes.cluster.name",
+                    "description": "kubernetes.cluster.name",
+                    "namespaces": ["kubernetes.cluster"],
+                    "scopes": [],
+                    "timeAggregations": ["concat", "distinct", "count"],
+                    "groupAggregations": ["concat", "distinct", "count"],
+                    "aggregationForGroup": "none",
+                    "hidden": false,
+                    "experimental": false,
+                    "deferred": false,
+                    "identity": false,
+                    "canMonitor": false,
+                    "canGroupBy": true,
+                    "canFilter": true,
+                    "generatedFrom": "com.draios.model.metrics.custom.CustomMetric$Tag",
+                    "publicId": "kube_cluster_name",
+                    "segment": false,
+                    "documentTimestamp": 1680305324248,
+                    "heuristic": false,
+                    "documentType": "metric"
+                  },
+                  "displayName": null,
+                  "sorting": null
+                },
+                {
+                  "id": "kubernetes.namespace.name",
+                  "descriptor": {
+                    "documentId": "kubernetes.namespace.name",
+                    "id": "kubernetes.namespace.name",
+                    "metricType": "tag",
+                    "type": "string",
+                    "scale": 0.0,
+                    "name": "kubernetes.namespace.name",
+                    "description": "kubernetes.namespace.name",
+                    "namespaces": ["kubernetes.namespace"],
+                    "scopes": [],
+                    "timeAggregations": ["concat", "distinct", "count"],
+                    "groupAggregations": ["concat", "distinct", "count"],
+                    "aggregationForGroup": "none",
+                    "hidden": false,
+                    "experimental": false,
+                    "deferred": false,
+                    "identity": false,
+                    "canMonitor": false,
+                    "canGroupBy": true,
+                    "canFilter": true,
+                    "generatedFrom": "com.draios.model.metrics.custom.CustomMetric$Tag",
+                    "publicId": "kube_namespace_name",
+                    "segment": false,
+                    "documentTimestamp": 1680305324248,
+                    "heuristic": false,
+                    "documentType": "metric"
+                  },
+                  "displayName": null,
+                  "sorting": null
+                },
+                {
+                  "id": "kubernetes.workload.type",
+                  "descriptor": {
+                    "documentId": "kubernetes.workload.type",
+                    "id": "kubernetes.workload.type",
+                    "metricType": "tag",
+                    "type": "string",
+                    "scale": 0.0,
+                    "name": "kubernetes.workload.type",
+                    "description": "kubernetes.workload.type",
+                    "namespaces": [
+                      "cloudProvider",
+                      "host.container",
+                      "ecs",
+                      "host.fs",
+                      "host.file",
+                      "host",
+                      "kubernetes",
+                      "kubernetes.cluster",
+                      "kubernetes.daemonSet",
+                      "kubernetes.deployment",
+                      "kubernetes.job",
+                      "kubernetes.namespace",
+                      "kubernetes.node",
+                      "kubernetes.pod",
+                      "kubernetes.replicaSet",
+                      "kubernetes.service",
+                      "kubernetes.statefulSet",
+                      "kubernetes.resourcequota",
+                      "kubernetes.hpa",
+                      "link",
+                      "mesos",
+                      "host.net",
+                      "host.process",
+                      "prometheus",
+                      "swarm",
+                      "prombeacon"
+                    ],
+                    "scopes": [],
+                    "timeAggregations": ["concat", "distinct", "count"],
+                    "groupAggregations": ["concat", "distinct", "count"],
+                    "aggregationForGroup": "none",
+                    "hidden": false,
+                    "experimental": false,
+                    "deferred": false,
+                    "identity": false,
+                    "canMonitor": false,
+                    "canGroupBy": true,
+                    "canFilter": true,
+                    "generatedFrom": "com.draios.model.metrics.custom.CustomMetric$Tag",
+                    "publicId": "kube_workload_type",
+                    "segment": false,
+                    "documentTimestamp": 1680305324248,
+                    "heuristic": false,
+                    "documentType": "metric"
+                  },
+                  "displayName": null,
+                  "sorting": null
+                },
+                {
+                  "id": "kubernetes.workload.name",
+                  "descriptor": {
+                    "documentId": "kubernetes.workload.name",
+                    "id": "kubernetes.workload.name",
+                    "metricType": "tag",
+                    "type": "string",
+                    "scale": 0.0,
+                    "name": "kubernetes.workload.name",
+                    "description": "kubernetes.workload.name",
+                    "namespaces": [
+                      "cloudProvider",
+                      "host.container",
+                      "ecs",
+                      "host.fs",
+                      "host.file",
+                      "host",
+                      "kubernetes",
+                      "kubernetes.cluster",
+                      "kubernetes.daemonSet",
+                      "kubernetes.deployment",
+                      "kubernetes.job",
+                      "kubernetes.namespace",
+                      "kubernetes.node",
+                      "kubernetes.pod",
+                      "kubernetes.replicaSet",
+                      "kubernetes.service",
+                      "kubernetes.statefulSet",
+                      "kubernetes.resourcequota",
+                      "kubernetes.hpa",
+                      "link",
+                      "mesos",
+                      "host.net",
+                      "host.process",
+                      "prometheus",
+                      "swarm",
+                      "prombeacon"
+                    ],
+                    "scopes": [],
+                    "timeAggregations": ["concat", "distinct", "count"],
+                    "groupAggregations": ["concat", "distinct", "count"],
+                    "aggregationForGroup": "none",
+                    "hidden": false,
+                    "experimental": false,
+                    "deferred": false,
+                    "identity": false,
+                    "canMonitor": false,
+                    "canGroupBy": true,
+                    "canFilter": true,
+                    "generatedFrom": "com.draios.model.metrics.custom.CustomMetric$Tag",
+                    "publicId": "kube_workload_name",
+                    "segment": false,
+                    "documentTimestamp": 1680305324248,
+                    "heuristic": false,
+                    "documentType": "metric"
+                  },
+                  "displayName": null,
+                  "sorting": null
+                },
+                {
+                  "id": "net.http.statusCode",
+                  "descriptor": {
+                    "segmentations": [],
+                    "documentId": "net.http.statusCode",
+                    "id": "net.http.statusCode",
+                    "metricType": "tag",
+                    "type": "string",
+                    "scale": 1.0,
+                    "name": "HTTP status code",
+                    "description": "HTTP response status code",
+                    "category": "network",
+                    "namespaces": ["host.net"],
+                    "scopes": ["host", "container"],
+                    "timeAggregations": ["concat", "distinct", "count"],
+                    "groupAggregations": ["concat", "distinct", "count"],
+                    "aggregationForGroup": "none",
+                    "createdAt": 1648212882000,
+                    "hidden": false,
+                    "experimental": false,
+                    "deferred": false,
+                    "identity": false,
+                    "canMonitor": false,
+                    "canGroupBy": false,
+                    "canFilter": true,
+                    "generatedFrom": "com.draios.model.metrics.http.HttpStatusCode",
+                    "publicId": "net_http_statuscode",
+                    "segment": false,
+                    "documentTimestamp": 1648212882000,
+                    "heuristic": false,
+                    "documentType": "metric"
+                  },
+                  "displayName": null,
+                  "sorting": null
+                }
+              ],
+              "limit": 10,
+              "direction": "desc"
+            }
+          }
+        ],
+        "applyScopeToAll": false,
+        "applySegmentationToAll": false,
+        "legendConfiguration": {
+          "enabled": true,
+          "position": "bottom",
+          "layout": "table",
+          "showCurrent": true,
+          "width": null,
+          "height": null
+        },
+        "axesConfiguration": {
+          "bottom": {
+            "enabled": true
+          },
+          "left": {
+            "enabled": true,
+            "displayName": null,
+            "unit": "auto",
+            "displayFormat": "auto",
+            "decimals": null,
+            "minValue": 0.0,
+            "maxValue": null,
+            "minInputFormat": "/s",
+            "maxInputFormat": "/s",
+            "scale": "linear"
+          },
+          "right": {
+            "enabled": true,
+            "displayName": null,
+            "unit": "auto",
+            "displayFormat": "auto",
+            "decimals": null,
+            "minValue": 0.0,
+            "maxValue": null,
+            "minInputFormat": "1",
+            "maxInputFormat": "1",
+            "scale": "linear"
+          }
+        }
+      },
+      {
+        "id": 36,
+        "type": "basicTimechart",
+        "name": "HTTP Requests Latency per Workload",
+        "description": "",
+        "nullValueDisplayText": null,
+        "links": null,
+        "basicQueries": [
+          {
+            "enabled": true,
+            "displayInfo": {
+              "displayName": "Workload < Namespace < Cluster",
+              "timeSeriesDisplayNameTemplate": "{{kube_workload_name}} < {{kube_namespace_name}} < {{kube_cluster_name}}",
+              "type": "lines"
+            },
+            "format": {
+              "unit": "relativeTime",
+              "inputFormat": "ns",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullZero",
+              "minInterval": null
+            },
+            "scope": {
+              "expressions": [],
+              "extendsDashboardScope": true
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "day"
+            },
+            "metrics": [
+              {
+                "id": "sysdig_container_net_http_request_time",
+                "timeAggregation": "avg",
+                "groupAggregation": "avg",
+                "descriptor": null,
+                "sorting": null
+              }
+            ],
+            "displayedValue": null,
+            "segmentation": {
+              "labels": [
+                {
+                  "id": "kubernetes.cluster.name",
+                  "descriptor": {
+                    "documentId": "kubernetes.cluster.name",
+                    "id": "kubernetes.cluster.name",
+                    "metricType": "tag",
+                    "type": "string",
+                    "scale": 0.0,
+                    "name": "kubernetes.cluster.name",
+                    "description": "kubernetes.cluster.name",
+                    "namespaces": ["kubernetes.cluster"],
+                    "scopes": [],
+                    "timeAggregations": ["concat", "distinct", "count"],
+                    "groupAggregations": ["concat", "distinct", "count"],
+                    "aggregationForGroup": "none",
+                    "hidden": false,
+                    "experimental": false,
+                    "deferred": false,
+                    "identity": false,
+                    "canMonitor": false,
+                    "canGroupBy": true,
+                    "canFilter": true,
+                    "generatedFrom": "com.draios.model.metrics.custom.CustomMetric$Tag",
+                    "publicId": "kube_cluster_name",
+                    "segment": false,
+                    "documentTimestamp": 1680305324248,
+                    "heuristic": false,
+                    "documentType": "metric"
+                  },
+                  "displayName": null,
+                  "sorting": null
+                },
+                {
+                  "id": "kubernetes.namespace.name",
+                  "descriptor": {
+                    "documentId": "kubernetes.namespace.name",
+                    "id": "kubernetes.namespace.name",
+                    "metricType": "tag",
+                    "type": "string",
+                    "scale": 0.0,
+                    "name": "kubernetes.namespace.name",
+                    "description": "kubernetes.namespace.name",
+                    "namespaces": ["kubernetes.namespace"],
+                    "scopes": [],
+                    "timeAggregations": ["concat", "distinct", "count"],
+                    "groupAggregations": ["concat", "distinct", "count"],
+                    "aggregationForGroup": "none",
+                    "hidden": false,
+                    "experimental": false,
+                    "deferred": false,
+                    "identity": false,
+                    "canMonitor": false,
+                    "canGroupBy": true,
+                    "canFilter": true,
+                    "generatedFrom": "com.draios.model.metrics.custom.CustomMetric$Tag",
+                    "publicId": "kube_namespace_name",
+                    "segment": false,
+                    "documentTimestamp": 1680305324248,
+                    "heuristic": false,
+                    "documentType": "metric"
+                  },
+                  "displayName": null,
+                  "sorting": null
+                },
+                {
+                  "id": "kubernetes.workload.type",
+                  "descriptor": {
+                    "documentId": "kubernetes.workload.type",
+                    "id": "kubernetes.workload.type",
+                    "metricType": "tag",
+                    "type": "string",
+                    "scale": 0.0,
+                    "name": "kubernetes.workload.type",
+                    "description": "kubernetes.workload.type",
+                    "namespaces": [
+                      "cloudProvider",
+                      "host.container",
+                      "ecs",
+                      "host.fs",
+                      "host.file",
+                      "host",
+                      "kubernetes",
+                      "kubernetes.cluster",
+                      "kubernetes.daemonSet",
+                      "kubernetes.deployment",
+                      "kubernetes.job",
+                      "kubernetes.namespace",
+                      "kubernetes.node",
+                      "kubernetes.pod",
+                      "kubernetes.replicaSet",
+                      "kubernetes.service",
+                      "kubernetes.statefulSet",
+                      "kubernetes.resourcequota",
+                      "kubernetes.hpa",
+                      "link",
+                      "mesos",
+                      "host.net",
+                      "host.process",
+                      "prometheus",
+                      "swarm",
+                      "prombeacon"
+                    ],
+                    "scopes": [],
+                    "timeAggregations": ["concat", "distinct", "count"],
+                    "groupAggregations": ["concat", "distinct", "count"],
+                    "aggregationForGroup": "none",
+                    "hidden": false,
+                    "experimental": false,
+                    "deferred": false,
+                    "identity": false,
+                    "canMonitor": false,
+                    "canGroupBy": true,
+                    "canFilter": true,
+                    "generatedFrom": "com.draios.model.metrics.custom.CustomMetric$Tag",
+                    "publicId": "kube_workload_type",
+                    "segment": false,
+                    "documentTimestamp": 1680305324248,
+                    "heuristic": false,
+                    "documentType": "metric"
+                  },
+                  "displayName": null,
+                  "sorting": null
+                },
+                {
+                  "id": "kubernetes.workload.name",
+                  "descriptor": {
+                    "documentId": "kubernetes.workload.name",
+                    "id": "kubernetes.workload.name",
+                    "metricType": "tag",
+                    "type": "string",
+                    "scale": 0.0,
+                    "name": "kubernetes.workload.name",
+                    "description": "kubernetes.workload.name",
+                    "namespaces": [
+                      "cloudProvider",
+                      "host.container",
+                      "ecs",
+                      "host.fs",
+                      "host.file",
+                      "host",
+                      "kubernetes",
+                      "kubernetes.cluster",
+                      "kubernetes.daemonSet",
+                      "kubernetes.deployment",
+                      "kubernetes.job",
+                      "kubernetes.namespace",
+                      "kubernetes.node",
+                      "kubernetes.pod",
+                      "kubernetes.replicaSet",
+                      "kubernetes.service",
+                      "kubernetes.statefulSet",
+                      "kubernetes.resourcequota",
+                      "kubernetes.hpa",
+                      "link",
+                      "mesos",
+                      "host.net",
+                      "host.process",
+                      "prometheus",
+                      "swarm",
+                      "prombeacon"
+                    ],
+                    "scopes": [],
+                    "timeAggregations": ["concat", "distinct", "count"],
+                    "groupAggregations": ["concat", "distinct", "count"],
+                    "aggregationForGroup": "none",
+                    "hidden": false,
+                    "experimental": false,
+                    "deferred": false,
+                    "identity": false,
+                    "canMonitor": false,
+                    "canGroupBy": true,
+                    "canFilter": true,
+                    "generatedFrom": "com.draios.model.metrics.custom.CustomMetric$Tag",
+                    "publicId": "kube_workload_name",
+                    "segment": false,
+                    "documentTimestamp": 1680305324248,
+                    "heuristic": false,
+                    "documentType": "metric"
+                  },
+                  "displayName": null,
+                  "sorting": null
+                }
+              ],
+              "limit": 10,
+              "direction": "desc"
+            }
+          }
+        ],
+        "applyScopeToAll": false,
+        "applySegmentationToAll": false,
+        "legendConfiguration": {
+          "enabled": true,
+          "position": "bottom",
+          "layout": "table",
+          "showCurrent": true,
+          "width": null,
+          "height": null
+        },
+        "axesConfiguration": {
+          "bottom": {
+            "enabled": true
+          },
+          "left": {
+            "enabled": true,
+            "displayName": null,
+            "unit": "auto",
+            "displayFormat": "auto",
+            "decimals": null,
+            "minValue": 0.0,
+            "maxValue": null,
+            "minInputFormat": "ns",
+            "maxInputFormat": "ns",
+            "scale": "linear"
+          },
+          "right": {
+            "enabled": true,
+            "displayName": null,
+            "unit": "auto",
+            "displayFormat": "auto",
+            "decimals": null,
+            "minValue": 0.0,
+            "maxValue": null,
+            "minInputFormat": "1",
+            "maxInputFormat": "1",
+            "scale": "linear"
+          }
+        }
+      },
+      {
+        "id": 26,
+        "type": "basicTimechart",
+        "name": "HTTP Error Count (4xx/5xx) per Workload",
+        "description": "",
+        "nullValueDisplayText": null,
+        "links": null,
+        "basicQueries": [
+          {
+            "enabled": true,
+            "displayInfo": {
+              "displayName": "Workload < Namespace < Cluster",
+              "timeSeriesDisplayNameTemplate": "{{kube_workload_name}} < {{kube_namespace_name}} < {{kube_cluster_name}}",
+              "type": "lines"
+            },
+            "format": {
+              "unit": "numberRate",
+              "inputFormat": "/s",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullZero",
+              "minInterval": null
+            },
+            "scope": {
+              "expressions": [],
+              "extendsDashboardScope": true
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "day"
+            },
+            "metrics": [
+              {
+                "id": "sysdig_container_net_http_error_count",
+                "timeAggregation": "timeAvg",
+                "groupAggregation": "sum",
+                "descriptor": null,
+                "sorting": null
+              }
+            ],
+            "displayedValue": null,
+            "segmentation": {
+              "labels": [
+                {
+                  "id": "kubernetes.cluster.name",
+                  "descriptor": {
+                    "documentId": "kubernetes.cluster.name",
+                    "id": "kubernetes.cluster.name",
+                    "metricType": "tag",
+                    "type": "string",
+                    "scale": 0.0,
+                    "name": "kubernetes.cluster.name",
+                    "description": "kubernetes.cluster.name",
+                    "namespaces": ["kubernetes.cluster"],
+                    "scopes": [],
+                    "timeAggregations": ["concat", "distinct", "count"],
+                    "groupAggregations": ["concat", "distinct", "count"],
+                    "aggregationForGroup": "none",
+                    "hidden": false,
+                    "experimental": false,
+                    "deferred": false,
+                    "identity": false,
+                    "canMonitor": false,
+                    "canGroupBy": true,
+                    "canFilter": true,
+                    "generatedFrom": "com.draios.model.metrics.custom.CustomMetric$Tag",
+                    "publicId": "kube_cluster_name",
+                    "segment": false,
+                    "documentTimestamp": 1680305324248,
+                    "heuristic": false,
+                    "documentType": "metric"
+                  },
+                  "displayName": null,
+                  "sorting": null
+                },
+                {
+                  "id": "kubernetes.namespace.name",
+                  "descriptor": {
+                    "documentId": "kubernetes.namespace.name",
+                    "id": "kubernetes.namespace.name",
+                    "metricType": "tag",
+                    "type": "string",
+                    "scale": 0.0,
+                    "name": "kubernetes.namespace.name",
+                    "description": "kubernetes.namespace.name",
+                    "namespaces": ["kubernetes.namespace"],
+                    "scopes": [],
+                    "timeAggregations": ["concat", "distinct", "count"],
+                    "groupAggregations": ["concat", "distinct", "count"],
+                    "aggregationForGroup": "none",
+                    "hidden": false,
+                    "experimental": false,
+                    "deferred": false,
+                    "identity": false,
+                    "canMonitor": false,
+                    "canGroupBy": true,
+                    "canFilter": true,
+                    "generatedFrom": "com.draios.model.metrics.custom.CustomMetric$Tag",
+                    "publicId": "kube_namespace_name",
+                    "segment": false,
+                    "documentTimestamp": 1680305324248,
+                    "heuristic": false,
+                    "documentType": "metric"
+                  },
+                  "displayName": null,
+                  "sorting": null
+                },
+                {
+                  "id": "kubernetes.workload.type",
+                  "descriptor": {
+                    "documentId": "kubernetes.workload.type",
+                    "id": "kubernetes.workload.type",
+                    "metricType": "tag",
+                    "type": "string",
+                    "scale": 0.0,
+                    "name": "kubernetes.workload.type",
+                    "description": "kubernetes.workload.type",
+                    "namespaces": [
+                      "cloudProvider",
+                      "host.container",
+                      "ecs",
+                      "host.fs",
+                      "host.file",
+                      "host",
+                      "kubernetes",
+                      "kubernetes.cluster",
+                      "kubernetes.daemonSet",
+                      "kubernetes.deployment",
+                      "kubernetes.job",
+                      "kubernetes.namespace",
+                      "kubernetes.node",
+                      "kubernetes.pod",
+                      "kubernetes.replicaSet",
+                      "kubernetes.service",
+                      "kubernetes.statefulSet",
+                      "kubernetes.resourcequota",
+                      "kubernetes.hpa",
+                      "link",
+                      "mesos",
+                      "host.net",
+                      "host.process",
+                      "prometheus",
+                      "swarm",
+                      "prombeacon"
+                    ],
+                    "scopes": [],
+                    "timeAggregations": ["concat", "distinct", "count"],
+                    "groupAggregations": ["concat", "distinct", "count"],
+                    "aggregationForGroup": "none",
+                    "hidden": false,
+                    "experimental": false,
+                    "deferred": false,
+                    "identity": false,
+                    "canMonitor": false,
+                    "canGroupBy": true,
+                    "canFilter": true,
+                    "generatedFrom": "com.draios.model.metrics.custom.CustomMetric$Tag",
+                    "publicId": "kube_workload_type",
+                    "segment": false,
+                    "documentTimestamp": 1680305324248,
+                    "heuristic": false,
+                    "documentType": "metric"
+                  },
+                  "displayName": null,
+                  "sorting": null
+                },
+                {
+                  "id": "kubernetes.workload.name",
+                  "descriptor": {
+                    "documentId": "kubernetes.workload.name",
+                    "id": "kubernetes.workload.name",
+                    "metricType": "tag",
+                    "type": "string",
+                    "scale": 0.0,
+                    "name": "kubernetes.workload.name",
+                    "description": "kubernetes.workload.name",
+                    "namespaces": [
+                      "cloudProvider",
+                      "host.container",
+                      "ecs",
+                      "host.fs",
+                      "host.file",
+                      "host",
+                      "kubernetes",
+                      "kubernetes.cluster",
+                      "kubernetes.daemonSet",
+                      "kubernetes.deployment",
+                      "kubernetes.job",
+                      "kubernetes.namespace",
+                      "kubernetes.node",
+                      "kubernetes.pod",
+                      "kubernetes.replicaSet",
+                      "kubernetes.service",
+                      "kubernetes.statefulSet",
+                      "kubernetes.resourcequota",
+                      "kubernetes.hpa",
+                      "link",
+                      "mesos",
+                      "host.net",
+                      "host.process",
+                      "prometheus",
+                      "swarm",
+                      "prombeacon"
+                    ],
+                    "scopes": [],
+                    "timeAggregations": ["concat", "distinct", "count"],
+                    "groupAggregations": ["concat", "distinct", "count"],
+                    "aggregationForGroup": "none",
+                    "hidden": false,
+                    "experimental": false,
+                    "deferred": false,
+                    "identity": false,
+                    "canMonitor": false,
+                    "canGroupBy": true,
+                    "canFilter": true,
+                    "generatedFrom": "com.draios.model.metrics.custom.CustomMetric$Tag",
+                    "publicId": "kube_workload_name",
+                    "segment": false,
+                    "documentTimestamp": 1680305324248,
+                    "heuristic": false,
+                    "documentType": "metric"
+                  },
+                  "displayName": null,
+                  "sorting": null
+                }
+              ],
+              "limit": 10,
+              "direction": "desc"
+            }
+          }
+        ],
+        "applyScopeToAll": false,
+        "applySegmentationToAll": false,
+        "legendConfiguration": {
+          "enabled": true,
+          "position": "bottom",
+          "layout": "table",
+          "showCurrent": true,
+          "width": null,
+          "height": null
+        },
+        "axesConfiguration": {
+          "bottom": {
+            "enabled": true
+          },
+          "left": {
+            "enabled": true,
+            "displayName": null,
+            "unit": "auto",
+            "displayFormat": "auto",
+            "decimals": null,
+            "minValue": 0.0,
+            "maxValue": null,
+            "minInputFormat": "/s",
+            "maxInputFormat": "/s",
+            "scale": "linear"
+          },
+          "right": {
+            "enabled": true,
+            "displayName": null,
+            "unit": "auto",
+            "displayFormat": "auto",
+            "decimals": null,
+            "minValue": 0.0,
+            "maxValue": null,
+            "minInputFormat": "1",
+            "maxInputFormat": "1",
+            "scale": "linear"
+          }
+        }
+      },
+      {
+        "id": 37,
+        "type": "basicTimechart",
+        "name": "Network Traffic per Pod",
+        "description": "",
+        "nullValueDisplayText": null,
+        "links": null,
+        "basicQueries": [
+          {
+            "enabled": true,
+            "displayInfo": {
+              "displayName": "↘ Inbound: Workload < Namespace < Cluster",
+              "timeSeriesDisplayNameTemplate": "↘ {{kube_workload_name}} < {{kube_namespace_name}} < {{kube_cluster_name}}",
+              "type": "lines"
+            },
+            "format": {
+              "unit": "byteRate",
+              "inputFormat": "B/s",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullZero",
+              "minInterval": null
+            },
+            "scope": {
+              "expressions": [],
+              "extendsDashboardScope": true
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "day"
+            },
+            "metrics": [
+              {
+                "id": "sysdig_container_net_in_bytes",
+                "timeAggregation": "timeAvg",
+                "groupAggregation": "sum",
+                "descriptor": null,
+                "sorting": null
+              }
+            ],
+            "displayedValue": null,
+            "segmentation": {
+              "labels": [
+                {
+                  "id": "kubernetes.cluster.name",
+                  "descriptor": {
+                    "documentId": "kubernetes.cluster.name",
+                    "id": "kubernetes.cluster.name",
+                    "metricType": "tag",
+                    "type": "string",
+                    "scale": 0.0,
+                    "name": "kubernetes.cluster.name",
+                    "description": "kubernetes.cluster.name",
+                    "namespaces": ["kubernetes.cluster"],
+                    "scopes": [],
+                    "timeAggregations": ["concat", "distinct", "count"],
+                    "groupAggregations": ["concat", "distinct", "count"],
+                    "aggregationForGroup": "none",
+                    "hidden": false,
+                    "experimental": false,
+                    "deferred": false,
+                    "identity": false,
+                    "canMonitor": false,
+                    "canGroupBy": true,
+                    "canFilter": true,
+                    "generatedFrom": "com.draios.model.metrics.custom.CustomMetric$Tag",
+                    "publicId": "kube_cluster_name",
+                    "segment": false,
+                    "documentTimestamp": 1680305324248,
+                    "heuristic": false,
+                    "documentType": "metric"
+                  },
+                  "displayName": null,
+                  "sorting": null
+                },
+                {
+                  "id": "kubernetes.namespace.name",
+                  "descriptor": {
+                    "documentId": "kubernetes.namespace.name",
+                    "id": "kubernetes.namespace.name",
+                    "metricType": "tag",
+                    "type": "string",
+                    "scale": 0.0,
+                    "name": "kubernetes.namespace.name",
+                    "description": "kubernetes.namespace.name",
+                    "namespaces": ["kubernetes.namespace"],
+                    "scopes": [],
+                    "timeAggregations": ["concat", "distinct", "count"],
+                    "groupAggregations": ["concat", "distinct", "count"],
+                    "aggregationForGroup": "none",
+                    "hidden": false,
+                    "experimental": false,
+                    "deferred": false,
+                    "identity": false,
+                    "canMonitor": false,
+                    "canGroupBy": true,
+                    "canFilter": true,
+                    "generatedFrom": "com.draios.model.metrics.custom.CustomMetric$Tag",
+                    "publicId": "kube_namespace_name",
+                    "segment": false,
+                    "documentTimestamp": 1680305324248,
+                    "heuristic": false,
+                    "documentType": "metric"
+                  },
+                  "displayName": null,
+                  "sorting": null
+                },
+                {
+                  "id": "kubernetes.workload.type",
+                  "descriptor": {
+                    "documentId": "kubernetes.workload.type",
+                    "id": "kubernetes.workload.type",
+                    "metricType": "tag",
+                    "type": "string",
+                    "scale": 0.0,
+                    "name": "kubernetes.workload.type",
+                    "description": "kubernetes.workload.type",
+                    "namespaces": [
+                      "cloudProvider",
+                      "host.container",
+                      "ecs",
+                      "host.fs",
+                      "host.file",
+                      "host",
+                      "kubernetes",
+                      "kubernetes.cluster",
+                      "kubernetes.daemonSet",
+                      "kubernetes.deployment",
+                      "kubernetes.job",
+                      "kubernetes.namespace",
+                      "kubernetes.node",
+                      "kubernetes.pod",
+                      "kubernetes.replicaSet",
+                      "kubernetes.service",
+                      "kubernetes.statefulSet",
+                      "kubernetes.resourcequota",
+                      "kubernetes.hpa",
+                      "link",
+                      "mesos",
+                      "host.net",
+                      "host.process",
+                      "prometheus",
+                      "swarm",
+                      "prombeacon"
+                    ],
+                    "scopes": [],
+                    "timeAggregations": ["concat", "distinct", "count"],
+                    "groupAggregations": ["concat", "distinct", "count"],
+                    "aggregationForGroup": "none",
+                    "hidden": false,
+                    "experimental": false,
+                    "deferred": false,
+                    "identity": false,
+                    "canMonitor": false,
+                    "canGroupBy": true,
+                    "canFilter": true,
+                    "generatedFrom": "com.draios.model.metrics.custom.CustomMetric$Tag",
+                    "publicId": "kube_workload_type",
+                    "segment": false,
+                    "documentTimestamp": 1680305324248,
+                    "heuristic": false,
+                    "documentType": "metric"
+                  },
+                  "displayName": null,
+                  "sorting": null
+                },
+                {
+                  "id": "kubernetes.workload.name",
+                  "descriptor": {
+                    "documentId": "kubernetes.workload.name",
+                    "id": "kubernetes.workload.name",
+                    "metricType": "tag",
+                    "type": "string",
+                    "scale": 0.0,
+                    "name": "kubernetes.workload.name",
+                    "description": "kubernetes.workload.name",
+                    "namespaces": [
+                      "cloudProvider",
+                      "host.container",
+                      "ecs",
+                      "host.fs",
+                      "host.file",
+                      "host",
+                      "kubernetes",
+                      "kubernetes.cluster",
+                      "kubernetes.daemonSet",
+                      "kubernetes.deployment",
+                      "kubernetes.job",
+                      "kubernetes.namespace",
+                      "kubernetes.node",
+                      "kubernetes.pod",
+                      "kubernetes.replicaSet",
+                      "kubernetes.service",
+                      "kubernetes.statefulSet",
+                      "kubernetes.resourcequota",
+                      "kubernetes.hpa",
+                      "link",
+                      "mesos",
+                      "host.net",
+                      "host.process",
+                      "prometheus",
+                      "swarm",
+                      "prombeacon"
+                    ],
+                    "scopes": [],
+                    "timeAggregations": ["concat", "distinct", "count"],
+                    "groupAggregations": ["concat", "distinct", "count"],
+                    "aggregationForGroup": "none",
+                    "hidden": false,
+                    "experimental": false,
+                    "deferred": false,
+                    "identity": false,
+                    "canMonitor": false,
+                    "canGroupBy": true,
+                    "canFilter": true,
+                    "generatedFrom": "com.draios.model.metrics.custom.CustomMetric$Tag",
+                    "publicId": "kube_workload_name",
+                    "segment": false,
+                    "documentTimestamp": 1680305324248,
+                    "heuristic": false,
+                    "documentType": "metric"
+                  },
+                  "displayName": null,
+                  "sorting": null
+                },
+                {
+                  "id": "kubernetes.pod.name",
+                  "descriptor": {
+                    "documentId": "kubernetes.pod.name",
+                    "id": "kubernetes.pod.name",
+                    "metricType": "tag",
+                    "type": "string",
+                    "scale": 0.0,
+                    "name": "kubernetes.pod.name",
+                    "description": "kubernetes.pod.name",
+                    "namespaces": [
+                      "cloudProvider",
+                      "host.container",
+                      "ecs",
+                      "host.fs",
+                      "host.file",
+                      "host",
+                      "kubernetes",
+                      "kubernetes.cluster",
+                      "kubernetes.daemonSet",
+                      "kubernetes.deployment",
+                      "kubernetes.job",
+                      "kubernetes.namespace",
+                      "kubernetes.node",
+                      "kubernetes.pod",
+                      "kubernetes.replicaSet",
+                      "kubernetes.service",
+                      "kubernetes.statefulSet",
+                      "kubernetes.resourcequota",
+                      "kubernetes.hpa",
+                      "link",
+                      "mesos",
+                      "host.net",
+                      "host.process",
+                      "prometheus",
+                      "swarm",
+                      "prombeacon"
+                    ],
+                    "scopes": [],
+                    "timeAggregations": ["concat", "distinct", "count"],
+                    "groupAggregations": ["concat", "distinct", "count"],
+                    "aggregationForGroup": "none",
+                    "hidden": false,
+                    "experimental": false,
+                    "deferred": false,
+                    "identity": false,
+                    "canMonitor": false,
+                    "canGroupBy": true,
+                    "canFilter": true,
+                    "generatedFrom": "com.draios.model.metrics.custom.CustomMetric$Tag",
+                    "publicId": "kube_pod_name",
+                    "segment": false,
+                    "documentTimestamp": 1680305324248,
+                    "heuristic": false,
+                    "documentType": "metric"
+                  },
+                  "displayName": null,
+                  "sorting": null
+                }
+              ],
+              "limit": 10,
+              "direction": "desc"
+            }
+          },
+          {
+            "enabled": true,
+            "displayInfo": {
+              "displayName": "↗ Outbound: Workload < Namespace < Cluster",
+              "timeSeriesDisplayNameTemplate": "↗ {{kube_workload_name}} < {{kube_namespace_name}} < {{kube_cluster_name}}",
+              "type": "lines"
+            },
+            "format": {
+              "unit": "byteRate",
+              "inputFormat": "B/s",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullZero",
+              "minInterval": null
+            },
+            "scope": {
+              "expressions": [],
+              "extendsDashboardScope": true
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "day"
+            },
+            "metrics": [
+              {
+                "id": "sysdig_container_net_out_bytes",
+                "timeAggregation": "timeAvg",
+                "groupAggregation": "sum",
+                "descriptor": null,
+                "sorting": null
+              }
+            ],
+            "displayedValue": null,
+            "segmentation": {
+              "labels": [
+                {
+                  "id": "kubernetes.cluster.name",
+                  "descriptor": {
+                    "documentId": "kubernetes.cluster.name",
+                    "id": "kubernetes.cluster.name",
+                    "metricType": "tag",
+                    "type": "string",
+                    "scale": 0.0,
+                    "name": "kubernetes.cluster.name",
+                    "description": "kubernetes.cluster.name",
+                    "namespaces": ["kubernetes.cluster"],
+                    "scopes": [],
+                    "timeAggregations": ["concat", "distinct", "count"],
+                    "groupAggregations": ["concat", "distinct", "count"],
+                    "aggregationForGroup": "none",
+                    "hidden": false,
+                    "experimental": false,
+                    "deferred": false,
+                    "identity": false,
+                    "canMonitor": false,
+                    "canGroupBy": true,
+                    "canFilter": true,
+                    "generatedFrom": "com.draios.model.metrics.custom.CustomMetric$Tag",
+                    "publicId": "kube_cluster_name",
+                    "segment": false,
+                    "documentTimestamp": 1680305324248,
+                    "heuristic": false,
+                    "documentType": "metric"
+                  },
+                  "displayName": null,
+                  "sorting": null
+                },
+                {
+                  "id": "kubernetes.namespace.name",
+                  "descriptor": {
+                    "documentId": "kubernetes.namespace.name",
+                    "id": "kubernetes.namespace.name",
+                    "metricType": "tag",
+                    "type": "string",
+                    "scale": 0.0,
+                    "name": "kubernetes.namespace.name",
+                    "description": "kubernetes.namespace.name",
+                    "namespaces": ["kubernetes.namespace"],
+                    "scopes": [],
+                    "timeAggregations": ["concat", "distinct", "count"],
+                    "groupAggregations": ["concat", "distinct", "count"],
+                    "aggregationForGroup": "none",
+                    "hidden": false,
+                    "experimental": false,
+                    "deferred": false,
+                    "identity": false,
+                    "canMonitor": false,
+                    "canGroupBy": true,
+                    "canFilter": true,
+                    "generatedFrom": "com.draios.model.metrics.custom.CustomMetric$Tag",
+                    "publicId": "kube_namespace_name",
+                    "segment": false,
+                    "documentTimestamp": 1680305324248,
+                    "heuristic": false,
+                    "documentType": "metric"
+                  },
+                  "displayName": null,
+                  "sorting": null
+                },
+                {
+                  "id": "kubernetes.workload.type",
+                  "descriptor": {
+                    "documentId": "kubernetes.workload.type",
+                    "id": "kubernetes.workload.type",
+                    "metricType": "tag",
+                    "type": "string",
+                    "scale": 0.0,
+                    "name": "kubernetes.workload.type",
+                    "description": "kubernetes.workload.type",
+                    "namespaces": [
+                      "cloudProvider",
+                      "host.container",
+                      "ecs",
+                      "host.fs",
+                      "host.file",
+                      "host",
+                      "kubernetes",
+                      "kubernetes.cluster",
+                      "kubernetes.daemonSet",
+                      "kubernetes.deployment",
+                      "kubernetes.job",
+                      "kubernetes.namespace",
+                      "kubernetes.node",
+                      "kubernetes.pod",
+                      "kubernetes.replicaSet",
+                      "kubernetes.service",
+                      "kubernetes.statefulSet",
+                      "kubernetes.resourcequota",
+                      "kubernetes.hpa",
+                      "link",
+                      "mesos",
+                      "host.net",
+                      "host.process",
+                      "prometheus",
+                      "swarm",
+                      "prombeacon"
+                    ],
+                    "scopes": [],
+                    "timeAggregations": ["concat", "distinct", "count"],
+                    "groupAggregations": ["concat", "distinct", "count"],
+                    "aggregationForGroup": "none",
+                    "hidden": false,
+                    "experimental": false,
+                    "deferred": false,
+                    "identity": false,
+                    "canMonitor": false,
+                    "canGroupBy": true,
+                    "canFilter": true,
+                    "generatedFrom": "com.draios.model.metrics.custom.CustomMetric$Tag",
+                    "publicId": "kube_workload_type",
+                    "segment": false,
+                    "documentTimestamp": 1680305324248,
+                    "heuristic": false,
+                    "documentType": "metric"
+                  },
+                  "displayName": null,
+                  "sorting": null
+                },
+                {
+                  "id": "kubernetes.workload.name",
+                  "descriptor": {
+                    "documentId": "kubernetes.workload.name",
+                    "id": "kubernetes.workload.name",
+                    "metricType": "tag",
+                    "type": "string",
+                    "scale": 0.0,
+                    "name": "kubernetes.workload.name",
+                    "description": "kubernetes.workload.name",
+                    "namespaces": [
+                      "cloudProvider",
+                      "host.container",
+                      "ecs",
+                      "host.fs",
+                      "host.file",
+                      "host",
+                      "kubernetes",
+                      "kubernetes.cluster",
+                      "kubernetes.daemonSet",
+                      "kubernetes.deployment",
+                      "kubernetes.job",
+                      "kubernetes.namespace",
+                      "kubernetes.node",
+                      "kubernetes.pod",
+                      "kubernetes.replicaSet",
+                      "kubernetes.service",
+                      "kubernetes.statefulSet",
+                      "kubernetes.resourcequota",
+                      "kubernetes.hpa",
+                      "link",
+                      "mesos",
+                      "host.net",
+                      "host.process",
+                      "prometheus",
+                      "swarm",
+                      "prombeacon"
+                    ],
+                    "scopes": [],
+                    "timeAggregations": ["concat", "distinct", "count"],
+                    "groupAggregations": ["concat", "distinct", "count"],
+                    "aggregationForGroup": "none",
+                    "hidden": false,
+                    "experimental": false,
+                    "deferred": false,
+                    "identity": false,
+                    "canMonitor": false,
+                    "canGroupBy": true,
+                    "canFilter": true,
+                    "generatedFrom": "com.draios.model.metrics.custom.CustomMetric$Tag",
+                    "publicId": "kube_workload_name",
+                    "segment": false,
+                    "documentTimestamp": 1680305324248,
+                    "heuristic": false,
+                    "documentType": "metric"
+                  },
+                  "displayName": null,
+                  "sorting": null
+                },
+                {
+                  "id": "kubernetes.pod.name",
+                  "descriptor": {
+                    "documentId": "kubernetes.pod.name",
+                    "id": "kubernetes.pod.name",
+                    "metricType": "tag",
+                    "type": "string",
+                    "scale": 0.0,
+                    "name": "kubernetes.pod.name",
+                    "description": "kubernetes.pod.name",
+                    "namespaces": [
+                      "cloudProvider",
+                      "host.container",
+                      "ecs",
+                      "host.fs",
+                      "host.file",
+                      "host",
+                      "kubernetes",
+                      "kubernetes.cluster",
+                      "kubernetes.daemonSet",
+                      "kubernetes.deployment",
+                      "kubernetes.job",
+                      "kubernetes.namespace",
+                      "kubernetes.node",
+                      "kubernetes.pod",
+                      "kubernetes.replicaSet",
+                      "kubernetes.service",
+                      "kubernetes.statefulSet",
+                      "kubernetes.resourcequota",
+                      "kubernetes.hpa",
+                      "link",
+                      "mesos",
+                      "host.net",
+                      "host.process",
+                      "prometheus",
+                      "swarm",
+                      "prombeacon"
+                    ],
+                    "scopes": [],
+                    "timeAggregations": ["concat", "distinct", "count"],
+                    "groupAggregations": ["concat", "distinct", "count"],
+                    "aggregationForGroup": "none",
+                    "hidden": false,
+                    "experimental": false,
+                    "deferred": false,
+                    "identity": false,
+                    "canMonitor": false,
+                    "canGroupBy": true,
+                    "canFilter": true,
+                    "generatedFrom": "com.draios.model.metrics.custom.CustomMetric$Tag",
+                    "publicId": "kube_pod_name",
+                    "segment": false,
+                    "documentTimestamp": 1680305324248,
+                    "heuristic": false,
+                    "documentType": "metric"
+                  },
+                  "displayName": null,
+                  "sorting": null
+                }
+              ],
+              "limit": 10,
+              "direction": "desc"
+            }
+          }
+        ],
+        "applyScopeToAll": false,
+        "applySegmentationToAll": false,
+        "legendConfiguration": {
+          "enabled": true,
+          "position": "bottom",
+          "layout": "table",
+          "showCurrent": true,
+          "width": null,
+          "height": null
+        },
+        "axesConfiguration": {
+          "bottom": {
+            "enabled": true
+          },
+          "left": {
+            "enabled": true,
+            "displayName": null,
+            "unit": "auto",
+            "displayFormat": "auto",
+            "decimals": null,
+            "minValue": 0.0,
+            "maxValue": null,
+            "minInputFormat": "B/s",
+            "maxInputFormat": "B/s",
+            "scale": "linear"
+          },
+          "right": {
+            "enabled": true,
+            "displayName": null,
+            "unit": "auto",
+            "displayFormat": "auto",
+            "decimals": null,
+            "minValue": 0.0,
+            "maxValue": null,
+            "minInputFormat": "1",
+            "maxInputFormat": "1",
+            "scale": "linear"
+          }
+        }
+      },
+      {
+        "id": 38,
+        "type": "advancedTimechart",
+        "name": "Percentage of CPU limit per Workload",
+        "description": "",
+        "nullValueDisplayText": null,
+        "links": null,
+        "advancedQueries": [
+          {
+            "query": "avg by(kube_cluster_name,kube_namespace_name,kube_workload_name) (sysdig_container_cpu_quota_used_percent{kube_workload_name=~$workload,kube_cluster_name=~$cluster,kube_namespace_name=~$namespace,kube_workload_type=~$type})",
+            "enabled": true,
+            "displayInfo": {
+              "displayName": "Workload < Namespace < Cluster",
+              "timeSeriesDisplayNameTemplate": "{{kube_workload_name}} < {{kube_namespace_name}} < {{kube_cluster_name}}",
+              "type": "lines"
+            },
+            "format": {
+              "unit": "%",
+              "inputFormat": "0-100",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullGap",
+              "minInterval": null
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "day"
+            }
+          }
+        ],
+        "legendConfiguration": {
+          "enabled": true,
+          "position": "bottom",
+          "layout": "table",
+          "showCurrent": true,
+          "width": null,
+          "height": null
+        },
+        "axesConfiguration": {
+          "bottom": {
+            "enabled": true
+          },
+          "left": {
+            "enabled": true,
+            "displayName": null,
+            "unit": "auto",
+            "displayFormat": "auto",
+            "decimals": null,
+            "minValue": 0.0,
+            "maxValue": null,
+            "minInputFormat": "0-100",
+            "maxInputFormat": "0-100",
+            "scale": "linear"
+          },
+          "right": {
+            "enabled": true,
+            "displayName": null,
+            "unit": "auto",
+            "displayFormat": "auto",
+            "decimals": null,
+            "minValue": 0.0,
+            "maxValue": null,
+            "minInputFormat": "1",
+            "maxInputFormat": "1",
+            "scale": "linear"
+          }
+        }
+      },
+      {
+        "id": 39,
+        "type": "advancedTimechart",
+        "name": "Percentage of Memory limit per Workload",
+        "description": "",
+        "nullValueDisplayText": null,
+        "links": null,
+        "advancedQueries": [
+          {
+            "query": "avg by(kube_cluster_name,kube_namespace_name,kube_workload_name) (sysdig_container_memory_limit_used_percent{kube_workload_name=~$workload,kube_cluster_name=~$cluster,kube_namespace_name=~$namespace,kube_workload_type=~$type})",
+            "enabled": true,
+            "displayInfo": {
+              "displayName": "Workload < Namespace < Cluster",
+              "timeSeriesDisplayNameTemplate": "{{kube_workload_name}} < {{kube_namespace_name}} < {{kube_cluster_name}}",
+              "type": "lines"
+            },
+            "format": {
+              "unit": "%",
+              "inputFormat": "0-100",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullGap",
+              "minInterval": null
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "day"
+            }
+          }
+        ],
+        "legendConfiguration": {
+          "enabled": true,
+          "position": "bottom",
+          "layout": "table",
+          "showCurrent": true,
+          "width": null,
+          "height": null
+        },
+        "axesConfiguration": {
+          "bottom": {
+            "enabled": true
+          },
+          "left": {
+            "enabled": true,
+            "displayName": null,
+            "unit": "auto",
+            "displayFormat": "auto",
+            "decimals": null,
+            "minValue": 0.0,
+            "maxValue": null,
+            "minInputFormat": "0-100",
+            "maxInputFormat": "0-100",
+            "scale": "linear"
+          },
+          "right": {
+            "enabled": true,
+            "displayName": null,
+            "unit": "auto",
+            "displayFormat": "auto",
+            "decimals": null,
+            "minValue": 0.0,
+            "maxValue": null,
+            "minInputFormat": "1",
+            "maxInputFormat": "1",
+            "scale": "linear"
+          }
+        }
+      },
+      {
+        "id": 40,
+        "type": "text",
+        "name": "New Panel (5)",
+        "description": "",
+        "nullValueDisplayText": null,
+        "links": null,
+        "markdownSource": "✅ Check for  unexpected low or high request rate. Itmight mean a malfunction in this or other systems or an attack.",
+        "transparentBackground": false,
+        "panelTitleVisible": false,
+        "textAutosized": false
+      },
+      {
+        "id": 41,
+        "type": "text",
+        "name": "New Panel (6)",
+        "description": "",
+        "nullValueDisplayText": null,
+        "links": null,
+        "markdownSource": "✅ Latency should be below your SLO. Check for resource constrains in **[Pod Overview](#/dashboard-template/view.kubernetes.pod.status)**",
+        "transparentBackground": false,
+        "panelTitleVisible": false,
+        "textAutosized": false
+      },
+      {
+        "id": 42,
+        "type": "text",
+        "name": "New Panel (7)",
+        "description": "",
+        "nullValueDisplayText": null,
+        "links": null,
+        "markdownSource": "✅ Error count should be as low as possible. Check for resource constrains in **[Pod Overview](#/dashboard-template/view.kubernetes.pod.status)**",
+        "transparentBackground": false,
+        "panelTitleVisible": false,
+        "textAutosized": false
+      },
+      {
+        "id": 43,
+        "type": "text",
+        "name": "New Panel (8)",
+        "description": "",
+        "nullValueDisplayText": null,
+        "links": null,
+        "markdownSource": "⚠️ Check traffic and connections to your apps. ",
+        "transparentBackground": false,
+        "panelTitleVisible": false,
+        "textAutosized": false
+      },
+      {
+        "id": 44,
+        "type": "text",
+        "name": "New Panel (9)",
+        "description": "",
+        "nullValueDisplayText": null,
+        "links": null,
+        "markdownSource": "✅ Latency should be below your SLO. Check for workload issues in **[Workload state](#/dashboard-template/view.kubernetes.workload.status)**",
+        "transparentBackground": false,
+        "panelTitleVisible": false,
+        "textAutosized": false
+      },
+      {
+        "id": 45,
+        "type": "text",
+        "name": "New Panel (10)",
+        "description": "",
+        "nullValueDisplayText": null,
+        "links": null,
+        "markdownSource": "✅ Error rate should be below your SLO. Check for resource constrains in **[Pod Overview](#/dashboard-template/view.kubernetes.pod.status)**",
+        "transparentBackground": false,
+        "panelTitleVisible": false,
+        "textAutosized": false
+      },
+      {
+        "id": 46,
+        "type": "advancedTimechart",
+        "name": "Containers Waiting By Reason",
+        "description": "Possible reasons:  ContainerCreating, CrashLoopBackOff, CreateContainerConfigError, ErrImagePull, ImagePullBackOff, CreateContainerError, InvalidImageName",
+        "nullValueDisplayText": "No containers in waiting state on the selected workloads",
+        "links": null,
+        "advancedQueries": [
+          {
+            "query": "kube_pod_container_status_waiting_reason{kube_cluster_name=~$cluster,kube_namespace_name=~$namespace,kube_workload_name=~$workload,kube_workload_type=~$type}",
+            "enabled": true,
+            "displayInfo": {
+              "displayName": "[REASON] Workload < Namespace < Cluster",
+              "timeSeriesDisplayNameTemplate": "[{{reason}}] {{kube_workload_name}} < {{kube_namespace_name}} < {{kube_cluster_name}}",
+              "type": "stackedArea"
+            },
+            "format": {
+              "unit": "number",
+              "inputFormat": "1",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullGap",
+              "minInterval": null
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "day"
+            }
+          }
+        ],
+        "legendConfiguration": {
+          "enabled": true,
+          "position": "bottom",
+          "layout": "table",
+          "showCurrent": true,
+          "width": null,
+          "height": null
+        },
+        "axesConfiguration": {
+          "bottom": {
+            "enabled": true
+          },
+          "left": {
+            "enabled": true,
+            "displayName": null,
+            "unit": "auto",
+            "displayFormat": "auto",
+            "decimals": 2,
+            "minValue": null,
+            "maxValue": null,
+            "minInputFormat": "1",
+            "maxInputFormat": "1",
+            "scale": "linear"
+          },
+          "right": {
+            "enabled": true,
+            "displayName": null,
+            "unit": "auto",
+            "displayFormat": "auto",
+            "decimals": null,
+            "minValue": 0.0,
+            "maxValue": null,
+            "minInputFormat": "1",
+            "maxInputFormat": "1",
+            "scale": "linear"
+          }
+        }
+      },
+      {
+        "id": 47,
+        "type": "advancedTimechart",
+        "name": "Pods Not Ready By Reason",
+        "description": "Possible reasons: Evicted, NodeLost, UnexpectedAdmissionError",
+        "nullValueDisplayText": "No containers in not ready state on the selected workloads",
+        "links": null,
+        "advancedQueries": [
+          {
+            "query": "kube_workload_pods_status_reason{kube_cluster_name=~$cluster,kube_namespace_name=~$namespace,kube_workload_name=~$workload,kube_workload_type=~$type}",
+            "enabled": true,
+            "displayInfo": {
+              "displayName": "[REASON] Workload < Namespace < Cluster",
+              "timeSeriesDisplayNameTemplate": "[{{reason}}] {{kube_workload_name}} < {{kube_namespace_name}} < {{kube_cluster_name}}",
+              "type": "stackedArea"
+            },
+            "format": {
+              "unit": "number",
+              "inputFormat": "1",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullGap",
+              "minInterval": null
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "day"
+            }
+          }
+        ],
+        "legendConfiguration": {
+          "enabled": true,
+          "position": "bottom",
+          "layout": "table",
+          "showCurrent": true,
+          "width": null,
+          "height": null
+        },
+        "axesConfiguration": {
+          "bottom": {
+            "enabled": true
+          },
+          "left": {
+            "enabled": true,
+            "displayName": null,
+            "unit": "auto",
+            "displayFormat": "auto",
+            "decimals": 2,
+            "minValue": null,
+            "maxValue": null,
+            "minInputFormat": "1",
+            "maxInputFormat": "1",
+            "scale": "linear"
+          },
+          "right": {
+            "enabled": true,
+            "displayName": null,
+            "unit": "auto",
+            "displayFormat": "auto",
+            "decimals": null,
+            "minValue": 0.0,
+            "maxValue": null,
+            "minInputFormat": "1",
+            "maxInputFormat": "1",
+            "scale": "linear"
+          }
+        }
+      },
+      {
+        "id": 48,
+        "type": "advancedTimechart",
+        "name": "Container Uncontrolled Terminated By Reason",
+        "description": "Possible reasons: OOMKilled, Error, ContainerCannotRun, DeadlineExceeded",
+        "nullValueDisplayText": "No pods terminated in a non controlled way on the selected workloads",
+        "links": null,
+        "advancedQueries": [
+          {
+            "query": "kube_pod_container_status_terminated_reason{job=\"\",kube_cluster_name=~$cluster,kube_namespace_name=~$namespace,kube_workload_name=~$workload,kube_workload_type=~$type,reason!=\"Completed\"}",
+            "enabled": true,
+            "displayInfo": {
+              "displayName": "[REASON] Workload < Namespace < Cluster",
+              "timeSeriesDisplayNameTemplate": "[{{reason}}] {{kube_workload_name}} < {{kube_namespace_name}} < {{kube_cluster_name}}",
+              "type": "stackedArea"
+            },
+            "format": {
+              "unit": "number",
+              "inputFormat": "1",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullGap",
+              "minInterval": null
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "day"
+            }
+          }
+        ],
+        "legendConfiguration": {
+          "enabled": true,
+          "position": "bottom",
+          "layout": "table",
+          "showCurrent": true,
+          "width": null,
+          "height": null
+        },
+        "axesConfiguration": {
+          "bottom": {
+            "enabled": true
+          },
+          "left": {
+            "enabled": true,
+            "displayName": null,
+            "unit": "auto",
+            "displayFormat": "auto",
+            "decimals": 2,
+            "minValue": null,
+            "maxValue": null,
+            "minInputFormat": "1",
+            "maxInputFormat": "1",
+            "scale": "linear"
+          },
+          "right": {
+            "enabled": true,
+            "displayName": null,
+            "unit": "auto",
+            "displayFormat": "auto",
+            "decimals": null,
+            "minValue": 0.0,
+            "maxValue": null,
+            "minInputFormat": "1",
+            "maxInputFormat": "1",
+            "scale": "linear"
+          }
+        }
+      },
+      {
+        "id": 49,
+        "type": "text",
+        "name": "Images running by Workload (2)",
+        "description": "",
+        "nullValueDisplayText": null,
+        "links": null,
+        "markdownSource": "## Images running by Workload",
+        "transparentBackground": false,
+        "panelTitleVisible": false,
+        "textAutosized": false
+      },
+      {
+        "id": 2,
+        "type": "advancedTimechart",
+        "name": "Memory usage per Workload",
+        "description": "",
+        "nullValueDisplayText": null,
+        "links": null,
+        "advancedQueries": [
+          {
+            "query": "sum by(kube_cluster_name,kube_namespace_name,kube_workload_name) (rate(sysdig_container_memory_used_bytes{kube_workload_name=~$workload,kube_cluster_name=~$cluster,kube_namespace_name=~$namespace,kube_workload_type=~$type}[$__interval]))",
+            "enabled": true,
+            "displayInfo": {
+              "displayName": "Workload < Namespace < Cluster",
+              "timeSeriesDisplayNameTemplate": "{{kube_workload_name}} < {{kube_namespace_name}} < {{kube_cluster_name}}",
+              "type": "lines"
+            },
+            "format": {
+              "unit": "byte",
+              "inputFormat": "B",
+              "displayFormat": "auto",
+              "decimals": null,
+              "yAxis": "auto",
+              "nullValueDisplayMode": "nullGap",
+              "minInterval": null
+            },
+            "compareTo": {
+              "enabled": false,
+              "delta": 1,
+              "timeFormat": "day"
+            }
+          }
+        ],
+        "legendConfiguration": {
+          "enabled": true,
+          "position": "bottom",
+          "layout": "table",
+          "showCurrent": true,
+          "width": null,
+          "height": null
+        },
+        "axesConfiguration": {
+          "bottom": {
+            "enabled": true
+          },
+          "left": {
+            "enabled": true,
+            "displayName": null,
+            "unit": "auto",
+            "displayFormat": "auto",
+            "decimals": null,
+            "minValue": 0.0,
+            "maxValue": null,
+            "minInputFormat": "B",
+            "maxInputFormat": "B",
+            "scale": "linear"
+          },
+          "right": {
+            "enabled": true,
+            "displayName": null,
+            "unit": "auto",
+            "displayFormat": "auto",
+            "decimals": null,
+            "minValue": 0.0,
+            "maxValue": null,
+            "minInputFormat": "1",
+            "maxInputFormat": "1",
+            "scale": "linear"
+          }
+        }
+      }
+    ],
+    "scopeExpressionList": [
+      {
+        "operand": "kubernetes.cluster.name",
+        "operator": "in",
+        "displayName": "cluster",
+        "value": ["silver"],
+        "descriptor": {
+          "documentId": "kubernetes.cluster.name",
+          "id": "kubernetes.cluster.name",
+          "metricType": "tag",
+          "type": "string",
+          "scale": 0.0,
+          "name": "kubernetes.cluster.name",
+          "description": "kubernetes.cluster.name",
+          "namespaces": ["kubernetes.cluster"],
+          "scopes": [],
+          "timeAggregations": ["concat", "distinct", "count"],
+          "groupAggregations": ["concat", "distinct", "count"],
+          "aggregationForGroup": "none",
+          "hidden": false,
+          "experimental": false,
+          "deferred": false,
+          "identity": false,
+          "canMonitor": false,
+          "canGroupBy": true,
+          "canFilter": true,
+          "generatedFrom": "com.draios.model.metrics.custom.CustomMetric$Tag",
+          "publicId": "kube_cluster_name",
+          "segment": false,
+          "documentTimestamp": 1680305324249,
+          "heuristic": false,
+          "documentType": "metric"
+        },
+        "variable": true,
+        "isVariable": true
+      },
+      {
+        "operand": "kubernetes.namespace.name",
+        "operator": "in",
+        "displayName": "namespace",
+        "value": ["4c2ba9-prod", "4c2ba9-tools"],
+        "descriptor": {
+          "documentId": "kubernetes.namespace.name",
+          "id": "kubernetes.namespace.name",
+          "metricType": "tag",
+          "type": "string",
+          "scale": 0.0,
+          "name": "kubernetes.namespace.name",
+          "description": "kubernetes.namespace.name",
+          "namespaces": ["kubernetes.namespace"],
+          "scopes": [],
+          "timeAggregations": ["concat", "distinct", "count"],
+          "groupAggregations": ["concat", "distinct", "count"],
+          "aggregationForGroup": "none",
+          "hidden": false,
+          "experimental": false,
+          "deferred": false,
+          "identity": false,
+          "canMonitor": false,
+          "canGroupBy": true,
+          "canFilter": true,
+          "generatedFrom": "com.draios.model.metrics.custom.CustomMetric$Tag",
+          "publicId": "kube_namespace_name",
+          "segment": false,
+          "documentTimestamp": 1680305324249,
+          "heuristic": false,
+          "documentType": "metric"
+        },
+        "variable": true,
+        "isVariable": true
+      },
+      {
+        "operand": "kubernetes.workload.name",
+        "operator": "in",
+        "displayName": "workload",
+        "value": [],
+        "descriptor": {
+          "documentId": "kubernetes.workload.name",
+          "id": "kubernetes.workload.name",
+          "metricType": "tag",
+          "type": "string",
+          "scale": 0.0,
+          "name": "kubernetes.workload.name",
+          "description": "kubernetes.workload.name",
+          "namespaces": [
+            "cloudProvider",
+            "host.container",
+            "ecs",
+            "host.fs",
+            "host.file",
+            "host",
+            "kubernetes",
+            "kubernetes.cluster",
+            "kubernetes.daemonSet",
+            "kubernetes.deployment",
+            "kubernetes.job",
+            "kubernetes.namespace",
+            "kubernetes.node",
+            "kubernetes.pod",
+            "kubernetes.replicaSet",
+            "kubernetes.service",
+            "kubernetes.statefulSet",
+            "kubernetes.resourcequota",
+            "kubernetes.hpa",
+            "link",
+            "mesos",
+            "host.net",
+            "host.process",
+            "prometheus",
+            "swarm",
+            "prombeacon"
+          ],
+          "scopes": [],
+          "timeAggregations": ["concat", "distinct", "count"],
+          "groupAggregations": ["concat", "distinct", "count"],
+          "aggregationForGroup": "none",
+          "hidden": false,
+          "experimental": false,
+          "deferred": false,
+          "identity": false,
+          "canMonitor": false,
+          "canGroupBy": true,
+          "canFilter": true,
+          "generatedFrom": "com.draios.model.metrics.custom.CustomMetric$Tag",
+          "publicId": "kube_workload_name",
+          "segment": false,
+          "documentTimestamp": 1680305324249,
+          "heuristic": false,
+          "documentType": "metric"
+        },
+        "variable": true,
+        "isVariable": true
+      },
+      {
+        "operand": "kubernetes.workload.type",
+        "operator": "in",
+        "displayName": "type",
+        "value": [],
+        "descriptor": {
+          "documentId": "kubernetes.workload.type",
+          "id": "kubernetes.workload.type",
+          "metricType": "tag",
+          "type": "string",
+          "scale": 0.0,
+          "name": "kubernetes.workload.type",
+          "description": "kubernetes.workload.type",
+          "namespaces": [
+            "cloudProvider",
+            "host.container",
+            "ecs",
+            "host.fs",
+            "host.file",
+            "host",
+            "kubernetes",
+            "kubernetes.cluster",
+            "kubernetes.daemonSet",
+            "kubernetes.deployment",
+            "kubernetes.job",
+            "kubernetes.namespace",
+            "kubernetes.node",
+            "kubernetes.pod",
+            "kubernetes.replicaSet",
+            "kubernetes.service",
+            "kubernetes.statefulSet",
+            "kubernetes.resourcequota",
+            "kubernetes.hpa",
+            "link",
+            "mesos",
+            "host.net",
+            "host.process",
+            "prometheus",
+            "swarm",
+            "prombeacon"
+          ],
+          "scopes": [],
+          "timeAggregations": ["concat", "distinct", "count"],
+          "groupAggregations": ["concat", "distinct", "count"],
+          "aggregationForGroup": "none",
+          "hidden": false,
+          "experimental": false,
+          "deferred": false,
+          "identity": false,
+          "canMonitor": false,
+          "canGroupBy": true,
+          "canFilter": true,
+          "generatedFrom": "com.draios.model.metrics.custom.CustomMetric$Tag",
+          "publicId": "kube_workload_type",
+          "segment": false,
+          "documentTimestamp": 1680305324249,
+          "heuristic": false,
+          "documentType": "metric"
+        },
+        "variable": true,
+        "isVariable": true
+      }
+    ],
+    "eventDisplaySettings": {
+      "enabled": true,
+      "queryParams": {
+        "severities": [],
+        "alertStatuses": [],
+        "categories": [],
+        "filter": null,
+        "teamScope": false
+      }
+    },
+    "version": 8,
+    "description": "Understand the status of applications (workloads) running in a cluster by monitoring status, health, resource usage and performance.",
+    "layout": [
+      {
+        "panelId": 14,
+        "x": 0,
+        "y": 15,
+        "w": 24,
+        "h": 1
+      },
+      {
+        "panelId": 15,
+        "x": 0,
+        "y": 0,
+        "w": 24,
+        "h": 1
+      },
+      {
+        "panelId": 16,
+        "x": 6,
+        "y": 16,
+        "w": 18,
+        "h": 8
+      },
+      {
+        "panelId": 17,
+        "x": 0,
+        "y": 57,
+        "w": 24,
+        "h": 1
+      },
+      {
+        "panelId": 25,
+        "x": 0,
+        "y": 40,
+        "w": 24,
+        "h": 1
+      },
+      {
+        "panelId": 27,
+        "x": 8,
+        "y": 50,
+        "w": 8,
+        "h": 7
+      },
+      {
+        "panelId": 28,
+        "x": 0,
+        "y": 50,
+        "w": 8,
+        "h": 7
+      },
+      {
+        "panelId": 29,
+        "x": 16,
+        "y": 1,
+        "w": 8,
+        "h": 7
+      },
+      {
+        "panelId": 34,
+        "x": 16,
+        "y": 50,
+        "w": 8,
+        "h": 7
+      },
+      {
+        "panelId": 35,
+        "x": 0,
+        "y": 42,
+        "w": 8,
+        "h": 7
+      },
+      {
+        "panelId": 36,
+        "x": 8,
+        "y": 42,
+        "w": 8,
+        "h": 7
+      },
+      {
+        "panelId": 26,
+        "x": 16,
+        "y": 42,
+        "w": 8,
+        "h": 7
+      },
+      {
+        "panelId": 37,
+        "x": 16,
+        "y": 58,
+        "w": 8,
+        "h": 7
+      },
+      {
+        "panelId": 40,
+        "x": 0,
+        "y": 41,
+        "w": 8,
+        "h": 1
+      },
+      {
+        "panelId": 41,
+        "x": 8,
+        "y": 41,
+        "w": 8,
+        "h": 1
+      },
+      {
+        "panelId": 42,
+        "x": 16,
+        "y": 41,
+        "w": 8,
+        "h": 1
+      },
+      {
+        "panelId": 43,
+        "x": 0,
+        "y": 49,
+        "w": 8,
+        "h": 1
+      },
+      {
+        "panelId": 44,
+        "x": 8,
+        "y": 49,
+        "w": 8,
+        "h": 1
+      },
+      {
+        "panelId": 45,
+        "x": 16,
+        "y": 49,
+        "w": 8,
+        "h": 1
+      },
+      {
+        "panelId": 49,
+        "x": 0,
+        "y": 65,
+        "w": 24,
+        "h": 1
+      },
+      {
+        "panelId": 1,
+        "x": 0,
+        "y": 8,
+        "w": 12,
+        "h": 7
+      },
+      {
+        "panelId": 4,
+        "x": 0,
+        "y": 16,
+        "w": 6,
+        "h": 4
+      },
+      {
+        "panelId": 5,
+        "x": 0,
+        "y": 20,
+        "w": 3,
+        "h": 2
+      },
+      {
+        "panelId": 6,
+        "x": 3,
+        "y": 20,
+        "w": 3,
+        "h": 2
+      },
+      {
+        "panelId": 8,
+        "x": 0,
+        "y": 24,
+        "w": 8,
+        "h": 8
+      },
+      {
+        "panelId": 10,
+        "x": 8,
+        "y": 24,
+        "w": 8,
+        "h": 8
+      },
+      {
+        "panelId": 11,
+        "x": 3,
+        "y": 22,
+        "w": 3,
+        "h": 2
+      },
+      {
+        "panelId": 12,
+        "x": 0,
+        "y": 22,
+        "w": 3,
+        "h": 2
+      },
+      {
+        "panelId": 18,
+        "x": 0,
+        "y": 58,
+        "w": 8,
+        "h": 7
+      },
+      {
+        "panelId": 19,
+        "x": 8,
+        "y": 58,
+        "w": 8,
+        "h": 7
+      },
+      {
+        "panelId": 24,
+        "x": 16,
+        "y": 24,
+        "w": 8,
+        "h": 8
+      },
+      {
+        "panelId": 38,
+        "x": 0,
+        "y": 1,
+        "w": 8,
+        "h": 7
+      },
+      {
+        "panelId": 39,
+        "x": 8,
+        "y": 1,
+        "w": 8,
+        "h": 7
+      },
+      {
+        "panelId": 46,
+        "x": 0,
+        "y": 32,
+        "w": 8,
+        "h": 8
+      },
+      {
+        "panelId": 47,
+        "x": 16,
+        "y": 32,
+        "w": 8,
+        "h": 8
+      },
+      {
+        "panelId": 48,
+        "x": 8,
+        "y": 32,
+        "w": 8,
+        "h": 8
+      },
+      {
+        "panelId": 2,
+        "x": 12,
+        "y": 8,
+        "w": 12,
+        "h": 7
+      }
+    ],
+    "sharingSettings": [
+      {
+        "role": "ROLE_RESOURCE_EDIT",
+        "member": {
+          "type": "TEAM",
+          "id": 35635,
+          "name": "4c2ba9-team",
+          "teamTheme": "#73A1F7"
+        }
+      }
+    ],
+    "schema": 3
+  }
+}


### PR DESCRIPTION
## Objective 
Monitor our systems to be able to get more information about them and use that to improve performance.
Set up 4 different dashboards.
1. Resource Allocation Dashboard: from BCGov template, this one shows us if we're requesting more than we need, how much of our available quota we're using, etc.
2. Workload Status & Performance: minimally modified from library dashboard of the same name. Shows which workloads are running smoothly and which ones are hitting their limits, breaks down by pods as well.
3. SQL Statistics: heavily modified from library dashboard SQL Troubleshooting. Shows which queries and tables are slow and resource-intensive. There's some max/avg time series panel that I left in there that doesn't seem quite right (often shows the avg as exceeding the max).
4. API Troubleshooting: highlighting & quantifying our worst endpoints, the slowest, the error-generating, and the invalid.

By default I set these to monitor the prod env, switch the scope up top to see dev or test.

[MDS-5164](https://bcmines.atlassian.net/browse/MDS-5164)

_Why are you making this change? Provide a short explanation and/or screenshots_
Some Sysdig resources:
[BCGov Sysdig documentation and more](https://docs.developer.gov.bc.ca/sysdig-monitor-setup-team/)
[Sysdig REST API Conventions](https://docs.sysdig.com/en/docs/developer-tools/sysdig-rest-api-conventions/)
[Sysdig API documentation](https://app.sysdigcloud.com/api/public/docs/index.html)
Some more things to look into:
[Configure a Custom Webhook Channel](https://docs.sysdig.com/en/docs/administration/administration-settings/notifications-management/set-up-notification-channels/configure-a-custom-webhook-channel/)
[Sysdig Captures](https://docs.sysdig.com/en/docs/sysdig-monitor/captures/configure-sysdig-captures/)