### PR TITLE
[MDS-5482] Hide nested table checkbox

### DIFF
--- a/services/core-web/src/styles/components/DocumentTableWithExpandedRows.scss
+++ b/services/core-web/src/styles/components/DocumentTableWithExpandedRows.scss
@@ -20,8 +20,14 @@
     }
 }
 
-.ant-table-row-level-1.no-sub-table-expandable-rows>td {
-    border: none;
+.ant-table-row-level-1.no-sub-table-expandable-rows {
+    &>td {
+        border: none;
+    }
+
+    .ant-checkbox-wrapper {
+        display: none;
+    }
 }
 
 .file-name-container {

--- a/services/minespace-web/src/styles/components/DocumentTableWithExpandedRows.scss
+++ b/services/minespace-web/src/styles/components/DocumentTableWithExpandedRows.scss
@@ -26,8 +26,14 @@
     }
 }
 
-.ant-table-row-level-1.no-sub-table-expandable-rows>td {
-    border: none;
+.ant-table-row-level-1.no-sub-table-expandable-rows {
+    &>td {
+        border: none;
+    }
+
+    .ant-checkbox-wrapper {
+        display: none;
+    }
 }
 
 .file-name-container {


### PR DESCRIPTION
## Objective 

[MDS-5482](https://bcmines.atlassian.net/browse/MDS-5482)

Implemented  CSS to hide the checkbox of previous versions of a document when expanded.

![image](https://github.com/bcgov/mds/assets/72251620/d0fecda0-d26f-4a40-be64-38ebffef2548)


![image](https://github.com/bcgov/mds/assets/72251620/1a829120-1a4c-41db-85e0-667fc6673587)

