### PR TITLE
[MDS-5315] fixed check on incident timezones

### DIFF
--- a/services/core-api/app/api/incidents/models/mine_incident.py
+++ b/services/core-api/app/api/incidents/models/mine_incident.py
@@ -248,8 +248,10 @@ class MineIncident(SoftDeleteMixin, AuditMixin, Base):
             if not tz_legacy:
                 if not incident_timezone or incident_timezone not in all_timezones:
                     raise AssertionError('invalid incident_timezone')
-            if incident_timestamp:
                 if incident_timestamp > datetime.now(timezone(incident_timezone)):
+                    raise AssertionError('incident_timestamp must not be in the future')
+            if incident_timestamp and tz_legacy:
+                if incident_timestamp > datetime.now(timezone('UTC')):
                     raise AssertionError('incident_timestamp must not be in the future')
         return value
         


### PR DESCRIPTION
## Objective 

[MDS-5315](https://bcmines.atlassian.net/browse/MDS-5315)

Missed some logic on checking the incident timezones in the BE validation