### PR TITLE
[MDS-5414] Fixed auth issue with some integrations in test env

### DIFF
--- a/services/core-api/app/extensions.py
+++ b/services/core-api/app/extensions.py
@@ -31,7 +31,9 @@ def get_jwt_by_audience(aud):
     }
 
     for audience_env, jwt_value in audience_jwt_map.items():
-        if os.environ.get(audience_env) in aud:
+        token_audience = os.environ.get(audience_env)
+
+        if token_audience and token_audience in aud:
             return jwt_value
 
     return None


### PR DESCRIPTION
## Objective 

[MDS-5414](https://bcmines.atlassian.net/browse/MDS-5414)

Fixed an error that pops up in dev and test when using integration credentials. Cause of this is that the `JWT_OIDC_AUDIENCE_CYPRESS` env variable is not set in these environments causing the audience check to crash with an error. This was previously solved in production by adding a value for the env variable, but this was not done in dev/test

![image](https://github.com/bcgov/mds/assets/66635118/d497010c-526f-423e-995c-20bb19a4496f)
