### PR TITLE
[MDS-5177] Permissions for Notice of Departure

### DIFF
--- a/services/core-api/app/api/notice_of_departure/resources/notice_of_departure.py
+++ b/services/core-api/app/api/notice_of_departure/resources/notice_of_departure.py
@@ -3,7 +3,7 @@ from flask_restplus import Resource, reqparse, inputs
 from app.extensions import api
 from app.api.utils.resources_mixins import UserMixin
 from app.api.activity.utils import trigger_notification
-from app.api.utils.access_decorators import (requires_any_of, EDIT_DO, MINESPACE_PROPONENT)
+from app.api.utils.access_decorators import (requires_any_of, EDIT_PERMIT, VIEW_ALL, MINESPACE_PROPONENT)
 from app.api.notice_of_departure.models.notice_of_departure import NoticeOfDeparture, NodStatus, NodType
 from app.api.notice_of_departure.dto import NOD_MODEL, UPDATE_NOD_MODEL
 from app.api.notice_of_departure.utils.validators import contact_validator
@@ -12,7 +12,7 @@ from app.api.notice_of_departure.utils.validators import contact_validator
 class NoticeOfDepartureResource(Resource, UserMixin):
 
     @api.doc(params={'nod_guid': 'Nod guid.'})
-    @requires_any_of([EDIT_DO, MINESPACE_PROPONENT])
+    @requires_any_of([EDIT_PERMIT, VIEW_ALL, MINESPACE_PROPONENT])
     @api.marshal_with(NOD_MODEL, code=200)
     def get(self, nod_guid):
         nod = NoticeOfDeparture.find_one(
@@ -20,7 +20,7 @@ class NoticeOfDepartureResource(Resource, UserMixin):
         return nod
 
     @api.doc(params={'nod_guid': 'Nod guid.'})
-    @requires_any_of([EDIT_DO, MINESPACE_PROPONENT])
+    @requires_any_of([EDIT_PERMIT, MINESPACE_PROPONENT])
     @api.expect(UPDATE_NOD_MODEL)
     @api.marshal_with(NOD_MODEL, code=200)
     def patch(self, nod_guid):
@@ -88,7 +88,7 @@ class NoticeOfDepartureResource(Resource, UserMixin):
         return update_nod
 
     @api.doc(params={'nod_guid': 'Nod guid.'})
-    @requires_any_of([EDIT_DO, MINESPACE_PROPONENT])
+    @requires_any_of([EDIT_PERMIT, MINESPACE_PROPONENT])
     def delete(self, nod_guid):
         nod = NoticeOfDeparture.find_one(nod_guid, True)
         nod.delete(nod_guid)

--- a/services/core-api/app/api/notice_of_departure/resources/notice_of_departure_document.py
+++ b/services/core-api/app/api/notice_of_departure/resources/notice_of_departure_document.py
@@ -5,8 +5,7 @@ from flask import request, current_app
 from flask_restplus import Resource
 
 from app.extensions import api
-from app.api.utils.access_decorators import (requires_any_of, VIEW_ALL, MINESPACE_PROPONENT,
-                                             EDIT_DO)
+from app.api.utils.access_decorators import (requires_any_of, MINESPACE_PROPONENT, EDIT_PERMIT)
 from app.api.utils.resources_mixins import UserMixin
 from app.api.utils.custom_reqparser import CustomReqparser
 
@@ -21,7 +20,7 @@ from app.api.services.document_manager_service import DocumentManagerService
 class MineNoticeOfDepartureNewDocumentUploadResource(Resource, UserMixin):
 
     @api.doc(description='Request a document_manager_guid for uploading a document')
-    @requires_any_of([EDIT_DO, MINESPACE_PROPONENT])
+    @requires_any_of([EDIT_PERMIT, MINESPACE_PROPONENT])
     def post(self, mine_guid):
         mine = Mine.find_by_mine_guid(mine_guid)
         if not mine:
@@ -40,7 +39,7 @@ class MineNoticeOfDepartureDocumentUploadResource(Resource, UserMixin):
             'GUID for the notice of departure to which the document should be associated'
         })
     @api.marshal_with(NOD_MODEL, code=200)
-    @requires_any_of([EDIT_DO, MINESPACE_PROPONENT])
+    @requires_any_of([EDIT_PERMIT, MINESPACE_PROPONENT])
     def put(self, nod_guid):
         parser = CustomReqparser()
         # Arguments required by MineDocument
@@ -83,6 +82,7 @@ class MineNoticeOfDepartureDocumentUploadResource(Resource, UserMixin):
 
 class MineNoticeOfDepartureDocumentResource(Resource, UserMixin):
 
+    @requires_any_of([EDIT_PERMIT])
     def delete(self, nod_guid, docman_guid):
         doc = NoticeOfDepartureDocumentXref.find_by_docman_guid(docman_guid)
 

