### PR TITLE
[MDS-5268] Document Versioning

### DIFF
--- a/services/document-manager/backend/app/docman/models/document.py
+++ b/services/document-manager/backend/app/docman/models/document.py
@@ -1,8 +1,6 @@
 import uuid
-from datetime import datetime
 
 from sqlalchemy.dialects.postgresql import UUID
-from sqlalchemy.schema import FetchedValue
 from app.extensions import db
 
 from app.utils.models_mixins import AuditMixin, Base
@@ -18,6 +16,8 @@ class Document(AuditMixin, Base):
     file_display_name = db.Column(db.String(255), nullable=False)
     path_display_name = db.Column(db.String(4096), nullable=False)
     object_store_path = db.Column(db.String)
+
+    versions = db.relationship('DocumentVersion', backref='document', lazy=True)
 
     def __repr__(self):
         return '<Document %r>' % self.document_id

--- a/services/document-manager/backend/app/docman/models/document_version.py
+++ b/services/document-manager/backend/app/docman/models/document_version.py
@@ -1,0 +1,40 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy.dialects.postgresql import UUID
+from app.extensions import db
+
+from app.utils.models_mixins import Base
+
+
+class DocumentVersion(Base):
+    __tablename__ = 'document_version'
+    id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    document_guid = db.Column(UUID(as_uuid=True), db.ForeignKey('document.document_guid'), nullable=False)
+    created_by = db.Column(db.String(60), nullable=False)
+    created_date = db.Column(db.DateTime, nullable=False)
+    upload_completed_date = db.Column(db.DateTime, nullable=True, default=datetime.utcnow)
+    object_store_version_id = db.Column(db.Integer, nullable=False)
+    file_display_name = db.Column(db.String(40), nullable=False)
+
+    def __repr__(self):
+        return '<DocumentVersion %r>' % self.id
+
+    def json(self):
+        return {
+            'id': str(self.id),
+            'document_guid': str(self.document_guid),
+            'created_by': self.created_by,
+            'created_date': str(self.created_date),
+            'upload_completed_date': str(self.upload_completed_date) if self.upload_completed_date else None,
+            'object_store_version_id': self.object_store_version_id,
+            'file_display_name': self.file_display_name
+        }
+
+    @classmethod
+    def find_by_id(cls, id):
+        return cls.query.filter_by(id=id).first()
+
+    @classmethod
+    def find_by_document_guid(cls, document_guid):
+        return cls.query.filter_by(document_guid=document_guid).all()

--- a/services/document-manager/backend/app/docman/resources/document.py
+++ b/services/document-manager/backend/app/docman/resources/document.py
@@ -1,24 +1,24 @@
-import uuid
-import os
-import requests
 import base64
+import os
 import time
-
+import uuid
 from datetime import datetime
-from wsgiref.handlers import format_date_time
 from urllib.parse import urlparse, quote
-from app.services.object_store_storage_service import ObjectStoreStorageService
+from wsgiref.handlers import format_date_time
 
-from werkzeug.exceptions import BadRequest, NotFound, Conflict, RequestEntityTooLarge, InternalServerError, BadGateway
-from flask import request, current_app, send_file, make_response, jsonify
-from flask_restplus import Resource, reqparse, marshal_with
-
-from app.docman.models.document import Document
-from app.extensions import api, cache
-from app.docman.response_models import DOCUMENT_MODEL
-from app.utils.access_decorators import requires_any_of, DOCUMENT_UPLOAD_ROLES, VIEW_ALL, MINESPACE_PROPONENT, GIS
-from app.constants import OBJECT_STORE_PATH, OBJECT_STORE_UPLOAD_RESOURCE, FILE_UPLOAD_SIZE, FILE_UPLOAD_OFFSET, FILE_UPLOAD_PATH, FILE_UPLOAD_EXPIRY, DOWNLOAD_TOKEN, TIMEOUT_24_HOURS, TUS_API_VERSION, TUS_API_SUPPORTED_VERSIONS, FORBIDDEN_FILETYPES
+import requests
 from app.config import Config
