### PR TITLE
[MDS-5365] converted document datetimes to strings

### DIFF
--- a/services/core-api/app/api/mines/documents/models/mine_document.py
+++ b/services/core-api/app/api/mines/documents/models/mine_document.py
@@ -121,7 +121,6 @@ class MineDocument(SoftDeleteMixin, AuditMixin, Base):
             'mine_guid': str(self.mine_guid),
             'document_manager_guid': str(self.document_manager_guid),
             'document_name': self.document_name,
-            'upload_date': self.upload_date,
             'create_user': self.create_user,
             'is_archived': self.is_archived,
             'archived_date': self.archived_date,

--- a/services/core-api/app/api/mines/documents/models/mine_document.py
+++ b/services/core-api/app/api/mines/documents/models/mine_document.py
@@ -91,7 +91,7 @@ class MineDocument(SoftDeleteMixin, AuditMixin, Base):
             'document_manager_guid': str(self.document_manager_guid),
             'document_manager_version_guid': str(uuid.uuid4()),
             'document_name': self.document_name,
-            'upload_date': self.upload_date,
+            'upload_date': str(self.upload_date),
             'create_user': self.create_user
         }
 
@@ -107,7 +107,7 @@ class MineDocument(SoftDeleteMixin, AuditMixin, Base):
                 'document_manager_guid': str(self.document_manager_guid),
                 'document_manager_version_guid': str(uuid.uuid4()),
                 'document_name': self.document_name,
-                'upload_date': self.upload_date,
+                'upload_date': str(self.upload_date),
                 'create_user': random.choice(users)
             })
 
@@ -126,6 +126,6 @@ class MineDocument(SoftDeleteMixin, AuditMixin, Base):
             'is_archived': self.is_archived,
             'archived_date': self.archived_date,
             'archived_by': self.archived_by,
-            'upload_date': self.upload_date,
+            'upload_date': str(self.upload_date),
             'versions': self.versions,
         }

--- a/services/core-api/app/api/mines/response_models.py
+++ b/services/core-api/app/api/mines/response_models.py
@@ -99,7 +99,7 @@ MINE_DOCUMENT_VERSION_MODEL = api.model(
         'document_manager_guid': fields.String,
         'document_manager_version_guid': fields.String,
         'document_name': fields.String,
-        'upload_date': fields.DateTime(dt_format='iso8601'),
+        'upload_date': fields.String,
         'create_user': fields.String,
     })
 
@@ -109,10 +109,10 @@ MINE_DOCUMENT_MODEL = api.model(
         'mine_guid': fields.String,
         'document_manager_guid': fields.String,
         'document_name': fields.String,
-        'upload_date': fields.DateTime(dt_format='iso8601'),
+        'upload_date': fields.String,
         'create_user': fields.String,
         'is_archived': fields.Boolean,
-        'archived_date': fields.DateTime(dt_format='iso8601'),
+        'archived_date': fields.String,
         'archived_by': fields.String,
         'versions': fields.List(fields.Nested(MINE_DOCUMENT_VERSION_MODEL))
     })
@@ -439,7 +439,7 @@ MINE_INCIDENT_DOCUMENT_MODEL = api.model(
         'document_manager_guid': fields.String,
         'document_name': fields.String,
         'mine_incident_document_type_code': fields.String,
-        'upload_date': fields.DateTime(dt_format='iso8601'),
+        'upload_date': fields.String,
         'update_user': fields.String
     })
 

--- a/services/core-api/app/api/mines/response_models.py
+++ b/services/core-api/app/api/mines/response_models.py
@@ -99,7 +99,7 @@ MINE_DOCUMENT_VERSION_MODEL = api.model(
         'document_manager_guid': fields.String,
         'document_manager_version_guid': fields.String,
         'document_name': fields.String,
-        'upload_date': fields.String,
+        'upload_date': fields.DateTime(dt_format='iso8601'),
         'create_user': fields.String,
     })
 
@@ -109,10 +109,10 @@ MINE_DOCUMENT_MODEL = api.model(
         'mine_guid': fields.String,
         'document_manager_guid': fields.String,
         'document_name': fields.String,
-        'upload_date': fields.String,
+        'upload_date': fields.DateTime(dt_format='iso8601'),
         'create_user': fields.String,
         'is_archived': fields.Boolean,
-        'archived_date': fields.DateTime,
+        'archived_date': fields.DateTime(dt_format='iso8601'),
         'archived_by': fields.String,
         'versions': fields.List(fields.Nested(MINE_DOCUMENT_VERSION_MODEL))
     })
@@ -439,7 +439,7 @@ MINE_INCIDENT_DOCUMENT_MODEL = api.model(
         'document_manager_guid': fields.String,
         'document_name': fields.String,
         'mine_incident_document_type_code': fields.String,
-        'upload_date': fields.DateTime,
+        'upload_date': fields.DateTime(dt_format='iso8601'),
         'update_user': fields.String
     })
 

--- a/services/core-api/app/api/mines/response_models.py
+++ b/services/core-api/app/api/mines/response_models.py
@@ -99,7 +99,7 @@ MINE_DOCUMENT_VERSION_MODEL = api.model(
         'document_manager_guid': fields.String,
         'document_manager_version_guid': fields.String,
         'document_name': fields.String,
-        'upload_date': fields.DateTime,
+        'upload_date': fields.String,
         'create_user': fields.String,
     })
 
@@ -109,7 +109,7 @@ MINE_DOCUMENT_MODEL = api.model(
         'mine_guid': fields.String,
         'document_manager_guid': fields.String,
         'document_name': fields.String,
-        'upload_date': fields.DateTime,
+        'upload_date': fields.String,
         'create_user': fields.String,
         'is_archived': fields.Boolean,
         'archived_date': fields.DateTime,


### PR DESCRIPTION
## Objective 

The `upload_date` in `mine_document` was being returned as a datetime.  Changed this to a string.

[MDS-5365](https://bcmines.atlassian.net/browse/MDS-5365)
