### PR TITLE
[MDS-5060] Switch to argocd cli to Force Sync Apps Upon Image Promotion

### DIFF
--- a/.github/workflows/core-api.build.deploy.dev.yaml
+++ b/.github/workflows/core-api.build.deploy.dev.yaml
@@ -66,10 +66,15 @@ jobs:
         uses: redhat-actions/openshift-tools-installer@v1
         with:
           oc: "4.7"
+      - name: Setup ArgoCD CLI
+        if: ${{ env.NEEDS_ROLLOUT=='true' }}
+        uses: imajeetyadav/argocd-cli@v1
+        with:
+          version: v2.7.8
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
-        run: ./gitops/watch-deployment.sh core-api dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }}
+        run: ./gitops/watch-deployment.sh core-api dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/core-api.build.deploy.dev.yaml
+++ b/.github/workflows/core-api.build.deploy.dev.yaml
@@ -89,7 +89,7 @@ jobs:
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: argocd login
-        run: argocd login --token=${{ secrets.ARGO_CD_CLI_JWT }} --server=${{ secrets.ARGOCD_SERVER }}
+        run: argocd login --auth-token=${{ secrets.ARGO_CD_CLI_JWT }} --server=${{ secrets.ARGOCD_SERVER }}
       - name: Notification
         run: ./gitops/watch-deployment.sh core-api dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }}
 

--- a/.github/workflows/core-api.build.deploy.dev.yaml
+++ b/.github/workflows/core-api.build.deploy.dev.yaml
@@ -66,11 +66,26 @@ jobs:
         uses: redhat-actions/openshift-tools-installer@v1
         with:
           oc: "4.7"
+      - uses: clowdhaus/argo-cd-action/@main
+        env:
+          # Only required for first step in job where API is called
+          # All subsequent setps in a job will not re-download the CLI
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          command: version
+          options: --client
+      - uses: clowdhaus/argo-cd-action/@main
+        # CLI has already been downloaded in prior step, no call to GitHub API
+        with:
+          command: version
+          options: --client
       - name: Setup ArgoCD CLI
         if: ${{ env.NEEDS_ROLLOUT=='true' }}
-        uses: imajeetyadav/argocd-cli@v1
+        uses: clowdhaus/argo-cd-action/@main
         with:
-          version: v2.7.8
+          version: 2.6.7
+          command: version
+          options: --client
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification

--- a/.github/workflows/core-api.build.deploy.dev.yaml
+++ b/.github/workflows/core-api.build.deploy.dev.yaml
@@ -80,12 +80,9 @@ jobs:
           command: version
           options: --client
       - name: Setup ArgoCD CLI
-        if: ${{ env.NEEDS_ROLLOUT=='true' }}
-        uses: clowdhaus/argo-cd-action/@main
+        uses: imajeetyadav/argocd-cli@v1
         with:
-          version: 2.6.7
-          command: version
-          options: --client
+          version: v2.7.9 # optional
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: argocd login

--- a/.github/workflows/core-api.build.deploy.dev.yaml
+++ b/.github/workflows/core-api.build.deploy.dev.yaml
@@ -89,7 +89,7 @@ jobs:
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: argocd login
-        run: argocd login --auth-token=${{ secrets.ARGO_CD_CLI_JWT }} --server=${{ secrets.ARGOCD_SERVER }}
+        run: argocd login --auth-token=${{ secrets.ARGO_CD_CLI_JWT }} --server=${{ secrets.ARGOCD_SERVER }} --grpc-web
       - name: Notification
         run: ./gitops/watch-deployment.sh core-api dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }}
 

--- a/.github/workflows/core-api.build.deploy.dev.yaml
+++ b/.github/workflows/core-api.build.deploy.dev.yaml
@@ -83,7 +83,7 @@ jobs:
         if: ${{ env.NEEDS_ROLLOUT=='true' }}
         uses: clowdhaus/argo-cd-action/@main
         with:
-          version: 2.7.9
+          version: 2.6.7
           command: version
           options: --client
       - name: oc login

--- a/.github/workflows/core-api.build.deploy.dev.yaml
+++ b/.github/workflows/core-api.build.deploy.dev.yaml
@@ -74,7 +74,7 @@ jobs:
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
-        run: ./gitops/watch-deployment.sh core-api dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
+        run: ./gitops/watch-deployment.sh core-api dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ vars.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/core-api.build.deploy.dev.yaml
+++ b/.github/workflows/core-api.build.deploy.dev.yaml
@@ -74,7 +74,7 @@ jobs:
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
-        run: ./gitops/watch-deployment.sh core-api dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ vars.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
+        run: ./gitops/watch-deployment.sh core-api dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/core-api.build.deploy.dev.yaml
+++ b/.github/workflows/core-api.build.deploy.dev.yaml
@@ -89,7 +89,7 @@ jobs:
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: argocd login
-        run: argocd login --auth-token ${{ secrets.ARGO_CD_CLI_JWT }} --server ${{ secrets.ARGOCD_SERVER }} --grpc-web --insecure
+        run: argocd login ${{ secrets.ARGOCD_SERVER }} --auth-token ${{ secrets.ARGO_CD_CLI_JWT }} --grpc-web --insecure
       - name: Notification
         run: ./gitops/watch-deployment.sh core-api dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }}
 

--- a/.github/workflows/core-api.build.deploy.dev.yaml
+++ b/.github/workflows/core-api.build.deploy.dev.yaml
@@ -83,13 +83,15 @@ jobs:
         if: ${{ env.NEEDS_ROLLOUT=='true' }}
         uses: clowdhaus/argo-cd-action/@main
         with:
-          version: 2.6.7
+          version: 2.7.9
           command: version
           options: --client
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
+      - name: argocd login
+        run: argocd login --token=${{ secrets.ARGO_CD_CLI_JWT }} --server=${{ secrets.ARGOCD_SERVER }}
       - name: Notification
-        run: ./gitops/watch-deployment.sh core-api dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGO_CD_CLI_JWT }}
+        run: ./gitops/watch-deployment.sh core-api dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/core-api.build.deploy.dev.yaml
+++ b/.github/workflows/core-api.build.deploy.dev.yaml
@@ -89,7 +89,7 @@ jobs:
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: argocd login
-        run: argocd login --auth-token ${{ secrets.ARGO_CD_CLI_JWT }} --server ${{ secrets.ARGOCD_SERVER }} --grpc-web
+        run: argocd login --auth-token ${{ secrets.ARGO_CD_CLI_JWT }} --server ${{ secrets.ARGOCD_SERVER }} --grpc-web --insecure
       - name: Notification
         run: ./gitops/watch-deployment.sh core-api dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }}
 

--- a/.github/workflows/core-api.build.deploy.dev.yaml
+++ b/.github/workflows/core-api.build.deploy.dev.yaml
@@ -89,7 +89,7 @@ jobs:
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: argocd login
-        run: argocd login --auth-token=${{ secrets.ARGO_CD_CLI_JWT }} --server=${{ secrets.ARGOCD_SERVER }} --grpc-web
+        run: argocd login --auth-token ${{ secrets.ARGO_CD_CLI_JWT }} --server ${{ secrets.ARGOCD_SERVER }} --grpc-web
       - name: Notification
         run: ./gitops/watch-deployment.sh core-api dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }}
 

--- a/.github/workflows/core-api.build.deploy.dev.yaml
+++ b/.github/workflows/core-api.build.deploy.dev.yaml
@@ -89,7 +89,7 @@ jobs:
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
-        run: ./gitops/watch-deployment.sh core-api dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
+        run: ./gitops/watch-deployment.sh core-api dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGO_CD_CLI_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/core-api.build.deploy.dev.yaml
+++ b/.github/workflows/core-api.build.deploy.dev.yaml
@@ -66,19 +66,6 @@ jobs:
         uses: redhat-actions/openshift-tools-installer@v1
         with:
           oc: "4.7"
-      - uses: clowdhaus/argo-cd-action/@main
-        env:
-          # Only required for first step in job where API is called
-          # All subsequent setps in a job will not re-download the CLI
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          command: version
-          options: --client
-      - uses: clowdhaus/argo-cd-action/@main
-        # CLI has already been downloaded in prior step, no call to GitHub API
-        with:
-          command: version
-          options: --client
       - name: Setup ArgoCD CLI
         uses: imajeetyadav/argocd-cli@v1
         with:

--- a/.github/workflows/core-api.build.deploy.dev.yaml
+++ b/.github/workflows/core-api.build.deploy.dev.yaml
@@ -72,10 +72,8 @@ jobs:
           version: v2.7.9 # optional
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
-      - name: argocd login
-        run: argocd login ${{ secrets.ARGOCD_SERVER }} --auth-token ${{ secrets.ARGO_CD_CLI_JWT }} --grpc-web --insecure
       - name: Notification
-        run: ./gitops/watch-deployment.sh core-api dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }}
+        run: ./gitops/watch-deployment.sh core-api dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGO_CD_CLI_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/core-api.deploy.prod.yaml
+++ b/.github/workflows/core-api.deploy.prod.yaml
@@ -48,9 +48,11 @@ jobs:
           oc: "4.7"
       - name: Setup ArgoCD CLI
         if: ${{ env.NEEDS_ROLLOUT=='true' }}
-        uses: imajeetyadav/argocd-cli@v1
+        uses: clowdhaus/argo-cd-action/@main
         with:
-          version: v2.7.8
+          version: 2.6.7
+          command: version
+          options: --client
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification

--- a/.github/workflows/core-api.deploy.prod.yaml
+++ b/.github/workflows/core-api.deploy.prod.yaml
@@ -47,12 +47,9 @@ jobs:
         with:
           oc: "4.7"
       - name: Setup ArgoCD CLI
