### PR TITLE
[MDS-5036] upgraded heap size for Core-Web build

### DIFF
--- a/services/core-web/Dockerfile.ci
+++ b/services/core-web/Dockerfile.ci
@@ -16,7 +16,7 @@ RUN yarn workspace @mds/common build
 # Build Core Web Only
 RUN yarn workspace @mds/core-web build
 
-ENV NODE_OPTIONS="--max-old-space-size=4096"
+ENV NODE_OPTIONS="--max-old-space-size=8192"
 
 # Remove dependencies
 RUN rm -rf /app/node_modules

--- a/services/core-web/Dockerfile.ci
+++ b/services/core-web/Dockerfile.ci
@@ -13,10 +13,11 @@ RUN yarn
 # Build Common Package
 RUN yarn workspace @mds/common build
 
+ENV NODE_OPTIONS="--max-old-space-size=4096"
+
 # Build Core Web Only
 RUN yarn workspace @mds/core-web build
 
-ENV NODE_OPTIONS="--max-old-space-size=8192"
 
 # Remove dependencies
 RUN rm -rf /app/node_modules


### PR DESCRIPTION
## Objective 

[MDS-5036](https://bcmines.atlassian.net/browse/MDS-5036)

Core-Web was running out of memory in the build function after the addition of Typescript.  Increased the allocation during build.
