### PR TITLE
[MDS-5487] Major Mine Application Save Draft Error

### DIFF
--- a/services/core-api/app/api/projects/major_mine_application/models/major_mine_application.py
+++ b/services/core-api/app/api/projects/major_mine_application/models/major_mine_application.py
@@ -171,8 +171,6 @@ class MajorMineApplication(SoftDeleteMixin, AuditMixin, Base):
             self.save(commit=False)
 
         if len(documents) > 0:
-            mine_document_guid =  documents[0]["mine_document_guid"]
-            project = MajorMineApplication.find_by_mine_document_guid(mine_document_guid).project
             mine = Mine.find_by_mine_guid(str(project.mine_guid))
             if not mine:
                 raise NotFound('Mine not found.')

--- a/services/minespace-web/src/components/pages/Project/ProjectPage.js
+++ b/services/minespace-web/src/components/pages/Project/ProjectPage.js
@@ -169,7 +169,8 @@ export class ProjectPage extends Component {
       if (["DFT", "CHR"].includes(status)) {
         return this.props.history.push({
           pathname: router.EDIT_MAJOR_MINE_APPLICATION.dynamicRoute(
-            this.props.project.project_guid
+            this.props.project.project_guid,
+            this.props.project.major_mine_application?.major_mine_application_guid
           ),
           state: { current: 1 },
         });


### PR DESCRIPTION
Save a draft of a major mine application was causing an error because the notification logic was trying to use the mine_document_guid from one of the documents to fetch the project for use in the notification (this doesn't exist yet in that particular array of documents on a save draft).

Turns out the project is actually already being passed in, so we didn't need to fetch it like that at all anyway, so just used the project prop instead of fetching it.

Also found a bug in the ProjectPage.js file that was creating a route with an `undefined` value.

## Objective 

[MDS-5487](https://bcmines.atlassian.net/browse/MDS-5487)