-        if: ${{ env.NEEDS_ROLLOUT=='true' }}
-        uses: clowdhaus/argo-cd-action/@main
+        uses: imajeetyadav/argocd-cli@v1
         with:
-          version: 2.6.7
-          command: version
-          options: --client
+          version: v2.7.9 # optional
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification

--- a/.github/workflows/core-api.deploy.prod.yaml
+++ b/.github/workflows/core-api.deploy.prod.yaml
@@ -46,10 +46,15 @@ jobs:
         uses: redhat-actions/openshift-tools-installer@v1
         with:
           oc: "4.7"
+      - name: Setup ArgoCD CLI
+        if: ${{ env.NEEDS_ROLLOUT=='true' }}
+        uses: imajeetyadav/argocd-cli@v1
+        with:
+          version: v2.7.8
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
-        run: ./gitops/watch-deployment.sh core-api prod ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }}
+        run: ./gitops/watch-deployment.sh core-api prod ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/core-api.deploy.prod.yaml
+++ b/.github/workflows/core-api.deploy.prod.yaml
@@ -54,7 +54,7 @@ jobs:
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
-        run: ./gitops/watch-deployment.sh core-api prod ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ vars.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
+        run: ./gitops/watch-deployment.sh core-api prod ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/core-api.deploy.prod.yaml
+++ b/.github/workflows/core-api.deploy.prod.yaml
@@ -54,7 +54,7 @@ jobs:
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
-        run: ./gitops/watch-deployment.sh core-api prod ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
+        run: ./gitops/watch-deployment.sh core-api prod ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ vars.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/core-api.deploy.prod.yaml
+++ b/.github/workflows/core-api.deploy.prod.yaml
@@ -56,7 +56,7 @@ jobs:
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
-        run: ./gitops/watch-deployment.sh core-api prod ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
+        run: ./gitops/watch-deployment.sh core-api prod ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGO_CD_CLI_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/core-api.deploy.test.yaml
+++ b/.github/workflows/core-api.deploy.test.yaml
@@ -57,7 +57,7 @@ jobs:
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
         if: ${{ env.NEEDS_ROLLOUT=='true' }}
-        run: ./gitops/watch-deployment.sh core-api test ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
+        run: ./gitops/watch-deployment.sh core-api test ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ vars.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/core-api.deploy.test.yaml
+++ b/.github/workflows/core-api.deploy.test.yaml
@@ -59,7 +59,7 @@ jobs:
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
         if: ${{ env.NEEDS_ROLLOUT=='true' }}
-        run: ./gitops/watch-deployment.sh core-api test ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
+        run: ./gitops/watch-deployment.sh core-api test ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGO_CD_CLI_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/core-api.deploy.test.yaml
+++ b/.github/workflows/core-api.deploy.test.yaml
@@ -47,12 +47,17 @@ jobs:
         uses: redhat-actions/openshift-tools-installer@v1
         with:
           oc: "4.7"
+      - name: Setup ArgoCD CLI
+        if: ${{ env.NEEDS_ROLLOUT=='true' }}
+        uses: imajeetyadav/argocd-cli@v1
+        with:
+          version: v2.7.8
       - name: oc login
         if: ${{ env.NEEDS_ROLLOUT=='true' }}
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
         if: ${{ env.NEEDS_ROLLOUT=='true' }}
-        run: ./gitops/watch-deployment.sh core-api test ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }}
+        run: ./gitops/watch-deployment.sh core-api test ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/core-api.deploy.test.yaml
+++ b/.github/workflows/core-api.deploy.test.yaml
@@ -57,7 +57,7 @@ jobs:
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
         if: ${{ env.NEEDS_ROLLOUT=='true' }}
-        run: ./gitops/watch-deployment.sh core-api test ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ vars.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
+        run: ./gitops/watch-deployment.sh core-api test ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/core-api.deploy.test.yaml
+++ b/.github/workflows/core-api.deploy.test.yaml
@@ -48,12 +48,9 @@ jobs:
         with:
           oc: "4.7"
       - name: Setup ArgoCD CLI
-        if: ${{ env.NEEDS_ROLLOUT=='true' }}
-        uses: clowdhaus/argo-cd-action/@main
+        uses: imajeetyadav/argocd-cli@v1
         with:
-          version: 2.6.7
-          command: version
-          options: --client
+          version: v2.7.9 # optional
       - name: oc login
         if: ${{ env.NEEDS_ROLLOUT=='true' }}
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}

--- a/.github/workflows/core-api.deploy.test.yaml
+++ b/.github/workflows/core-api.deploy.test.yaml
@@ -49,9 +49,11 @@ jobs:
           oc: "4.7"
       - name: Setup ArgoCD CLI
         if: ${{ env.NEEDS_ROLLOUT=='true' }}
-        uses: imajeetyadav/argocd-cli@v1
+        uses: clowdhaus/argo-cd-action/@main
         with:
-          version: v2.7.8
+          version: 2.6.7
+          command: version
+          options: --client
       - name: oc login
         if: ${{ env.NEEDS_ROLLOUT=='true' }}
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}

--- a/.github/workflows/core-web.build.deploy.dev.yaml
+++ b/.github/workflows/core-web.build.deploy.dev.yaml
@@ -50,10 +50,15 @@ jobs:
         uses: redhat-actions/openshift-tools-installer@v1
         with:
           oc: "4.7"
+      - name: Setup ArgoCD CLI
+        if: ${{ env.NEEDS_ROLLOUT=='true' }}
+        uses: imajeetyadav/argocd-cli@v1
+        with:
+          version: v2.7.8
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
-        run: ./gitops/watch-deployment.sh core-web dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }}
+        run: ./gitops/watch-deployment.sh core-web dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/core-web.build.deploy.dev.yaml
+++ b/.github/workflows/core-web.build.deploy.dev.yaml
@@ -58,7 +58,7 @@ jobs:
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
-        run: ./gitops/watch-deployment.sh core-web dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
+        run: ./gitops/watch-deployment.sh core-web dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ vars.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/core-web.build.deploy.dev.yaml
+++ b/.github/workflows/core-web.build.deploy.dev.yaml
@@ -58,7 +58,7 @@ jobs:
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
-        run: ./gitops/watch-deployment.sh core-web dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ vars.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
+        run: ./gitops/watch-deployment.sh core-web dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/core-web.build.deploy.dev.yaml
+++ b/.github/workflows/core-web.build.deploy.dev.yaml
@@ -60,7 +60,7 @@ jobs:
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
-        run: ./gitops/watch-deployment.sh core-web dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
+        run: ./gitops/watch-deployment.sh core-web dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGO_CD_CLI_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/core-web.build.deploy.dev.yaml
+++ b/.github/workflows/core-web.build.deploy.dev.yaml
@@ -51,12 +51,9 @@ jobs:
         with:
           oc: "4.7"
       - name: Setup ArgoCD CLI
-        if: ${{ env.NEEDS_ROLLOUT=='true' }}
-        uses: clowdhaus/argo-cd-action/@main
+        uses: imajeetyadav/argocd-cli@v1
         with:
-          version: 2.6.7
-          command: version
-          options: --client
+          version: v2.7.9 # optional
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification

--- a/.github/workflows/core-web.build.deploy.dev.yaml
+++ b/.github/workflows/core-web.build.deploy.dev.yaml
@@ -52,9 +52,11 @@ jobs:
           oc: "4.7"
       - name: Setup ArgoCD CLI
         if: ${{ env.NEEDS_ROLLOUT=='true' }}
-        uses: imajeetyadav/argocd-cli@v1
+        uses: clowdhaus/argo-cd-action/@main
         with:
-          version: v2.7.8
+          version: 2.6.7
+          command: version
+          options: --client
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification

--- a/.github/workflows/core-web.deploy.prod.yaml
+++ b/.github/workflows/core-web.deploy.prod.yaml
@@ -48,7 +48,7 @@ jobs:
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
-        run: ./gitops/watch-deployment.sh core-web prod ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
+        run: ./gitops/watch-deployment.sh core-web prod ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ vars.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/core-web.deploy.prod.yaml
+++ b/.github/workflows/core-web.deploy.prod.yaml
@@ -42,9 +42,11 @@ jobs:
           oc: "4.7"
       - name: Setup ArgoCD CLI
         if: ${{ env.NEEDS_ROLLOUT=='true' }}
-        uses: imajeetyadav/argocd-cli@v1
+        uses: clowdhaus/argo-cd-action/@main
         with:
-          version: v2.7.8
+          version: 2.6.7
+          command: version
+          options: --client
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification

--- a/.github/workflows/core-web.deploy.prod.yaml
+++ b/.github/workflows/core-web.deploy.prod.yaml
@@ -50,7 +50,7 @@ jobs:
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
-        run: ./gitops/watch-deployment.sh core-web prod ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
+        run: ./gitops/watch-deployment.sh core-web prod ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGO_CD_CLI_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/core-web.deploy.prod.yaml
+++ b/.github/workflows/core-web.deploy.prod.yaml
@@ -48,7 +48,7 @@ jobs:
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
-        run: ./gitops/watch-deployment.sh core-web prod ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ vars.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
+        run: ./gitops/watch-deployment.sh core-web prod ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/core-web.deploy.prod.yaml
+++ b/.github/workflows/core-web.deploy.prod.yaml
@@ -41,12 +41,9 @@ jobs:
         with:
           oc: "4.7"
       - name: Setup ArgoCD CLI
-        if: ${{ env.NEEDS_ROLLOUT=='true' }}
-        uses: clowdhaus/argo-cd-action/@main
+        uses: imajeetyadav/argocd-cli@v1
         with:
-          version: 2.6.7
-          command: version
-          options: --client
+          version: v2.7.9 # optional
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification

