### PR TITLE
[MDS-5264] Skip waiting for rollout when promoting MineSpace with no changes

### DIFF
--- a/.github/workflows/minespace.deploy.test.yaml
+++ b/.github/workflows/minespace.deploy.test.yaml
@@ -42,8 +42,10 @@ jobs:
         with:
           oc: "4.7"
       - name: oc login
+        if: ${{ env.NEEDS_ROLLOUT=='true' }}
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
+        if: ${{ env.NEEDS_ROLLOUT=='true' }}
         run: ./gitops/watch-deployment.sh minespace test ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }}
 
   run-if-failed:

--- a/gitops/commit.sh
+++ b/gitops/commit.sh
@@ -15,12 +15,24 @@ TIMESTAMP=$(date +"%y-%m-%d-%H-%M-%S")
 git config --global user.name $ACTOR_NAME
 git config --global user.email "dev@mds.gov.bc.ca"
 
+function set_rollout_needed_env() {
+    if [[ -n "$GITHUB_ENV" ]]; then
+        echo "NEEDS_ROLLOUT=$1" >> "$GITHUB_ENV"
+    fi
+}
+
 function commit() {
     git add -A
 
     if ! git diff-index --quiet HEAD; then
         git commit -m "$@"
         git push origin main
+
+        echo "$@"
+        set_rollout_needed_env true
+    else
+        echo "$TARGET_APP $TARGET_ENV is already at latest version"
+        set_rollout_needed_env false
     fi
 }
 


### PR DESCRIPTION
## Objective 

[MDS-5264](https://bcmines.atlassian.net/browse/MDS-5264)
A good chunk of the "failed" Github action runs happened when trying to promote a service when no changes have been made to the service. This will cause `watch-deployment.sh ` to run until it times out after 15min as it will wait for a revision change that never happens.

Applied a fix for this to MS, will roll it out to the other services after doing some live tests
