### PR TITLE
[MDS-5300] Added health check probe to docman celery

### DIFF
--- a/services/document-manager/backend/app/__init__.py
+++ b/services/document-manager/backend/app/__init__.py
@@ -2,6 +2,7 @@ import sys
 import json
 import os
 
+
 from flask import Flask, current_app, request
 from flask_cors import CORS
 from flask_restplus import Resource
@@ -17,6 +18,7 @@ from app.docman.resources import *
 from app.commands import register_commands
 from app.routes import register_routes
 from app.extensions import api, cache, db, jwt, migrate
+from app.utils.celery_health_check import HealthCheckProbe
 
 from .config import Config
 
@@ -70,6 +72,9 @@ def make_celery(app=None):
         backend=app.config['CELERY_RESULT_BACKEND'],
         broker=app.config['CELERY_BROKER_URL'])
     celery.conf.update(app.config)
+
+    # Add Celery StartStopStep for Health Check Probing
+    celery.steps['worker'].add(HealthCheckProbe)
 
     TaskBase = celery.Task
 

--- a/services/document-manager/backend/app/utils/celery_health_check.py
+++ b/services/document-manager/backend/app/utils/celery_health_check.py
@@ -1,0 +1,52 @@
+from pathlib import Path
+
+from celery import bootsteps
+from celery.signals import worker_ready, worker_shutdown
+
+LIVENESS_FILE = Path("/tmp/liveness_check")
+READINESS_FILE = Path("/tmp/readiness_check")
+
+
+class HealthCheckProbe(bootsteps.StartStopStep):
+    """
+    Probe that can be used to determine liveness and readiness status
+    of the given Celery worker.
+
+    Creates /tmp/readiness_check when the worker starts up
+    Updated /tmp/liveness_check every 1s as long as the worker is running.
+
+    These files can be read by any monitoring scripts to determine whether or not 
+    the celery worker is running.
+
+    This solution is heavily inspired by https://github.com/celery/celery/issues/4079
+    and is inteded as a replacement for `celery inspect` which causes high CPU usage
+    and pod restarts. https://bcmines.atlassian.net/browse/MDS-5300
+    """
+
+    requires = {'celery.worker.components:Timer'}
+
+    def __init__(self, worker, **kwargs):
+        self.requests = []
+        self.tref = None
+
+    def start(self, worker):
+        # Update liveness file every second
+        self.tref = worker.timer.call_repeatedly(
+            1.0, self.update_liveness_file, (worker,), priority=10,
+        )
+
+    def stop(self, worker):
+        LIVENESS_FILE.unlink(missing_ok=True)
+
+    def update_liveness_file(self, worker):
+        LIVENESS_FILE.touch()
+
+
+@worker_ready.connect
+def worker_ready(**_):
+    READINESS_FILE.touch()
+
+
+@worker_shutdown.connect
+def worker_shutdown(**_):
+    READINESS_FILE.unlink(missing_ok=True)


### PR DESCRIPTION
## Objective 

[MDS-5300](https://bcmines.atlassian.net/browse/MDS-5300)

Added health check probe to Docman Worker (celery). This is an attempt to resolve the high cpu usage + restarts experienced with Celery in dev/test/prod using `celery inspect ping` for health checks. 

It's a known issue with the current health checks that it can cause high CPU usage according to https://github.com/celery/celery/issues/4079, and the solution is heavily inspired by the proposed solutions there.

*Solution*
1. Have a "liveness file" regularly updated by the celery worker by using celery signals
2. Update the OC liveness checks to see when the liveness file was latest updated, if it hasn't been updated in a while, the worker is not functioning properly, and the worker can be considered unhealthy

Gitops repo PR with updated health check: https://github.com/bcgov-c/tenant-gitops-4c2ba9/pull/33


