### PR TITLE
[MDS-5250] added action creator types/example

### DIFF
--- a/services/common/package.json
+++ b/services/common/package.json
@@ -7,8 +7,8 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "webpack --env production && tsc --declaration --emitDeclarationOnly",
-    "watch": "webpack --watch --watch-poll --hot --env development & tsc --watch --declaration --emitDeclarationOnly"
+    "build": "webpack --env production",
+    "watch": "webpack --watch --watch-poll --hot --env development"
   },
   "dependencies": {
     "@babel/runtime": "7.15.3",

--- a/services/common/tsconfig.json
+++ b/services/common/tsconfig.json
@@ -12,6 +12,7 @@
     "jsx": "react",
     "declaration": true,
     "declarationMap": true,
+    "declarationDir": "dist",
     "moduleResolution": "node",
     "sourceMap": true,
     "allowJs": true /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */,

--- a/services/common/webpack.config.ts
+++ b/services/common/webpack.config.ts
@@ -24,7 +24,17 @@ module.exports = (mode) => {
         {
           test: /\.(ts|tsx)$/,
           exclude: /node_modules/,
-          use: ["babel-loader", "ts-loader"],
+          use: [
+            {
+              loader: "babel-loader",
+            },
+            {
+              loader: "ts-loader",
+              options: {
+                transpileOnly: false,
+              },
+            },
+          ],
         },
         {
           test: /\.(js|jsx)$/,

--- a/services/core-web/common/actionCreators/noticeOfDepartureActionCreator.ts
+++ b/services/core-web/common/actionCreators/noticeOfDepartureActionCreator.ts
@@ -1,42 +1,176 @@
-import { INoticeOfDeparture } from "@mds/common";
-import * as actionTypes from "../constants/actionTypes";
-import { NOTICES_OF_DEPARTURE } from "../constants/reducerTypes";
-import { RootState } from "@/App";
+import { notification } from "antd";
+import { hideLoading, showLoading } from "react-redux-loading-bar";
+import {
+  ENVIRONMENT,
+  IDocumentPayload,
+  INoticeOfDeparture,
+  ICreateNoticeOfDeparture,
+} from "@mds/common";
+import { error, request, success } from "../actions/genericActions";
+import {
+  ADD_DOCUMENT_TO_NOTICE_OF_DEPARTURE,
+  CREATE_NOTICE_OF_DEPARTURE,
+  GET_DETAILED_NOTICE_OF_DEPARTURE,
+  GET_NOTICES_OF_DEPARTURE,
+  UPDATE_NOTICE_OF_DEPARTURE,
+} from "../constants/reducerTypes";
+import CustomAxios from "../customAxios";
+import {
+  NOTICE_OF_DEPARTURE,
+  NOTICES_OF_DEPARTURE,
+  NOTICES_OF_DEPARTURE_DOCUMENT,
+  NOTICES_OF_DEPARTURE_DOCUMENTS,
+} from "../constants/API";
+import { createRequestHeader } from "../utils/RequestHeaders";
+import {
+  storeNoticeOfDeparture,
+  storeNoticesOfDeparture,
+} from "../actions/noticeOfDepartureActions";
+import { AxiosResponse } from "axios";
+import { AppThunk } from "@/store/appThunk.type";
 
-interface NoDState {
-  nods: INoticeOfDeparture[];
-  noticeOfDeparture: INoticeOfDeparture | Record<string, never>;
-}
+export const createNoticeOfDeparture =
+  (
+    payload: Partial<ICreateNoticeOfDeparture>
+  ): AppThunk<Promise<AxiosResponse<INoticeOfDeparture>>> =>
+  (dispatch): Promise<AxiosResponse<INoticeOfDeparture>> => {
+    dispatch(request(CREATE_NOTICE_OF_DEPARTURE));
+    dispatch(showLoading("modal"));
 
-const initialState: NoDState = {
-  nods: [],
-  noticeOfDeparture: {},
+    return CustomAxios()
+      .post(`${ENVIRONMENT.apiUrl}${NOTICES_OF_DEPARTURE()}`, payload, createRequestHeader())
+      .then((response: AxiosResponse<INoticeOfDeparture>) => {
+        notification.success({
+          message: "Successfully created Notice of Departure.",
+          duration: 10,
+        });
+        dispatch(success(CREATE_NOTICE_OF_DEPARTURE));
+        return response;
+      })
+      .catch((err) => {
+        dispatch(error(CREATE_NOTICE_OF_DEPARTURE));
+        throw new Error(err);
+      })
+      .finally(() => dispatch(hideLoading("modal")));
+  };
+
+export const fetchNoticesOfDeparture =
+  (mine_guid): AppThunk =>
+  (dispatch) => {
+    dispatch(request(GET_NOTICES_OF_DEPARTURE));
+    dispatch(showLoading());
+    const headers = {
+      ...createRequestHeader(),
+      params: {
+        mine_guid,
+      },
+    };
+    return CustomAxios()
+      .get(`${ENVIRONMENT.apiUrl}${NOTICES_OF_DEPARTURE()}`, headers)
+      .then((response) => {
+        dispatch(success(GET_NOTICES_OF_DEPARTURE));
+        dispatch(storeNoticesOfDeparture(response.data));
+        return response;
+      })
+      .catch(() => dispatch(error(GET_NOTICES_OF_DEPARTURE)))
+      .finally(() => dispatch(hideLoading()));
+  };
+
+export const updateNoticeOfDeparture =
+  ({ nodGuid }, payload): AppThunk<Promise<AxiosResponse<INoticeOfDeparture>>> =>
+  (dispatch): Promise<AxiosResponse<INoticeOfDeparture>> => {
+    dispatch(request(UPDATE_NOTICE_OF_DEPARTURE));
+    dispatch(showLoading("modal"));
+    return CustomAxios()
+      .patch(`${ENVIRONMENT.apiUrl}${NOTICE_OF_DEPARTURE(nodGuid)}`, payload, createRequestHeader())
+      .then((response) => {
+        notification.success({
+          message: "Successfully updated Notice of Departure.",
+          duration: 10,
+        });
+        dispatch(success(UPDATE_NOTICE_OF_DEPARTURE));
+        return response;
+      })
+      .catch((err) => {
+        dispatch(error(UPDATE_NOTICE_OF_DEPARTURE));
+        throw new Error(err);
+      })
+      .finally(() => dispatch(hideLoading("modal")));
+  };
+
+export const fetchDetailedNoticeOfDeparture = (
+  nod_guid
+): AppThunk<Promise<AxiosResponse<INoticeOfDeparture>>> => {
+  return async (dispatch): Promise<AxiosResponse<INoticeOfDeparture>> => {
+    dispatch(request(GET_DETAILED_NOTICE_OF_DEPARTURE));
+    dispatch(showLoading());
+    try {
+      try {
+        const response: AxiosResponse<INoticeOfDeparture> = await CustomAxios().get(
+          `${ENVIRONMENT.apiUrl}${NOTICE_OF_DEPARTURE(nod_guid)}`,
+          createRequestHeader()
+        );
+        dispatch(success(GET_DETAILED_NOTICE_OF_DEPARTURE));
+        dispatch(storeNoticeOfDeparture(response.data));
+        return response;
+      } catch {
+        dispatch(error(GET_DETAILED_NOTICE_OF_DEPARTURE));
+      }
+    } finally {
+      dispatch(hideLoading());
+    }
+  };
 };
 
-export const noticeOfDepartureReducer = (state: NoDState = initialState, action) => {
-  switch (action.type) {
-    case actionTypes.STORE_NOTICES_OF_DEPARTURE:
-      return {
-        ...state,
-        nods: action.payload.records,
-      };
-    case actionTypes.STORE_NOTICE_OF_DEPARTURE:
-      return {
-        ...state,
-        noticeOfDeparture: action.payload,
-      };
-    default:
-      return state;
+export const addDocumentToNoticeOfDeparture =
+  (
+    { noticeOfDepartureGuid }: { noticeOfDepartureGuid: string },
+    payload: IDocumentPayload
+  ): AppThunk =>
+  (dispatch) => {
+    dispatch(showLoading("modal"));
+    dispatch(request(ADD_DOCUMENT_TO_NOTICE_OF_DEPARTURE));
+    return CustomAxios()
+      .put(
+        `${ENVIRONMENT.apiUrl}${NOTICES_OF_DEPARTURE_DOCUMENTS(noticeOfDepartureGuid)}`,
+        payload,
+        createRequestHeader()
+      )
+      .then((response) => {
+        dispatch(success(ADD_DOCUMENT_TO_NOTICE_OF_DEPARTURE));
+        return response;
+      })
+      .catch((err) => {
+        dispatch(error(ADD_DOCUMENT_TO_NOTICE_OF_DEPARTURE));
+        throw new Error(err);
+      })
+      .finally(() => dispatch(hideLoading("modal")));
+  };
+
+export const removeFileFromDocumentManager = ({
+  nod_guid,
+  document_manager_guid,
+}: {
+  nod_guid: string;
+  document_manager_guid: string;
+}) => {
+  if (!document_manager_guid) {
+    throw new Error("Must provide document_manager_guid");
   }
+
+  return CustomAxios()
+    .delete(
+      `${ENVIRONMENT.apiUrl + NOTICES_OF_DEPARTURE_DOCUMENT(nod_guid, document_manager_guid)}`,
+      createRequestHeader()
+    )
+    .then((response) => {
+      notification.success({
+        message: "Successfully deleted document.",
+        duration: 10,
+      });
+      return response;
+    })
+    .catch((err) => {
+      throw new Error(err);
+    });
 };
-
-const noticeOfDepartureReducerObject = {
-  [NOTICES_OF_DEPARTURE]: noticeOfDepartureReducer,
-};
-
-export const getNoticesOfDeparture = (state: RootState): INoticeOfDeparture[] =>
-  state[NOTICES_OF_DEPARTURE].nods;
-export const getNoticeOfDeparture = (state: RootState): INoticeOfDeparture =>
-  state[NOTICES_OF_DEPARTURE].noticeOfDeparture;
-
-export default noticeOfDepartureReducerObject;

--- a/services/core-web/common/actionCreators/noticeOfDepartureActionCreator.ts
+++ b/services/core-web/common/actionCreators/noticeOfDepartureActionCreator.ts
@@ -1,150 +1,42 @@
-import { notification } from "antd";
-import { hideLoading, showLoading } from "react-redux-loading-bar";
-import { ENVIRONMENT } from "@mds/common";
-import { error, request, success } from "../actions/genericActions";
-import {
-  CREATE_NOTICE_OF_DEPARTURE,
-  ADD_DOCUMENT_TO_NOTICE_OF_DEPARTURE,
-  GET_NOTICES_OF_DEPARTURE,
-  GET_DETAILED_NOTICE_OF_DEPARTURE,
-  UPDATE_NOTICE_OF_DEPARTURE,
-} from "../constants/reducerTypes";
-import CustomAxios from "../customAxios";
-import {
-  NOTICES_OF_DEPARTURE,
-  NOTICES_OF_DEPARTURE_DOCUMENTS,
-  NOTICE_OF_DEPARTURE,
-  NOTICES_OF_DEPARTURE_DOCUMENT,
-} from "../constants/API";
-import { createRequestHeader } from "../utils/RequestHeaders";
-import {
-  storeNoticesOfDeparture,
-  storeNoticeOfDeparture,
-} from "../actions/noticeOfDepartureActions";
+import { INoticeOfDeparture } from "@mds/common";
+import * as actionTypes from "../constants/actionTypes";
+import { NOTICES_OF_DEPARTURE } from "../constants/reducerTypes";
+import { RootState } from "@/App";
 
-export const createNoticeOfDeparture =
-  (payload): any =>
-  (dispatch) => {
-    dispatch(request(CREATE_NOTICE_OF_DEPARTURE));
-    dispatch(showLoading("modal"));
+interface NoDState {
+  nods: INoticeOfDeparture[];
+  noticeOfDeparture: INoticeOfDeparture | Record<string, never>;
+}
 
-    return CustomAxios()
-      .post(`${ENVIRONMENT.apiUrl}${NOTICES_OF_DEPARTURE()}`, payload, createRequestHeader())
-      .then((response) => {
-        notification.success({
-          message: "Successfully created Notice of Departure.",
-          duration: 10,
-        });
-        dispatch(success(CREATE_NOTICE_OF_DEPARTURE));
-        return response;
-      })
-      .catch((err) => {
-        dispatch(error(CREATE_NOTICE_OF_DEPARTURE));
-        throw new Error(err);
-      })
-      .finally(() => dispatch(hideLoading("modal")));
-  };
-
-export const fetchNoticesOfDeparture =
-  (mine_guid): any =>
-  (dispatch) => {
-    dispatch(request(GET_NOTICES_OF_DEPARTURE));
-    dispatch(showLoading());
-    const headers = {
-      ...createRequestHeader(),
-      params: {
-        mine_guid,
-      },
-    };
-    return CustomAxios()
-      .get(`${ENVIRONMENT.apiUrl}${NOTICES_OF_DEPARTURE()}`, headers)
-      .then((response) => {
-        dispatch(success(GET_NOTICES_OF_DEPARTURE));
-        dispatch(storeNoticesOfDeparture(response.data));
-        return response;
-      })
-      .catch(() => dispatch(error(GET_NOTICES_OF_DEPARTURE)))
-      .finally(() => dispatch(hideLoading()));
-  };
-
-export const updateNoticeOfDeparture =
-  ({ nodGuid }, payload): any =>
-  (dispatch) => {
-    dispatch(request(UPDATE_NOTICE_OF_DEPARTURE));
-    dispatch(showLoading("modal"));
-    return CustomAxios()
-      .patch(`${ENVIRONMENT.apiUrl}${NOTICE_OF_DEPARTURE(nodGuid)}`, payload, createRequestHeader())
-      .then((response) => {
-        notification.success({
-          message: "Successfully updated Notice of Departure.",
-          duration: 10,
-        });
-        dispatch(success(UPDATE_NOTICE_OF_DEPARTURE));
-        return response;
-      })
-      .catch((err) => {
-        dispatch(error(UPDATE_NOTICE_OF_DEPARTURE));
-        throw new Error(err);
-      })
-      .finally(() => dispatch(hideLoading("modal")));
-  };
-
-export const fetchDetailedNoticeOfDeparture =
-  (nod_guid): any =>
-  (dispatch) => {
-    dispatch(request(GET_DETAILED_NOTICE_OF_DEPARTURE));
-    dispatch(showLoading());
-    return CustomAxios()
-      .get(`${ENVIRONMENT.apiUrl}${NOTICE_OF_DEPARTURE(nod_guid)}`, createRequestHeader())
-      .then((response) => {
-        dispatch(success(GET_DETAILED_NOTICE_OF_DEPARTURE));
-        dispatch(storeNoticeOfDeparture(response.data));
-        return response;
-      })
-      .catch(() => dispatch(error(GET_DETAILED_NOTICE_OF_DEPARTURE)))
-      .finally(() => dispatch(hideLoading()));
-  };
-
-export const addDocumentToNoticeOfDeparture =
-  ({ noticeOfDepartureGuid }, payload): any =>
-  (dispatch) => {
-    dispatch(showLoading("modal"));
-    dispatch(request(ADD_DOCUMENT_TO_NOTICE_OF_DEPARTURE));
-    return CustomAxios()
-      .put(
-        `${ENVIRONMENT.apiUrl}${NOTICES_OF_DEPARTURE_DOCUMENTS(noticeOfDepartureGuid)}`,
-        payload,
-        createRequestHeader()
-      )
-      .then((response) => {
-        dispatch(success(ADD_DOCUMENT_TO_NOTICE_OF_DEPARTURE));
-        return response;
-      })
-      .catch((err) => {
-        dispatch(error(ADD_DOCUMENT_TO_NOTICE_OF_DEPARTURE));
-        throw new Error(err);
-      })
-      .finally(() => dispatch(hideLoading("modal")));
-  };
-
-export const removeFileFromDocumentManager = ({ nod_guid, document_manager_guid }) => {
-  if (!document_manager_guid) {
-    throw new Error("Must provide document_manager_guid");
-  }
-
-  return CustomAxios()
-    .delete(
-      `${ENVIRONMENT.apiUrl + NOTICES_OF_DEPARTURE_DOCUMENT(nod_guid, document_manager_guid)}`,
-      createRequestHeader()
-    )
-    .then((response) => {
-      notification.success({
-        message: "Successfully deleted document.",
-        duration: 10,
-      });
-      return response;
-    })
-    .catch((err) => {
-      throw new Error(err);
-    });
+const initialState: NoDState = {
+  nods: [],
+  noticeOfDeparture: {},
 };
+
+export const noticeOfDepartureReducer = (state: NoDState = initialState, action) => {
+  switch (action.type) {
+    case actionTypes.STORE_NOTICES_OF_DEPARTURE:
+      return {
+        ...state,
+        nods: action.payload.records,
+      };
+    case actionTypes.STORE_NOTICE_OF_DEPARTURE:
+      return {
+        ...state,
+        noticeOfDeparture: action.payload,
+      };
+    default:
+      return state;
+  }
+};
+
+const noticeOfDepartureReducerObject = {
+  [NOTICES_OF_DEPARTURE]: noticeOfDepartureReducer,
+};
+
+export const getNoticesOfDeparture = (state: RootState): INoticeOfDeparture[] =>
+  state[NOTICES_OF_DEPARTURE].nods;
+export const getNoticeOfDeparture = (state: RootState): INoticeOfDeparture =>
+  state[NOTICES_OF_DEPARTURE].noticeOfDeparture;
+
+export default noticeOfDepartureReducerObject;

--- a/services/core-web/common/reducers/noticeOfDepartureReducer.ts
+++ b/services/core-web/common/reducers/noticeOfDepartureReducer.ts
@@ -1,10 +1,11 @@
 import { INoticeOfDeparture } from "@mds/common";
 import * as actionTypes from "../constants/actionTypes";
 import { NOTICES_OF_DEPARTURE } from "../constants/reducerTypes";
+import { RootState } from "@/App";
 
 interface NoDState {
   nods: INoticeOfDeparture[];
-  noticeOfDeparture: INoticeOfDeparture | NonNullable<unknown>;
+  noticeOfDeparture: INoticeOfDeparture | Record<string, never>;
 }
 
 const initialState: NoDState = {
@@ -33,9 +34,9 @@ const noticeOfDepartureReducerObject = {
   [NOTICES_OF_DEPARTURE]: noticeOfDepartureReducer,
 };
 
-export const getNoticesOfDeparture = (state): INoticeOfDeparture[] =>
+export const getNoticesOfDeparture = (state: RootState): INoticeOfDeparture[] =>
   state[NOTICES_OF_DEPARTURE].nods;
-export const getNoticeOfDeparture = (state): INoticeOfDeparture =>
+export const getNoticeOfDeparture = (state: RootState): INoticeOfDeparture =>
   state[NOTICES_OF_DEPARTURE].noticeOfDeparture;
 
 export default noticeOfDepartureReducerObject;

--- a/services/core-web/src/App.tsx
+++ b/services/core-web/src/App.tsx
@@ -9,6 +9,9 @@ import configureStore from "./store/configureStore";
 
 export const store = configureStore();
 
+export type RootState = ReturnType<typeof store.getState>;
+export type AppDispatch = typeof store.dispatch;
+
 const App = () => (
   <BrowserRouter basename={process.env.BASE_PATH}>
     <ScrollToTopWrapper>

--- a/services/core-web/src/store/appThunk.type.ts
+++ b/services/core-web/src/store/appThunk.type.ts
@@ -1,0 +1,16 @@
+import { ThunkAction } from "redux-thunk";
+import { RootState } from "@/App";
+import { AnyAction } from "redux";
+
+/**
+ * A custom type alias for a Redux Thunk action.
+ *
+ * @template ReturnType The expected base return type.  This is only needed if you are using the return value of the thunk.
+ * @template ExtraArgument The type of the extra argument passed to the thunk. Defaults to `unknown`.
+ */
+export type AppThunk<ReturnType = void, ExtraArgument = unknown> = ThunkAction<
+  ReturnType, // The return type of the thunk.
+  RootState, // The type of the root state of the Redux store.
+  ExtraArgument, // The type of the extra argument passed to the thunk.
+  AnyAction // The type of the Redux action being dispatched.
+>;

--- a/services/minespace-web/common/reducers/noticeOfDepartureReducer.ts
+++ b/services/minespace-web/common/reducers/noticeOfDepartureReducer.ts
@@ -1,10 +1,11 @@
 import { INoticeOfDeparture } from "@mds/common";
 import * as actionTypes from "../constants/actionTypes";
 import { NOTICES_OF_DEPARTURE } from "../constants/reducerTypes";
+import { RootState } from "@/App";
 
 interface NoDState {
   nods: INoticeOfDeparture[];
-  noticeOfDeparture: INoticeOfDeparture | NonNullable<unknown>;
+  noticeOfDeparture: INoticeOfDeparture | Record<string, never>;
 }
 
 const initialState: NoDState = {
@@ -33,9 +34,9 @@ const noticeOfDepartureReducerObject = {
   [NOTICES_OF_DEPARTURE]: noticeOfDepartureReducer,
 };
 
-export const getNoticesOfDeparture = (state): INoticeOfDeparture[] =>
+export const getNoticesOfDeparture = (state: RootState): INoticeOfDeparture[] =>
   state[NOTICES_OF_DEPARTURE].nods;
-export const getNoticeOfDeparture = (state): INoticeOfDeparture =>
+export const getNoticeOfDeparture = (state: RootState): INoticeOfDeparture =>
   state[NOTICES_OF_DEPARTURE].noticeOfDeparture;
 
 export default noticeOfDepartureReducerObject;

--- a/services/minespace-web/src/store/appThunk.type.ts
+++ b/services/minespace-web/src/store/appThunk.type.ts
@@ -1,0 +1,16 @@
+import { ThunkAction } from "redux-thunk";
+import { RootState } from "@/App";
+import { AnyAction } from "redux";
+
+/**
+ * A custom type alias for a Redux Thunk action.
+ *
+ * @template ReturnType The expected base return type.  This is only needed if you are using the return value of the thunk.
+ * @template ExtraArgument The type of the extra argument passed to the thunk. Defaults to `unknown`.
+ */
+export type AppThunk<ReturnType = void, ExtraArgument = unknown> = ThunkAction<
+  ReturnType, // The return type of the thunk.
+  RootState, // The type of the root state of the Redux store.
+  ExtraArgument, // The type of the extra argument passed to the thunk.
+  AnyAction // The type of the Redux action being dispatched.
+>;


### PR DESCRIPTION
## Objective 

Converting the forms for the NoD section to tsx was taking a little longer than expected, so I broke out the reusable pieces here so everyone can have them.

Added a utility type `AppThunk` to be used in action creators.
Included updated NoD action creator as usage example.
Fixed common package `watch` so that newly added components will be updated

[MDS-5250](https://bcmines.atlassian.net/browse/MDS-5250)
