### PR TITLE
[MDS-5335] Editing Minespace User Mines

### DIFF
--- a/services/core-web/common/utils/helpers.ts
+++ b/services/core-web/common/utils/helpers.ts
@@ -166,7 +166,7 @@ export const sortListObjectsByPropertyDate = (list, property) => list.sort(dateS
 
 // Case insensitive filter for a SELECT field by label string
 export const caseInsensitiveLabelFilter = (input, option) =>
-  option.props.children.toLowerCase().includes(input.toLowerCase());
+  option.children.toLowerCase().includes(input.toLowerCase());
 
 // function taken directly from redux-forms (https://redux-form.com/6.0.0-rc.1/examples/normalizing)
 // automatically adds dashes to phone number

--- a/services/core-web/src/components/Forms/EditMinespaceUser.js
+++ b/services/core-web/src/components/Forms/EditMinespaceUser.js
@@ -5,7 +5,7 @@ import { Form } from "@ant-design/compatible";
 import "@ant-design/compatible/assets/index.css";
 import { Button, Col, Row } from "antd";
 import { requiredList } from "@common/utils/Validate";
-import { resetForm } from "@common/utils/helpers";
+import { nullableStringSorter, resetForm } from "@common/utils/helpers";
 import RenderField from "@/components/common/RenderField";
 import * as FORM from "@/constants/forms";
 import { renderConfig } from "@/components/common/config";
@@ -21,6 +21,7 @@ const propTypes = {
 
 export const EditMinespaceUser = (props) => {
   const { mines, handleSubmit, handleChange, handleSearch } = props;
+  const isModal = true; // currently no instance where it's not in a modal
   return (
     <Form layout="vertical" onSubmit={handleSubmit}>
       <Col span={24}>
@@ -45,10 +46,11 @@ export const EditMinespaceUser = (props) => {
                 label="Mines*"
                 placeholder="Select the mines this user can access"
                 component={renderConfig.MULTI_SELECT}
-                data={mines}
+                data={mines.sort(nullableStringSorter("label"))}
                 onChange={handleChange}
                 onSearch={handleSearch}
                 validate={[requiredList]}
+                props={{ isModal }}
               />
             </Form.Item>
           </Col>

--- a/services/core-web/src/components/admin/NewMinespaceUser.js
+++ b/services/core-web/src/components/admin/NewMinespaceUser.js
@@ -7,6 +7,7 @@ import { bindActionCreators } from "redux";
 import { fetchMineNameList } from "@common/actionCreators/mineActionCreator";
 import CustomPropTypes from "@/customPropTypes";
 import AddMinespaceUser from "@/components/Forms/AddMinespaceUser";
+import { nullableStringSorter } from "@common/utils/helpers";
 
 const propTypes = {
   fetchMineNameList: PropTypes.func.isRequired,
@@ -38,10 +39,12 @@ export const NewMinespaceUser = (props) => {
       <h3>Create Proponent</h3>
       {mines && (
         <AddMinespaceUser
-          mines={mines.map((mine) => ({
-            value: mine.mine_guid,
-            label: `${mine.mine_name} - ${mine.mine_no}`,
-          }))}
+          mines={mines
+            .map((mine) => ({
+              value: mine.mine_guid,
+              label: `${mine.mine_name} - ${mine.mine_no}`,
+            }))
+            .sort(nullableStringSorter("label"))}
           minespaceUserEmailHash={minespaceUserEmailHash}
           onSubmit={handleSubmit}
           handleChange={handleChange}

--- a/services/core-web/src/components/admin/UpdateMinespaceUser.js
+++ b/services/core-web/src/components/admin/UpdateMinespaceUser.js
@@ -42,23 +42,13 @@ export class UpdateMinespaceUser extends Component {
     }));
   };
 
-  filterUserMines = () => {
-    if (this.props.initialValues.mineNames) {
-      const userMines = this.props.initialValues.mineNames.map((mn) => mn.mine_guid);
-      return userMines.map((mine) => {
-        return this.props.minespaceUserMines.find((m) => m.mine_guid === mine);
-      });
-    }
-    return [];
-  };
-
   render() {
     return (
       <div>
         <h3>Edit Proponent</h3>
         {this.props.mines && (
           <EditMinespaceUser
-            mines={this.parseMinesAsOptions([...this.props.mines, ...this.filterUserMines()])}
+            mines={this.parseMinesAsOptions([...this.props.mines])}
             initalValueOptions={this.props.initialValues.mineNames}
             initialValues={{
               ...this.props.initialValues,

--- a/services/core-web/src/components/common/RenderMultiSelect.js
+++ b/services/core-web/src/components/common/RenderMultiSelect.js
@@ -19,6 +19,7 @@ const propTypes = {
   filterOption: PropTypes.oneOfType([PropTypes.func, PropTypes.bool]),
   disabled: PropTypes.bool,
   onSearch: PropTypes.func,
+  isModal: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -29,45 +30,51 @@ const defaultProps = {
   meta: {},
   onSearch: () => {},
   filterOption: false,
+  isModal: false,
 };
 
-export const RenderMultiSelect = (props) => (
-  <div>
-    <Form.Item
-      label={props.label}
-      validateStatus={
-        props.meta.touched ? (props.meta.error && "error") || (props.meta.warning && "warning") : ""
-      }
-      help={
-        props.meta.touched &&
-        ((props.meta.error && <span>{props.meta.error}</span>) ||
-          (props.meta.warning && <span>{props.meta.warning}</span>))
-      }
-    >
-      <Select
-        virtual={false}
-        disabled={!props.data || props.disabled}
-        mode="multiple"
-        size="small"
-        getPopupContainer={(trigger) => trigger.parentNode}
-        placeholder={props.placeholder}
-        id={props.id}
-        onSearch={props.onSearch}
-        value={props.input.value ? props.input.value : undefined}
-        onChange={props.input.onChange}
-        filterOption={props.filterOption || caseInsensitiveLabelFilter}
-        showArrow
+export const RenderMultiSelect = (props) => {
+  const extraProps = props.isModal ? null : { getPopupContainer: (trigger) => trigger.parentNode };
+  return (
+    <div>
+      <Form.Item
+        label={props.label}
+        validateStatus={
+          props.meta.touched
+            ? (props.meta.error && "error") || (props.meta.warning && "warning")
+            : ""
+        }
+        help={
+          props.meta.touched &&
+          ((props.meta.error && <span>{props.meta.error}</span>) ||
+            (props.meta.warning && <span>{props.meta.warning}</span>))
+        }
       >
-        {props.data &&
-          props.data.map(({ value, label, tooltip }) => (
-            <Select.Option key={value} value={value} title={tooltip}>
-              {label}
-            </Select.Option>
-          ))}
-      </Select>
-    </Form.Item>
-  </div>
-);
+        <Select
+          virtual={false}
+          disabled={!props.data || props.disabled}
+          mode="multiple"
+          size="small"
+          placeholder={props.placeholder}
+          id={props.id}
+          onSearch={props.onSearch}
+          value={props.input.value ? props.input.value : undefined}
+          onChange={props.input.onChange}
+          filterOption={props.filterOption || caseInsensitiveLabelFilter}
+          showArrow
+          {...extraProps}
+        >
+          {props.data &&
+            props.data.map(({ value, label, tooltip }) => (
+              <Select.Option key={value} value={value} title={tooltip}>
+                {label}
+              </Select.Option>
+            ))}
+        </Select>
+      </Form.Item>
+    </div>
+  );
+};
 
 RenderMultiSelect.propTypes = propTypes;
 RenderMultiSelect.defaultProps = defaultProps;

--- a/services/core-web/src/components/common/wrappers/AddPartyComponentWrapper.js
+++ b/services/core-web/src/components/common/wrappers/AddPartyComponentWrapper.js
@@ -45,12 +45,11 @@ const defaultAddPartyFormState = {
 };
 
 export class AddPartyComponentWrapper extends Component {
-  state = { isPerson: true, addingParty: false };
-
-  componentWillMount = () => {
-    // Form values are reset to default when mounted as the modal may have been closed with the form showing.
+  constructor(props) {
+    super(props);
+    this.state = { isPerson: true, addingParty: false };
     this.resetAddPartyForm();
-  };
+  }
 
   componentWillReceiveProps = (nextProps) => {
     if (
@@ -128,6 +127,7 @@ export class AddPartyComponentWrapper extends Component {
     this.setState({ isPerson: value.target.value });
   };
 
+  // eslint-disable-next-line react/require-render-return
   render = () => {
     const ChildComponent = this.props.content;
     return (

--- a/services/core-web/src/components/modalContent/UpdateMinespaceUserModal.js
+++ b/services/core-web/src/components/modalContent/UpdateMinespaceUserModal.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import UpdateMinespaceUser from "@/components/admin/UpdateMinespaceUser";
 
 const propTypes = {
-  onSubmit: PropTypes.func.isRequired,
+  handleSubmit: PropTypes.func.isRequired,
   title: PropTypes.string,
 };
 

--- a/services/core-web/src/customPropTypes/minespace.js
+++ b/services/core-web/src/customPropTypes/minespace.js
@@ -1,7 +1,7 @@
 import { PropTypes, shape } from "prop-types";
 
 export const minespaceUser = shape({
-  email: PropTypes.string.isRequired,
+  email_or_username: PropTypes.string.isRequired,
   user_id: PropTypes.string.isRequired,
   keycloak_guid: PropTypes.string,
   mines: PropTypes.arrayOf(PropTypes.string),

--- a/services/core-web/src/tests/components/admin/__snapshots__/NewMinespaceUser.spec.js.snap
+++ b/services/core-web/src/tests/components/admin/__snapshots__/NewMinespaceUser.spec.js.snap
@@ -22,16 +22,16 @@ exports[`NewMinespaceUser renders properly 1`] = `
     mines={
       Array [
         Object {
-          "label": "New Mine - BLAH6194",
-          "value": "fc72863d-83e8-46ba-90f9-87b0ed78823f",
+          "label": "Legit Mine - BLAH6734",
+          "value": "75692b61-7ab9-406b-b1f5-8c9b857404ac",
         },
         Object {
           "label": "Mine Two - BLAH0502",
           "value": "89a65274-581d-4862-8630-99f5f7687089",
         },
         Object {
-          "label": "Legit Mine - BLAH6734",
-          "value": "75692b61-7ab9-406b-b1f5-8c9b857404ac",
+          "label": "New Mine - BLAH6194",
+          "value": "fc72863d-83e8-46ba-90f9-87b0ed78823f",
         },
       ]
     }

--- a/services/minespace-web/common/utils/helpers.ts
+++ b/services/minespace-web/common/utils/helpers.ts
@@ -166,7 +166,7 @@ export const sortListObjectsByPropertyDate = (list, property) => list.sort(dateS
 
 // Case insensitive filter for a SELECT field by label string
 export const caseInsensitiveLabelFilter = (input, option) =>
-  option.props.children.toLowerCase().includes(input.toLowerCase());
+  option.children.toLowerCase().includes(input.toLowerCase());
 
 // function taken directly from redux-forms (https://redux-form.com/6.0.0-rc.1/examples/normalizing)
 // automatically adds dashes to phone number


### PR DESCRIPTION
## Objective 
- in a modal, the multiselect component dropdown covers the input, preventing the users from searching. Make it visible.
- tons of issues came up in the console, dealt with a couple of them
  - not console issue, but sorted the list of mines for easier reading
  - UpdateMinsespaceUser: not previously flagged as an issue, but combining filterUserMines() to the list of mines was showing all of the user's mines in the dropdown more than once. 
  - helpers: antd complained about using props instead of children directly
  - AddPartyComponentWrapper: the componentWillMount function is deprecated, and not necessary anyway because the modal is destroyed on close now. Not sure why eslint was complaining about the render function return, maybe an issue with the Carousel?
  - UpdateMinespaceUser: both the parent and child of this component called it handleSubmit
  - PropTypes.minespaceUser: changed it to the field that's being used here.

[MDS-5335](https://bcmines.atlassian.net/browse/MDS-5335)

_Why are you making this change? Provide a short explanation and/or screenshots_
This one is more of a bandaid, if there is a better way to determine from within the multiselect that it's within a modal, I would like to know it. The multi select component really does need to know if it's within a modal or not in order to render correctly- because it puts calculated styles directly on the element, a CSS solution isn't very effective. I could have removed the getPopupContainer function entirely, but I know that this affects scroll outside of modals and there were many instances of the multi select component that would have to be checked.