+from app.constants import OBJECT_STORE_PATH, OBJECT_STORE_UPLOAD_RESOURCE, FILE_UPLOAD_SIZE, FILE_UPLOAD_OFFSET, \
+    FILE_UPLOAD_PATH, FILE_UPLOAD_EXPIRY, DOWNLOAD_TOKEN, TIMEOUT_24_HOURS, TUS_API_VERSION, TUS_API_SUPPORTED_VERSIONS, \
+    FORBIDDEN_FILETYPES
+from app.docman.models.document import Document
+from app.docman.response_models import DOCUMENT_MODEL
+from app.extensions import api, cache
+from app.services.object_store_storage_service import ObjectStoreStorageService
+from app.utils.access_decorators import requires_any_of, DOCUMENT_UPLOAD_ROLES, VIEW_ALL, MINESPACE_PROPONENT, GIS
+from flask import request, current_app, send_file, make_response, jsonify
+from flask_restplus import Resource, reqparse
+from werkzeug.exceptions import BadRequest, NotFound, Conflict, RequestEntityTooLarge, InternalServerError, BadGateway
 
 CACHE_TIMEOUT = TIMEOUT_24_HOURS
 
@@ -51,7 +51,7 @@ class DocumentListResource(Resource):
         max_file_size = Config.MAX_CONTENT_LENGTH
         if file_size > max_file_size:
             raise RequestEntityTooLarge(
-                f'The maximum file upload size is {max_file_size/1024/1024}MB.')
+                f'The maximum file upload size is {max_file_size / 1024 / 1024}MB.')
 
         # Validate the file name and file type
         data = self.parser.parse_args()
@@ -343,3 +343,119 @@ class DocumentResource(Resource):
         if not document:
             raise NotFound('Document not found')
         return document
+
+    # TODO: This is just a copy of the POST method from the DocumentResource class. It needs to be updated to accept a document guid and upload the file to the existing document.
+    @requires_any_of(DOCUMENT_UPLOAD_ROLES)
+    def post(self, document_guid):
+        document = Document.query.filter_by(document_guid=document_guid).one_or_none()
+
+        if request.headers.get('Tus-Resumable') is None:
+            raise BadRequest('Received file upload for unsupported file transfer protocol')
+
+        # Validate the file size
+        file_size = request.headers.get('Upload-Length')
+        if not file_size:
+            raise BadRequest('Received file upload of unspecified size')
+        file_size = int(file_size)
+        max_file_size = Config.MAX_CONTENT_LENGTH
+        if file_size > max_file_size:
+            raise RequestEntityTooLarge(
+                f'The maximum file upload size is {max_file_size / 1024 / 1024}MB.')
+
+        # Validate the file name and file type
+        data = self.parser.parse_args()
+        filename = data.get('filename') or request.headers.get('Filename')
+        if not filename:
+            raise BadRequest('File name cannot be empty')
+        if filename.endswith(FORBIDDEN_FILETYPES):
+            raise BadRequest('File type is forbidden')
+
+        # Create the path string for this file
+        document_guid = document.document_guid
+        base_folder = Config.UPLOADED_DOCUMENT_DEST
+        folder = data.get('folder') or request.headers.get('Folder')
+        folder = os.path.join(base_folder, folder)
+        file_path = os.path.join(folder, document_guid)
+        pretty_folder = data.get('pretty_folder') or request.headers.get('Pretty-Folder')
+        pretty_path = os.path.join(base_folder, pretty_folder, filename)
+
+        # If the object store is enabled, send the post request through to TUSD to the object store
+        object_store_path = None
+        current_app.logger.debug('Document Store enabled: ' + str(Config.OBJECT_STORE_ENABLED))
+        if Config.OBJECT_STORE_ENABLED:
+
+            # Add the path to be used in the post-finish tusd hook to set the correct object store path
+            headers = {key: value for (key, value) in request.headers if key != 'Host'}
+            path = base64.b64encode(document.file_path.encode('utf-8')).decode('utf-8')
+            doc_guid = base64.b64encode(document_guid.encode('utf-8')).decode('utf-8')
+            upload_metadata = request.headers['Upload-Metadata']
+            headers['Upload-Metadata'] = f'{upload_metadata},path {path},doc_guid {doc_guid}'
+
+            # Send the request
+            resp = None
+            try:
+                resp = requests.post(url=Config.TUSD_URL, headers=headers, data=request.data)
+            except Exception as e:
+                message = f'POST request to object store raised an exception:\n{e}'
+                current_app.logger.error(message)
+                raise InternalServerError(message)
+
+            # Validate the request
+            if resp.status_code != requests.codes.created:
+                message = f'POST request to object store failed: {resp.status_code} ({resp.reason}): {resp._content}'
+                current_app.logger.error(f'POST resp.request:\n{resp.request.__dict__}')
+                current_app.logger.error(f'POST resp:\n{resp.__dict__}')
+                current_app.logger.error(message)
+                if resp.status_code == requests.codes.not_found:
+                    raise NotFound(message)
+                raise BadGateway(message)
+
+            # Set object store upload data in cache
+            object_store_upload_resource = urlparse(resp.headers['Location']).path.split('/')[-1]
+            object_store_path = Config.S3_PREFIX + object_store_upload_resource.split('+')[0]
+            cache.set(
+                OBJECT_STORE_UPLOAD_RESOURCE(document_guid), object_store_upload_resource,
+                CACHE_TIMEOUT)
+            cache.set(OBJECT_STORE_PATH(document_guid), object_store_path, CACHE_TIMEOUT)
+
+        # Else, create an empty file at this path in the file system
+        else:
+            try:
+                if not os.path.exists(folder):
+                    os.makedirs(folder)
+                with open(file_path, 'wb') as f:
+                    f.seek(file_size - 1)
+                    f.write(b'\0')
+            except IOError as e:
+                current_app.logger.error(e)
+                raise InternalServerError('Unable to create file')
+
+        # Cache data to be used in future PATCH requests
+        upload_expiry = format_date_time(time.time() + CACHE_TIMEOUT)
+        cache.set(FILE_UPLOAD_EXPIRY(document_guid), upload_expiry, CACHE_TIMEOUT)
+        cache.set(FILE_UPLOAD_SIZE(document_guid), file_size, CACHE_TIMEOUT)
+        cache.set(FILE_UPLOAD_OFFSET(document_guid), 0, CACHE_TIMEOUT)
+        cache.set(FILE_UPLOAD_PATH(document_guid), file_path, CACHE_TIMEOUT)
+
+        # TODO: Update this
+        # Create document record
+        document = Document(
+            document_guid=document_guid,
+            full_storage_path=file_path,
+            upload_started_date=datetime.utcnow(),
+            file_display_name=filename,
+            path_display_name=pretty_path,
+            object_store_path=object_store_path)
+        document.save()
+
+        # Create and send response
+        response = make_response(jsonify(document_manager_guid=document_guid), 201)
+        response.headers['Tus-Resumable'] = TUS_API_VERSION
+        response.headers['Tus-Version'] = TUS_API_SUPPORTED_VERSIONS
+        response.headers['Location'] = f'{Config.DOCUMENT_MANAGER_URL}/documents/{document_guid}'
+        response.headers['Upload-Offset'] = 0
+        response.headers['Upload-Expires'] = upload_expiry
+        response.headers[
+            'Access-Control-Expose-Headers'] = 'Tus-Resumable,Tus-Version,Location,Upload-Offset,Upload-Expires,Content-Type'
+        response.autocorrect_location_header = False
+        return response

