### PR TITLE
[MDS-5199] Move permit M-246 from mine 1641022 to mine 1300281

### DIFF
--- a/services/core-api/app/api/mines/mine/resources/mine.py
+++ b/services/core-api/app/api/mines/mine/resources/mine.py
@@ -206,7 +206,7 @@ class MineListResource(Resource, UserMixin):
             mines_name_query = Mine.query.filter(name_filter | number_filter)
 
             permit_query = Mine.query.join(MinePermitXref).join(Permit).filter(
-                permit_filter, Permit.deleted_ind == False)
+                permit_filter, Permit.deleted_ind == False, MinePermitXref.deleted_ind == False)
             mines_query = mines_name_query.union(permit_query)
 
         # Filter by Major Mine, if provided


### PR DESCRIPTION
## Objective 

[MDS-5199](https://bcmines.atlassian.net/browse/MDS-5199)

_Why are you making this change? Provide a short explanation and/or screenshots_
- I added criteria to filter records that have not been soft deleted in the mine permit xref table.
