### PR TITLE
[MDS-5487] new application error fix

### DIFF
--- a/services/core-api/app/api/projects/major_mine_application/models/major_mine_application.py
+++ b/services/core-api/app/api/projects/major_mine_application/models/major_mine_application.py
@@ -3,7 +3,7 @@ from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.dialects.postgresql import UUID
 
 from sqlalchemy.schema import FetchedValue
-from werkzeug.exceptions import BadRequest
+from werkzeug.exceptions import BadRequest, NotFound
 from app.extensions import db
 
 from app.config import Config
@@ -171,9 +171,12 @@ class MajorMineApplication(SoftDeleteMixin, AuditMixin, Base):
             self.save(commit=False)
 
         if len(documents) > 0:
-            mine_document_guid = documents[0].mine_document_guid
+            mine_document_guid =  documents[0]["mine_document_guid"]
             project = MajorMineApplication.find_by_mine_document_guid(mine_document_guid).project
-            mine = Mine.find_by_mine_guid(project.mine_guid)
+            mine = Mine.find_by_mine_guid(str(project.mine_guid))
+            if not mine:
+                raise NotFound('Mine not found.')
+
             ProjectUtil.notifiy_file_updates(project, mine)
 
         return self


### PR DESCRIPTION
## Objective 

Updated how document property is accessed in a dict
passed mine guid as string to find by mine guid function (it was a uuid which was causing another error that wasn't being reached yet.

[MDS-5487](https://bcmines.atlassian.net/browse/MDS-5487)

_Why are you making this change? Provide a short explanation and/or screenshots_
