### PR TITLE
[MDS-5385] document data missing from document table

### DIFF
--- a/services/core-web/src/components/common/DocumentTable.js
+++ b/services/core-web/src/components/common/DocumentTable.js
@@ -119,8 +119,6 @@ const openArchiveModal = (event, props, documents) => {
 };
 
 export const DocumentTable = (props) => {
-  console.log("inside documentTable");
-  console.log(props);
   const isMinimalView = props.view === "minimal";
   const canDelete = !props.isViewOnly && props.removeDocument;
   const canArchive =

--- a/services/core-web/src/components/common/DocumentTable.js
+++ b/services/core-web/src/components/common/DocumentTable.js
@@ -67,21 +67,28 @@ const renderFileType = (file) => {
   return index === -1 ? null : file.substr(index);
 };
 
-const parseFiles = (versions, documentType) =>
-  versions.map((version, index) => ({
+const parseVersions = (versions, documentType) =>
+  versions.map((version) => ({
     key: version.mine_document_version_guid,
     file_location:
       Strings.MAJOR_MINES_APPLICATION_DOCUMENT_TYPE_CODE_LOCATION[documentType] ||
       Strings.EMPTY_FIELD,
     file_type: renderFileType(version.document_name) || Strings.EMPTY_FIELD,
-    number_of_versions: index === 0 ? versions.length - 1 : 0,
     ...version,
   }));
 
 const transformRowData = (document) => {
-  const files = parseFiles(document.versions, document.major_mine_application_document_type);
-  const currentFile = files[0];
-  const pastFiles = files.slice(1);
+  const pastFiles = parseVersions(document.versions, document.major_mine_application_document_type);
+  const currentFile = {
+    key: document.key,
+    file_location:
+      Strings.MAJOR_MINES_APPLICATION_DOCUMENT_TYPE_CODE_LOCATION[
+        document.major_mine_application_document_type
+      ] || Strings.EMPTY_FIELD,
+    file_type: renderFileType(document.document_name) || Strings.EMPTY_FIELD,
+    number_of_versions: document?.versions?.length,
+    ...document,
+  };
 
   return {
     ...currentFile,
@@ -112,6 +119,8 @@ const openArchiveModal = (event, props, documents) => {
 };
 
 export const DocumentTable = (props) => {
+  console.log("inside documentTable");
+  console.log(props);
   const isMinimalView = props.view === "minimal";
   const canDelete = !props.isViewOnly && props.removeDocument;
   const canArchive =


### PR DESCRIPTION

- Document table data wasn't showing up in the document tables in the final application page. It was found the retrieval of current document data was setup to be taken from version array but current document data doesn't ever appear there. 

- Change made in `transformRowData` function inside `DoucmentTable.js` to just retrieve current document data from the document object

[MDS-5385](https://bcmines.atlassian.net/browse/MDS-5385)

