### PR TITLE
[MDS-5471] - Document Version file display name

### DIFF
--- a/services/document-manager/backend/app/docman/models/document_version.py
+++ b/services/document-manager/backend/app/docman/models/document_version.py
@@ -18,7 +18,7 @@ class DocumentVersion(Base):
         db.DateTime, nullable=True, default=datetime.utcnow)
     upload_completed_date = db.Column(db.DateTime, nullable=True)
     object_store_version_id = db.Column(db.String(256), nullable=True)
-    file_display_name = db.Column(db.String(40), nullable=False)
+    file_display_name = db.Column(db.String(255), nullable=False)
 
     def __repr__(self):
         return '<DocumentVersion %r>' % self.id

--- a/services/document-manager/backend/migrations/versions/c02786c20bfd_update_file_display_name_characters.py
+++ b/services/document-manager/backend/migrations/versions/c02786c20bfd_update_file_display_name_characters.py
@@ -1,0 +1,31 @@
+"""update-file-display-name-characters
+
+Revision ID: c02786c20bfd
+Revises: c383dfee5001
+Create Date: 2023-09-06 18:44:39.595932
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'c02786c20bfd'
+down_revision = 'c383dfee5001'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("document_version") as batch_op:
+        batch_op.alter_column('file_display_name',
+                              type_=sa.String(length=255),
+                              existing_type=sa.String(length=40),
+                              existing_nullable=False)
+
+def downgrade():
+    with op.batch_alter_table("document_version") as batch_op:
+        batch_op.alter_column('file_display_name',
+                              type_=sa.String(length=40),
+                              existing_type=sa.String(length=255),
+                              existing_nullable=False)


### PR DESCRIPTION
Increased the maximum allowable length for the 'file_display_name' field in the 'document_version' model from 40 to 255 characters. This change brings the file_display_name length in line with the original document upload.

## Objective 

[MDS-5471](https://bcmines.atlassian.net/browse/MDS-5471)
