### PR TITLE
[MDS-5264] Increased max node heap size on webpack workers

### DIFF
--- a/services/core-web/Dockerfile.ci
+++ b/services/core-web/Dockerfile.ci
@@ -7,13 +7,14 @@ WORKDIR /app
 # Copy all files to the working directory
 COPY . .
 
+ENV NODE_OPTIONS="--max-old-space-size=4096"
+
 # Install Dependencies
 RUN yarn
 
 # Build Common Package
 RUN yarn workspace @mds/common build
 
-ENV NODE_OPTIONS="--max-old-space-size=4096"
 
 # Build Core Web Only
 RUN yarn workspace @mds/core-web build

--- a/services/core-web/webpack.parts.js
+++ b/services/core-web/webpack.parts.js
@@ -51,7 +51,7 @@ exports.loadJS = ({ include, exclude } = {}) => ({
             options: {
               workers: 1,
               workerParallelJobs: 50,
-              workerNodeArgs: ["--max-old-space-size=1024"],
+              workerNodeArgs: ["--max-old-space-size=3072"],
             },
           },
           "babel-loader?cacheDirectory",
@@ -74,7 +74,7 @@ exports.loadTS = ({ include, exclude } = {}) => ({
             options: {
               workers: 1,
               workerParallelJobs: 50,
-              workerNodeArgs: ["--max-old-space-size=1024"],
+              workerNodeArgs: ["--max-old-space-size=3072"],
             },
           },
           "babel-loader?cacheDirectory",

--- a/services/minespace-web/Dockerfile.ci
+++ b/services/minespace-web/Dockerfile.ci
@@ -7,6 +7,8 @@ WORKDIR /app
 # Install app dependencies
 COPY . .
 
+ENV NODE_OPTIONS="--max-old-space-size=4096"
+
 # Install Dependencies
 RUN yarn
 
@@ -16,7 +18,6 @@ RUN yarn workspace @mds/common build
 # Build Core Web Only
 RUN yarn workspace @mds/minespace-web build
 
-ENV NODE_OPTIONS="--max-old-space-size=4096"
 
 # Remove dependencies
 RUN rm -rf /app/node_modules

--- a/services/minespace-web/webpack.parts.js
+++ b/services/minespace-web/webpack.parts.js
@@ -50,7 +50,7 @@ exports.loadJS = ({ include, exclude } = {}) => ({
             options: {
               workers: 1,
               workerParallelJobs: 50,
-              workerNodeArgs: ["--max-old-space-size=1024"],
+              workerNodeArgs: ["--max-old-space-size=4096"],
             },
           },
           "babel-loader?cacheDirectory",
@@ -73,7 +73,7 @@ exports.loadTS = ({ include, exclude } = {}) => ({
             options: {
               workers: 1,
               workerParallelJobs: 50,
-              workerNodeArgs: ["--max-old-space-size=1024"],
+              workerNodeArgs: ["--max-old-space-size=4096"],
             },
           },
           "babel-loader?cacheDirectory",

--- a/services/minespace-web/webpack.parts.js
+++ b/services/minespace-web/webpack.parts.js
@@ -50,7 +50,7 @@ exports.loadJS = ({ include, exclude } = {}) => ({
             options: {
               workers: 1,
               workerParallelJobs: 50,
-              workerNodeArgs: ["--max-old-space-size=4096"],
+              workerNodeArgs: ["--max-old-space-size=3072"],
             },
           },
           "babel-loader?cacheDirectory",
@@ -73,7 +73,7 @@ exports.loadTS = ({ include, exclude } = {}) => ({
             options: {
               workers: 1,
               workerParallelJobs: 50,
-              workerNodeArgs: ["--max-old-space-size=4096"],
+              workerNodeArgs: ["--max-old-space-size=3072"],
             },
           },
           "babel-loader?cacheDirectory",


### PR DESCRIPTION
## Objective 

[MDS-5264](https://bcmines.atlassian.net/browse/MDS-5264)

Increased max heap size of webpack workers to (hopefully) fix the out of memory errors that happen when building MineSpace

_Why are you making this change? Provide a short explanation and/or screenshots_
