### PR TITLE
[MDS-5286] Updating minespace uploader styling

### DIFF
--- a/services/minespace-web/src/components/Forms/incidents/IncidentForm.js
+++ b/services/minespace-web/src/components/Forms/incidents/IncidentForm.js
@@ -662,7 +662,7 @@ const renderUploadInitialNotificationDocuments = (
                 onRemoveFile={parentHandlers?.deleteDocument}
                 mineGuid={match.params?.mineGuid}
                 component={IncidentFileUpload}
-                labelIdle='<strong class="filepond--label-action">Supporting Document Upload</strong><div>Accepted filetypes: .kmz .doc .docx .xlsx .pdf</div>'
+                labelIdle='<strong class="filepond--label-action">Drag & drop your files or Browse</strong><div>Accepted filetypes: .kmz .doc .docx .xlsx .pdf</div>'
               />
             </Form.Item>
           </Col>

--- a/services/minespace-web/src/components/Forms/incidents/UploadIncidentDocumentForm.js
+++ b/services/minespace-web/src/components/Forms/incidents/UploadIncidentDocumentForm.js
@@ -93,7 +93,7 @@ const UploadIncidentDocumentForm = (props) => {
                 onRemoveFile={onRemoveFile}
                 mineGuid={props.mineGuid}
                 component={IncidentFileUpload}
-                labelIdle='<strong class="filepond--label-action">Supporting Document Upload</strong><div>Accepted filetypes: .kmz .doc .docx .xlsx .pdf</div>'
+                labelIdle='<strong class="filepond--label-action">Drag & drop your files or Browse</strong><div>Accepted filetypes: .kmz .doc .docx .xlsx .pdf</div>'
                 validate={[required]}
               />
             </Form.Item>

--- a/services/minespace-web/src/components/Forms/noticeOfDeparture/AddNoticeOfDepartureForm.tsx
+++ b/services/minespace-web/src/components/Forms/noticeOfDeparture/AddNoticeOfDepartureForm.tsx
@@ -113,9 +113,8 @@ export const renderContacts: React.FC<RenderContactsProps> = (props) => {
   );
 };
 
-const AddNoticeOfDepartureForm: React.FC<
-  InjectedFormProps<ICreateNoD> & AddNoticeOfDepartureProps
-> = (props) => {
+const AddNoticeOfDepartureForm: React.FC<InjectedFormProps<ICreateNoD> &
+  AddNoticeOfDepartureProps> = (props) => {
   const { permits, onSubmit, closeModal, handleSubmit, mineGuid, change } = props;
   const [submitting, setSubmitting] = useState(false);
   const [hasChecklist, setHasChecklist] = useState(false);
@@ -332,7 +331,7 @@ const AddNoticeOfDepartureForm: React.FC<
                 );
               },
               labelIdle:
-                '<strong class="filepond--label-action">Supporting Document Upload</strong><div>Accepted filetypes: .kmz .doc .docx .xlsx .pdf</div>',
+                '<strong class="filepond--label-action">Drag & drop your files or Browse</strong><div>Accepted filetypes: .kmz .doc .docx .xlsx .pdf</div>',
               onRemoveFile: onRemoveFile,
               mineGuid: mineGuid,
               allowMultiple: true,

--- a/services/minespace-web/src/components/Forms/noticeOfDeparture/EditNoticeOfDepartureForm.tsx
+++ b/services/minespace-web/src/components/Forms/noticeOfDeparture/EditNoticeOfDepartureForm.tsx
@@ -42,9 +42,8 @@ interface EditNoticeOfDepartureFormProps {
   change?: (field: string, value: any) => void;
 }
 
-const EditNoticeOfDepartureForm: React.FC<
-  InjectedFormProps<Partial<ICreateNoD>> & EditNoticeOfDepartureFormProps
-> = (props) => {
+const EditNoticeOfDepartureForm: React.FC<InjectedFormProps<Partial<ICreateNoD>> &
+  EditNoticeOfDepartureFormProps> = (props) => {
   const { onSubmit, closeModal, handleSubmit, mineGuid, noticeOfDeparture, pristine } = props;
   const { permit, nod_guid, nod_no, nod_status } = noticeOfDeparture;
   const [submitting, setSubmitting] = useState(false);
@@ -265,7 +264,7 @@ const EditNoticeOfDepartureForm: React.FC<
                 );
               },
               labelIdle:
-                '<strong class="filepond--label-action">Supporting Document Upload</strong><div>Accepted filetypes: .kmz .doc .docx .xlsx .pdf</div>',
+                '<strong class="filepond--label-action">Drag & drop your files or Browse</strong><div>Accepted filetypes: .kmz .doc .docx .xlsx .pdf</div>',
               onRemoveFile: onRemoveFile,
               mineGuid: mineGuid,
               allowMultiple: true,

--- a/services/minespace-web/src/styles/overrides/filepond-overrides.scss
+++ b/services/minespace-web/src/styles/overrides/filepond-overrides.scss
@@ -5,7 +5,7 @@
 
 /* the text color of the drop label*/
 .filepond--drop-label {
-  color: $gov-grey-dark; //#555;
+  color: rgba(49, 49, 50, 1); //#555;
 }
 
 /* underline color for "Browse" button */
@@ -15,16 +15,6 @@
   &:focus {
     outline: none !important;
   }
-}
-
-/* the background color of the filepond drop area */
-.filepond--panel-root {
-  background-color: $white; //#eee;
-}
-
-/* the border radius of the drop area */
-.filepond--panel-root {
-  border-radius: $border-radius-base;
 }
 
 /* the border radius of the file item */