--- a/.github/workflows/core-web.deploy.prod.yaml
+++ b/.github/workflows/core-web.deploy.prod.yaml
@@ -40,10 +40,15 @@ jobs:
         uses: redhat-actions/openshift-tools-installer@v1
         with:
           oc: "4.7"
+      - name: Setup ArgoCD CLI
+        if: ${{ env.NEEDS_ROLLOUT=='true' }}
+        uses: imajeetyadav/argocd-cli@v1
+        with:
+          version: v2.7.8
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
-        run: ./gitops/watch-deployment.sh core-web prod ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }}
+        run: ./gitops/watch-deployment.sh core-web prod ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/core-web.deploy.test.yaml
+++ b/.github/workflows/core-web.deploy.test.yaml
@@ -45,9 +45,11 @@ jobs:
           oc: "4.7"
       - name: Setup ArgoCD CLI
         if: ${{ env.NEEDS_ROLLOUT=='true' }}
-        uses: imajeetyadav/argocd-cli@v1
+        uses: clowdhaus/argo-cd-action/@main
         with:
-          version: v2.7.8
+          version: 2.6.7
+          command: version
+          options: --client
       - name: oc login
         if: ${{ env.NEEDS_ROLLOUT=='true' }}
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}

--- a/.github/workflows/core-web.deploy.test.yaml
+++ b/.github/workflows/core-web.deploy.test.yaml
@@ -53,7 +53,7 @@ jobs:
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
         if: ${{ env.NEEDS_ROLLOUT=='true' }}
-        run: ./gitops/watch-deployment.sh core-web test ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
+        run: ./gitops/watch-deployment.sh core-web test ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ vars.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/core-web.deploy.test.yaml
+++ b/.github/workflows/core-web.deploy.test.yaml
@@ -43,12 +43,17 @@ jobs:
         uses: redhat-actions/openshift-tools-installer@v1
         with:
           oc: "4.7"
+      - name: Setup ArgoCD CLI
+        if: ${{ env.NEEDS_ROLLOUT=='true' }}
+        uses: imajeetyadav/argocd-cli@v1
+        with:
+          version: v2.7.8
       - name: oc login
         if: ${{ env.NEEDS_ROLLOUT=='true' }}
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
         if: ${{ env.NEEDS_ROLLOUT=='true' }}
-        run: ./gitops/watch-deployment.sh core-web test ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }}
+        run: ./gitops/watch-deployment.sh core-web test ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/core-web.deploy.test.yaml
+++ b/.github/workflows/core-web.deploy.test.yaml
@@ -44,12 +44,9 @@ jobs:
         with:
           oc: "4.7"
       - name: Setup ArgoCD CLI
-        if: ${{ env.NEEDS_ROLLOUT=='true' }}
-        uses: clowdhaus/argo-cd-action/@main
+        uses: imajeetyadav/argocd-cli@v1
         with:
-          version: 2.6.7
-          command: version
-          options: --client
+          version: v2.7.9 # optional
       - name: oc login
         if: ${{ env.NEEDS_ROLLOUT=='true' }}
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}

--- a/.github/workflows/core-web.deploy.test.yaml
+++ b/.github/workflows/core-web.deploy.test.yaml
@@ -55,7 +55,7 @@ jobs:
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
         if: ${{ env.NEEDS_ROLLOUT=='true' }}
-        run: ./gitops/watch-deployment.sh core-web test ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
+        run: ./gitops/watch-deployment.sh core-web test ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGO_CD_CLI_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/core-web.deploy.test.yaml
+++ b/.github/workflows/core-web.deploy.test.yaml
@@ -53,7 +53,7 @@ jobs:
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
         if: ${{ env.NEEDS_ROLLOUT=='true' }}
-        run: ./gitops/watch-deployment.sh core-web test ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ vars.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
+        run: ./gitops/watch-deployment.sh core-web test ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/docman.build.deploy.dev.yaml
+++ b/.github/workflows/docman.build.deploy.dev.yaml
@@ -53,7 +53,7 @@ jobs:
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
-        run: ./gitops/watch-deployment.sh docman dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
+        run: ./gitops/watch-deployment.sh docman dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ vars.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/docman.build.deploy.dev.yaml
+++ b/.github/workflows/docman.build.deploy.dev.yaml
@@ -53,7 +53,7 @@ jobs:
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
-        run: ./gitops/watch-deployment.sh docman dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ vars.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
+        run: ./gitops/watch-deployment.sh docman dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/docman.build.deploy.dev.yaml
+++ b/.github/workflows/docman.build.deploy.dev.yaml
@@ -47,9 +47,11 @@ jobs:
           oc: "4.7"
       - name: Setup ArgoCD CLI
         if: ${{ env.NEEDS_ROLLOUT=='true' }}
-        uses: imajeetyadav/argocd-cli@v1
+        uses: clowdhaus/argo-cd-action/@main
         with:
-          version: v2.7.8
+          version: 2.6.7
+          command: version
+          options: --client
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification

--- a/.github/workflows/docman.build.deploy.dev.yaml
+++ b/.github/workflows/docman.build.deploy.dev.yaml
@@ -45,10 +45,15 @@ jobs:
         uses: redhat-actions/openshift-tools-installer@v1
         with:
           oc: "4.7"
+      - name: Setup ArgoCD CLI
+        if: ${{ env.NEEDS_ROLLOUT=='true' }}
+        uses: imajeetyadav/argocd-cli@v1
+        with:
+          version: v2.7.8
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
-        run: ./gitops/watch-deployment.sh docman dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }}
+        run: ./gitops/watch-deployment.sh docman dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/docman.build.deploy.dev.yaml
+++ b/.github/workflows/docman.build.deploy.dev.yaml
@@ -55,7 +55,7 @@ jobs:
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
-        run: ./gitops/watch-deployment.sh docman dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
+        run: ./gitops/watch-deployment.sh docman dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGO_CD_CLI_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/docman.build.deploy.dev.yaml
+++ b/.github/workflows/docman.build.deploy.dev.yaml
@@ -46,12 +46,9 @@ jobs:
         with:
           oc: "4.7"
       - name: Setup ArgoCD CLI
-        if: ${{ env.NEEDS_ROLLOUT=='true' }}
-        uses: clowdhaus/argo-cd-action/@main
+        uses: imajeetyadav/argocd-cli@v1
         with:
-          version: 2.6.7
-          command: version
-          options: --client
+          version: v2.7.9 # optional
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification

--- a/.github/workflows/docman.deploy.prod.yaml
+++ b/.github/workflows/docman.deploy.prod.yaml
@@ -42,12 +42,9 @@ jobs:
         with:
           oc: "4.7"
       - name: Setup ArgoCD CLI
-        if: ${{ env.NEEDS_ROLLOUT=='true' }}
-        uses: clowdhaus/argo-cd-action/@main
+        uses: imajeetyadav/argocd-cli@v1
         with:
-          version: 2.6.7
-          command: version
-          options: --client
+          version: v2.7.9 # optional
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification

--- a/.github/workflows/docman.deploy.prod.yaml
+++ b/.github/workflows/docman.deploy.prod.yaml
@@ -51,7 +51,7 @@ jobs:
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
-        run: ./gitops/watch-deployment.sh docman prod ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
+        run: ./gitops/watch-deployment.sh docman prod ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGO_CD_CLI_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/docman.deploy.prod.yaml
+++ b/.github/workflows/docman.deploy.prod.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
-        run: ./gitops/watch-deployment.sh docman prod ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ vars.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
+        run: ./gitops/watch-deployment.sh docman prod ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/docman.deploy.prod.yaml
+++ b/.github/workflows/docman.deploy.prod.yaml
@@ -41,10 +41,15 @@ jobs:
         uses: redhat-actions/openshift-tools-installer@v1
         with:
           oc: "4.7"
+      - name: Setup ArgoCD CLI
+        if: ${{ env.NEEDS_ROLLOUT=='true' }}
+        uses: imajeetyadav/argocd-cli@v1
+        with:
+          version: v2.7.8
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
-        run: ./gitops/watch-deployment.sh docman prod ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }}
+        run: ./gitops/watch-deployment.sh docman prod ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/docman.deploy.prod.yaml
+++ b/.github/workflows/docman.deploy.prod.yaml
@@ -43,9 +43,11 @@ jobs:
           oc: "4.7"
       - name: Setup ArgoCD CLI
         if: ${{ env.NEEDS_ROLLOUT=='true' }}
-        uses: imajeetyadav/argocd-cli@v1
+        uses: clowdhaus/argo-cd-action/@main
         with:
-          version: v2.7.8
+          version: 2.6.7
+          command: version
+          options: --client
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification

--- a/.github/workflows/docman.deploy.prod.yaml
+++ b/.github/workflows/docman.deploy.prod.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
-        run: ./gitops/watch-deployment.sh docman prod ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
+        run: ./gitops/watch-deployment.sh docman prod ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ vars.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/docman.deploy.test.yaml
+++ b/.github/workflows/docman.deploy.test.yaml
@@ -42,12 +42,9 @@ jobs:
         with:
           oc: "4.7"
       - name: Setup ArgoCD CLI
-        if: ${{ env.NEEDS_ROLLOUT=='true' }}
-        uses: clowdhaus/argo-cd-action/@main
+        uses: imajeetyadav/argocd-cli@v1
         with:
-          version: 2.6.7
-          command: version
-          options: --client
+          version: v2.7.9 # optional
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification

--- a/.github/workflows/docman.deploy.test.yaml
+++ b/.github/workflows/docman.deploy.test.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
-        run: ./gitops/watch-deployment.sh docman test ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
+        run: ./gitops/watch-deployment.sh docman test ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ vars.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/docman.deploy.test.yaml
+++ b/.github/workflows/docman.deploy.test.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
-        run: ./gitops/watch-deployment.sh docman test ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ vars.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
+        run: ./gitops/watch-deployment.sh docman test ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/docman.deploy.test.yaml
+++ b/.github/workflows/docman.deploy.test.yaml
@@ -51,7 +51,7 @@ jobs:
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
-        run: ./gitops/watch-deployment.sh docman test ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
+        run: ./gitops/watch-deployment.sh docman test ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGO_CD_CLI_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/docman.deploy.test.yaml
+++ b/.github/workflows/docman.deploy.test.yaml
@@ -43,9 +43,11 @@ jobs:
           oc: "4.7"
       - name: Setup ArgoCD CLI
         if: ${{ env.NEEDS_ROLLOUT=='true' }}
-        uses: imajeetyadav/argocd-cli@v1
+        uses: clowdhaus/argo-cd-action/@main
         with:
-          version: v2.7.8
+          version: 2.6.7
+          command: version
+          options: --client
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification

--- a/.github/workflows/docman.deploy.test.yaml
+++ b/.github/workflows/docman.deploy.test.yaml
@@ -41,10 +41,15 @@ jobs:
         uses: redhat-actions/openshift-tools-installer@v1
         with:
           oc: "4.7"
+      - name: Setup ArgoCD CLI
+        if: ${{ env.NEEDS_ROLLOUT=='true' }}
+        uses: imajeetyadav/argocd-cli@v1
+        with:
+          version: v2.7.8
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
-        run: ./gitops/watch-deployment.sh docman test ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }}
+        run: ./gitops/watch-deployment.sh docman test ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/filesystem-provider.build.deploy.dev.yaml
+++ b/.github/workflows/filesystem-provider.build.deploy.dev.yaml
@@ -50,10 +50,15 @@ jobs:
         uses: redhat-actions/openshift-tools-installer@v1
         with:
           oc: "4.7"
+      - name: Setup ArgoCD CLI
+        if: ${{ env.NEEDS_ROLLOUT=='true' }}
+        uses: imajeetyadav/argocd-cli@v1
+        with:
+          version: v2.7.8
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
-        run: ./gitops/watch-deployment.sh filesystem-provider dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }}
+        run: ./gitops/watch-deployment.sh filesystem-provider dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/filesystem-provider.build.deploy.dev.yaml
+++ b/.github/workflows/filesystem-provider.build.deploy.dev.yaml
@@ -60,7 +60,7 @@ jobs:
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
-        run: ./gitops/watch-deployment.sh filesystem-provider dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
+        run: ./gitops/watch-deployment.sh filesystem-provider dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGO_CD_CLI_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/filesystem-provider.build.deploy.dev.yaml
+++ b/.github/workflows/filesystem-provider.build.deploy.dev.yaml
@@ -58,7 +58,7 @@ jobs:
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
-        run: ./gitops/watch-deployment.sh filesystem-provider dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
+        run: ./gitops/watch-deployment.sh filesystem-provider dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ vars.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/filesystem-provider.build.deploy.dev.yaml
+++ b/.github/workflows/filesystem-provider.build.deploy.dev.yaml
@@ -58,7 +58,7 @@ jobs:
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
-        run: ./gitops/watch-deployment.sh filesystem-provider dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ vars.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
+        run: ./gitops/watch-deployment.sh filesystem-provider dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/filesystem-provider.build.deploy.dev.yaml
+++ b/.github/workflows/filesystem-provider.build.deploy.dev.yaml
@@ -51,12 +51,9 @@ jobs:
         with:
           oc: "4.7"
       - name: Setup ArgoCD CLI
-        if: ${{ env.NEEDS_ROLLOUT=='true' }}
-        uses: clowdhaus/argo-cd-action/@main
+        uses: imajeetyadav/argocd-cli@v1
         with:
-          version: 2.6.7
-          command: version
-          options: --client
+          version: v2.7.9 # optional
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification

--- a/.github/workflows/filesystem-provider.build.deploy.dev.yaml
+++ b/.github/workflows/filesystem-provider.build.deploy.dev.yaml
@@ -52,9 +52,11 @@ jobs:
           oc: "4.7"
       - name: Setup ArgoCD CLI
         if: ${{ env.NEEDS_ROLLOUT=='true' }}
-        uses: imajeetyadav/argocd-cli@v1
+        uses: clowdhaus/argo-cd-action/@main
         with:
-          version: v2.7.8
+          version: 2.6.7
+          command: version
+          options: --client
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification

--- a/.github/workflows/filesystem-provider.deploy.prod.yaml
+++ b/.github/workflows/filesystem-provider.deploy.prod.yaml
@@ -42,12 +42,9 @@ jobs:
         with:
           oc: "4.7"
       - name: Setup ArgoCD CLI
-        if: ${{ env.NEEDS_ROLLOUT=='true' }}
-        uses: clowdhaus/argo-cd-action/@main
+        uses: imajeetyadav/argocd-cli@v1
         with:
-          version: 2.6.7
-          command: version
-          options: --client
+          version: v2.7.9 # optional
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification

--- a/.github/workflows/filesystem-provider.deploy.prod.yaml
+++ b/.github/workflows/filesystem-provider.deploy.prod.yaml
@@ -51,7 +51,7 @@ jobs:
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
-        run: ./gitops/watch-deployment.sh filesystem-provider prod ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
+        run: ./gitops/watch-deployment.sh filesystem-provider prod ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGO_CD_CLI_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/filesystem-provider.deploy.prod.yaml
+++ b/.github/workflows/filesystem-provider.deploy.prod.yaml
@@ -43,9 +43,11 @@ jobs:
           oc: "4.7"
       - name: Setup ArgoCD CLI
         if: ${{ env.NEEDS_ROLLOUT=='true' }}
-        uses: imajeetyadav/argocd-cli@v1
+        uses: clowdhaus/argo-cd-action/@main
         with:
-          version: v2.7.8
+          version: 2.6.7
+          command: version
+          options: --client
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification

--- a/.github/workflows/filesystem-provider.deploy.prod.yaml
+++ b/.github/workflows/filesystem-provider.deploy.prod.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
-        run: ./gitops/watch-deployment.sh filesystem-provider prod ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
+        run: ./gitops/watch-deployment.sh filesystem-provider prod ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ vars.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/filesystem-provider.deploy.prod.yaml
+++ b/.github/workflows/filesystem-provider.deploy.prod.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
-        run: ./gitops/watch-deployment.sh filesystem-provider prod ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ vars.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
+        run: ./gitops/watch-deployment.sh filesystem-provider prod ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/filesystem-provider.deploy.prod.yaml
+++ b/.github/workflows/filesystem-provider.deploy.prod.yaml
@@ -41,10 +41,15 @@ jobs:
         uses: redhat-actions/openshift-tools-installer@v1
         with:
           oc: "4.7"
+      - name: Setup ArgoCD CLI
+        if: ${{ env.NEEDS_ROLLOUT=='true' }}
+        uses: imajeetyadav/argocd-cli@v1
+        with:
+          version: v2.7.8
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
-        run: ./gitops/watch-deployment.sh filesystem-provider prod ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }}
+        run: ./gitops/watch-deployment.sh filesystem-provider prod ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/filesystem-provider.deploy.test.yaml
+++ b/.github/workflows/filesystem-provider.deploy.test.yaml
@@ -42,12 +42,9 @@ jobs:
         with:
           oc: "4.7"
       - name: Setup ArgoCD CLI
-        if: ${{ env.NEEDS_ROLLOUT=='true' }}
-        uses: clowdhaus/argo-cd-action/@main
+        uses: imajeetyadav/argocd-cli@v1
         with:
-          version: 2.6.7
-          command: version
-          options: --client
+          version: v2.7.9 # optional
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification

--- a/.github/workflows/filesystem-provider.deploy.test.yaml
+++ b/.github/workflows/filesystem-provider.deploy.test.yaml
@@ -41,10 +41,15 @@ jobs:
         uses: redhat-actions/openshift-tools-installer@v1
         with:
           oc: "4.7"
+      - name: Setup ArgoCD CLI
+        if: ${{ env.NEEDS_ROLLOUT=='true' }}
+        uses: imajeetyadav/argocd-cli@v1
+        with:
+          version: v2.7.8
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
-        run: ./gitops/watch-deployment.sh filesystem-provider test ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }}
+        run: ./gitops/watch-deployment.sh filesystem-provider test ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/filesystem-provider.deploy.test.yaml
+++ b/.github/workflows/filesystem-provider.deploy.test.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
-        run: ./gitops/watch-deployment.sh filesystem-provider test ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
+        run: ./gitops/watch-deployment.sh filesystem-provider test ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ vars.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/filesystem-provider.deploy.test.yaml
+++ b/.github/workflows/filesystem-provider.deploy.test.yaml
@@ -51,7 +51,7 @@ jobs:
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
-        run: ./gitops/watch-deployment.sh filesystem-provider test ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
+        run: ./gitops/watch-deployment.sh filesystem-provider test ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGO_CD_CLI_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/filesystem-provider.deploy.test.yaml
+++ b/.github/workflows/filesystem-provider.deploy.test.yaml
@@ -43,9 +43,11 @@ jobs:
           oc: "4.7"
       - name: Setup ArgoCD CLI
         if: ${{ env.NEEDS_ROLLOUT=='true' }}
-        uses: imajeetyadav/argocd-cli@v1
+        uses: clowdhaus/argo-cd-action/@main
         with:
-          version: v2.7.8
+          version: 2.6.7
+          command: version
+          options: --client
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification

