### PR TITLE
[MDS-4668] Pagination for mine-summary endpoint

### DIFF
--- a/services/core-api/app/api/exports/mines/models/mine_summary_view.py
+++ b/services/core-api/app/api/exports/mines/models/mine_summary_view.py
@@ -86,3 +86,4 @@ class MineSummaryView(Base):
             cache.set(cache_name, cache_data, timeout=TIMEOUT_60_MINUTES)
 
         return cache_data
+        

--- a/services/core-api/app/api/exports/mines/resources/mine_summary_resource.py
+++ b/services/core-api/app/api/exports/mines/resources/mine_summary_resource.py
@@ -36,5 +36,3 @@ class MineSummaryResource(Resource):
         data = MineSummaryView.get_paginated_data(page, per_page)
 
         return data
-        
-        

--- a/services/core-api/app/api/exports/response_models.py
+++ b/services/core-api/app/api/exports/response_models.py
@@ -70,6 +70,13 @@ MINE_SUMMARY_MODEL = api.model(
         'permittee_address_prov': fields.String
     })
 
+MINE_SUMMARY_MODEL_LIST = api.model('MineSummaryList', {
+    'mines': fields.List(fields.Nested(MINE_SUMMARY_MODEL)),
+    'total': fields.Integer,
+    'current_page': fields.Integer,
+    'per_page': fields.Integer
+})
+
 STATIC_CONTENT_MODEL = api.model(
     'StaticContentModel', {
         'mineDisturbanceOptions':

--- a/services/core-api/tests/exports/test_export_success.py
+++ b/services/core-api/tests/exports/test_export_success.py
@@ -15,11 +15,11 @@ def test_mine_summary_export_paginated(test_client, db_session, auth_headers):
 
     assert get_resp.status_code == 200
 
-    get_data = json.loads(get_resp.data.decode())
+    get_data = json.loads(get_resp.data.decode()).get('data')
 
-    assert len(get_data['mines']) == PER_PAGE_DEFAULT
+    assert len(get_data['mines']) <= PER_PAGE_DEFAULT
     assert get_data['per_page'] == PER_PAGE_DEFAULT
-    assert get_data['page'] == PAGE_DEFAULT
+    assert get_data['current_page'] == PAGE_DEFAULT
     assert get_data['total'] == MineSummaryView.query.count()
 
 def test_core_static_content_success(test_client, db_session, auth_headers):

--- a/services/core-api/tests/exports/test_export_success.py
+++ b/services/core-api/tests/exports/test_export_success.py
@@ -1,4 +1,6 @@
 import json, pytest, uuid
+from app.api.exports.mines.models.mine_summary_view import MineSummaryView
+from app.api.exports.mines.resources.mine_summary_resource import PAGE_DEFAULT, PER_PAGE_DEFAULT
 
 
 def test_mine_summary_export_success(test_client, db_session, auth_headers):
@@ -7,6 +9,15 @@ def test_mine_summary_export_success(test_client, db_session, auth_headers):
 
     assert get_resp.status_code == 200
 
+def test_mine_summary_export_paginated(test_client, db_session, auth_headers):
+    get_resp = test_client.get(
+        f'/exports/mine-summary', headers=auth_headers['full_auth_header'])
+
+    assert get_resp.status_code == 200
+    assert len(get_resp['mines']) == PER_PAGE_DEFAULT
+    assert get_resp['per_page'] == PER_PAGE_DEFAULT
+    assert get_resp['page'] == PAGE_DEFAULT
+    assert len(get_resp['total']) == len(MineSummaryView.get_all())
 
 def test_core_static_content_success(test_client, db_session, auth_headers):
     get_resp = test_client.get(

--- a/services/core-api/tests/exports/test_export_success.py
+++ b/services/core-api/tests/exports/test_export_success.py
@@ -14,10 +14,13 @@ def test_mine_summary_export_paginated(test_client, db_session, auth_headers):
         f'/exports/mine-summary', headers=auth_headers['full_auth_header'])
 
     assert get_resp.status_code == 200
-    assert len(get_resp['mines']) == PER_PAGE_DEFAULT
-    assert get_resp['per_page'] == PER_PAGE_DEFAULT
-    assert get_resp['page'] == PAGE_DEFAULT
-    assert len(get_resp['total']) == len(MineSummaryView.get_all())
+
+    get_data = json.loads(get_resp.data.decode())
+
+    assert len(get_data['mines']) == PER_PAGE_DEFAULT
+    assert get_data['per_page'] == PER_PAGE_DEFAULT
+    assert get_data['page'] == PAGE_DEFAULT
+    assert get_data['total'] == MineSummaryView.query.count()
 
 def test_core_static_content_success(test_client, db_session, auth_headers):
     get_resp = test_client.get(


### PR DESCRIPTION
## Objective 
- paginate the mine-summary endpoint so that it doesn't fail

[MDS-4668](https://bcmines.atlassian.net/browse/MDS-4668)

_Why are you making this change? Provide a short explanation and/or screenshots_
Swagger afterwards (most mine fields are cropped out from the image):
![image](https://user-images.githubusercontent.com/102187683/230490192-4a5d8399-bd78-46de-ac78-0cdc5442a4be.png)
![image](https://user-images.githubusercontent.com/102187683/230490236-223523fe-fbb3-4fc1-b0fb-23e71612a550.png)