@@ -75,8 +65,8 @@
 
 /* bordered drop area */
 .filepond--panel-root {
-  background-color: transparent;
-  border: 2px solid $primary-color;
+  background-color: rgba(230, 235, 240, 1); /* the background color of the filepond drop area */
+  border-radius: $border-radius-base; /* the border radius of the drop area */
 }
 
 .filepond--root {

--- a/services/minespace-web/src/styles/overrides/filepond-overrides.scss
+++ b/services/minespace-web/src/styles/overrides/filepond-overrides.scss
@@ -5,7 +5,7 @@
 
 /* the text color of the drop label*/
 .filepond--drop-label {
-  color: rgba(49, 49, 50, 1); //#555;
+  color: $font-colour;
 }
 
 /* underline color for "Browse" button */
@@ -65,8 +65,8 @@
 
 /* bordered drop area */
 .filepond--panel-root {
-  background-color: rgba(230, 235, 240, 1); /* the background color of the filepond drop area */
-  border-radius: $border-radius-base; /* the border radius of the drop area */
+  background-color: $filepond-drop-bg;
+  border-radius: $border-radius-base;
 }
 
 .filepond--root {

--- a/services/minespace-web/src/styles/settings/theme.scss
+++ b/services/minespace-web/src/styles/settings/theme.scss
@@ -80,6 +80,9 @@ $component-background: $white; //#fff;
 // Popover background color
 $popover-background: $component-background;
 
+// The background color of the filepond drop area
+$filepond-drop-bg: #E6EBF0;
+
 // font, headings, etc
 $font-family: "BCSans", "Noto Sans", Verdana, Arial, sans-serif; //"Myriad Pro", sans-serif; //-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol',   'Noto Color Emoji';
 $code-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace;


### PR DESCRIPTION
## Objective 

[MDS-5286](https://bcmines.atlassian.net/browse/MDS-5286)

_Why are you making this change? Provide a short explanation and/or screenshots_

Update the styling for all the upload areas. And change the text from `Supporting Document Upload` to `Drag & drop your files or Browse`, the label in the other upload areas are kept as it is.

![Screenshot 2023-06-08 100549](https://github.com/bcgov/mds/assets/118843449/a5fd6c9f-0625-4bae-b7c4-4938238d4971)