--- a/.github/workflows/filesystem-provider.deploy.test.yaml
+++ b/.github/workflows/filesystem-provider.deploy.test.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
-        run: ./gitops/watch-deployment.sh filesystem-provider test ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ vars.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
+        run: ./gitops/watch-deployment.sh filesystem-provider test ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/minespace.build.deploy.dev.yaml
+++ b/.github/workflows/minespace.build.deploy.dev.yaml
@@ -60,7 +60,7 @@ jobs:
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
-        run: ./gitops/watch-deployment.sh minespace dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
+        run: ./gitops/watch-deployment.sh minespace dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGO_CD_CLI_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/minespace.build.deploy.dev.yaml
+++ b/.github/workflows/minespace.build.deploy.dev.yaml
@@ -58,7 +58,7 @@ jobs:
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
-        run: ./gitops/watch-deployment.sh minespace dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ vars.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
+        run: ./gitops/watch-deployment.sh minespace dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/minespace.build.deploy.dev.yaml
+++ b/.github/workflows/minespace.build.deploy.dev.yaml
@@ -58,7 +58,7 @@ jobs:
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
-        run: ./gitops/watch-deployment.sh minespace dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
+        run: ./gitops/watch-deployment.sh minespace dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ vars.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/minespace.build.deploy.dev.yaml
+++ b/.github/workflows/minespace.build.deploy.dev.yaml
@@ -51,12 +51,9 @@ jobs:
         with:
           oc: "4.7"
       - name: Setup ArgoCD CLI
-        if: ${{ env.NEEDS_ROLLOUT=='true' }}
-        uses: clowdhaus/argo-cd-action/@main
+        uses: imajeetyadav/argocd-cli@v1
         with:
-          version: 2.6.7
-          command: version
-          options: --client
+          version: v2.7.9 # optional
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification

--- a/.github/workflows/minespace.build.deploy.dev.yaml
+++ b/.github/workflows/minespace.build.deploy.dev.yaml
@@ -52,9 +52,11 @@ jobs:
           oc: "4.7"
       - name: Setup ArgoCD CLI
         if: ${{ env.NEEDS_ROLLOUT=='true' }}
-        uses: imajeetyadav/argocd-cli@v1
+        uses: clowdhaus/argo-cd-action/@main
         with:
-          version: v2.7.8
+          version: 2.6.7
+          command: version
+          options: --client
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification

--- a/.github/workflows/minespace.build.deploy.dev.yaml
+++ b/.github/workflows/minespace.build.deploy.dev.yaml
@@ -50,10 +50,15 @@ jobs:
         uses: redhat-actions/openshift-tools-installer@v1
         with:
           oc: "4.7"
+      - name: Setup ArgoCD CLI
+        if: ${{ env.NEEDS_ROLLOUT=='true' }}
+        uses: imajeetyadav/argocd-cli@v1
+        with:
+          version: v2.7.8
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
-        run: ./gitops/watch-deployment.sh minespace dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }}
+        run: ./gitops/watch-deployment.sh minespace dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/minespace.deploy.prod.yaml
+++ b/.github/workflows/minespace.deploy.prod.yaml
@@ -42,12 +42,9 @@ jobs:
         with:
           oc: "4.7"
       - name: Setup ArgoCD CLI
-        if: ${{ env.NEEDS_ROLLOUT=='true' }}
-        uses: clowdhaus/argo-cd-action/@main
+        uses: imajeetyadav/argocd-cli@v1
         with:
-          version: 2.6.7
-          command: version
-          options: --client
+          version: v2.7.9 # optional
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification

--- a/.github/workflows/minespace.deploy.prod.yaml
+++ b/.github/workflows/minespace.deploy.prod.yaml
@@ -51,7 +51,7 @@ jobs:
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
-        run: ./gitops/watch-deployment.sh minespace prod ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
+        run: ./gitops/watch-deployment.sh minespace prod ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGO_CD_CLI_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/minespace.deploy.prod.yaml
+++ b/.github/workflows/minespace.deploy.prod.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
-        run: ./gitops/watch-deployment.sh minespace prod ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
+        run: ./gitops/watch-deployment.sh minespace prod ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ vars.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/minespace.deploy.prod.yaml
+++ b/.github/workflows/minespace.deploy.prod.yaml
@@ -43,9 +43,11 @@ jobs:
           oc: "4.7"
       - name: Setup ArgoCD CLI
         if: ${{ env.NEEDS_ROLLOUT=='true' }}
-        uses: imajeetyadav/argocd-cli@v1
+        uses: clowdhaus/argo-cd-action/@main
         with:
-          version: v2.7.8
+          version: 2.6.7
+          command: version
+          options: --client
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification

--- a/.github/workflows/minespace.deploy.prod.yaml
+++ b/.github/workflows/minespace.deploy.prod.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
-        run: ./gitops/watch-deployment.sh minespace prod ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ vars.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
+        run: ./gitops/watch-deployment.sh minespace prod ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/minespace.deploy.prod.yaml
+++ b/.github/workflows/minespace.deploy.prod.yaml
@@ -41,10 +41,15 @@ jobs:
         uses: redhat-actions/openshift-tools-installer@v1
         with:
           oc: "4.7"
+      - name: Setup ArgoCD CLI
+        if: ${{ env.NEEDS_ROLLOUT=='true' }}
+        uses: imajeetyadav/argocd-cli@v1
+        with:
+          version: v2.7.8
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
-        run: ./gitops/watch-deployment.sh minespace prod ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }}
+        run: ./gitops/watch-deployment.sh minespace prod ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/minespace.deploy.test.yaml
+++ b/.github/workflows/minespace.deploy.test.yaml
@@ -52,7 +52,7 @@ jobs:
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
         if: ${{ env.NEEDS_ROLLOUT=='true' }}
-        run: ./gitops/watch-deployment.sh minespace test ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ vars.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
+        run: ./gitops/watch-deployment.sh minespace test ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/minespace.deploy.test.yaml
+++ b/.github/workflows/minespace.deploy.test.yaml
@@ -54,7 +54,7 @@ jobs:
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
         if: ${{ env.NEEDS_ROLLOUT=='true' }}
-        run: ./gitops/watch-deployment.sh minespace test ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
+        run: ./gitops/watch-deployment.sh minespace test ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGO_CD_CLI_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/minespace.deploy.test.yaml
+++ b/.github/workflows/minespace.deploy.test.yaml
@@ -44,9 +44,11 @@ jobs:
           oc: "4.7"
       - name: Setup ArgoCD CLI
         if: ${{ env.NEEDS_ROLLOUT=='true' }}
-        uses: imajeetyadav/argocd-cli@v1
+        uses: clowdhaus/argo-cd-action/@main
         with:
-          version: v2.7.8
+          version: 2.6.7
+          command: version
+          options: --client
       - name: oc login
         if: ${{ env.NEEDS_ROLLOUT=='true' }}
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}

--- a/.github/workflows/minespace.deploy.test.yaml
+++ b/.github/workflows/minespace.deploy.test.yaml
@@ -42,12 +42,17 @@ jobs:
         uses: redhat-actions/openshift-tools-installer@v1
         with:
           oc: "4.7"
+      - name: Setup ArgoCD CLI
+        if: ${{ env.NEEDS_ROLLOUT=='true' }}
+        uses: imajeetyadav/argocd-cli@v1
+        with:
+          version: v2.7.8
       - name: oc login
         if: ${{ env.NEEDS_ROLLOUT=='true' }}
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
         if: ${{ env.NEEDS_ROLLOUT=='true' }}
-        run: ./gitops/watch-deployment.sh minespace test ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }}
+        run: ./gitops/watch-deployment.sh minespace test ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/minespace.deploy.test.yaml
+++ b/.github/workflows/minespace.deploy.test.yaml
@@ -43,12 +43,9 @@ jobs:
         with:
           oc: "4.7"
       - name: Setup ArgoCD CLI
-        if: ${{ env.NEEDS_ROLLOUT=='true' }}
-        uses: clowdhaus/argo-cd-action/@main
+        uses: imajeetyadav/argocd-cli@v1
         with:
-          version: 2.6.7
-          command: version
-          options: --client
+          version: v2.7.9 # optional
       - name: oc login
         if: ${{ env.NEEDS_ROLLOUT=='true' }}
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}

--- a/.github/workflows/minespace.deploy.test.yaml
+++ b/.github/workflows/minespace.deploy.test.yaml
@@ -52,7 +52,7 @@ jobs:
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
         if: ${{ env.NEEDS_ROLLOUT=='true' }}
-        run: ./gitops/watch-deployment.sh minespace test ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
+        run: ./gitops/watch-deployment.sh minespace test ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ vars.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/nris.build.deploy.dev.yaml
+++ b/.github/workflows/nris.build.deploy.dev.yaml
@@ -45,10 +45,15 @@ jobs:
         uses: redhat-actions/openshift-tools-installer@v1
         with:
           oc: "4.7"
+      - name: Setup ArgoCD CLI
+        if: ${{ env.NEEDS_ROLLOUT=='true' }}
+        uses: imajeetyadav/argocd-cli@v1
+        with:
+          version: v2.7.8
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
-        run: ./gitops/watch-deployment.sh nris dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }}
+        run: ./gitops/watch-deployment.sh nris dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/nris.build.deploy.dev.yaml
+++ b/.github/workflows/nris.build.deploy.dev.yaml
@@ -53,7 +53,7 @@ jobs:
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
-        run: ./gitops/watch-deployment.sh nris dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
+        run: ./gitops/watch-deployment.sh nris dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ vars.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/nris.build.deploy.dev.yaml
+++ b/.github/workflows/nris.build.deploy.dev.yaml
@@ -53,7 +53,7 @@ jobs:
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
-        run: ./gitops/watch-deployment.sh nris dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ vars.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
+        run: ./gitops/watch-deployment.sh nris dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/nris.build.deploy.dev.yaml
+++ b/.github/workflows/nris.build.deploy.dev.yaml
@@ -47,9 +47,11 @@ jobs:
           oc: "4.7"
       - name: Setup ArgoCD CLI
         if: ${{ env.NEEDS_ROLLOUT=='true' }}
