### PR TITLE
[MDS-5176] Fix drop-down code in reportable incidents

### DIFF
--- a/migrations/sql/V2023.04.13.08.15__update_compliance_articles.sql
+++ b/migrations/sql/V2023.04.13.08.15__update_compliance_articles.sql
@@ -1,0 +1,10 @@
+UPDATE compliance_article 
+  SET paragraph = '1'
+WHERE 
+  article_act_code = 'HSRCM' 
+AND 
+  section = '1'
+AND
+  sub_section = '7'
+AND
+  paragraph = '3';

--- a/services/core-api/app/api/mines/incidents/resources/mine_incidents.py
+++ b/services/core-api/app/api/mines/incidents/resources/mine_incidents.py
@@ -24,7 +24,7 @@ def _compliance_article_is_do_subparagraph(ca):
     if ca is None:
         return False
 
-    return ca.article_act_code == 'HSRCM' and ca.section == '1' and ca.sub_section == '7' and ca.paragraph == '3' and ca.sub_paragraph is not None
+    return ca.article_act_code == 'HSRCM' and ca.section == '1' and ca.sub_section == '7' and ca.paragraph == '1' and ca.sub_paragraph is not None
 
 
 class MineIncidentListResource(Resource, UserMixin):

--- a/services/core-api/tests/status_code_gen.py
+++ b/services/core-api/tests/status_code_gen.py
@@ -171,7 +171,7 @@ def SampleDangerousOccurrenceSubparagraphs(num):
         db.session.query(ComplianceArticle).filter(ComplianceArticle.article_act_code == 'HSRCM',
                                                    ComplianceArticle.section == '1',
                                                    ComplianceArticle.sub_section == '7',
-                                                   ComplianceArticle.paragraph == '3',
+                                                   ComplianceArticle.paragraph == '1',
                                                    ComplianceArticle.sub_paragraph != None).all(),
         num)
 

--- a/services/core-web/common/selectors/staticContentSelectors.js
+++ b/services/core-web/common/selectors/staticContentSelectors.js
@@ -339,7 +339,7 @@ export const getDangerousOccurrenceSubparagraphOptions = createSelector(
           code.article_act_code === "HSRCM" &&
           code.section === "1" &&
           code.sub_section === "7" &&
-          code.paragraph === "3" &&
+          code.paragraph === "1" &&
           code.sub_paragraph !== null
       )
       .map((code) => {

--- a/services/minespace-web/common/selectors/staticContentSelectors.js
+++ b/services/minespace-web/common/selectors/staticContentSelectors.js
@@ -339,7 +339,7 @@ export const getDangerousOccurrenceSubparagraphOptions = createSelector(
           code.article_act_code === "HSRCM" &&
           code.section === "1" &&
           code.sub_section === "7" &&
-          code.paragraph === "3" &&
+          code.paragraph === "1" &&
           code.sub_paragraph !== null
       )
       .map((code) => {


### PR DESCRIPTION
## Objective 

[MDS-5176](https://bcmines.atlassian.net/browse/MDS-5176)

_Why are you making this change? Provide a short explanation and/or screenshots_

The code list in the drop down was revised and moved from Section 1.7.3 to Section 1.7.1 and therefore I created a migration script to update the compliance_article table in the database to reflect the new code.

![image](https://user-images.githubusercontent.com/72251620/231871240-6200a9ab-8105-41d8-a008-56dd9e8c557f.png)


