### PR TITLE
[MDS-5224] TSF Update Error

### DIFF
--- a/services/core-web/src/components/Forms/PartyRelationships/AddPartyRelationshipForm.js
+++ b/services/core-web/src/components/Forms/PartyRelationships/AddPartyRelationshipForm.js
@@ -252,9 +252,10 @@ export class AddPartyRelationshipForm extends Component {
                   <Field
                     id="start_date"
                     name="start_date"
-                    label="Start Date"
+                    label="* Start Date"
                     placeholder="yyyy-mm-dd"
                     component={renderConfig.DATE}
+                    validate={[required]}
                   />
                 </Form.Item>
               </Col>

--- a/services/core-web/src/components/mine/ContactInfo/ViewPartyRelationships.js
+++ b/services/core-web/src/components/mine/ContactInfo/ViewPartyRelationships.js
@@ -66,13 +66,12 @@ export class ViewPartyRelationships extends Component {
   constructor(props) {
     super(props);
     this.RoleConfirmation = React.createRef();
+    this.state = {
+      selectedPartyRelationshipType: {},
+      selectedPartyRelationship: {},
+      uploadedFiles: [],
+    };
   }
-
-  state = {
-    selectedPartyRelationshipType: {},
-    selectedPartyRelationship: {},
-    uploadedFiles: [],
-  };
 
   onFileLoad = (documentName, document_manager_guid) => {
     this.setState((prevState) => ({
@@ -87,7 +86,7 @@ export class ViewPartyRelationships extends Component {
   };
 
   onSubmitAddPartyRelationship = (values) => {
-    const payload = {
+    const payload = this.formatValuesEndCurrent({
       mine_guid: this.props.mine.mine_guid,
       mine_party_appt_type_code: this.state.selectedPartyRelationshipType,
       party_guid: values.party_guid,
@@ -96,7 +95,7 @@ export class ViewPartyRelationships extends Component {
       end_date: values.end_date,
       end_current: values.end_current,
       union_rep_company: values.union_rep_company,
-    };
+    });
 
     return this.props
       .addPartyRelationship(payload)
@@ -198,13 +197,25 @@ export class ViewPartyRelationships extends Component {
     });
   };
 
+  formatValuesEndCurrent = (values) => {
+    let end_current = values.end_current ?? true;
+    if (values.end_date) {
+      const endDate = new Date(values.end_date);
+      endDate.setTime(endDate.getTime() + endDate.getTimezoneOffset() * 60000);
+      end_current = endDate >= new Date();
+    }
+    return { ...values, end_current };
+  };
+
   onSubmitEditPartyRelationship = (values) => {
-    const payload = this.state.selectedPartyRelationship;
+    let payload = this.state.selectedPartyRelationship;
 
     payload.start_date = values.start_date;
     payload.end_date = values.end_date;
     payload.union_rep_company = values.union_rep_company;
     payload.related_guid = values.related_guid || payload.related_guid;
+
+    payload = this.formatValuesEndCurrent(payload);
 
     return this.props.updatePartyRelationship(payload).then(() => {
       this.props.fetchPartyRelationships({
@@ -458,6 +469,7 @@ export class ViewPartyRelationships extends Component {
               placement="topRight"
               {...this.confirmationProps(this.state.selectedPartyRelationshipType)}
             >
+              {/* eslint-disable-next-line jsx-a11y/control-has-associated-label */}
               <button
                 type="button"
                 ref={this.RoleConfirmation}

--- a/services/core-web/src/tests/components/Forms/__snapshots__/AddPartyRelationshipForm.spec.js.snap
+++ b/services/core-web/src/tests/components/Forms/__snapshots__/AddPartyRelationshipForm.spec.js.snap
@@ -44,9 +44,14 @@ exports[`AddPartyRelationshipForm renders properly 1`] = `
         <Field
           component={[Function]}
           id="start_date"
-          label="Start Date"
+          label="* Start Date"
           name="start_date"
           placeholder="yyyy-mm-dd"
+          validate={
+            Array [
+              [Function],
+            ]
+          }
         />
       </FormItem>
     </Col>


### PR DESCRIPTION
## Objective 
### Some context
- adding new QP from the contacts page is very different from adding through the TSF page, where the contacts page was missing validation and fields that the TSF page had
- but the contacts page is the only way to view/edit historical data (and it does need editing) and I didn't want to close that by requiring that the appointment is the current one
- previous fix made it so that QP appt could be submitted through the contacts page but without the additional validations, so it was possible to create more than one active QP, which would cause an error the next time the form was submitted through the QP page
- the error it was triggering was not very readable

### Changes made
- fixed the error output by importing the correct BadRequest- which changed it from "HTTPStatusCode object isn't callable" to the intended message of "There is currently not exactly one active appointment"
- made the Start Date required when filling out the Add or Edit relationship form
- set end_current to true when the end date is undefined or in the future (today is considered the past)

[MDS-5224](https://bcmines.atlassian.net/browse/MDS-5224)
