### PR TITLE
[MDS-5200] Fixed notifications not being displayed in core

### DIFF
--- a/services/core-api/app/api/activity/models/activity_notification.py
+++ b/services/core-api/app/api/activity/models/activity_notification.py
@@ -7,6 +7,7 @@ from cerberus import Validator
 from app.api.utils.models_mixins import AuditMixin, Base
 from sqlalchemy.dialects.postgresql import UUID, JSONB
 from sqlalchemy.schema import FetchedValue
+from sqlalchemy import func
 from app.extensions import db
 from sqlalchemy.sql import table, column
 from app.api.utils.include.user_info import User
@@ -194,7 +195,7 @@ class ActivityNotification(AuditMixin, Base):
 
     @classmethod
     def find_all_by_recipient(cls, user, page, per_page):
-        query = cls.query.filter_by(notification_recipient=user).order_by(cls.create_timestamp.desc())
+        query = cls.query.filter(func.lower(ActivityNotification.notification_recipient)==user.lower()).order_by(cls.create_timestamp.desc())
 
         if (page):
             result = query.paginate(page, per_page, error_out=False)

--- a/services/core-api/tests/activity/test_activity_list_resource.py
+++ b/services/core-api/tests/activity/test_activity_list_resource.py
@@ -25,3 +25,31 @@ class TestActivityListResource:
         assert get_data['records'][0]['notification_recipient'] == username
         document = get_data['records'][0]['notification_document']
         assert document['metadata']['mine']['mine_guid'] == str(mine.mine_guid)
+
+    def test_get_activities_by_user_ignores_case(self, test_client, db_session, auth_headers):
+        """Should return the correct number of records ignoring the case of the requsted username"""
+        username_lower = 'test@bceid'
+        username_upper = 'TEST@BCEID'
+        batch_size = 2
+        mine = MineFactory(minimal=True)
+        ActivityFactory.create_batch(size=batch_size, mine=mine)
+        ActivityFactory.create_batch(size=batch_size, mine=mine, user=username_lower)
+        ActivityFactory.create_batch(size=batch_size, mine=mine, user=username_upper)
+
+        get_resp_lower = test_client.get(
+            f'/activities?user={username_lower}',
+            headers=auth_headers['full_auth_header'])
+
+        get_resp_upper = test_client.get(
+            f'/activities?user={username_upper}',
+            headers=auth_headers['full_auth_header'])
+
+        get_data_lower = json.loads(get_resp_lower.data.decode())
+        get_data_upper = json.loads(get_resp_upper.data.decode())
+
+        assert len(get_data_lower['records']) == 4
+        assert get_data_lower['total'] == 4
+
+        get_data_upper = json.loads(get_resp_upper.data.decode())
+        assert len(get_data_upper['records']) == 4
+        assert get_data_upper['total'] == 4

--- a/services/core-api/tests/activity/test_activity_list_resource.py
+++ b/services/core-api/tests/activity/test_activity_list_resource.py
@@ -50,6 +50,5 @@ class TestActivityListResource:
         assert len(get_data_lower['records']) == 4
         assert get_data_lower['total'] == 4
 
-        get_data_upper = json.loads(get_resp_upper.data.decode())
         assert len(get_data_upper['records']) == 4
         assert get_data_upper['total'] == 4


### PR DESCRIPTION
## Objective 

[MDS-5200](https://bcmines.atlassian.net/browse/MDS-5200)

Fixes an issue where notifications fail to load in core. The issue has been identified as IDIR usernames changing case from lower case to upper case during the SSO migration, and the activities endpoint being case-sensitive. 

_Why are you making this change? Provide a short explanation and/or screenshots_
