### PR TITLE
[MDS-5315] Removed checking of timezone on legacy incidents

### DIFF
--- a/services/core-api/app/api/incidents/models/mine_incident.py
+++ b/services/core-api/app/api/incidents/models/mine_incident.py
@@ -38,6 +38,7 @@ class MineIncident(SoftDeleteMixin, AuditMixin, Base):
     incident_timezone = db.Column(db.String)
     incident_description = db.Column(db.String, nullable=False)
     incident_location = db.Column(db.String)
+    tz_legacy = db.Column(db.Boolean)
 
     reported_timestamp = db.Column(db.DateTime)
     reported_by_name = db.Column(db.String)
@@ -238,13 +239,15 @@ class MineIncident(SoftDeleteMixin, AuditMixin, Base):
                 raise AssertionError('followup_inspection_number must not exceed 100 characters.')
         return followup_inspection_number
 
-    @validates('incident_timestamp', 'incident_timezone')
+    @validates('incident_timestamp', 'incident_timezone', 'tz_legacy')
     def validate_incident_timestamp(self, key, value):
         if key =='incident_timezone':
             incident_timestamp = self.incident_timestamp
             incident_timezone = value
-            if not incident_timezone or incident_timezone not in all_timezones:
-                raise AssertionError('invalid incident_timezone')
+            tz_legacy = self.tz_legacy
+            if not tz_legacy:
+                if not incident_timezone or incident_timezone not in all_timezones:
+                    raise AssertionError('invalid incident_timezone')
             if incident_timestamp:
                 if incident_timestamp > datetime.now(timezone(incident_timezone)):
                     raise AssertionError('incident_timestamp must not be in the future')


### PR DESCRIPTION
## Objective 

updating a legacy incident was checking the validity of the timezone.  Added a check to only validate the timezone if the incident is not a legacy one.

[MDS-5315](https://bcmines.atlassian.net/browse/MDS-5315)
