### PR TITLE
[MDS-5145] Incident Location Selection

### DIFF
--- a/migrations/sql/V2023.05.01.09.28__mine_incident_location.sql
+++ b/migrations/sql/V2023.05.01.09.28__mine_incident_location.sql
@@ -1,0 +1,3 @@
+ALTER TABLE
+    mine_incident
+    ADD COLUMN incident_location varchar(30);

--- a/services/core-api/app/api/incidents/models/mine_incident.py
+++ b/services/core-api/app/api/incidents/models/mine_incident.py
@@ -36,6 +36,7 @@ class MineIncident(SoftDeleteMixin, AuditMixin, Base):
 
     incident_timestamp = db.Column(db.DateTime, nullable=False)
     incident_description = db.Column(db.String, nullable=False)
+    incident_location = db.Column(db.String)
 
     reported_timestamp = db.Column(db.DateTime)
     reported_by_name = db.Column(db.String)
@@ -189,6 +190,7 @@ class MineIncident(SoftDeleteMixin, AuditMixin, Base):
                mine,
                incident_timestamp,
                incident_description,
+               incident_location=None,
                determination_type_code=None,
                mine_determination_type_code=None,
                mine_determination_representative=None,
@@ -199,6 +201,7 @@ class MineIncident(SoftDeleteMixin, AuditMixin, Base):
         mine_incident = cls(
             incident_timestamp=incident_timestamp,
             incident_description=incident_description,
+            incident_location=incident_location,
             reported_timestamp=reported_timestamp,
             reported_by_name=reported_by_name,
             determination_type_code=determination_type_code,

--- a/services/core-api/app/api/incidents/response_models.py
+++ b/services/core-api/app/api/incidents/response_models.py
@@ -65,6 +65,7 @@ MINE_INCIDENT_MODEL = api.model(
         'major_mine_ind': fields.Boolean,
         'incident_timestamp': fields.DateTime,
         'incident_description': fields.String,
+        'incident_location': fields.String,
         'reported_timestamp': fields.DateTime,
         'reported_by_name': fields.String,
         'reported_by_email': fields.String,

--- a/services/core-api/app/api/mines/incidents/resources/mine_incidents.py
+++ b/services/core-api/app/api/mines/incidents/resources/mine_incidents.py
@@ -36,6 +36,7 @@ class MineIncidentListResource(Resource, UserMixin):
         location='json',
         required=True)
     parser.add_argument('incident_description', type=str, location='json', required=True)
+    parser.add_argument('incident_location', type=str, location='json', required=True)
     parser.add_argument(
         'reported_timestamp',
         type=lambda x: datetime.strptime(x, '%Y-%m-%d %H:%M') if x else None,
@@ -125,6 +126,7 @@ class MineIncidentListResource(Resource, UserMixin):
             mine,
             data['incident_timestamp'],
             data['incident_description'],
+            data['incident_location'],
             data['determination_type_code'],
             mine_determination_type_code=data['mine_determination_type_code'],
             mine_determination_representative=data['mine_determination_representative'],
@@ -248,6 +250,7 @@ class MineIncidentResource(Resource, UserMixin):
         location='json',
         store_missing=False)
     parser.add_argument('incident_description', type=str, location='json', store_missing=False)
+    parser.add_argument('incident_location', type=str, location='json', store_missing=False)
     parser.add_argument(
         'reported_timestamp',
         type=lambda x: datetime.strptime(x, '%Y-%m-%d %H:%M') if x else None,

--- a/services/core-api/app/api/mines/response_models.py
+++ b/services/core-api/app/api/mines/response_models.py
@@ -447,6 +447,7 @@ MINE_INCIDENT_MODEL = api.model(
         'mine_name': fields.String,
         'incident_timestamp': DateTime,
         'incident_description': fields.String,
+        'incident_location': fields.String,
         'reported_timestamp': DateTime,
         'reported_by_name': fields.String,
         'reported_by_email': fields.String,

--- a/services/core-api/tests/factories.py
+++ b/services/core-api/tests/factories.py
@@ -382,6 +382,7 @@ class MineIncidentFactory(BaseFactory):
     mine_guid = factory.SelfAttribute('mine.mine_guid')
     incident_timestamp = factory.Faker('past_datetime')
     incident_description = factory.Faker('sentence', nb_words=20, variable_nb_words=True)
+    incident_location = factory.fuzzy.FuzzyChoice(['surface', 'underground', None])
     reported_timestamp = factory.Faker('past_datetime')
     reported_by_name = factory.Faker('name')
     reported_by_phone_no = factory.Faker('numerify', text='###-###-####')

--- a/services/core-api/tests/factories.py
+++ b/services/core-api/tests/factories.py
@@ -43,7 +43,7 @@ from app.api.mines.reports.models.mine_report import MineReport
 from app.api.mines.reports.models.mine_report_submission import MineReportSubmission
 from app.api.mines.reports.models.mine_report_comment import MineReportComment
 from app.api.mines.comments.models.mine_comment import MineComment
-from app.api.constants import PERMIT_LINKED_CONTACT_TYPES
+from app.api.constants import PERMIT_LINKED_CONTACT_TYPES, TSF_ALLOWED_CONTACT_TYPES
 from app.api.mines.explosives_permit.models.explosives_permit import ExplosivesPermit, ExplosivesPermitMagazine
 from app.api.projects.project.models.project import Project
 from app.api.projects.project_contact.models.project_contact import ProjectContact
@@ -628,7 +628,7 @@ class MinePartyAppointmentFactory(BaseFactory):
                                       PERMIT_LINKED_CONTACT_TYPES else None)
     mine_tailings_storage_facility_guid = factory.LazyAttribute(
         lambda o: o.mine.mine_tailings_storage_facilities[0].mine_tailings_storage_facility_guid
-        if o.mine_party_appt_type_code == 'EOR' else None)
+        if o.mine_party_appt_type_code in TSF_ALLOWED_CONTACT_TYPES else None)
 
 
 class PartyOrgBookEntityFactory(BaseFactory):

--- a/services/core-api/tests/mines/incidents/test_mine_incident_list_resource.py
+++ b/services/core-api/tests/mines/incidents/test_mine_incident_list_resource.py
@@ -44,6 +44,7 @@ class TestPostMineIncident:
             'incident_timestamp': '2019-01-01 00:00',
             'reported_timestamp': '2019-01-01 00:00',
             'incident_description': incident.incident_description,
+            'incident_location': 'surface'
         }
         post_resp = test_client.post(
             f'/mines/{mine.mine_guid}/incidents',
@@ -53,4 +54,5 @@ class TestPostMineIncident:
         assert post_resp.status_code == 201, post_resp.response
         assert post_data['incident_timestamp'] == test_incident_data['incident_timestamp']
         assert post_data['incident_description'] == test_incident_data['incident_description']
+        assert post_data['incident_location'] == test_incident_data['incident_location']
         assert post_data['reported_timestamp'] == str(test_incident_data['reported_timestamp'])

--- a/services/core-api/tests/mines/incidents/test_mine_incident_resource.py
+++ b/services/core-api/tests/mines/incidents/test_mine_incident_resource.py
@@ -43,6 +43,7 @@ class TestPutMineIncident:
             'incident_timestamp': '2019-01-01 00:00',
             'reported_timestamp': '2019-01-01 00:00',
             'incident_description': incident.incident_description,
+            'incident_location': incident.incident_location,
             'reported_by_name': incident.reported_by_name,
             'reported_by_email': incident.reported_by_email,
             'reported_by_phone_no': incident.reported_by_phone_no,
@@ -78,6 +79,7 @@ class TestPutMineIncident:
         assert put_data['incident_timestamp'] == data['incident_timestamp']
         assert put_data['reported_timestamp'] == data['reported_timestamp']
         assert put_data['incident_description'] == data['incident_description']
+        assert put_data['incident_location'] == data['incident_location']
         assert put_data['reported_by_name'] == data['reported_by_name']
         assert put_data['reported_by_email'] == data['reported_by_email']
         assert put_data['reported_by_phone_no'] == data['reported_by_phone_no']

--- a/services/core-api/tests/mines/mine/resources/test_mine_incident_resource.py
+++ b/services/core-api/tests/mines/mine/resources/test_mine_incident_resource.py
@@ -40,6 +40,7 @@ def test_post_mine_incidents_happy(test_client, db_session, auth_headers):
         'incident_timestamp': now_time_string,
         'reported_timestamp': now_time_string,
         'incident_description': "Someone got a paper cut",
+        'incident_location': 'surface'
     }
 
     post_resp = test_client.post(
@@ -49,6 +50,7 @@ def test_post_mine_incidents_happy(test_client, db_session, auth_headers):
     post_data = json.loads(post_resp.data.decode())
     assert post_data['mine_guid'] == str(test_mine_guid)
     assert post_data['determination_type_code'] == data['determination_type_code']
+    assert post_data['incident_location'] == data['incident_location']
     assert post_data['incident_timestamp'] == now_time_string
 
     # datetime.fromisoformat is in python 3.7
@@ -66,6 +68,7 @@ def test_post_mine_incidents_including_optional_fields(test_client, db_session, 
         'incident_timestamp': now_time_string,
         'reported_timestamp': now_time_string,
         'incident_description': 'Someone got a paper cut',
+        'incident_location': 'surface',
         'mine_determination_type_code': 'NDO',
         'mine_determination_representative': 'Billy'
     }
@@ -79,6 +82,7 @@ def test_post_mine_incidents_including_optional_fields(test_client, db_session, 
     assert post_data['determination_type_code'] == data['determination_type_code']
     assert post_data['incident_timestamp'] == now_time_string
     assert post_data['incident_description'] == data['incident_description']
+    assert post_data['incident_location'] == data['incident_location']
     assert post_data['mine_determination_type_code'] == data['mine_determination_type_code']
     assert post_data['mine_determination_representative'] == data[
         'mine_determination_representative']
@@ -99,6 +103,7 @@ def test_post_mine_incidents_dangerous_occurrence_happy(test_client, db_session,
         'incident_timestamp': now_time_string,
         'reported_timestamp': now_time_string,
         'incident_description': "Someone got a really bad paper cut",
+        'incident_location': 'underground',
         'dangerous_occurrence_subparagraph_ids': do_ids
     }
 
@@ -111,6 +116,7 @@ def test_post_mine_incidents_dangerous_occurrence_happy(test_client, db_session,
     assert post_data['determination_type_code'] == data['determination_type_code']
     assert post_data['incident_timestamp'] == now_time_string
     assert post_data['incident_description'] == data['incident_description']
+    assert post_data['incident_location'] == data['incident_location']
     assert set(post_data['dangerous_occurrence_subparagraph_ids']) == set(
         data['dangerous_occurrence_subparagraph_ids'])
 
@@ -123,6 +129,7 @@ def test_post_mine_incidents_dangerous_occurrence_no_subs(test_client, db_sessio
         'determination_type_code': 'DO',
         'incident_timestamp': now_time_string,
         'incident_description': "Someone got a really bad paper cut",
+        'incident_location': 'underground',
         'dangerous_occurrence_subparagraph_ids': []
     }
 
@@ -225,6 +232,7 @@ def test_put_mine_incidents_dangerous_occurrence_no_subs(test_client, db_session
         'determination_type_code': 'DO',
         'incident_timestamp': new_time_string,
         'incident_description': "Someone got a really bad paper cut",
+        'incident_location': 'underground',
         'dangerous_occurrence_subparagraph_ids': []
     }
 

--- a/services/core-web/common/utils/Validate.js
+++ b/services/core-web/common/utils/Validate.js
@@ -86,6 +86,9 @@ export const required = (value) => (value || value === 0 ? undefined : "This is 
 export const requiredRadioButton = (value) =>
   value !== null && value !== undefined ? undefined : "This is a required field";
 
+export const requiredNotUndefined = (value) =>
+  value !== undefined ? undefined : "This is a required field";
+
 export const requiredList = (value) =>
   value && value.length > 0 ? undefined : "This is a required field";
 

--- a/services/core-web/src/components/Forms/incidents/IncidentCategoryCheckboxGroup.js
+++ b/services/core-web/src/components/Forms/incidents/IncidentCategoryCheckboxGroup.js
@@ -111,7 +111,7 @@ const IncidentCategoryCheckboxGroup = (props) => {
                   padding: "6px",
                 }}
               >
-                <Checkbox value={category.value}>
+                <Checkbox value={category.value} style={{ fontSize: "1rem" }}>
                   <b>{category.label}</b>
                 </Checkbox>
               </Row>

--- a/services/minespace-web/common/utils/Validate.js
+++ b/services/minespace-web/common/utils/Validate.js
@@ -86,6 +86,9 @@ export const required = (value) => (value || value === 0 ? undefined : "This is 
 export const requiredRadioButton = (value) =>
   value !== null && value !== undefined ? undefined : "This is a required field";
 
+export const requiredNotUndefined = (value) =>
+  value !== undefined ? undefined : "This is a required field";
+
 export const requiredList = (value) =>
   value && value.length > 0 ? undefined : "This is a required field";
 

--- a/services/minespace-web/src/components/Forms/incidents/IncidentForm.js
+++ b/services/minespace-web/src/components/Forms/incidents/IncidentForm.js
@@ -17,6 +17,7 @@ import {
   dateNotBeforeStrictOther,
   wholeNumber,
   requiredRadioButton,
+  requiredNotUndefined,
 } from "@common/utils/Validate";
 import { normalizePhone } from "@common/utils/helpers";
 import * as Strings from "@common/constants/strings";
@@ -95,12 +96,8 @@ const retrieveIncidentDetailsDynamicValidation = (childProps) => {
 };
 
 const confirmationSubmission = (childProps) => {
-  const {
-    applicationSubmitted,
-    location,
-    confirmedSubmission,
-    setConfirmedSubmission,
-  } = childProps;
+  const { applicationSubmitted, location, confirmedSubmission, setConfirmedSubmission } =
+    childProps;
   return (
     !applicationSubmitted &&
     location?.state?.current === 2 && (
@@ -199,14 +196,14 @@ const renderIncidentStatusCallout = (childProps) => {
 
   return (
     <Callout
-      message={
+      message={(
         <div>
           <h4 id="initial-report" style={{ color: "#313132", fontWeight: 700 }}>
             {title}
           </h4>
           <p>{message}</p>
         </div>
-      }
+      )}
       severity={severity}
     />
   );
@@ -283,6 +280,13 @@ const renderIncidentDetails = (childProps, formDisabled) => {
     managementRepContacted,
   } = retrieveIncidentDetailsDynamicValidation({ formValues });
 
+  const showUnspecified = formDisabled && !formValues.incident_location;
+  const locationOptions = [
+    { label: "Surface", value: "surface" },
+    { label: "Underground", value: "underground" },
+    ...(showUnspecified ? [{ label: "Not Specified", value: "" }] : []),
+  ];
+
   return (
     <Row gutter={[16]}>
       <Col span={24}>
@@ -296,6 +300,16 @@ const renderIncidentDetails = (childProps, formDisabled) => {
         </Typography.Paragraph>
       </Col>
       <Col span={24}>
+        <Form.Item label="Incident Location">
+          <Field
+            id="incident_location"
+            name="incident_location"
+            disabled={formDisabled}
+            component={renderConfig.RADIO}
+            validate={[requiredRadioButton]}
+            customOptions={locationOptions}
+          />
+        </Form.Item>
         <Form.Item label="Incident date and time">
           <Field
             id="incident_timestamp"
@@ -409,7 +423,7 @@ const renderIncidentDetails = (childProps, formDisabled) => {
             name="verbal_notification_provided"
             component={renderConfig.RADIO}
             disabled={formDisabled}
-            validate={[requiredRadioButton]}
+            validate={[requiredNotUndefined]}
           />
         </Form.Item>
       </Col>
@@ -626,8 +640,7 @@ const renderUploadInitialNotificationDocuments = (
                     document_manager_guid,
                     Strings.INCIDENT_DOCUMENT_TYPES.initial,
                     INITIAL_INCIDENT_DOCUMENTS_FORM_FIELD
-                  )
-                }
+                  )}
                 onRemoveFile={parentHandlers?.deleteDocument}
                 mineGuid={match.params?.mineGuid}
                 component={IncidentFileUpload}
@@ -653,8 +666,7 @@ const renderUploadInitialNotificationDocuments = (
                     parentHandlers.openUploadIncidentDocumentsModal(
                       e,
                       Strings.INCIDENT_DOCUMENT_TYPES.initial
-                    )
-                  }
+                    )}
                   className="full-mobile violet violet-border"
                 >
                   + Add Documentation
@@ -701,8 +713,7 @@ const renderUploadInitialNotificationDocuments = (
                       document_manager_guid,
                       Strings.INCIDENT_DOCUMENT_TYPES.final,
                       FINAL_REPORT_DOCUMENTS_FORM_FIELD
-                    )
-                  }
+                    )}
                   onRemoveFile={parentHandlers?.deleteDocument}
                   mineGuid={match.params?.mineGuid}
                   component={IncidentFileUpload}
@@ -727,8 +738,7 @@ const renderUploadInitialNotificationDocuments = (
                     parentHandlers.openUploadIncidentDocumentsModal(
                       e,
                       Strings.INCIDENT_DOCUMENT_TYPES.final
-                    )
-                  }
+                    )}
                   className="full-mobile violet violet-border"
                 >
                   + Add Final Report

--- a/services/minespace-web/src/tests/components/Forms/incidents/__snapshots__/IncidentForm.spec.js.snap
+++ b/services/minespace-web/src/tests/components/Forms/incidents/__snapshots__/IncidentForm.spec.js.snap
@@ -171,6 +171,38 @@ exports[`IncidentForm renders properly 1`] = `
         >
           <FormItem
             hasFeedback={false}
+            label="Incident Location"
+          >
+            <Field
+              component={[Function]}
+              customOptions={
+                Array [
+                  Object {
+                    "label": "Surface",
+                    "value": "surface",
+                  },
+                  Object {
+                    "label": "Underground",
+                    "value": "underground",
+                  },
+                  Object {
+                    "label": "Not Specified",
+                    "value": "",
+                  },
+                ]
+              }
+              disabled={true}
+              id="incident_location"
+              name="incident_location"
+              validate={
+                Array [
+                  [Function],
+                ]
+              }
+            />
+          </FormItem>
+          <FormItem
+            hasFeedback={false}
             label="Incident date and time"
           >
             <Field


### PR DESCRIPTION
## Objective 
- add in the "location" radio group to incident form
- BONUS: fixed text size of "Other" category option
- BONUS: fixed test_mine_party_appt_document_upload_resource- was failing intermittently because the mine party appt code was being generated randomly from 20 options, and when it was TQP, there was no TSF guid being generated (so failing probably ~5% of the time)

[MDS-5145](https://bcmines.atlassian.net/browse/MDS-5145)

_Why are you making this change? Provide a short explanation and/or screenshots_
