### PR TITLE
[MDS-5363] Core: Fixed file upload 401 error for large files

### DIFF
--- a/services/core-web/package.json
+++ b/services/core-web/package.json
@@ -91,7 +91,7 @@
     "styled-components": "5.2.0",
     "test-reducer-package": "1.0.14",
     "ts-loader": "8.4.0",
-    "tus-js-client": "1.8.0",
+    "tus-js-client": "3.1.0",
     "uuid": "8.3.1"
   },
   "devDependencies": {

--- a/services/core-web/src/components/common/FileUpload.js
+++ b/services/core-web/src/components/common/FileUpload.js
@@ -9,7 +9,7 @@ import { FunnelPlotOutlined } from "@ant-design/icons";
 import "filepond/dist/filepond.min.css";
 import FilePondPluginFileValidateSize from "filepond-plugin-file-validate-size";
 import FilePondPluginFileValidateType from "filepond-plugin-file-validate-type";
-import tus from "tus-js-client";
+import * as tus from "tus-js-client";
 import { ENVIRONMENT } from "@mds/common";
 import { APPLICATION_OCTET_STREAM } from "@/constants/fileTypes";
 import { createRequestHeader } from "@common/utils/RequestHeaders";
@@ -69,7 +69,14 @@ class FileUpload extends React.Component {
             filename: file.name,
             filetype: file.type || APPLICATION_OCTET_STREAM,
           },
-          headers: createRequestHeader().headers,
+          onBeforeRequest: (req) => {
+            // Set authorization header on each request to make use
+            // of the new token in case of a token refresh was performed
+            var xhr = req.getUnderlyingObject();
+            const { headers } = createRequestHeader();
+
+            xhr.setRequestHeader("Authorization", headers.Authorization);
+          },
           onError: (err) => {
             notification.error({
               message: `Failed to upload ${file.name}: ${err}`,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2425,7 +2425,7 @@ __metadata:
     ts-jest: 24.3.0
     ts-loader: 8.4.0
     ts-node: ^10.9.1
-    tus-js-client: 1.8.0
+    tus-js-client: 3.1.0
     typescript: 4.7.4
     url-loader: 2.3.0
     uuid: 8.3.1
@@ -6918,7 +6918,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"buffer-from@npm:1.x, buffer-from@npm:^1.0.0":
+"buffer-from@npm:1.x, buffer-from@npm:^1.0.0, buffer-from@npm:^1.1.2":
   version: 1.1.2
   resolution: "buffer-from@npm:1.1.2"
   checksum: 0448524a562b37d4d7ed9efd91685a5b77a50672c556ea254ac9a6d30e3403a517d8981f10e565db24e8339413b43c97ca2951f10e399c6125a0d8911f5679bb
@@ -14977,6 +14977,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"js-base64@npm:^3.7.2":
+  version: 3.7.5
+  resolution: "js-base64@npm:3.7.5"
+  checksum: 67a78c8b1c47b73f1c6fba1957e9fe6fd9dc78ac93ac46cc2e43472dcb9cf150d126fb0e593192e88e0497354fa634d17d255add7cc6ee3c7b4d29870faa8e18
+  languageName: node
+  linkType: hard
+
 "js-git@npm:^0.7.8":
   version: 0.7.8
   resolution: "js-git@npm:0.7.8"
@@ -19563,6 +19570,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"proper-lockfile@npm:^4.1.2":
+  version: 4.1.2
+  resolution: "proper-lockfile@npm:4.1.2"
+  dependencies:
+    graceful-fs: ^4.2.4
+    retry: ^0.12.0
+    signal-exit: ^3.0.2
+  checksum: 00078ee6a61c216a56a6140c7d2a98c6c733b3678503002dc073ab8beca5d50ca271de4c85fca13b9b8ee2ff546c36674d1850509b84a04a5d0363bcb8638939
+  languageName: node
+  linkType: hard
+
 "proto-list@npm:~1.2.1":
   version: 1.2.4
   resolution: "proto-list@npm:1.2.4"
@@ -24024,6 +24042,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tus-js-client@npm:3.1.0":
+  version: 3.1.0
+  resolution: "tus-js-client@npm:3.1.0"
+  dependencies:
+    buffer-from: ^1.1.2
+    combine-errors: ^3.0.3
+    is-stream: ^2.0.0
+    js-base64: ^3.7.2
+    lodash.throttle: ^4.1.1
+    proper-lockfile: ^4.1.2
+    url-parse: ^1.5.7
+  checksum: a86b3613661df7dfa61e834573703d111cea078ff5659c6578930e79ff07b068600a26d919024b27f5b6f1de7342cdd7dd3ba9a36290a7ca350fe6afe1ea18cd
+  languageName: node
+  linkType: hard
+
 "tv4@npm:^1.3":
   version: 1.3.0
   resolution: "tv4@npm:1.3.0"
@@ -24423,7 +24456,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"url-parse@npm:^1.4.3":
+"url-parse@npm:^1.4.3, url-parse@npm:^1.5.7":
   version: 1.5.10
   resolution: "url-parse@npm:1.5.10"
   dependencies:


### PR DESCRIPTION
Replaces https://github.com/bcgov/mds/pull/2613 (so tests can successfully run)

**Objective**
[MDS-5363](https://bcmines.atlassian.net/browse/MDS-5363)

Wanted to test out how the current file zip functionality holds up for large files, but I kept hitting a 401 error while uploading a big file to core.

**Cause**
Currently, the auth token expires after 5min and the current implementation didn't account for that.

**Solution**
Make sure to use the current token for each tusd request