### PR TITLE
[MDS-5296] Paginate query used for nris etl

### DIFF
--- a/services/nris-api/backend/app/nris/etl/nris_etl.py
+++ b/services/nris-api/backend/app/nris/etl/nris_etl.py
@@ -85,12 +85,29 @@ def import_nris_xml():
 
 
 def etl_nris_data():
-    nris_data = db.session.query(NRISRawData).all()
+    nris_data = db.session.query(NRISRawData) \
+        .paginate(per_page=100)
 
-    print('Parsing {} assessments'.format(len(nris_data)))
+    has_next_page = True
+    i = 0
 
-    for item in nris_data:
-        _parse_nris_element(item.nris_data)
+    print('Parsing {} assessments'.format(nris_data.total))
+
+    # Parse nris elements iteratively using pagination
+    # Print "progress" as we go
+    while has_next_page:
+        has_next_page = bool(nris_data.next_num)
+
+        for item in nris_data.items:
+            i = i+1
+
+            if(i % 100 == 0):
+                print(i, '/', nris_data.total)
+
+            _parse_nris_element(item.nris_data)
+        nris_data = nris_data.next()
+
+
 
 
 def _parse_element_text(_element):


### PR DESCRIPTION
## Objective 

[MDS-5296](https://bcmines.atlassian.net/browse/MDS-5296)

Updated NRIS etl script to load data paginated + added added a progress indicator to the job.

*Why?*
The nris etl script is very slow (30min+), and my suspicion is that it uses a long time to load all the data it needs into memory.
Also, there's no logging in place for, so during that time it's impossible to know if the job is actually running or stuck by looking at the logs