--- a/services/document-manager/backend/migrations/alembic.ini
+++ b/services/document-manager/backend/migrations/alembic.ini
@@ -8,7 +8,7 @@
 # the 'revision' command, regardless of autogenerate
 # revision_environment = false
 schema_name = docman
-script_location = .\
+script_location = ./
 
 # Logging configuration
 [loggers]

--- a/services/document-manager/backend/migrations/versions/17d4ce4dea98_add_document_versioning.py
+++ b/services/document-manager/backend/migrations/versions/17d4ce4dea98_add_document_versioning.py
@@ -1,0 +1,42 @@
+"""add document versioning
+
+Revision ID: 17d4ce4dea98
+Revises: 4a4950ed26bd
+Create Date: 2023-06-16 12:15:22.391281
+
+"""
+import datetime
+import uuid
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision = '17d4ce4dea98'
+down_revision = '4a4950ed26bd'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_unique_constraint('document_guid_unique', 'document', ['document_guid'])
+    op.create_table(
+        'document_version',
+        sa.Column('id', postgresql.UUID(as_uuid=True), primary_key=True, default=uuid.uuid4),
+        sa.Column('document_guid', postgresql.UUID(as_uuid=True), sa.ForeignKey('document.document_guid'), nullable=False),
+        sa.Column('created_by', sa.String(length=60), nullable=False),
+        sa.Column('created_date', sa.DateTime(), nullable=False),
+        sa.Column('upload_completed_date', sa.DateTime(), nullable=True, default=datetime.datetime.utcnow),
+        sa.Column('object_store_version_id', sa.String(), nullable=False),
+        sa.Column('file_display_name', sa.String(length=40), nullable=False),
+    )
+    
+    
+    op.add_column('document', sa.Column('created_by', sa.String(length=60), nullable=True))    
+        
+
+
+def downgrade():
+    op.drop_table('document_version')
+    op.drop_column('document', 'created_by')

--- a/services/tusd/Dockerfile
+++ b/services/tusd/Dockerfile
@@ -1,5 +1,17 @@
 FROM tusproject/tusd:v1.3.0
 
 COPY init.sh .