-        uses: imajeetyadav/argocd-cli@v1
+        uses: clowdhaus/argo-cd-action/@main
         with:
-          version: v2.7.8
+          version: 2.6.7
+          command: version
+          options: --client
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification

--- a/.github/workflows/nris.build.deploy.dev.yaml
+++ b/.github/workflows/nris.build.deploy.dev.yaml
@@ -46,12 +46,9 @@ jobs:
         with:
           oc: "4.7"
       - name: Setup ArgoCD CLI
-        if: ${{ env.NEEDS_ROLLOUT=='true' }}
-        uses: clowdhaus/argo-cd-action/@main
+        uses: imajeetyadav/argocd-cli@v1
         with:
-          version: 2.6.7
-          command: version
-          options: --client
+          version: v2.7.9 # optional
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification

--- a/.github/workflows/nris.build.deploy.dev.yaml
+++ b/.github/workflows/nris.build.deploy.dev.yaml
@@ -55,7 +55,7 @@ jobs:
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
-        run: ./gitops/watch-deployment.sh nris dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
+        run: ./gitops/watch-deployment.sh nris dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGO_CD_CLI_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/nris.deploy.prod.yaml
+++ b/.github/workflows/nris.deploy.prod.yaml
@@ -42,12 +42,9 @@ jobs:
         with:
           oc: "4.7"
       - name: Setup ArgoCD CLI
-        if: ${{ env.NEEDS_ROLLOUT=='true' }}
-        uses: clowdhaus/argo-cd-action/@main
+        uses: imajeetyadav/argocd-cli@v1
         with:
-          version: 2.6.7
-          command: version
-          options: --client
+          version: v2.7.9 # optional
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification

--- a/.github/workflows/nris.deploy.prod.yaml
+++ b/.github/workflows/nris.deploy.prod.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
-        run: ./gitops/watch-deployment.sh nris prod ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ vars.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
+        run: ./gitops/watch-deployment.sh nris prod ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/nris.deploy.prod.yaml
+++ b/.github/workflows/nris.deploy.prod.yaml
@@ -43,9 +43,11 @@ jobs:
           oc: "4.7"
       - name: Setup ArgoCD CLI
         if: ${{ env.NEEDS_ROLLOUT=='true' }}
-        uses: imajeetyadav/argocd-cli@v1
+        uses: clowdhaus/argo-cd-action/@main
         with:
-          version: v2.7.8
+          version: 2.6.7
+          command: version
+          options: --client
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification

--- a/.github/workflows/nris.deploy.prod.yaml
+++ b/.github/workflows/nris.deploy.prod.yaml
@@ -41,10 +41,15 @@ jobs:
         uses: redhat-actions/openshift-tools-installer@v1
         with:
           oc: "4.7"
+      - name: Setup ArgoCD CLI
+        if: ${{ env.NEEDS_ROLLOUT=='true' }}
+        uses: imajeetyadav/argocd-cli@v1
+        with:
+          version: v2.7.8
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
-        run: ./gitops/watch-deployment.sh nris prod ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }}
+        run: ./gitops/watch-deployment.sh nris prod ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/nris.deploy.prod.yaml
+++ b/.github/workflows/nris.deploy.prod.yaml
@@ -51,7 +51,7 @@ jobs:
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
-        run: ./gitops/watch-deployment.sh nris prod ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
+        run: ./gitops/watch-deployment.sh nris prod ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGO_CD_CLI_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/nris.deploy.prod.yaml
+++ b/.github/workflows/nris.deploy.prod.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
-        run: ./gitops/watch-deployment.sh nris prod ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
+        run: ./gitops/watch-deployment.sh nris prod ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ vars.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/nris.deploy.test.yaml
+++ b/.github/workflows/nris.deploy.test.yaml
@@ -51,7 +51,7 @@ jobs:
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
-        run: ./gitops/watch-deployment.sh nris test ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
+        run: ./gitops/watch-deployment.sh nris test ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGO_CD_CLI_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/nris.deploy.test.yaml
+++ b/.github/workflows/nris.deploy.test.yaml
@@ -42,12 +42,9 @@ jobs:
         with:
           oc: "4.7"
       - name: Setup ArgoCD CLI
-        if: ${{ env.NEEDS_ROLLOUT=='true' }}
-        uses: clowdhaus/argo-cd-action/@main
+        uses: imajeetyadav/argocd-cli@v1
         with:
-          version: 2.6.7
-          command: version
-          options: --client
+          version: v2.7.9 # optional
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification

--- a/.github/workflows/nris.deploy.test.yaml
+++ b/.github/workflows/nris.deploy.test.yaml
@@ -41,10 +41,15 @@ jobs:
         uses: redhat-actions/openshift-tools-installer@v1
         with:
           oc: "4.7"
+      - name: Setup ArgoCD CLI
+        if: ${{ env.NEEDS_ROLLOUT=='true' }}
+        uses: imajeetyadav/argocd-cli@v1
+        with:
+          version: v2.7.8
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
-        run: ./gitops/watch-deployment.sh nris test ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }}
+        run: ./gitops/watch-deployment.sh nris test ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/nris.deploy.test.yaml
+++ b/.github/workflows/nris.deploy.test.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
-        run: ./gitops/watch-deployment.sh nris test ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
+        run: ./gitops/watch-deployment.sh nris test ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ vars.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/nris.deploy.test.yaml
+++ b/.github/workflows/nris.deploy.test.yaml
@@ -43,9 +43,11 @@ jobs:
           oc: "4.7"
       - name: Setup ArgoCD CLI
         if: ${{ env.NEEDS_ROLLOUT=='true' }}
-        uses: imajeetyadav/argocd-cli@v1
+        uses: clowdhaus/argo-cd-action/@main
         with:
-          version: v2.7.8
+          version: 2.6.7
+          command: version
+          options: --client
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification

--- a/.github/workflows/nris.deploy.test.yaml
+++ b/.github/workflows/nris.deploy.test.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
-        run: ./gitops/watch-deployment.sh nris test ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ vars.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
+        run: ./gitops/watch-deployment.sh nris test ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/tusd.build.deploy.dev.yaml
+++ b/.github/workflows/tusd.build.deploy.dev.yaml
@@ -46,10 +46,15 @@ jobs:
         uses: redhat-actions/openshift-tools-installer@v1
         with:
           oc: "4.7"
+      - name: Setup ArgoCD CLI
+        if: ${{ env.NEEDS_ROLLOUT=='true' }}
+        uses: imajeetyadav/argocd-cli@v1
+        with:
+          version: v2.7.8
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
-        run: ./gitops/watch-deployment.sh tusd dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }}
+        run: ./gitops/watch-deployment.sh tusd dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/tusd.build.deploy.dev.yaml
+++ b/.github/workflows/tusd.build.deploy.dev.yaml
@@ -48,9 +48,11 @@ jobs:
           oc: "4.7"
       - name: Setup ArgoCD CLI
         if: ${{ env.NEEDS_ROLLOUT=='true' }}
-        uses: imajeetyadav/argocd-cli@v1
+        uses: clowdhaus/argo-cd-action/@main
         with:
-          version: v2.7.8
+          version: 2.6.7
+          command: version
+          options: --client
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification

--- a/.github/workflows/tusd.build.deploy.dev.yaml
+++ b/.github/workflows/tusd.build.deploy.dev.yaml
@@ -54,7 +54,7 @@ jobs:
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
-        run: ./gitops/watch-deployment.sh tusd dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ vars.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
+        run: ./gitops/watch-deployment.sh tusd dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/tusd.build.deploy.dev.yaml
+++ b/.github/workflows/tusd.build.deploy.dev.yaml
@@ -54,7 +54,7 @@ jobs:
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
-        run: ./gitops/watch-deployment.sh tusd dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
+        run: ./gitops/watch-deployment.sh tusd dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ vars.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/tusd.build.deploy.dev.yaml
+++ b/.github/workflows/tusd.build.deploy.dev.yaml
@@ -47,12 +47,9 @@ jobs:
         with:
           oc: "4.7"
       - name: Setup ArgoCD CLI
-        if: ${{ env.NEEDS_ROLLOUT=='true' }}
-        uses: clowdhaus/argo-cd-action/@main
+        uses: imajeetyadav/argocd-cli@v1
         with:
-          version: 2.6.7
-          command: version
-          options: --client
+          version: v2.7.9 # optional
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification

--- a/.github/workflows/tusd.build.deploy.dev.yaml
+++ b/.github/workflows/tusd.build.deploy.dev.yaml
@@ -56,7 +56,7 @@ jobs:
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
-        run: ./gitops/watch-deployment.sh tusd dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
+        run: ./gitops/watch-deployment.sh tusd dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGO_CD_CLI_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/tusd.deploy.prod.yaml
+++ b/.github/workflows/tusd.deploy.prod.yaml
@@ -42,9 +42,11 @@ jobs:
           oc: "4.7"
       - name: Setup ArgoCD CLI
         if: ${{ env.NEEDS_ROLLOUT=='true' }}
-        uses: imajeetyadav/argocd-cli@v1
+        uses: clowdhaus/argo-cd-action/@main
         with:
-          version: v2.7.8
+          version: 2.6.7
+          command: version
+          options: --client
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification

--- a/.github/workflows/tusd.deploy.prod.yaml
+++ b/.github/workflows/tusd.deploy.prod.yaml
@@ -41,12 +41,9 @@ jobs:
         with:
           oc: "4.7"
       - name: Setup ArgoCD CLI
