### PR TITLE
[MDS-5264] Increased github actions timeout

### DIFF
--- a/.github/workflows/core-api.build.deploy.dev.yaml
+++ b/.github/workflows/core-api.build.deploy.dev.yaml
@@ -55,7 +55,7 @@ jobs:
 
   trigger-gitops:
     runs-on: ubuntu-20.04
-    timeout-minutes: 10
+    timeout-minutes: 15
     needs: [build-backend, build-flyway]
     steps:
       - name: Checkout

--- a/.github/workflows/core-api.deploy.test.yaml
+++ b/.github/workflows/core-api.deploy.test.yaml
@@ -35,7 +35,7 @@ jobs:
 
   trigger-gitops:
     runs-on: ubuntu-20.04
-    timeout-minutes: 10
+    timeout-minutes: 15
     needs: promote-image-to-test
     steps:
       - name: Checkout

--- a/.github/workflows/core-web.build.deploy.dev.yaml
+++ b/.github/workflows/core-web.build.deploy.dev.yaml
@@ -39,7 +39,7 @@ jobs:
 
   trigger-gitops:
     runs-on: ubuntu-20.04
-    timeout-minutes: 10
+    timeout-minutes: 15
     needs: build-frontend
     steps:
       - name: Checkout

--- a/.github/workflows/core-web.deploy.test.yaml
+++ b/.github/workflows/core-web.deploy.test.yaml
@@ -29,7 +29,7 @@ jobs:
 
   trigger-gitops:
     runs-on: ubuntu-20.04
-    timeout-minutes: 10
+    timeout-minutes: 15
     needs: promote-image-to-test
     steps:
       - name: Checkout

--- a/.github/workflows/minespace.build.deploy.dev.yaml
+++ b/.github/workflows/minespace.build.deploy.dev.yaml
@@ -39,7 +39,7 @@ jobs:
 
   trigger-gitops:
     runs-on: ubuntu-20.04
-    timeout-minutes: 10
+    timeout-minutes: 15
     needs: [build-minespace]
     steps:
       - name: Checkout

--- a/.github/workflows/minespace.deploy.test.yaml
+++ b/.github/workflows/minespace.deploy.test.yaml
@@ -30,7 +30,7 @@ jobs:
 
   trigger-gitops:
     runs-on: ubuntu-20.04
-    timeout-minutes: 10
+    timeout-minutes: 15
     needs: promote-image
     steps:
       - name: Checkout


### PR DESCRIPTION
## Objective 

[MDS-5264](https://bcmines.atlassian.net/browse/MDS-5264)

Increased the timeout for our Github actions as they seem to time out even if the actual deployment succeeds. Doing a quick test to see if this helps reduce the amount of "failed" builds before digging any deeper.
_Why are you making this change? Provide a short explanation and/or screenshots_