+COPY ./hooks/post-finish ./hooks/
+
+USER root
+
+RUN chmod +x ./hooks/post-finish
+
+RUN apk add --no-cache curl \
+    && apk add --no-cache python3 \
+    && pip3 install --upgrade pip \
+    && pip3 install awscli \
+    && apk add --no-cache jq \
+    && chmod +x ./hooks/post-finish
 
 ENTRYPOINT [ "./init.sh" ]

--- a/services/tusd/Dockerfile.ci
+++ b/services/tusd/Dockerfile.ci
@@ -1,6 +1,18 @@
 FROM tusproject/tusd:v1.3.0
 
 COPY init.sh .
+COPY ./hooks/post-finish ./hooks/
+
+USER root
+
+RUN chmod +x ./hooks/post-finish
+
+RUN apk add --no-cache curl \
+    && apk add --no-cache python3 \
+    && pip3 install --upgrade pip \
+    && pip3 install awscli \
+    && apk add --no-cache jq \
+    && chmod +x ./hooks/post-finish
 
 WORKDIR /srv/tusd-data
 

--- a/services/tusd/hooks/post-finish
+++ b/services/tusd/hooks/post-finish
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+# print a message to the tusd log
+echo "post-finish hook called"
+
+# Set the AWS credentials
+export AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID
+export AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY
+
+# Read the JSON-encoded object from stdin
+read -r stdin_data
+
+# Extract the Upload object from the JSON-encoded object
+upload=$(echo "$stdin_data" | jq -r '.Upload')
+
+# Extract all the HTTP headers from the JSON-encoded object
+headers=$(echo "$stdin_data" | jq -r '.HTTPRequest.Header | to_entries | map("\(.key): \(.value | join(","))") | join("\n")')
+
+# Extract the ID and Size properties from the Upload object
+id=$(echo "$upload" | jq -r '.ID')
+size=$(echo "$upload" | jq -r '.Size')
+
+echo "Upload ID $id ($size bytes) finished"
+
+storageKey=$(echo "$upload" | jq -r '.Storage.Key')
+
+versions=$(aws s3api list-object-versions --bucket $S3_BUCKET_ID --prefix $storageKey --endpoint-url "https://$S3_ENDPOINT" --output json)
+
+# Retrieve the version number of the uploaded file and the last modified date
+version=$(echo "$versions" | jq -r --arg storageKey "$storageKey" '{ versionId: (.Versions[] | select(.Key == $storageKey and .IsLatest == true) | .VersionId), timestamp: (.Versions[] | select(.Key == $storageKey and .IsLatest == true) | .LastModified) }')
+
+aws_exit_code=$?
+if [ $aws_exit_code -ne 0 ]; then
+  echo "aws command failed with exit code $aws_exit_code"
+fi
+
+# Forward the request through the hooks-http option
+json_data=$(echo "{\"version\": $version, \"Upload\": $upload}" | tr -d '\r\n' | tr -d '\0')
+curl -X POST -H "Content-Type: application/json" -H "$headers" -H "Hook-Name: post-finish" -d "$json_data" $DOCUMENT_MANAGER_URL/tusd-hooks

--- a/services/tusd/init.sh
+++ b/services/tusd/init.sh
@@ -1,3 +1,4 @@
 #!/bin/sh
 
-tusd -s3-endpoint=${S3_ENDPOINT} -s3-bucket=${S3_BUCKET_ID} -s3-object-prefix=${S3_PREFIX} --hooks-enabled-events post-finish --hooks-http ${DOCUMENT_MANAGER_URL}/tusd-hooks --hooks-http-retry 5 --hooks-http-backoff 2 -hooks-http-forward-headers=Authorization
+chmod +x ./hooks/post-finish
+tusd -s3-endpoint=${S3_ENDPOINT} -s3-bucket=${S3_BUCKET_ID} -s3-object-prefix=${S3_PREFIX} --hooks-enabled-events post-finish --hooks-dir ./hooks --hooks-http ${DOCUMENT_MANAGER_URL}/tusd-hooks --hooks-http-retry 5 --hooks-http-backoff 2 -hooks-http-forward-headers=Authorization


### PR DESCRIPTION
## Objective 

[MDS-5268](https://bcmines.atlassian.net/browse/MDS-5268)

- Created a custom `post-finish` hook in TUSD that returns the file version along with the creation timestamp
- added a migration to the docman database that adds a document_version table
- implemented functionality to save the document version when the `post-finish` hook is called

# Unfinished
- Started creating a post endpoint in docman that takes a document guid which will serve to update existing files
  - This is largely just a copy of the original POST function at this point (if anyone gets to it, feel free to use or get rid of it)

# Next Up
- Need to create a function in Core-Api that fetches the version information for files before their info is sent to the front end


