### PR TITLE
[MDS-5272] Removed duplicate response creation when uploading new file

### DIFF
--- a/services/document-manager/backend/app/docman/resources/document.py
+++ b/services/document-manager/backend/app/docman/resources/document.py
@@ -71,16 +71,6 @@ class DocumentListResource(Resource):
             object_store_path=object_store_path)
         document.save()
 
-        # Create and send response
-        response = make_response(jsonify(document_manager_guid=document_guid), 201)
-        response.headers['Tus-Resumable'] = TUS_API_VERSION
-        response.headers['Tus-Version'] = TUS_API_SUPPORTED_VERSIONS
-        response.headers['Location'] = f'{Config.DOCUMENT_MANAGER_URL}/documents/{document_guid}'
-        response.headers['Upload-Offset'] = 0
-        response.headers['Upload-Expires'] = upload_expiry
-        response.headers[
-            'Access-Control-Expose-Headers'] = 'Tus-Resumable,Tus-Version,Location,Upload-Offset,Upload-Expires,Content-Type'
-        response.autocorrect_location_header = False
         return response
 
     def get(self):


### PR DESCRIPTION
## Objective 

[MDS-5272](https://bcmines.atlassian.net/browse/MDS-5272)

Removed a duplicate snipped causing an error when uploading a new file as `upload_expiry` is not defined anywhere. This functionality is covered in the `DocumentUploadHelper.initiate_document_upload` method a couple of lines up