### PR TITLE
[MDS-5468] - Fix Major Project Documents Tab Loading (MS)

### DIFF
--- a/services/minespace-web/src/components/common/DocumentTable.tsx
+++ b/services/minespace-web/src/components/common/DocumentTable.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import CoreTable from "@/components/common/CoreTable";
 import {
   documentNameColumn,
@@ -85,6 +85,7 @@ export const DocumentTable = ({
   const isMinimalView: boolean = view === "minimal";
 
   const parseDocuments = (docs: any[]): MineDocument[] => {
+    if (!docs) return [];
     let parsedDocs: MineDocument[];
     if (docs.length && docs[0] instanceof MineDocument) {
       parsedDocs = docs;
@@ -99,7 +100,13 @@ export const DocumentTable = ({
     });
   };
 
-  const [documents, setDocuments] = useState<MineDocument[]>(parseDocuments(props.documents));
+  const [documents, setDocuments] = useState<MineDocument[]>();
+
+  useEffect(() => {
+    if (props.documents) {
+      setDocuments(parseDocuments(props.documents));
+    }
+  }, [props.documents]);
 
   const openArchiveModal = (event, docs: MineDocument[]) => {
     const mineGuid = docs[0].mine_guid;

--- a/services/minespace-web/src/components/pages/Project/ProjectPage.js
+++ b/services/minespace-web/src/components/pages/Project/ProjectPage.js
@@ -62,7 +62,8 @@ export class ProjectPage extends Component {
           }
           return null;
         })
-        .then(({ data }) => {
+        .then((response) => {
+          const { data = {} } = response || { data: {} };
           this.props.fetchEMLIContactsByRegion(data.mine_region, data.major_mine_ind);
           this.setState({
             isLoaded: true,
@@ -79,7 +80,7 @@ export class ProjectPage extends Component {
 
   fetchArchivedDocuments(activeTab = this.state.activeTab) {
     let filters = { project_guid: this.props?.project?.project_guid, is_archived: true };
-    if (activeTab == "major-mine-application") {
+    if (activeTab === "major-mine-application") {
       filters = {
         ...(this.props?.project?.major_mine_application?.major_mine_application_guid && {
           major_mine_application_guid: this.props?.project?.major_mine_application

--- a/services/minespace-web/src/tests/components/common/__snapshots__/DocumentTable.spec.js.snap
+++ b/services/minespace-web/src/tests/components/common/__snapshots__/DocumentTable.spec.js.snap
@@ -32,36 +32,5 @@ exports[`DocumentTable renders properly 1`] = `
       },
     ]
   }
-  dataSource={
-    Array [
-      MineDocument {
-        "allowed_actions": Array [
-          "Open in document viewer",
-          "Download file",
-          "Replace file",
-          "Archive file",
-          "Delete",
-        ],
-        "archived_by": undefined,
-        "archived_date": undefined,
-        "category": undefined,
-        "create_user": undefined,
-        "document_manager_guid": "d7f64a25-6eaf-4bed-97fe-fd63ac347c70",
-        "document_name": "test.pdf",
-        "entity_title": "",
-        "file_type": ".pdf",
-        "is_archived": false,
-        "is_latest_version": true,
-        "key": "33e6b965-2402-4229-a213-23bbe7fd3e99",
-        "mine_document_guid": "33e6b965-2402-4229-a213-23bbe7fd3e99",
-        "mine_guid": "59e73109-48f7-4ad2-977c-3005b5bff010",
-        "number_prev_versions": 0,
-        "update_timestamp": undefined,
-        "update_user": undefined,
-        "upload_date": undefined,
-        "versions": Array [],
-      },
-    ]
-  }
 />
 `;


### PR DESCRIPTION
## Objective 

Moved the setting of documents from the props from directly in the useState, to a useEffect dependent on the pressence of the documents props.

Also, made the `parseDocuments` function return an empty array if no docs are passed in.

The projectPage was also complaining about destructuring a null response, so I updated that to handle null more gracefully

[MDS-5468](https://bcmines.atlassian.net/browse/MDS-5468)
