### PR TITLE
[MDS-5318] Fixed sidebar scroll functionality after antd upgrade

### DIFF
--- a/services/core-web/src/components/common/ScrollSideMenu.js
+++ b/services/core-web/src/components/common/ScrollSideMenu.js
@@ -43,8 +43,8 @@ export class ScrollSideMenu extends Component {
     // For example: #blasting&state=bd74ea1c-09e5-4d7e-810f-d3558969293a&session_state=1c577088-15a8-4ae2-...
     let link =
       this.props.location &&
-      this.props.location.hash &&
-      !this.props.location.hash.startsWith("#state")
+        this.props.location.hash &&
+        !this.props.location.hash.startsWith("#state")
         ? this.props.location.hash
         : undefined;
 
@@ -53,9 +53,13 @@ export class ScrollSideMenu extends Component {
     }
 
     // Extracts "#blasting" from "#blasting&state=bd74ea1c-09e5-4d7e-810f-d...", for example.
-    link = link.substr(0, link.indexOf("&"));
+    if (link.includes('&')) {
+      link = link.substr(0, link.indexOf("&"));
+    }
+
     this.updateUrlRoute(link);
-    this.anchor.handleScrollTo(link);
+
+    document.querySelector(link)?.scrollIntoView()
   }
 
   handleAnchorOnClick = (e, link) => {
@@ -93,9 +97,6 @@ export class ScrollSideMenu extends Component {
           offsetTop={160}
           onChange={this.handleAnchorOnChange}
           onClick={this.handleAnchorOnClick}
-          ref={(anchor) => {
-            this.anchor = anchor;
-          }}
         >
           {this.props.menuOptions.map(({ href, title }) => (
             <Anchor.Link key={title} href={`#${href}`} title={title} className="now-menu-link" />

--- a/services/core-web/src/components/noticeOfWork/applications/NOWSideMenu.js
+++ b/services/core-web/src/components/noticeOfWork/applications/NOWSideMenu.js
@@ -48,8 +48,8 @@ export class NOWSideMenu extends Component {
     // For example: #blasting&state=bd74ea1c-09e5-4d7e-810f-d3558969293a&session_state=1c577088-15a8-4ae2-...
     let link =
       this.props.location &&
-      this.props.location.hash &&
-      !this.props.location.hash.startsWith("#state")
+        this.props.location.hash &&
+        !this.props.location.hash.startsWith("#state")
         ? this.props.location.hash
         : undefined;
 
@@ -58,9 +58,11 @@ export class NOWSideMenu extends Component {
     }
 
     // Extracts "#blasting" from "#blasting&state=bd74ea1c-09e5-4d7e-810f-d...", for example.
-    link = link.substr(0, link.indexOf("&"));
+    if (link.includes('&')) {
+      link = link.substr(0, link.indexOf("&"));
+    }
     this.updateUrlRoute(link);
-    this.anchor.handleScrollTo(link);
+    document.querySelector(link)?.scrollIntoView()
   }
 
   handleAnchorOnClick = (e, link) => {
@@ -125,9 +127,6 @@ export class NOWSideMenu extends Component {
           offsetTop={160}
           onChange={this.handleAnchorOnChange}
           onClick={this.handleAnchorOnClick}
-          ref={(anchor) => {
-            this.anchor = anchor;
-          }}
         >
           {sideMenuOptions(this.props.tabSection, hasPermitConditionsFlow)
             .filter(

--- a/services/minespace-web/src/components/common/ScrollSideMenu.js
+++ b/services/minespace-web/src/components/common/ScrollSideMenu.js
@@ -43,8 +43,8 @@ export class ScrollSideMenu extends Component {
     // For example: #blasting&state=bd74ea1c-09e5-4d7e-810f-d3558969293a&session_state=1c577088-15a8-4ae2-...
     let link =
       this.props.location &&
-      this.props.location.hash &&
-      !this.props.location.hash.startsWith("#state")
+        this.props.location.hash &&
+        !this.props.location.hash.startsWith("#state")
         ? this.props.location.hash
         : undefined;
 
@@ -53,9 +53,13 @@ export class ScrollSideMenu extends Component {
     }
 
     // Extracts "#blasting" from "#blasting&state=bd74ea1c-09e5-4d7e-810f-d...", for example.
-    link = link.substr(0, link.indexOf("&"));
+    if (link.includes('&')) {
+      link = link.substr(0, link.indexOf("&"));
+    }
+
     this.updateUrlRoute(link);
-    this.anchor.handleScrollTo(link);
+
+    document.querySelector(link)?.scrollIntoView()
   }
 
   handleAnchorOnClick = (e, link) => {
@@ -93,17 +97,9 @@ export class ScrollSideMenu extends Component {
           offsetTop={160}
           onChange={this.handleAnchorOnChange}
           onClick={this.handleAnchorOnClick}
-          ref={(anchor) => {
-            this.anchor = anchor;
-          }}
         >
           {this.props.menuOptions.map(({ href, title }) => (
-            <Anchor.Link
-              key={title}
-              href={`#${href}`}
-              title={title}
-              className="ms-menu-link side-menu-item"
-            />
+            <Anchor.Link key={title} href={`#${href}`} title={title} className="now-menu-link" />
           ))}
         </Anchor>
       </div>


### PR DESCRIPTION
## Objective 

[MDS-5318](https://bcmines.atlassian.net/browse/MDS-5318)

Fixed an issue where core web / Minespace crashes with a js error when using the scroll to hash functionality on pages that use the ScrollSideMenu/NowSideMenu components.

**Why?**
The `ref` property of the antd `Anchor` component was removed in antd `4.24.0` causing the `anchor` we try to scroll to to be undefined. 

**How?**
Switch to using plain old js query selector for scrolling as it currently  provides no suitable replacement for such functionality
