### PR TITLE
[CHORE] Updated video output location of Minespace cypress tests

### DIFF
--- a/.github/workflows/minespace.unit.yaml
+++ b/.github/workflows/minespace.unit.yaml
@@ -65,4 +65,4 @@ jobs:
         if: always()
         with:
           name: cypress-recording
-          path: services/core-web/cypress/videos
+          path: services/minespace-web/cypress/videos


### PR DESCRIPTION
## Objective 

Updated video output location of Minespace cypress tests. This was incorrectly set to upload from the `core` folder