### PR TITLE
[MDS-5262] Updated filesystem provider cli directory

### DIFF
--- a/services/filesystem-provider/Dockerfile.ci
+++ b/services/filesystem-provider/Dockerfile.ci
@@ -16,14 +16,10 @@ RUN apt-get update \
     supervisor \     
     procps     
 
+RUN mkdir /tmp/DOTNET_CLI_HOME
 
-# Provide user permissions to temp dotnet workspace
-RUN mkdir /.dotnet
-RUN chmod -R 700 /.dotnet
-RUN chown -R 1001:0 /.dotnet
-
-ENV DOTNET_CLI_HOME /.dotnet
-ENV XDG_DATA_HOME /.dotnet
+ENV DOTNET_CLI_HOME /tmp/DOTNET_CLI_HOME
+ENV XDG_DATA_HOME /tmp
 
 RUN cd ${APP_ROOT}/app && dotnet restore && dotnet build
 


### PR DESCRIPTION
## Objective 

[MDS-5262](https://bcmines.atlassian.net/browse/MDS-5262)

Updated dotnet cli folder to `/tmp` to hopefully resolve a permission issue that happens in dev.
Unfortunately cannot reproduce this locally so flying a bit blind 😓 

![image](https://github.com/bcgov/mds/assets/66635118/92aea619-0ece-4d33-a36c-7dbd509a1e22)

