### PR TITLE
[MDS-5296] Include permit information in NRIS ETL job

### DIFF
--- a/services/nris-api/backend/app/nris/etl/nris_etl.py
+++ b/services/nris-api/backend/app/nris/etl/nris_etl.py
@@ -86,6 +86,9 @@ def import_nris_xml():
 
 def etl_nris_data():
     nris_data = db.session.query(NRISRawData).all()
+
+    print('Parsing {} assessments'.format(len(nris_data)))
+
     for item in nris_data:
         _parse_nris_element(item.nris_data)
 
@@ -134,12 +137,21 @@ def _parse_nris_element(input):
         closing = data.find('report_closing')
         notes = data.find('officer_notes')
 
+        authorization = data.find('authorization')
+
         inspection.mine_no = _parse_element_text(mine_number)
         inspection.inspector_idir = _parse_element_text(inspector)
         inspection.inspection_introduction = _parse_element_text(intro)
         inspection.inspection_preamble = _parse_element_text(preamble)
         inspection.inspection_closing = _parse_element_text(closing)
         inspection.officer_notes = _parse_element_text(notes)
+
+        # Parse Authorization (Permit)
+        if authorization is not None:
+            inspection.inspection_auth_source_id = _parse_element_text(authorization.find('source_id'))
+            inspection.inspection_auth_source_application = _parse_element_text(authorization.find('source_application'))
+            inspection.inspection_auth_status = _parse_element_text(authorization.find('auth_status'))
+            inspection.inspection_auth_type = _parse_element_text(authorization.find('auth_type'))
 
         db.session.add(inspection)
 


### PR DESCRIPTION
## Objective 

[MDS-5296](https://bcmines.atlassian.net/browse/MDS-5296)

Added parsing of permit information to NRIS ETL job. 
This will (hopefully) eliminate the need for the BI team to run their transformation scripts, and the PowerBI Gateway entirely. 