### PR TITLE
[MDS-5189] Bug when adding/updating QP from contacts page

### DIFF
--- a/services/core-web/src/components/Forms/PartyRelationships/AddPartyRelationshipForm.js
+++ b/services/core-web/src/components/Forms/PartyRelationships/AddPartyRelationshipForm.js
@@ -12,7 +12,7 @@ import { required, validateDateRanges } from "@common/utils/Validate";
 import { renderConfig } from "@/components/common/config";
 import PartySelectField from "@/components/common/PartySelectField";
 import * as FORM from "@/constants/forms";
-import { EngineerOfRecordOptions } from "@/components/Forms/PartyRelationships/EngineerOfRecordOptions";
+import { TSFOptions } from "@/components/Forms/PartyRelationships/TSFOptions";
 import { UnionRepOptions } from "@/components/Forms/PartyRelationships/UnionRepOptions";
 import { PermitteeOptions } from "@/components/Forms/PartyRelationships/PermitteeOptions";
 import CustomPropTypes from "@/customPropTypes";
@@ -143,11 +143,14 @@ const validate = (values, props) => {
 };
 
 export class AddPartyRelationshipForm extends Component {
-  state = {
-    skipDateValidation: false,
-    currentAppointment: {},
-    selectedParty: null,
-  };
+  constructor(props) {
+    super(props);
+    this.state = {
+      skipDateValidation: false,
+      currentAppointment: {},
+      selectedParty: null,
+    };
+  }
 
   // When the start_date and/or the related_guid are changed this checks to see if the the only appointment
   // it violates is the current one. A state variable is set that toggles a check box if it only violates the current appointment.
@@ -193,8 +196,9 @@ export class AddPartyRelationshipForm extends Component {
   render() {
     let options;
     switch (this.props.partyRelationshipType.mine_party_appt_type_code) {
+      case "TQP":
       case "EOR":
-        options = <EngineerOfRecordOptions mine={this.props.mine} />;
+        options = <TSFOptions mine={this.props.mine} />;
         break;
       case "URP":
         options = <UnionRepOptions />;

--- a/services/core-web/src/components/Forms/PartyRelationships/EditPartyRelationshipForm.js
+++ b/services/core-web/src/components/Forms/PartyRelationships/EditPartyRelationshipForm.js
@@ -9,7 +9,7 @@ import { resetForm } from "@common/utils/helpers";
 import { validateDateRanges } from "@common/utils/Validate";
 import { renderConfig } from "@/components/common/config";
 import * as FORM from "@/constants/forms";
-import EngineerOfRecordOptions from "@/components/Forms/PartyRelationships/EngineerOfRecordOptions";
+import TSFOptions from "@/components/Forms/PartyRelationships/TSFOptions";
 import UnionRepOptions from "@/components/Forms/PartyRelationships/UnionRepOptions";
 import { PermitteeOptions } from "@/components/Forms/PartyRelationships/PermitteeOptions";
 import CustomPropTypes from "@/customPropTypes";
@@ -80,8 +80,9 @@ export const EditPartyRelationshipForm = (props) => {
   let options;
   const isRelatedGuidSet = !!props.partyRelationship.related_guid;
   switch (props.partyRelationship.mine_party_appt_type_code) {
+    case "TQP":
     case "EOR":
-      options = <EngineerOfRecordOptions mine={props.mine} />;
+      options = <TSFOptions mine={props.mine} />;
       break;
     case "URP":
       options = <UnionRepOptions />;

--- a/services/core-web/src/components/Forms/PartyRelationships/TSFOptions.js
+++ b/services/core-web/src/components/Forms/PartyRelationships/TSFOptions.js
@@ -3,7 +3,7 @@ import { Field } from "redux-form";
 import { Form } from "@ant-design/compatible";
 import "@ant-design/compatible/assets/index.css";
 import { Col, Row } from "antd";
-import { required } from "@common/utils/Validate";
+import { notnone } from "@common/utils/Validate";
 import { createDropDownList } from "@common/utils/helpers";
 import { renderConfig } from "@/components/common/config";
 import CustomPropTypes from "@/customPropTypes";
@@ -16,7 +16,7 @@ const defaultProps = {
   mine: {},
 };
 
-export const EngineerOfRecordOptions = (props) => {
+export const TSFOptions = (props) => {
   const tsfDropdown = createDropDownList(
     props.mine.mine_tailings_storage_facilities,
     "mine_tailings_storage_facility_name",
@@ -35,7 +35,7 @@ export const EngineerOfRecordOptions = (props) => {
             doNotPinDropdown
             component={renderConfig.SELECT}
             data={tsfDropdown}
-            validate={[required]}
+            validate={[notnone]}
           />
         </Form.Item>
       </Col>
@@ -43,7 +43,7 @@ export const EngineerOfRecordOptions = (props) => {
   );
 };
 
-EngineerOfRecordOptions.propTypes = propTypes;
-EngineerOfRecordOptions.defaultProps = defaultProps;
+TSFOptions.propTypes = propTypes;
+TSFOptions.defaultProps = defaultProps;
 
-export default EngineerOfRecordOptions;
+export default TSFOptions;

--- a/services/core-web/src/components/mine/ContactInfo/PartyRelationships/Contact.js
+++ b/services/core-web/src/components/mine/ContactInfo/PartyRelationships/Contact.js
@@ -2,7 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import CustomPropTypes from "@/customPropTypes";
 import { DefaultContact } from "@/components/mine/ContactInfo/PartyRelationships/DefaultContact";
-import { EngineerOfRecord } from "@/components/mine/ContactInfo/PartyRelationships/EngineerOfRecord";
+import { TSFContact } from "@/components/mine/ContactInfo/PartyRelationships/TSFContact";
 import { Permittee } from "@/components/mine/ContactInfo/PartyRelationships/Permittee";
 import { UnionRep } from "@/components/mine/ContactInfo/PartyRelationships/UnionRep";
 
@@ -43,8 +43,9 @@ export const Contact = (props) => {
   let component;
 
   switch (props.partyRelationship.mine_party_appt_type_code) {
+    case "TQP":
     case "EOR":
-      component = <EngineerOfRecord {...props} />;
+      component = <TSFContact {...props} />;
       break;
     case "URP":
       component = <UnionRep {...props} />;

--- a/services/core-web/src/components/mine/ContactInfo/PartyRelationships/TSFContact.js
+++ b/services/core-web/src/components/mine/ContactInfo/PartyRelationships/TSFContact.js
@@ -16,7 +16,7 @@ const propTypes = {
   compact: PropTypes.bool.isRequired,
 };
 
-export const EngineerOfRecord = (props) => {
+export const TSFContact = (props) => {
   const tsf = props.mine.mine_tailings_storage_facilities.find(
     ({ mine_tailings_storage_facility_guid }) =>
       mine_tailings_storage_facility_guid === props.partyRelationship.related_guid
@@ -40,6 +40,6 @@ export const EngineerOfRecord = (props) => {
   );
 };
 
-EngineerOfRecord.propTypes = propTypes;
+TSFContact.propTypes = propTypes;
 
-export default EngineerOfRecord;
+export default TSFContact;

--- a/services/core-web/src/tests/components/Forms/__snapshots__/EditPartyRelationshipForm.spec.js.snap
+++ b/services/core-web/src/tests/components/Forms/__snapshots__/EditPartyRelationshipForm.spec.js.snap
@@ -43,7 +43,7 @@ exports[`EditPartyRelationshipForm renders properly 1`] = `
       </FormItem>
     </Col>
   </Row>
-  <EngineerOfRecordOptions
+  <TSFOptions
     mine={Object {}}
   />
   <div

--- a/services/core-web/src/tests/components/mine/ContactInfo/PartyRelationships/TSFContact.spec.js
+++ b/services/core-web/src/tests/components/mine/ContactInfo/PartyRelationships/TSFContact.spec.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { shallow } from "enzyme";
-import EngineerOfRecord from "@/components/mine/ContactInfo/PartyRelationships/EngineerOfRecord";
+import TSFContact from "@/components/mine/ContactInfo/PartyRelationships/TSFContact";
 import * as MOCK from "@/tests/mocks/dataMocks";
 
 const dispatchProps = {};
@@ -30,9 +30,9 @@ beforeEach(() => {
   setupReducerProps();
 });
 
-describe("EngineerOfRecord", () => {
+describe("TSFContact", () => {
   it("renders properly", () => {
-    const component = shallow(<EngineerOfRecord {...dispatchProps} {...reducerProps} />);
+    const component = shallow(<TSFContact {...dispatchProps} {...reducerProps} />);
     expect(component).toMatchSnapshot();
   });
 });

--- a/services/core-web/src/tests/components/mine/ContactInfo/PartyRelationships/__snapshots__/TSFContact.spec.js.snap
+++ b/services/core-web/src/tests/components/mine/ContactInfo/PartyRelationships/__snapshots__/TSFContact.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`EngineerOfRecord renders properly 1`] = `
+exports[`TSFContact renders properly 1`] = `
 <DefaultContact
   compact={false}
   editPermission="role_edit_parties"


### PR DESCRIPTION
## Objective 
- historical data on prod is missing the TSF guid for QP appointments
- the add & edit forms accessible from the mine's contact page did not include a TSF input, this would create errors when submitting either form
- allow users to add this missing information to existing records and include it with new submissions
- functionality already existed for EoR appointments, made some adjustments so that it works the same for QP, renamed a couple of components to reflect this change.
- now the TSF name should show up on the page just like EoR, and be "undefined" when missing, so users can see that the information is missing
- noticed that the "required" validation didn't work for the select input, changed it to notnone, which catches when None is selected

[MDS-5189](https://bcmines.atlassian.net/browse/MDS-5189)
Bonus:
[MDS-4987](https://bcmines.atlassian.net/browse/MDS-4987)