-        if: ${{ env.NEEDS_ROLLOUT=='true' }}
-        uses: clowdhaus/argo-cd-action/@main
+        uses: imajeetyadav/argocd-cli@v1
         with:
-          version: 2.6.7
-          command: version
-          options: --client
+          version: v2.7.9 # optional
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification

--- a/.github/workflows/tusd.deploy.prod.yaml
+++ b/.github/workflows/tusd.deploy.prod.yaml
@@ -50,7 +50,7 @@ jobs:
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
-        run: ./gitops/watch-deployment.sh tusd prod ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
+        run: ./gitops/watch-deployment.sh tusd prod ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGO_CD_CLI_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/tusd.deploy.prod.yaml
+++ b/.github/workflows/tusd.deploy.prod.yaml
@@ -48,7 +48,7 @@ jobs:
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
-        run: ./gitops/watch-deployment.sh tusd prod ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ vars.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
+        run: ./gitops/watch-deployment.sh tusd prod ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/tusd.deploy.prod.yaml
+++ b/.github/workflows/tusd.deploy.prod.yaml
@@ -48,7 +48,7 @@ jobs:
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
-        run: ./gitops/watch-deployment.sh tusd prod ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
+        run: ./gitops/watch-deployment.sh tusd prod ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ vars.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/tusd.deploy.prod.yaml
+++ b/.github/workflows/tusd.deploy.prod.yaml
@@ -40,10 +40,15 @@ jobs:
         uses: redhat-actions/openshift-tools-installer@v1
         with:
           oc: "4.7"
+      - name: Setup ArgoCD CLI
+        if: ${{ env.NEEDS_ROLLOUT=='true' }}
+        uses: imajeetyadav/argocd-cli@v1
+        with:
+          version: v2.7.8
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
-        run: ./gitops/watch-deployment.sh tusd prod ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }}
+        run: ./gitops/watch-deployment.sh tusd prod ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/tusd.deploy.test.yaml
+++ b/.github/workflows/tusd.deploy.test.yaml
@@ -50,7 +50,7 @@ jobs:
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
-        run: ./gitops/watch-deployment.sh tusd test ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
+        run: ./gitops/watch-deployment.sh tusd test ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGO_CD_CLI_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/tusd.deploy.test.yaml
+++ b/.github/workflows/tusd.deploy.test.yaml
@@ -42,9 +42,11 @@ jobs:
           oc: "4.7"
       - name: Setup ArgoCD CLI
         if: ${{ env.NEEDS_ROLLOUT=='true' }}
-        uses: imajeetyadav/argocd-cli@v1
+        uses: clowdhaus/argo-cd-action/@main
         with:
-          version: v2.7.8
+          version: 2.6.7
+          command: version
+          options: --client
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification

--- a/.github/workflows/tusd.deploy.test.yaml
+++ b/.github/workflows/tusd.deploy.test.yaml
@@ -41,12 +41,9 @@ jobs:
         with:
           oc: "4.7"
       - name: Setup ArgoCD CLI
-        if: ${{ env.NEEDS_ROLLOUT=='true' }}
-        uses: clowdhaus/argo-cd-action/@main
+        uses: imajeetyadav/argocd-cli@v1
         with:
-          version: 2.6.7
-          command: version
-          options: --client
+          version: v2.7.9 # optional
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification

--- a/.github/workflows/tusd.deploy.test.yaml
+++ b/.github/workflows/tusd.deploy.test.yaml
@@ -48,7 +48,7 @@ jobs:
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
-        run: ./gitops/watch-deployment.sh tusd test ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
+        run: ./gitops/watch-deployment.sh tusd test ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ vars.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/tusd.deploy.test.yaml
+++ b/.github/workflows/tusd.deploy.test.yaml
@@ -40,10 +40,15 @@ jobs:
         uses: redhat-actions/openshift-tools-installer@v1
         with:
           oc: "4.7"
+      - name: Setup ArgoCD CLI
+        if: ${{ env.NEEDS_ROLLOUT=='true' }}
+        uses: imajeetyadav/argocd-cli@v1
+        with:
+          version: v2.7.8
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
-        run: ./gitops/watch-deployment.sh tusd test ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }}
+        run: ./gitops/watch-deployment.sh tusd test ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/.github/workflows/tusd.deploy.test.yaml
+++ b/.github/workflows/tusd.deploy.test.yaml
@@ -48,7 +48,7 @@ jobs:
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
-        run: ./gitops/watch-deployment.sh tusd test ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ vars.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
+        run: ./gitops/watch-deployment.sh tusd test ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGOCD_JWT }}
 
   run-if-failed:
     runs-on: ubuntu-20.04

--- a/gitops/watch-deployment.sh
+++ b/gitops/watch-deployment.sh
@@ -26,7 +26,7 @@ echo -e "\n"
 echo "Watching for new revision of $TARGET_APP to be rolled out"
 echo "Waiting for $TARGET_APP to sync and be in healthy state"
 
-argocd login
+argocd login $ARGO_SERVER --core
 argocd app sync $TARGET_APP
 argocd app wait $TARGET_APP
 

--- a/gitops/watch-deployment.sh
+++ b/gitops/watch-deployment.sh
@@ -26,8 +26,9 @@ echo -e "\n"
 echo "Watching for new revision of $TARGET_APP to be rolled out"
 echo "Waiting for $TARGET_APP to sync and be in healthy state"
 
-argocd app sync $TARGET_APP --server $ARGOCD_SERVER --auth-token $ARGOCD_AUTH_TOKEN
-argocd app wait $TARGET_APP --server $ARGOCD_SERVER --auth-token $ARGOCD_AUTH_TOKEN
+APP="mds-$TARGET_APP-$ENV"
+argocd app sync $APP --server $ARGOCD_SERVER --auth-token $ARGOCD_AUTH_TOKEN
+argocd app wait $APP --server $ARGOCD_SERVER --auth-token $ARGOCD_AUTH_TOKEN
 
 echo "Target Revision is achieved $CURRENT_REVISION"
 

--- a/gitops/watch-deployment.sh
+++ b/gitops/watch-deployment.sh
@@ -26,9 +26,8 @@ echo -e "\n"
 echo "Watching for new revision of $TARGET_APP to be rolled out"
 echo "Waiting for $TARGET_APP to sync and be in healthy state"
 
-argocd login $ARGOCD_SERVER
-argocd app sync $TARGET_APP
-argocd app wait $TARGET_APP
+argocd app sync $TARGET_APP --server $ARGOCD_SERVER --auth-token $ARGOCD_AUTH_TOKEN
+argocd app wait $TARGET_APP --server $ARGOCD_SERVER --auth-token $ARGOCD_AUTH_TOKEN
 
 echo "Target Revision is achieved $CURRENT_REVISION"
 

--- a/gitops/watch-deployment.sh
+++ b/gitops/watch-deployment.sh
@@ -5,6 +5,8 @@ TARGET_APP=${1?"Enter App Name !"}
 ENV=${2?"Enter ENV Name !"}
 GIT_SHA=${3?"Enter GIT SHA of commit!"}
 DISCORD_DEPLOYMENT_WEBHOOK=${4?"Enter DISCORD_DEPLOYMENT_WEBHOOK!"}
+export ARGOCD_SERVER=${5?"Enter ARGOCD_SERVER!"}
+export ARGOCD_AUTH_TOKEN=${6?"Enter ARGOCD_AUTH_TOKEN!"}
 
 REPO_LOCATION=$(git rev-parse --show-toplevel)
 
@@ -22,13 +24,10 @@ echo "Current Revision of $TARGET_APP is $CURRENT_REVISION"
 
 echo -e "\n"
 echo "Watching for new revision of $TARGET_APP to be rolled out"
-echo "Polling to watch rollout to achieve the target revision of $TARGET_REVISION"
+echo "Waiting for $TARGET_APP to sync and be in healthy state"
 
-until [ $CURRENT_REVISION == $TARGET_REVISION ]; do
-    sleep 2
-    CURRENT_REVISION=$(get_revision)
-    echo "Refreshing the revision of $TARGET_APP, currently $CURRENT_REVISION, waiting for $TARGET_REVISION"
-done
+argocd app sync $TARGET_APP
+argocd app wait $TARGET_APP
 
 echo "Target Revision is achieved $CURRENT_REVISION"
 

--- a/gitops/watch-deployment.sh
+++ b/gitops/watch-deployment.sh
@@ -5,8 +5,6 @@ TARGET_APP=${1?"Enter App Name !"}
 ENV=${2?"Enter ENV Name !"}
 GIT_SHA=${3?"Enter GIT SHA of commit!"}
 DISCORD_DEPLOYMENT_WEBHOOK=${4?"Enter DISCORD_DEPLOYMENT_WEBHOOK!"}
-export ARGOCD_SERVER=${5?"Enter ARGOCD_SERVER!"}
-export ARGOCD_AUTH_TOKEN=${6?"Enter ARGOCD_AUTH_TOKEN!"}
 
 REPO_LOCATION=$(git rev-parse --show-toplevel)
 
@@ -26,8 +24,8 @@ echo -e "\n"
 echo "Watching for new revision of $TARGET_APP to be rolled out"
 echo "Waiting for $TARGET_APP to sync and be in healthy state"
 
-argocd app sync $TARGET_APP --server $ARGOCD_SERVER --auth-token $ARGOCD_AUTH_TOKEN
-argocd app wait $TARGET_APP --server $ARGOCD_SERVER --auth-token $ARGOCD_AUTH_TOKEN
+argocd app sync $TARGET_APP
+argocd app wait $TARGET_APP
 
 echo "Target Revision is achieved $CURRENT_REVISION"
 

