### PR TITLE
[MDS-5005] Unable to change mine name

### DIFF
--- a/services/core-api/app/api/mines/mine/resources/mine.py
+++ b/services/core-api/app/api/mines/mine/resources/mine.py
@@ -515,5 +515,5 @@ def _throw_error_if_mine_exists(mine_name):
         name_filter = Mine.mine_name.ilike(mine_name.strip())
         mines_name_query = Mine.query.filter(name_filter)
         mines_with_name = mines_name_query.all()
-        if len(mines_with_name) > 0:
+        if len(mines_with_name) > 0 and mines_with_name[0].deleted_ind == False:
             raise BadRequest(f'Mine No: {mines_with_name[0].mine_no} already has that name.')

--- a/services/core-api/app/api/mines/mine/resources/mine.py
+++ b/services/core-api/app/api/mines/mine/resources/mine.py
@@ -513,7 +513,7 @@ def _throw_error_if_mine_exists(mine_name):
     # query the mine tables and check if that mine name exists
     if mine_name:
         name_filter = Mine.mine_name.ilike(mine_name.strip())
-        mines_name_query = Mine.query.filter(name_filter)
+        mines_name_query = Mine.query.filter(name_filter).filter_by(deleted_ind=False)
         mines_with_name = mines_name_query.all()
-        if len(mines_with_name) > 0 and mines_with_name[0].deleted_ind == False:
+        if len(mines_with_name) > 0:
             raise BadRequest(f'Mine No: {mines_with_name[0].mine_no} already has that name.')


### PR DESCRIPTION
## Objective

- It was found that mine#1650126 does still exist within production database, however it's deleted_ind was set to true, so it doesn't show up in the list of mines when searching in the mines page. When updating mine name we only retrieved results for comparison based on the name, so mine#1650126 will come back as a result even though deleted_ind has a value of true.

- The Change is so searching to see if name already exists only uses results with deleted_ind of value false for comparison 

[MDS-5005](https://bcmines.atlassian.net/browse/MDS-5005)
