### PR TITLE
[MDS-5310] 500 error on updating existing incidents

### DIFF
--- a/services/core-api/app/api/incidents/models/mine_incident.py
+++ b/services/core-api/app/api/incidents/models/mine_incident.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from pytz import timezone
+from pytz import timezone, all_timezones
 import uuid
 
 from sqlalchemy.dialects.postgresql import UUID
@@ -243,7 +243,7 @@ class MineIncident(SoftDeleteMixin, AuditMixin, Base):
         if key =='incident_timezone':
             incident_timestamp = self.incident_timestamp
             incident_timezone = value
-            if not incident_timezone or incident_timezone not in pytz.all_timezones:
+            if not incident_timezone or incident_timezone not in all_timezones:
                 raise AssertionError('invalid incident_timezone')
             if incident_timestamp:
                 if incident_timestamp > datetime.now(timezone(incident_timezone)):

--- a/services/core-api/app/api/incidents/models/mine_incident.py
+++ b/services/core-api/app/api/incidents/models/mine_incident.py
@@ -243,6 +243,8 @@ class MineIncident(SoftDeleteMixin, AuditMixin, Base):
         if key =='incident_timezone':
             incident_timestamp = self.incident_timestamp
             incident_timezone = value
+            if not incident_timezone or incident_timezone not in pytz.all_timezones:
+                raise AssertionError('invalid incident_timezone')
             if incident_timestamp:
                 if incident_timestamp > datetime.now(timezone(incident_timezone)):
                     raise AssertionError('incident_timestamp must not be in the future')

--- a/services/core-web/common/utils/Validate.js
+++ b/services/core-web/common/utils/Validate.js
@@ -185,6 +185,11 @@ export const dateNotInFutureTZ = (value) => {
   return value && !moment(value).isBefore() ? "Date cannot be in the future" : undefined;
 };
 
+export const dateTimezoneRequired = memoize((timezoneField) => (_value, allValues) => {
+  const formTimezone = allValues[timezoneField];
+  return formTimezone && formTimezone.length > 0 ? undefined : "Please select a timezone";
+});
+
 export const dateInFuture = (value) =>
   value && new Date(value) < new Date() ? "Date must be in the future" : undefined;
 

--- a/services/core-web/src/components/Forms/incidents/IncidentForm.js
+++ b/services/core-web/src/components/Forms/incidents/IncidentForm.js
@@ -21,6 +21,7 @@ import {
   requiredNotUndefined,
   dateNotBeforeStrictOther,
   dateNotInFutureTZ,
+  dateTimezoneRequired,
 } from "@common/utils/Validate";
 import { normalizePhone, normalizeDatetime, formatDate } from "@common/utils/helpers";
 import * as Strings from "@common/constants/strings";
@@ -254,7 +255,11 @@ const renderInitialReport = (incidentCategoryCodeOptions, locationOptions, isEdi
                 name="incident_timestamp"
                 disabled={!isEditMode}
                 normalize={normalizeDatetime}
-                validate={[dateNotInFutureTZ, required]}
+                validate={[
+                  dateNotInFutureTZ,
+                  required,
+                  // dateTimezoneRequired("incident_timezone")
+                ]}
                 props={{ timezoneFieldProps: { name: "incident_timezone" } }}
                 component={RenderDateTimeTz}
               />
@@ -966,12 +971,7 @@ export const IncidentForm = (props) => {
       <Row>
         <Col span={24}>{renderEditSaveControls(props, isEditMode, isNewIncident)}</Col>
         <Col span={16} offset={4}>
-          {renderInitialReport(
-            incidentCategoryCodeOptions,
-            locationOptions,
-            isEditMode,
-            props.form
-          )}
+          {renderInitialReport(incidentCategoryCodeOptions, locationOptions, isEditMode)}
           <br />
           {renderDocumentation(props, isEditMode, localHandlers, parentHandlers)}
           <br />

--- a/services/core-web/src/components/Forms/incidents/IncidentForm.js
+++ b/services/core-web/src/components/Forms/incidents/IncidentForm.js
@@ -255,11 +255,7 @@ const renderInitialReport = (incidentCategoryCodeOptions, locationOptions, isEdi
                 name="incident_timestamp"
                 disabled={!isEditMode}
                 normalize={normalizeDatetime}
-                validate={[
-                  dateNotInFutureTZ,
-                  required,
-                  // dateTimezoneRequired("incident_timezone")
-                ]}
+                validate={[dateNotInFutureTZ, required, dateTimezoneRequired("incident_timezone")]}
                 props={{ timezoneFieldProps: { name: "incident_timezone" } }}
                 component={RenderDateTimeTz}
               />

--- a/services/core-web/src/styles/settings/themeOverride.scss
+++ b/services/core-web/src/styles/settings/themeOverride.scss
@@ -853,7 +853,7 @@ select {
 }
 
 .ant-table-row-expand-icon-cell>span {
-  z-index: 100;
+  z-index: 49;
   position: absolute;
   top: 50%;
   transform: translateY(-50%);

--- a/services/minespace-web/common/utils/Validate.js
+++ b/services/minespace-web/common/utils/Validate.js
@@ -185,6 +185,11 @@ export const dateNotInFutureTZ = (value) => {
   return value && !moment(value).isBefore() ? "Date cannot be in the future" : undefined;
 };
 
+export const dateTimezoneRequired = memoize((timezoneField) => (_value, allValues) => {
+  const formTimezone = allValues[timezoneField];
+  return formTimezone && formTimezone.length > 0 ? undefined : "Please select a timezone";
+});
+
 export const dateInFuture = (value) =>
   value && new Date(value) < new Date() ? "Date must be in the future" : undefined;
 

--- a/services/minespace-web/src/components/Forms/incidents/IncidentForm.js
+++ b/services/minespace-web/src/components/Forms/incidents/IncidentForm.js
@@ -15,6 +15,7 @@ import {
   number,
   dateNotInFuture,
   dateNotInFutureTZ,
+  dateTimezoneRequired,
   dateNotBeforeStrictOther,
   wholeNumber,
   requiredRadioButton,
@@ -327,7 +328,7 @@ const renderIncidentDetails = (childProps) => {
             id="incident_timestamp"
             name="incident_timestamp"
             disabled={formDisabled}
-            validate={[dateNotInFutureTZ, required]}
+            validate={[dateNotInFutureTZ, required, dateTimezoneRequired("incident_timezone")]}
             normalize={normalizeDatetime}
             component={RenderDateTimeTz}
             props={{ timezoneFieldProps: { name: "incident_timezone" } }}

--- a/services/minespace-web/src/tests/components/Forms/incidents/__snapshots__/IncidentForm.spec.js.snap
+++ b/services/minespace-web/src/tests/components/Forms/incidents/__snapshots__/IncidentForm.spec.js.snap
@@ -236,6 +236,7 @@ exports[`IncidentForm renders properly 1`] = `
                 Array [
                   [Function],
                   [Function],
+                  [Function],
                 ]
               }
             />


### PR DESCRIPTION
## Objective 
- error when updating "legacy" incidents because no validation on the incident_timezone specifically (so would run into error when validating timestamp, error was not helpful)
- added both FE & BE validation
- fixed z-index on expand row icons to not be in front of header
[MDS-5310](https://bcmines.atlassian.net/browse/MDS-5310)
