### PR TITLE
[MDS-5036] - ts-loader version update

### DIFF
--- a/services/core-web/package.json
+++ b/services/core-web/package.json
@@ -89,7 +89,7 @@
     "string-similarity": "3.0.0",
     "styled-components": "5.2.0",
     "test-reducer-package": "1.0.14",
-    "ts-loader": "8.2.0",
+    "ts-loader": "8.4.0",
     "tus-js-client": "1.8.0",
     "uuid": "8.3.1"
   },

--- a/services/minespace-web/package.json
+++ b/services/minespace-web/package.json
@@ -122,7 +122,7 @@
     "terser-webpack-plugin": "1.3.0",
     "thread-loader": "2.1.3",
     "ts-jest": "24.3.0",
-    "ts-loader": "8.2.0",
+    "ts-loader": "8.4.0",
     "url-loader": "2.3.0",
     "webpack": "4.41.5",
     "webpack-cli": "3.3.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2068,7 +2068,7 @@ __metadata:
     test-reducer-package: 1.0.14
     thread-loader: 2.1.3
     ts-jest: 24.3.0
-    ts-loader: 8.2.0
+    ts-loader: 8.4.0
     tus-js-client: 1.8.0
     typescript: 4.7.4
     url-loader: 2.3.0
@@ -2216,7 +2216,7 @@ __metadata:
     terser-webpack-plugin: 1.3.0
     thread-loader: 2.1.3
     ts-jest: 24.3.0
-    ts-loader: 8.2.0
+    ts-loader: 8.4.0
     tus-js-client: 1.8.0
     typescript: 4.7.4
     url-loader: 2.3.0
@@ -20660,9 +20660,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ts-loader@npm:8.2.0":
-  version: 8.2.0
-  resolution: "ts-loader@npm:8.2.0"
+"ts-loader@npm:8.4.0":
+  version: 8.4.0
+  resolution: "ts-loader@npm:8.4.0"
   dependencies:
     chalk: ^4.1.0
     enhanced-resolve: ^4.0.0
@@ -20672,7 +20672,7 @@ __metadata:
   peerDependencies:
     typescript: "*"
     webpack: "*"
-  checksum: 976504f95f2e4568fc04a596dad7b57d943b23199011c4cb30eba42e7ba12489f9b310839964f5f16b356e4e3f6d28faf7a46d8c62d3934a07db0b23768ea434
+  checksum: 79da0f364c013231bff28baede3f4f4081b1cca30b24df2d9f31a0517e0524eca2c8e4d438b853b1566a3a8eb9ff51ab0b36743346f0b3d5daa7001c98e5c738
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Objective 

Was seeing some errors using ts-loader version 8.2.0.  Upgraded to 8.2.4 (the most recent that is compatable with webpack v4)

[MDS-5036](https://bcmines.atlassian.net/browse/MDS-5036)
