### PR TITLE
[MDS-5470] - Optimized CSV export of Notice of Work details

### DIFF
--- a/services/core-api/app/api/exports/now_application/resources/now_application_gis_export_resource.py
+++ b/services/core-api/app/api/exports/now_application/resources/now_application_gis_export_resource.py
@@ -19,7 +19,6 @@ class NowApplicationGisExportResource(Resource):
     def get(self):
         model = inspect(NowApplicationGisExport)
         headers = [c.name or "" for c in model.columns]
-        cache.clear()
 
         def generate():
             data = StringIO()
@@ -29,7 +28,7 @@ class NowApplicationGisExportResource(Resource):
             data.seek(0)
             data.truncate(0)
 
-            for r in NowApplicationGisExport.query.yield_per(250):
+            for r in NowApplicationGisExport.query.yield_per(50):
                 writer.writerow(r.csv_row())
                 yield data.getvalue()
                 data.seek(0)

--- a/services/core-api/app/api/exports/now_application/resources/now_application_gis_export_resource.py
+++ b/services/core-api/app/api/exports/now_application/resources/now_application_gis_export_resource.py
@@ -1,31 +1,38 @@
-import csv
+import time
 from io import StringIO
-from flask import Response
-from flask_restplus import Resource
+
+from flask import stream_with_context, Response, current_app
+import csv
 from sqlalchemy.inspection import inspect
-
+from flask_restplus import Resource
 from ..models.now_application_gis_export import NowApplicationGisExport
-
 from app.extensions import api, cache
 from app.api.utils.access_decorators import VIEW_ALL, GIS, requires_any_of
 from app.api.constants import NOW_APPLICATION_GIS_EXPORT, TIMEOUT_60_MINUTES
 
-
 class NowApplicationGisExportResource(Resource):
     @api.doc(
         description=
-        'This endpoint returns a CSV export of Notice of Work details indended for uses by the GIS team.'
+        'This endpoint returns a CSV export of Notice of Work details intended for uses by the GIS team.'
     )
     @requires_any_of([VIEW_ALL, GIS])
     def get(self):
-        csv_string = cache.get(NOW_APPLICATION_GIS_EXPORT)
-        if not csv_string:
-            model = inspect(NowApplicationGisExport)
-            si = StringIO()
-            cw = csv.writer(si)
-            cw.writerow([c.name or "" for c in model.columns])
-            rows = NowApplicationGisExport.query.all()
-            cw.writerows([r.csv_row() for r in rows])
-            csv_string = si.getvalue()
-            cache.set(NOW_APPLICATION_GIS_EXPORT, csv_string, timeout=TIMEOUT_60_MINUTES)
-        return Response(csv_string, mimetype='text/csv')
+        model = inspect(NowApplicationGisExport)
+        headers = [c.name or "" for c in model.columns]
+        cache.clear()
+
+        def generate():
+            data = StringIO()
+            writer = csv.writer(data)
+            writer.writerow(headers)
+            yield data.getvalue()
+            data.seek(0)
+            data.truncate(0)
+
+            for r in NowApplicationGisExport.query.yield_per(250):
+                writer.writerow(r.csv_row())
+                yield data.getvalue()
+                data.seek(0)
+                data.truncate(0)
+
+        return Response(stream_with_context(generate()), mimetype='text/csv')


### PR DESCRIPTION
The previous implementation was caching the entire output CSV. This was replaced with a generator to stream the CSV content to the client as it's being produced, making the system more efficient when large data sets are processed. This change will improve performance and memory usage (and hopefully prevent crashes for BCGW). 

The solution itself was pretty straightforward, but took me a while to figure out how to test this locally since we normally don't have this view available locally.  Will have to figure out a system for Jason to test it 🤔 

## Objective 

[MDS-5470](https://bcmines.atlassian.net/browse/MDS-5470)
