### PR TITLE
[MDS-5449] fixing to show 10 subscribed mines

### DIFF
--- a/services/core-web/src/components/homepage/HomeMineActivity.tsx
+++ b/services/core-web/src/components/homepage/HomeMineActivity.tsx
@@ -13,6 +13,7 @@ import { IMine, IMineAlert } from "@mds/common";
 import * as routes from "@/constants/routes";
 import { RootState } from "@/App";
 import { ActionCreator } from "@/interfaces/actionCreator";
+import * as router from "@/constants/routes";
 
 interface HomeMineActivityProps {
   subscribedMines: IMine[];
@@ -112,17 +113,22 @@ const HomeMineActivity: FC<HomeMineActivityProps> = ({
     <Row gutter={16}>
       <Col span={12}>
         <div className="home-bordered-content" id="home-subscribed-mines-container">
-          <Typography.Title level={4}>Subscribed Mines</Typography.Title>
+          <Typography.Title level={4}>My Subscribed Mines</Typography.Title>
           <Typography.Paragraph>
             Your subscribed mines. To subscribe to more mines, go to the mine&apos;s overview page
             and select &quot;Subscribe to Mine&quot; from the options menu.
           </Typography.Paragraph>
-          {userMines.map((mine) => (
+          {userMines.slice(0, 10).map((mine) => (
             <Skeleton loading={!subscribedMinesLoaded} active key={`subscribed-${mine.mine_guid}`}>
               <SubscribedMine mine={mine} />
             </Skeleton>
           ))}
-          {subscribedMinesLoaded && userMines.length === 0 && <NoSubscribedMines />}
+
+          {subscribedMinesLoaded && userMines.length === 0 ? (
+            <NoSubscribedMines />
+          ) : (
+            <Link to={router.CUSTOM_HOME_PAGE.route}>View all subscribed mines</Link>
+          )}
         </div>
       </Col>
 


### PR DESCRIPTION
## Objective 

[MDS-5449](https://bcmines.atlassian.net/browse/MDS-5449)

- Show the first 10 records of subscribed mine
- Add link to “view all subscribed mines” and  link is to My Dashboard
- Change the title of My Dashboard to “My Subscribed Mines”

_Why are you making this change? Provide a short explanation and/or screenshots_
![Screenshot 2023-09-15 152154](https://github.com/bcgov/mds/assets/118843449/b82c7d65-46ac-43d1-9da3-acd400f5db23)
