### PR TITLE
[MDS-5487] Introduced checks to ensure the presence of 'projectGuid' and 'projec…

### DIFF
--- a/services/minespace-web/src/components/pages/Project/ProjectSummaryPage.tsx
+++ b/services/minespace-web/src/components/pages/Project/ProjectSummaryPage.tsx
@@ -227,7 +227,9 @@ export const ProjectSummaryPage: FC<ProjectSummaryPageProps> = (props) => {
       if (!isEditMode) {
         handleCreateProjectSummary(values, message);
       }
-      handleUpdateProjectSummary(values, message);
+      if (projectGuid && projectSummaryGuid) {
+        handleUpdateProjectSummary(values, message);
+      }
     }
     handleTabChange(newActiveTab);
   };
@@ -244,7 +246,9 @@ export const ProjectSummaryPage: FC<ProjectSummaryPageProps> = (props) => {
       if (!isEditMode) {
         handleCreateProjectSummary(values, message);
       }
-      handleUpdateProjectSummary(values, message);
+      if (projectGuid && projectSummaryGuid) {
+        handleUpdateProjectSummary(values, message);
+      }
     }
     handleTabChange(newActiveTab);
   };


### PR DESCRIPTION
Introduced checks to ensure the presence of 'projectGuid' and 'projectSummaryGuid' before making a call to 'handleUpdateProjectSummary'. This prevents potential issues related to attempts to update a project summary that may not have a valid reference in the system.

## Objective 

[MDS-5487](https://bcmines.atlassian.net/browse/MDS-5487)

_Why are you making this change? Provide a short explanation and/or screenshots_
