### PR TITLE
[MDS-5414] Removed support for silver keycloak instance

### DIFF
--- a/services/core-api/.env-example
+++ b/services/core-api/.env-example
@@ -60,9 +60,6 @@ JWT_OIDC_AUDIENCE_VFCBC=mds-vfcbc-4589
 JWT_OIDC_WELL_KNOWN_CONFIG_BCGW=https://test.loginproxy.gov.bc.ca/auth/realms/standard/.well-known/openid-configuration
 JWT_OIDC_AUDIENCE_BCGW=mds-bcgw-4792
 
-JWT_OIDC_WELL_KNOWN_CONFIG_V1=https://test.oidc.gov.bc.ca/auth/realms/mds/.well-known/openid-configuration
-JWT_OIDC_AUDIENCE_V1=mines-application-test
-
 JWT_OIDC_WELL_KNOWN_CONFIG_DOCMAN_CELERY=https://test.loginproxy.gov.bc.ca/auth/realms/standard/.well-known/openid-configuration
 JWT_OIDC_AUDIENCE_DOCMAN_CELERY=mds-docman-celery-internal-4865
 

--- a/services/core-api/README.md
+++ b/services/core-api/README.md
@@ -192,12 +192,11 @@ Other reasons:
 
 In order to handle the above cases, we have a jwt-manager implementation that works with multiple OIDC audiences and configurations.
 
-core-api currently works with the following sso providers.
+core-api currently works with the following sso providers:
 
 1. Gold SSO - [All Environments](https://bcgov.github.io/sso-requests/my-dashboard/integrations)
-2. Silver SSO - [Test](https://test.oidc.gov.bc.ca/auth/admin/mds/console/#/realms/mds) and [Production](https://oidc.gov.bc.ca/auth/admin/mds/console/#/realms/mds)
 
-Both Gold and Silver SSO is based off [Keycloack IDM](https://www.keycloak.org/)
+The gold SSO is based off [Keycloack IDM](https://www.keycloak.org/)
 
 The SSO login is used for authentication and role assignments for all of MDS users.
 

--- a/services/core-api/app/__init__.py
+++ b/services/core-api/app/__init__.py
@@ -36,7 +36,7 @@ from app.api.dams.namespace import api as dams_api
 from app.commands import register_commands
 from app.config import Config
 # alias api to avoid confusion with api folder (speifically on unittest.mock.patch calls)
-from app.extensions import db, jwtv2, jwtv1, jwt, jwt_bcmi, jwt_fncs, jwt_gentax, jwt_nris, jwt_vfcbc, jwt_bcgw, jwt_docman_celery, api as root_api_namespace, cache
+from app.extensions import db, jwtv2, jwt, jwt_bcmi, jwt_fncs, jwt_gentax, jwt_nris, jwt_vfcbc, jwt_bcgw, jwt_docman_celery, api as root_api_namespace, cache
 from app.api.utils.setup_marshmallow import setup_marshmallow
 from sqlalchemy.sql import text
 from app.tasks.celery import celery
@@ -113,7 +113,6 @@ def register_extensions(app, test_config=None):
 
         if test_config is None:
             jwtv2.init_app(app)
-            jwtv1.init_app(app)
             jwt_bcmi.init_app(app)
             jwt_fncs.init_app(app)
             jwt_gentax.init_app(app)

--- a/services/core-api/app/extensions.py
+++ b/services/core-api/app/extensions.py
@@ -40,8 +40,6 @@ db = SQLAlchemy()
 
 # Gold SSO
 jwtv2 = JwtManager(None, os.environ.get('JWT_OIDC_WELL_KNOWN_CONFIG'), None, 'RS256', None, None, os.environ.get('JWT_OIDC_AUDIENCE'), None, None, False, False, None, JWT_ROLE_CALLBACK, None)
-# Existing Keycloak for integration clients
-jwtv1 = JwtManager(None, os.environ.get('JWT_OIDC_WELL_KNOWN_CONFIG_V1'), None, 'RS256', None, None, os.environ.get('JWT_OIDC_AUDIENCE_V1'), None, None, False, False, None, JWT_ROLE_CALLBACK_V1, None)
 
 # Gold SSO - Register Config Per Integration Client: 
 
@@ -64,16 +62,17 @@ test_config = TestConfig()
 jwt = JwtManager(None, test_config.JWT_OIDC_WELL_KNOWN_CONFIG, None, 'RS256', None, None, test_config.JWT_OIDC_TEST_AUDIENCE, None, None, False, True, test_config.JWT_OIDC_TEST_KEYS, JWT_ROLE_CALLBACK, test_config.JWT_OIDC_TEST_PRIVATE_KEY_PEM)
 
 def getJwtManager():
-    kc_realms = 'oidc.gov.bc.ca'
+    legacy_token_issuer = 'oidc.gov.bc.ca'
     auth_header = jwt.get_token_auth_header()
     token = jwt_jose.get_unverified_claims(auth_header)
 
     iss = token.get('iss')
     aud = token.get('aud')
 
-    if kc_realms in iss:
+    if legacy_token_issuer in iss:
         print(f"\n **Client from oidc.gov.bc.ca Detected - Client ID: {aud}\n")
-        return jwtv1
+        raise AuthError({'code': 'auth_fail',
+                    'description': 'Token issuer oidc.gov.bc.ca is no longer supported. Please contact the mds team.'}, 401)
 
     if iss in test_config.JWT_OIDC_TEST_ISSUER:
         jwt_result = jwt

--- a/services/core-api/app/extensions.py
+++ b/services/core-api/app/extensions.py
@@ -14,9 +14,6 @@ from .helper import Api
 def JWT_ROLE_CALLBACK(jwt_dict):
     return (jwt_dict.get('client_roles') or [])
 
-def JWT_ROLE_CALLBACK_V1(jwt_dict):
-        return (jwt_dict['realm_access']['roles'])
-
 def get_jwt_by_audience(aud):
     audience_jwt_map = {
         'JWT_OIDC_AUDIENCE': jwtv2,


### PR DESCRIPTION
## Objective 

[MDS-5414](https://bcmines.atlassian.net/browse/MDS-5414)

Removed support for the silver keycloak instance from the core API. The oidc.gov.bc.ca has been decommissioned and is producing an error on startup
