### PR TITLE
[MDS-5262] Added Authorization check to AmazonS3GetImage endpoint

### DIFF
--- a/services/core-web/src/components/syncfusion/AmazonS3Provider.js
+++ b/services/core-web/src/components/syncfusion/AmazonS3Provider.js
@@ -15,6 +15,7 @@ import {
 import { createRequestHeader } from "@common/utils/RequestHeaders";
 import { openDocumentViewer } from "@common/actions/documentViewerActions";
 import { isDocumentOpenable } from "@/components/syncfusion/DocumentViewer";
+import keycloak from "@/keycloak";
 
 const propTypes = {
   path: PropTypes.string.isRequired,
@@ -79,7 +80,7 @@ export class AmazonS3Provider extends SampleBase {
       const xhr = new XMLHttpRequest();
       xhr.open("POST", this.filemanager.ajaxSettings.downloadUrl, true);
       xhr.responseType = "blob";
-      xhr.onload = function() {
+      xhr.onload = function () {
         if (this.status === 200) {
           let name = "";
 
@@ -104,7 +105,7 @@ export class AmazonS3Provider extends SampleBase {
           } else {
             window.location = anchorUrl;
           }
-          setTimeout(function() {
+          setTimeout(function () {
             URL.revokeObjectURL(anchorUrl);
           }, 100);
         }
@@ -160,7 +161,7 @@ export class AmazonS3Provider extends SampleBase {
               const data = JSON.parse(args.ajaxSettings.data);
               data.path = this.pathPrefix + data.path;
               args.ajaxSettings.data = JSON.stringify(data);
-              args.ajaxSettings.beforeSend = function(args) {
+              args.ajaxSettings.beforeSend = function (args) {
                 args.httpRequest.setRequestHeader(
                   "Authorization",
                   createRequestHeader().headers.Authorization
@@ -176,6 +177,8 @@ export class AmazonS3Provider extends SampleBase {
                 "/AmazonS3GetImage?path=",
                 `/AmazonS3GetImage?path=${this.pathPrefix}`
               );
+
+              args.imageUrl += `&token=${keycloak.token}`;
             }}
             menuClick={this.menuClick}
             toolbarClick={this.toolbarClick}

--- a/services/filesystem-provider/Dockerfile
+++ b/services/filesystem-provider/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:3.1
+FROM mcr.microsoft.com/dotnet/sdk:7.0
 
 USER 0
 
@@ -16,15 +16,19 @@ COPY ej2-amazon-s3-aspcore-file-provider ${APP_ROOT}/app
 
 COPY init.sh .
 
+# Provide user permissions to temp dotnet workspace
+RUN mkdir /.dotnet
+RUN chmod -R 700 /.dotnet
+RUN chown -R 1001:0 /.dotnet
+
+ENV DOTNET_CLI_HOME /.dotnet
+ENV XDG_DATA_HOME /.dotnet
+
 RUN cd ${APP_ROOT}/app && dotnet restore && dotnet build
 
 RUN chmod -R 700 ${APP_ROOT}/app
 RUN chown -R 1001:0 ${APP_ROOT}/app
 
-# Provide user permissions to temp dotnet workspace
-RUN mkdir /.dotnet
-RUN chmod -R 700 /.dotnet
-RUN chown -R 1001:0 /.dotnet
 
 USER 1001
 EXPOSE 62870

--- a/services/filesystem-provider/Dockerfile.ci
+++ b/services/filesystem-provider/Dockerfile.ci
@@ -16,15 +16,20 @@ RUN apt-get update \
     supervisor \     
     procps     
 
+
+# Provide user permissions to temp dotnet workspace
+RUN mkdir /.dotnet
+RUN chmod -R 700 /.dotnet
+RUN chown -R 1001:0 /.dotnet
+
+ENV DOTNET_CLI_HOME /.dotnet
+ENV XDG_DATA_HOME /.dotnet
+
 RUN cd ${APP_ROOT}/app && dotnet restore && dotnet build
 
 RUN chmod -R 777 ${APP_ROOT}/app
 RUN chown -R 1001:0 ${APP_ROOT}/app
 
-# Provide user permissions to temp dotnet workspace
-RUN mkdir /.dotnet
-RUN chmod -R 777 /.dotnet
-RUN chown -R 1001:0 /.dotnet
 
 USER 1001
 EXPOSE 62870

--- a/services/filesystem-provider/ej2-amazon-s3-aspcore-file-provider/Controllers/AmazonS3ProviderController.cs
+++ b/services/filesystem-provider/ej2-amazon-s3-aspcore-file-provider/Controllers/AmazonS3ProviderController.cs
@@ -63,6 +63,7 @@ namespace EJ2AmazonS3ASPCoreFileProvider.Controllers
         // Gets the image(s) from the given path
         [HttpGet]
         [Route("AmazonS3GetImage")]
+        [Authorize("View")]
         public IActionResult AmazonS3GetImage(FileManagerDirectoryContent args)
         {
             return operation.GetImage(args.Path, args.Id, false, null, args.Data);

--- a/services/filesystem-provider/ej2-amazon-s3-aspcore-file-provider/EJ2AmazonS3ASPCoreFileProvider.csproj
+++ b/services/filesystem-provider/ej2-amazon-s3-aspcore-file-provider/EJ2AmazonS3ASPCoreFileProvider.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <IsTransformWebConfigDisabled>true</IsTransformWebConfigDisabled>
   </PropertyGroup>
 
@@ -10,12 +10,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.0.15" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.14" />
-    <PackageReference Include="DotNetEnv" Version="2.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.14" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.106" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.7" />
+    <PackageReference Include="DotNetEnv" Version="2.5.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="7.0.7" />
     <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.1.3" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageReference Include="Syncfusion.EJ2.AspNet.Core" Version="19.1.0.57" />
     <PackageReference Include="Syncfusion.EJ2.PdfViewer.AspNet.Core.Linux" Version="19.1.0.57" />
     <!-- NOTE: We may need these dependencies in the future if we implement the document/spreadsheet viewer -->

--- a/services/filesystem-provider/ej2-amazon-s3-aspcore-file-provider/Program.cs
+++ b/services/filesystem-provider/ej2-amazon-s3-aspcore-file-provider/Program.cs
@@ -1,5 +1,7 @@
 ﻿using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Hosting;
 
 namespace EJ2FileManagerService
 {
@@ -7,11 +9,20 @@ namespace EJ2FileManagerService
     {
         public static void Main(string[] args)
         {
-            CreateWebHostBuilder(args).Build().Run();
+            CreateWebHostBuilder(args).Run();
         }
 
-        public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
-            WebHost.CreateDefaultBuilder(args)
-                .UseStartup<Startup>();
+        public static WebApplication CreateWebHostBuilder(string[] args)
+        {
+            var builder = WebApplication.CreateBuilder(args);
+
+            var startup = new Startup(builder.Configuration);
+            startup.ConfigureServices(builder.Services);
+
+            var app = builder.Build();
+
+            startup.Configure(app, builder.Environment.IsDevelopment());
+            return app;
+        }
     }
 }

--- a/services/filesystem-provider/ej2-amazon-s3-aspcore-file-provider/appsettings.Development.json
+++ b/services/filesystem-provider/ej2-amazon-s3-aspcore-file-provider/appsettings.Development.json
@@ -3,7 +3,9 @@
     "LogLevel": {
       "Default": "Debug",
       "System": "Information",
-      "Microsoft": "Information"
+      "Microsoft": "Warning",
+      "Microsoft.AspNetCore": "Warning",
+      "Microsoft.AspNetCore.HttpLogging.HttpLoggingMiddleware": "Information"
     }
   }
 }

--- a/services/filesystem-provider/ej2-amazon-s3-aspcore-file-provider/appsettings.json
+++ b/services/filesystem-provider/ej2-amazon-s3-aspcore-file-provider/appsettings.json
@@ -2,7 +2,10 @@
   "https_port": 443,
   "Logging": {
     "LogLevel": {
-      "Default": "Information"
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.AspNetCore": "Warning",
+      "Microsoft.AspNetCore.HttpLogging.HttpLoggingMiddleware": "Information"
     }
   },
   "AllowedHosts": "*"


### PR DESCRIPTION
## Objective 

[MDS-5262](https://bcmines.atlassian.net/browse/MDS-5262)

Added Authorization check (View All permission) to the Filesystem providers `AmazonS3GetImage` endpoint.
I think this was left out when first implemented as Syncfusion's frontend components did not support passing along Auth headers for image requests (and they still don't).

**Solution:**
1. Pass along the auth token as a GET param (yikes) for image requests, unfortunately suggested way forward from SyncFusion
2. Intercept this on the Filesystem provider side and transform it into an Auth header (this happens before any logging takes place, so the token is not logged)

**Extra**
Snuck in some upgrades as the filesystem service hasn't been touched in a couple of years
- Upgraded from .NET 3.1 to 7.0 as 3.1 has reached its end of life.
- Enabled .NET HttpLogging

