### PR TITLE
[MDS-5465] Enable Cypress tests and add y-padding style

### DIFF
--- a/services/minespace-web/cypress/e2e/index.cy.ts
+++ b/services/minespace-web/cypress/e2e/index.cy.ts
@@ -1,12 +1,12 @@
 describe("Mines Page", () => {
   const url = Cypress.env("CYPRESS_MINESPACE_WEB_TEST_URL");
   beforeEach(() => {
-    // cy.login();
+    cy.login();
   });
 
   it("should navigate to the mines page successfully", () => {
-    // cy.visit(`${url}/mines`);
+    cy.visit(`${url}/mines`);
     // Assert that landing on the home page is successful
-    // cy.url({ timeout: 10000 }).should("include", "/mines");
+    cy.url({ timeout: 10000 }).should("include", "/mines");
   });
 });

--- a/services/minespace-web/cypress/support/commands.ts
+++ b/services/minespace-web/cypress/support/commands.ts
@@ -24,9 +24,9 @@ Cypress.Commands.add("login", () => {
     req.reply(response);
   });
 
-  // cy.visit(url);
-  // cy.contains("Log in with BCeID").click();
-  // cy.get("#username").type(Cypress.env("CYPRESS_TEST_USER"));
-  // cy.get("#password").type(Cypress.env("CYPRESS_TEST_PASSWORD"));
-  // cy.get("#kc-login").click();
+  cy.visit(url);
+  cy.contains("Log in with BCeID").click();
+  cy.get("#username").type(Cypress.env("CYPRESS_TEST_USER"));
+  cy.get("#password").type(Cypress.env("CYPRESS_TEST_PASSWORD"));
+  cy.get("#kc-login").click();
 });

--- a/services/minespace-web/src/styles/generic/layout.scss
+++ b/services/minespace-web/src/styles/generic/layout.scss
@@ -80,6 +80,10 @@
   &--bottom {
     padding-bottom: $default-padding-sm;
   }
+  &--y {
+    padding-top: $default-padding-sm;
+    padding-bottom: $default-padding-sm;
+  }
   padding: $default-padding-sm;
 }
 


### PR DESCRIPTION
The previously commented out Cypress test commands have been un-commented out to enable running of integration tests. Test commands include 'cy.login()', 'cy.visit(`url/mines`)' and URL assertion statement in `index.cy.ts`, and authentication process in `commands.ts`.

Since it was having similar failures to what is now on test, this will hopefully allow recreation of the issue.

Noticed a missing style in scss added that back in.

## Objective 

[MDS-5465](https://bcmines.atlassian.net/browse/MDS-5465)
