### PR TITLE
[MDS-5181] Added support for gold docman client to Core API

### DIFF
--- a/services/core-api/.env-example
+++ b/services/core-api/.env-example
@@ -59,6 +59,9 @@ JWT_OIDC_AUDIENCE_BCGW=mds-bcgw-4792
 JWT_OIDC_WELL_KNOWN_CONFIG_V1=https://test.oidc.gov.bc.ca/auth/realms/mds/.well-known/openid-configuration
 JWT_OIDC_AUDIENCE_V1=mines-application-test
 
+JWT_OIDC_WELL_KNOWN_CONFIG_DOCMAN_CELERY=https://test.loginproxy.gov.bc.ca/auth/realms/standard/.well-known/openid-configuration
+JWT_OIDC_AUDIENCE_DOCMAN_CELERY=mds-docman-celery-internal-4865
+
 LDAP_IDIR_USERNAME=fnlastn
 LDAP_IDIR_PASSWORD=idirpw
 

--- a/services/core-api/app/api/now_applications/resources/now_application_document_resource.py
+++ b/services/core-api/app/api/now_applications/resources/now_application_document_resource.py
@@ -158,6 +158,7 @@ class NOWApplicationDocumentIdentityResource(Resource, UserMixin):
     parser.add_argument('description', type=str, location='json')
 
     @api.response(201, 'Successfully linked document.')
+    @requires_role_edit_permit
     def post(self, application_guid):
         data = self.parser.parse_args()
         document_manager_document_guid = data.get('document_manager_document_guid')

--- a/services/core-api/app/extensions.py
+++ b/services/core-api/app/extensions.py
@@ -26,6 +26,7 @@ def get_jwt_by_audience(aud):
         'JWT_OIDC_AUDIENCE_NRIS': jwt_nris,
         'JWT_OIDC_AUDIENCE_VFCBC': jwt_vfcbc,
         'JWT_OIDC_AUDIENCE_BCGW': jwt_bcgw,
+        'JWT_OIDC_AUDIENCE_DOCMAN_CELERY': jwt_docman_celery,
     }
 
     for audience_env, jwt_value in audience_jwt_map.items():
@@ -49,6 +50,9 @@ jwt_gentax = JwtManager(None, os.environ.get('JWT_OIDC_WELL_KNOWN_CONFIG_GENTAX'
 jwt_nris = JwtManager(None, os.environ.get('JWT_OIDC_WELL_KNOWN_CONFIG_NRIS'), None, 'RS256', None, None, os.environ.get('JWT_OIDC_AUDIENCE_NRIS'), None, None, False, False, None, JWT_ROLE_CALLBACK, None)
 jwt_vfcbc = JwtManager(None, os.environ.get('JWT_OIDC_WELL_KNOWN_CONFIG_VFCBC'), None, 'RS256', None, None, os.environ.get('JWT_OIDC_AUDIENCE_VFCBC'), None, None, False, False, None, JWT_ROLE_CALLBACK, None)
 jwt_bcgw = JwtManager(None, os.environ.get('JWT_OIDC_WELL_KNOWN_CONFIG_BCGW'), None, 'RS256', None, None, os.environ.get('JWT_OIDC_AUDIENCE_BCGW'), None, None, False, False, None, JWT_ROLE_CALLBACK, None)
+
+# Gold SSO - Register Config Per Integration Client for Internal Services:
+jwt_docman_celery = JwtManager(None, os.environ.get('JWT_OIDC_WELL_KNOWN_CONFIG_DOCMAN_CELERY'), None, 'RS256', None, None, os.environ.get('JWT_OIDC_AUDIENCE_DOCMAN_CELERY'), None, None, False, False, None, JWT_ROLE_CALLBACK, None)
 
 
 # Test JWT Config for integration tests

--- a/services/core-api/tests/auth/test_expected_auth.py
+++ b/services/core-api/tests/auth/test_expected_auth.py
@@ -52,7 +52,7 @@ from app.api.projects.information_requirements_table.resources.information_requi
 from app.api.projects.information_requirements_table.resources.requirements import RequirementsResource
 from app.api.projects.major_mine_application.resources.major_mine_application import MajorMineApplicationResource
 from app.api.projects.project_decision_package.resources.project_decision_package import ProjectDecisionPackageResource, ProjectDecisionPackageListResource
-
+from app.api.now_applications.resources.now_application_document_resource import NOWApplicationDocumentIdentityResource
 
 @pytest.mark.parametrize(
     "resource,method,expected_roles",
@@ -88,6 +88,7 @@ from app.api.projects.project_decision_package.resources.project_decision_packag
      (MineVarianceListResource, "post", [EDIT_VARIANCE, MINESPACE_PROPONENT]),
      (MineVarianceResource, "get", [VIEW_ALL, MINESPACE_PROPONENT]),
      (MineVarianceResource, "put", [EDIT_VARIANCE, MINESPACE_PROPONENT]),
+     (NOWApplicationDocumentIdentityResource, "post", [EDIT_PERMIT]),
      (PartyListResource, "get", [VIEW_ALL, MINESPACE_PROPONENT]),
      (PartyListResource, "post", [EDIT_PARTY, MINESPACE_PROPONENT]), (PartyResource, "get", [VIEW_ALL]),
      (PartyResource, "put", [EDIT_PARTY, MINESPACE_PROPONENT]), (PartyResource, "delete", [MINE_ADMIN]),


### PR DESCRIPTION
## Objective 

[MDS-5181](https://bcmines.atlassian.net/browse/MDS-5181)
Added support for authenticating with the gold docman client for calls to the Core API.
Also noticed that the `document-identity` endpoint was missing a role check, so added that.