--- a/services/core-web/src/components/mine/NoticeOfDeparture/MineNoticeOfDeparture.js
+++ b/services/core-web/src/components/mine/NoticeOfDeparture/MineNoticeOfDeparture.js
@@ -13,10 +13,13 @@ import { getMineGuid, getMines } from "@common/selectors/mineSelectors";
 import { getNoticesOfDeparture } from "@common/selectors/noticeOfDepartureSelectors";
 import { fetchPermits } from "@common/actionCreators/permitActionCreator";
 import { useLocation } from "react-router-dom";
+import { USER_ROLES } from "@mds/common";
+import { getUserAccessData } from "@common/selectors/authenticationSelectors";
 import { modalConfig } from "@/components/modalContent/config";
 import CustomPropTypes from "@/customPropTypes";
 import { MINE_NOTICES_OF_DEPARTURE } from "@/constants/routes";
 import MineNoticeOfDepartureTable from "./MineNoticeOfDepartureTable";
+import * as Permission from "@/constants/permissions";
 
 const propTypes = {
   mines: PropTypes.objectOf(CustomPropTypes.mine).isRequired,
@@ -26,6 +29,7 @@ const propTypes = {
   fetchPermits: PropTypes.func.isRequired,
   fetchNoticesOfDeparture: PropTypes.func.isRequired,
   fetchDetailedNoticeOfDeparture: PropTypes.func.isRequired,
+  userRoles: PropTypes.arrayOf(PropTypes.string).isRequired,
 };
 
 export const MineNoticeOfDeparture = (props) => {
@@ -53,7 +57,9 @@ export const MineNoticeOfDeparture = (props) => {
     const detailedNoticeOfDeparture = await props.fetchDetailedNoticeOfDeparture(
       selectedNoticeOfDeparture.nod_guid
     );
-    const title = "View Notice of Departure";
+    const title = props.userRoles.includes(USER_ROLES[Permission.EDIT_PERMITS])
+      ? "Edit Notice of Departure"
+      : "View Notice of Departure";
     props.openModal({
       props: {
         noticeOfDeparture: detailedNoticeOfDeparture.data,
@@ -113,6 +119,7 @@ const mapStateToProps = (state) => ({
   mines: getMines(state),
   mineGuid: getMineGuid(state),
   nods: getNoticesOfDeparture(state),
+  userRoles: getUserAccessData(state),
 });
 
 const mapDispatchToProps = (dispatch) =>

--- a/services/core-web/src/components/mine/NoticeOfDeparture/MineNoticeOfDeparture.js
+++ b/services/core-web/src/components/mine/NoticeOfDeparture/MineNoticeOfDeparture.js
@@ -12,9 +12,9 @@ import {
 import { getMineGuid, getMines } from "@common/selectors/mineSelectors";
 import { getNoticesOfDeparture } from "@common/selectors/noticeOfDepartureSelectors";
 import { fetchPermits } from "@common/actionCreators/permitActionCreator";
+import { useLocation } from "react-router-dom";
 import { modalConfig } from "@/components/modalContent/config";
 import CustomPropTypes from "@/customPropTypes";
-import { useLocation } from "react-router-dom";
 import { MINE_NOTICES_OF_DEPARTURE } from "@/constants/routes";
 import MineNoticeOfDepartureTable from "./MineNoticeOfDepartureTable";
 
@@ -62,7 +62,7 @@ export const MineNoticeOfDeparture = (props) => {
         mine,
       },
       width: "50vw",
-      content: modalConfig.VIEW_NOTICE_OF_DEPARTURE_MODAL,
+      content: modalConfig.NOTICE_OF_DEPARTURE_MODAL,
     });
   };
 

--- a/services/core-web/src/components/modalContent/NoticeOfDepartureModal.js
+++ b/services/core-web/src/components/modalContent/NoticeOfDepartureModal.js
@@ -128,7 +128,7 @@ export const renderContacts = (props, disabled = false) => {
 
 renderContacts.propTypes = renderContactsPropTypes;
 
-const ViewNoticeOfDepartureModal = (props) => {
+const NoticeOfDepartureModal = (props) => {
   const [statusOptions, setStatusOptions] = React.useState([]);
   const [documentArray, setDocumentArray] = useState([]);
   const [uploadedFiles, setUploadedFiles] = useState([]);
@@ -450,7 +450,7 @@ const ViewNoticeOfDepartureModal = (props) => {
   );
 };
 
-ViewNoticeOfDepartureModal.propTypes = propTypes;
+NoticeOfDepartureModal.propTypes = propTypes;
 
 const mapStateToProps = (state) => ({
   noticeOfDeparture: getNoticeOfDeparture(state),
@@ -478,4 +478,4 @@ export default compose(
     forceUnregisterOnUnmount: true,
     enableReinitialize: true,
   })
-)(ViewNoticeOfDepartureModal);
+)(NoticeOfDepartureModal);

--- a/services/core-web/src/components/modalContent/config.js
+++ b/services/core-web/src/components/modalContent/config.js
@@ -52,7 +52,7 @@ import UpdateNoWDateModal from "./UpdateNoWDateModal";
 import EMLIContactModal from "./EMLIContactModal";
 import UpdateMinespaceUserModal from "./UpdateMinespaceUserModal";
 import ManageDocumentsDownloadPackageModal from "./ManageDocumentsDownloadPackageModal";
-import ViewNoticeOfDepartureModal from "./ViewNoticeOfDepartureModal";
+import NoticeOfDepartureModal from "./NoticeOfDepartureModal";
 import UploadProjectDecisionPackageDocumentModal from "./UploadProjectDecisionPackageDocumentModal";
 import UpdateProjectDecisionPackageDocumentModal from "./UpdateProjectDecisionPackageDocumentModal";
 import AddMineAlertModal from "./AddMineAlertModal";
@@ -113,7 +113,7 @@ export const modalConfig = {
   EMLI_CONTACT_MODAL: EMLIContactModal,
   UPDATE_MINESPACE_USERS: UpdateMinespaceUserModal,
   NOW_MANAGE_DOCUMENTS_DOWNLOAD_PACKAGE_MODAL: ManageDocumentsDownloadPackageModal,
-  VIEW_NOTICE_OF_DEPARTURE_MODAL: ViewNoticeOfDepartureModal,
+  NOTICE_OF_DEPARTURE_MODAL: NoticeOfDepartureModal,
   UPLOAD_PROJECT_DECISION_PACKAGE_DOCUMENT_MODAL: UploadProjectDecisionPackageDocumentModal,
   UPDATE_PROJECT_DECISION_PACKAGE_DOCUMENT_MODAL: UpdateProjectDecisionPackageDocumentModal,
   ADD_MINE_ALERT: AddMineAlertModal,

--- a/services/core-web/src/tests/components/modalContent/NoticeOfDepartureModal.spec.js
+++ b/services/core-web/src/tests/components/modalContent/NoticeOfDepartureModal.spec.js
@@ -1,9 +1,9 @@
 import React from "react";
 import { shallow } from "enzyme";
 // eslint-disable-next-line import/no-unresolved
-import ViewNoticeOfDepartureModal from "@/components/modalContent/ViewNoticeOfDepartureModal";
-import { MINE_RESPONSE, NOTICE_OF_DEPARTURE_DETAILS } from "@/tests/mocks/dataMocks";
 import { Provider } from "react-redux";
+import NoticeOfDepartureModal from "@/components/modalContent/NoticeOfDepartureModal";
+import { MINE_RESPONSE, NOTICE_OF_DEPARTURE_DETAILS } from "@/tests/mocks/dataMocks";
 import { store } from "@/App";
 
 const dispatchProps = {};
@@ -29,11 +29,11 @@ beforeEach(() => {
   setupProps();
 });
 
-describe("ViewNoticeOfDepartureModal", () => {
+describe("NoticeOfDepartureModal", () => {
   it("renders properly", () => {
     const component = shallow(
       <Provider store={store}>
-        <ViewNoticeOfDepartureModal {...dispatchProps} {...props} />
+        <NoticeOfDepartureModal {...dispatchProps} {...props} />
       </Provider>
     );
     expect(component).toMatchSnapshot();

--- a/services/core-web/src/tests/components/modalContent/__snapshots__/NoticeOfDepartureModal.spec.js.snap
+++ b/services/core-web/src/tests/components/modalContent/__snapshots__/NoticeOfDepartureModal.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ViewNoticeOfDepartureModal renders properly 1`] = `
+exports[`NoticeOfDepartureModal renders properly 1`] = `
 <ContextProvider
   value={
     Object {


### PR DESCRIPTION
## Objective 

[MDS-5177](https://bcmines.atlassian.net/browse/MDS-5177)
- ensure that the right people have the right access to the NoD information

### Summary of changes:
- BE permissions for NoD:
  - EDIT_DO --> EDIT_PERMITS
  - add restrictions to deleting NoD documents
  - allow VIEW_ALL to view the NoD data
- FE NoD modal form changes:
  - create a "view only" mode for the form when they don't have EDIT_PERMITS permission: 
    - don't show the file upload or delete
    - allow the form to be disabled
    - change buttons from Update/Cancel to Close
    - disable the form 
  - modal title is Edit or View NoD depending on what they're doing
    - there's no "Create" because it must be created in MS, didn't touch the MS side

#### Edit Mode
![image](https://user-images.githubusercontent.com/102187683/233505216-023ed6c6-307b-4ba9-b8a0-2ca69931b93f.png)
#### View Mode
![image](https://user-images.githubusercontent.com/102187683/233505237-f889a6b1-0612-46a6-8f9a-49d5620cb53e.png)