--- a/gitops/watch-deployment.sh
+++ b/gitops/watch-deployment.sh
@@ -5,8 +5,8 @@ TARGET_APP=${1?"Enter App Name !"}
 ENV=${2?"Enter ENV Name !"}
 GIT_SHA=${3?"Enter GIT SHA of commit!"}
 DISCORD_DEPLOYMENT_WEBHOOK=${4?"Enter DISCORD_DEPLOYMENT_WEBHOOK!"}
-export ARGOCD_SERVER=${5?"Enter ARGOCD_SERVER!"}
-export ARGOCD_AUTH_TOKEN=${6?"Enter ARGOCD_AUTH_TOKEN!"}
+ARGOCD_SERVER=${5?"Enter ARGOCD_SERVER!"}
+ARGOCD_AUTH_TOKEN=${6?"Enter ARGOCD_AUTH_TOKEN!"}
 
 REPO_LOCATION=$(git rev-parse --show-toplevel)
 
@@ -26,8 +26,8 @@ echo -e "\n"
 echo "Watching for new revision of $TARGET_APP to be rolled out"
 echo "Waiting for $TARGET_APP to sync and be in healthy state"
 
-argocd app sync $TARGET_APP
-argocd app wait $TARGET_APP
+argocd app sync $TARGET_APP --server $ARGOCD_SERVER --auth-token $ARGOCD_AUTH_TOKEN
+argocd app wait $TARGET_APP --server $ARGOCD_SERVER --auth-token $ARGOCD_AUTH_TOKEN
 
 echo "Target Revision is achieved $CURRENT_REVISION"
 

--- a/gitops/watch-deployment.sh
+++ b/gitops/watch-deployment.sh
@@ -5,8 +5,8 @@ TARGET_APP=${1?"Enter App Name !"}
 ENV=${2?"Enter ENV Name !"}
 GIT_SHA=${3?"Enter GIT SHA of commit!"}
 DISCORD_DEPLOYMENT_WEBHOOK=${4?"Enter DISCORD_DEPLOYMENT_WEBHOOK!"}
-export ARGO_SERVER=${5?"Enter ARGOCD_SERVER!"}
-export ARGO_TOKEN=${6?"Enter ARGOCD_AUTH_TOKEN!"}
+export ARGOCD_SERVER=${5?"Enter ARGOCD_SERVER!"}
+export ARGOCD_AUTH_TOKEN=${6?"Enter ARGOCD_AUTH_TOKEN!"}
 
 REPO_LOCATION=$(git rev-parse --show-toplevel)
 
@@ -26,7 +26,7 @@ echo -e "\n"
 echo "Watching for new revision of $TARGET_APP to be rolled out"
 echo "Waiting for $TARGET_APP to sync and be in healthy state"
 
-argocd login $ARGO_SERVER --core
+argocd login $ARGOCD_SERVER
 argocd app sync $TARGET_APP
 argocd app wait $TARGET_APP
 

--- a/gitops/watch-deployment.sh
+++ b/gitops/watch-deployment.sh
@@ -5,8 +5,8 @@ TARGET_APP=${1?"Enter App Name !"}
 ENV=${2?"Enter ENV Name !"}
 GIT_SHA=${3?"Enter GIT SHA of commit!"}
 DISCORD_DEPLOYMENT_WEBHOOK=${4?"Enter DISCORD_DEPLOYMENT_WEBHOOK!"}
-ARGOCD_SERVER=${5?"Enter ARGOCD_SERVER!"}
-ARGOCD_AUTH_TOKEN=${6?"Enter ARGOCD_AUTH_TOKEN!"}
+export ARGOCD_SERVER=${5?"Enter ARGOCD_SERVER!"}
+export ARGOCD_AUTH_TOKEN=${6?"Enter ARGOCD_AUTH_TOKEN!"}
 
 REPO_LOCATION=$(git rev-parse --show-toplevel)
 
@@ -26,8 +26,9 @@ echo -e "\n"
 echo "Watching for new revision of $TARGET_APP to be rolled out"
 echo "Waiting for $TARGET_APP to sync and be in healthy state"
 
-argocd app sync $TARGET_APP --server $ARGOCD_SERVER --auth-token $ARGOCD_AUTH_TOKEN
-argocd app wait $TARGET_APP --server $ARGOCD_SERVER --auth-token $ARGOCD_AUTH_TOKEN
+argocd login
+argocd app sync $TARGET_APP
+argocd app wait $TARGET_APP
 
 echo "Target Revision is achieved $CURRENT_REVISION"
 

--- a/gitops/watch-deployment.sh
+++ b/gitops/watch-deployment.sh
@@ -26,7 +26,7 @@ echo -e "\n"
 echo "Watching for new revision of $TARGET_APP to be rolled out"
 echo "Waiting for $TARGET_APP to sync and be in healthy state"
 
-argocd login $ARGOCD_SERVER --auth-token $ARGOCD_AUTH_TOKEN
+argocd login $ARGOCD_SERVER --auth-token $ARGOCD_AUTH_TOKEN --username github_actions_cli_2
 argocd app sync $TARGET_APP
 argocd app wait $TARGET_APP
 

--- a/gitops/watch-deployment.sh
+++ b/gitops/watch-deployment.sh
@@ -5,8 +5,8 @@ TARGET_APP=${1?"Enter App Name !"}
 ENV=${2?"Enter ENV Name !"}
 GIT_SHA=${3?"Enter GIT SHA of commit!"}
 DISCORD_DEPLOYMENT_WEBHOOK=${4?"Enter DISCORD_DEPLOYMENT_WEBHOOK!"}
-export ARGOCD_SERVER=${5?"Enter ARGOCD_SERVER!"}
-export ARGOCD_AUTH_TOKEN=${6?"Enter ARGOCD_AUTH_TOKEN!"}
+ARGOCD_SERVER=${5?"Enter ARGOCD_SERVER!"}
+ARGOCD_AUTH_TOKEN=${6?"Enter ARGOCD_AUTH_TOKEN!"}
 
 REPO_LOCATION=$(git rev-parse --show-toplevel)
 
@@ -26,7 +26,7 @@ echo -e "\n"
 echo "Watching for new revision of $TARGET_APP to be rolled out"
 echo "Waiting for $TARGET_APP to sync and be in healthy state"
 
-argocd login
+argocd login $ARGOCD_SERVER --auth-token $ARGOCD_AUTH_TOKEN
 argocd app sync $TARGET_APP
 argocd app wait $TARGET_APP
 

--- a/gitops/watch-deployment.sh
+++ b/gitops/watch-deployment.sh
@@ -5,6 +5,8 @@ TARGET_APP=${1?"Enter App Name !"}
 ENV=${2?"Enter ENV Name !"}
 GIT_SHA=${3?"Enter GIT SHA of commit!"}
 DISCORD_DEPLOYMENT_WEBHOOK=${4?"Enter DISCORD_DEPLOYMENT_WEBHOOK!"}
+ARGOCD_SERVER=${5?"Enter ARGOCD_SERVER!"}
+ARGOCD_AUTH_TOKEN=${6?"Enter ARGOCD_AUTH_TOKEN!"}
 
 REPO_LOCATION=$(git rev-parse --show-toplevel)
 
@@ -24,8 +26,8 @@ echo -e "\n"
 echo "Watching for new revision of $TARGET_APP to be rolled out"
 echo "Waiting for $TARGET_APP to sync and be in healthy state"
 
-argocd app sync $TARGET_APP
-argocd app wait $TARGET_APP
+argocd app sync $TARGET_APP --server $ARGOCD_SERVER --auth-token $ARGOCD_AUTH_TOKEN
+argocd app wait $TARGET_APP --server $ARGOCD_SERVER --auth-token $ARGOCD_AUTH_TOKEN
 
 echo "Target Revision is achieved $CURRENT_REVISION"
 

--- a/gitops/watch-deployment.sh
+++ b/gitops/watch-deployment.sh
@@ -5,8 +5,8 @@ TARGET_APP=${1?"Enter App Name !"}
 ENV=${2?"Enter ENV Name !"}
 GIT_SHA=${3?"Enter GIT SHA of commit!"}
 DISCORD_DEPLOYMENT_WEBHOOK=${4?"Enter DISCORD_DEPLOYMENT_WEBHOOK!"}
-ARGOCD_SERVER=${5?"Enter ARGOCD_SERVER!"}
-ARGOCD_AUTH_TOKEN=${6?"Enter ARGOCD_AUTH_TOKEN!"}
+export ARGO_SERVER=${5?"Enter ARGOCD_SERVER!"}
+export ARGO_TOKEN=${6?"Enter ARGOCD_AUTH_TOKEN!"}
 
 REPO_LOCATION=$(git rev-parse --show-toplevel)
 
@@ -26,7 +26,7 @@ echo -e "\n"
 echo "Watching for new revision of $TARGET_APP to be rolled out"
 echo "Waiting for $TARGET_APP to sync and be in healthy state"
 
-argocd login $ARGOCD_SERVER --auth-token $ARGOCD_AUTH_TOKEN --username github_actions_cli_2
+argocd login
 argocd app sync $TARGET_APP
 argocd app wait $TARGET_APP
 


### PR DESCRIPTION
## Objective 

[MDS-5064](https://bcmines.atlassian.net/browse/MDS-5064)

When image promotion happens, ./gitops/commit.sh runs to push a new commit to tenant gitops, so that argo cd can redeploy. 

sometimes this commit is actioned on very fast before watch-deployment can start doing its job 

the revision number is updated and watch-deployment keeps waiting, hanging.. This is a false positive failure. The watch-deployment needs to be more robust in identifying a promotion and notify accurately. 

Solution is to use argocd cli to force sync of apps when image promotion happens and wait for the status to become healthy.
