### PR TITLE
[MDS-5363] download all application file button set disable and some css adjustment

### DIFF
--- a/services/core-web/src/components/common/DocumentColumns.tsx
+++ b/services/core-web/src/components/common/DocumentColumns.tsx
@@ -118,9 +118,7 @@ export const documentNameColumnNew = (
     render: (text: string, record: MineDocument) => {
       const docLink = (
         <a
-          style={
-            record?.number_prev_versions > 0 && !record?.is_archived ? { marginLeft: "14px" } : {}
-          }
+          style={record?.number_prev_versions > 0 ? { marginLeft: "14px" } : {}}
           onClick={() => downloadFileFromDocumentManager(record)}
         >
           {text}

--- a/services/core-web/src/components/mine/Projects/MajorMineApplicationTab.js
+++ b/services/core-web/src/components/mine/Projects/MajorMineApplicationTab.js
@@ -87,7 +87,6 @@ export class MajorMineApplicationTab extends Component {
     this.handleScroll();
   }
 
-
   async fetchData() {
     const { projectGuid } = this.props.match.params;
     const project = await this.props.fetchProjectById(projectGuid);
@@ -154,18 +153,18 @@ export class MajorMineApplicationTab extends Component {
   };
 
   renderArchivedDocuments = () => {
-    return <ArchivedDocumentsSection
-      additionalColumns={[
-        renderCategoryColumn(
-          "category_code",
-          "Category",
-          Strings.CATEGORY_CODE,
-          true
-        ),
-      ]}
-      documents={this.props.mineDocuments && this.props.mineDocuments.length > 0
-        ? this.props.mineDocuments.map((doc) => new MajorMineApplicationDocument(doc)) : []}
-    />
+    return (
+      <ArchivedDocumentsSection
+        additionalColumns={[
+          renderCategoryColumn("category_code", "Category", Strings.CATEGORY_CODE, true),
+        ]}
+        documents={
+          this.props.mineDocuments && this.props.mineDocuments.length > 0
+            ? this.props.mineDocuments.map((doc) => new MajorMineApplicationDocument(doc))
+            : []
+        }
+      />
+    );
   };
 
   render() {
@@ -274,6 +273,7 @@ export class MajorMineApplicationTab extends Component {
           />
           <Button
             style={{ float: "right" }}
+            disabled={documents.length === 0}
             className="ant-btn ant-btn-primary"
             onClick={() => {
               this.setState({
@@ -293,7 +293,7 @@ export class MajorMineApplicationTab extends Component {
             "Primary Documents",
             "primary-documents",
             documents.filter((doc) => doc.major_mine_application_document_type_code === "PRM") ||
-            [],
+              [],
             true
           )}
           <br />
@@ -301,7 +301,7 @@ export class MajorMineApplicationTab extends Component {
             "Spatial Components",
             "spatial-components",
             documents.filter((doc) => doc.major_mine_application_document_type_code === "SPT") ||
-            [],
+              [],
             true
           )}
           <br />
@@ -309,7 +309,7 @@ export class MajorMineApplicationTab extends Component {
             "Supporting Documents",
             "supporting-documents",
             documents.filter((doc) => doc.major_mine_application_document_type_code === "SPR") ||
-            [],
+              [],
             true
           )}
           <br />

--- a/services/core-web/src/styles/components/Tables.scss
+++ b/services/core-web/src/styles/components/Tables.scss
@@ -16,8 +16,6 @@
         span.ant-badge-status {
           white-space: nowrap;
         }
-
-        line-height: 3;
       }
     }
   }

--- a/services/core-web/src/tests/components/mine/Projects/__snapshots__/MajorMineApplicationTab.spec.js.snap
+++ b/services/core-web/src/tests/components/mine/Projects/__snapshots__/MajorMineApplicationTab.spec.js.snap
@@ -203,6 +203,7 @@ exports[`ProjectDocumentsTab renders properly 1`] = `
     />
     <Button
       className="ant-btn ant-btn-primary"
+      disabled={true}
       onClick={[Function]}
       style={
         Object {

--- a/services/minespace-web/src/components/common/DocumentColumns.tsx
+++ b/services/minespace-web/src/components/common/DocumentColumns.tsx
@@ -121,9 +121,7 @@ export const documentNameColumnNew = (
     render: (text: string, record: MineDocument) => {
       const docLink = (
         <a
-          style={
-            record?.number_prev_versions > 0 && !record?.is_archived ? { marginLeft: "14px" } : {}
-          }
+          style={record?.number_prev_versions > 0 ? { marginLeft: "14px" } : {}}
           onClick={() => downloadFileFromDocumentManager(record)}
         >
           {text}


### PR DESCRIPTION

## Objective 
- The `Download All Application Files` was changed to be disabled if there are no application files for the project
- Did some small adjustments to css for document table

[MDS-5363](https://bcmines.atlassian.net/browse/MDS-5363)


![Screenshot (159)](https://github.com/bcgov/mds/assets/127789479/0ba51eab-cd77-4490-8468-a867599c90c9)

