### PR TITLE
[MDS-5056] UTC Validation for TSF EOR/QP

### DIFF
--- a/services/core-web/common/utils/Validate.js
+++ b/services/core-web/common/utils/Validate.js
@@ -193,7 +193,7 @@ export const dateTimezoneRequired = memoize((timezoneField) => (_value, allValue
 });
 
 export const dateInFuture = (value) =>
-  value && new Date(value) < new Date() ? "Date must be in the future" : undefined;
+  value && !moment(value).isAfter() ? "Date must be in the future" : undefined;
 
 export const dateNotBeforeOther = memoize((other) => (value) =>
   value && other && new Date(value) <= new Date(other)

--- a/services/minespace-web/common/utils/Validate.js
+++ b/services/minespace-web/common/utils/Validate.js
@@ -193,7 +193,7 @@ export const dateTimezoneRequired = memoize((timezoneField) => (_value, allValue
 });
 
 export const dateInFuture = (value) =>
-  value && new Date(value) < new Date() ? "Date must be in the future" : undefined;
+  value && !moment(value).isAfter() ? "Date must be in the future" : undefined;
 
 export const dateNotBeforeOther = memoize((other) => (value) =>
   value && other && new Date(value) <= new Date(other)


### PR DESCRIPTION
## Objective 
- fix the validation, odd things happening with timezones
- the input gets passed into validation like "2023-09-19"
- OLD: `new Date("2023-09-19")` returns `Mon Sep 18 2023 18:00:00 GMT-0600`, and this is what was being compared to the current date/time to test if it's in the future.
- NEW: `moment("2023-09-19")` returns `Tue Sep 19 2023 00:00:00 GMT-0600`- this is what I have changed it to, so it will be midnight of that day in the user's local timezone instead of UTC.
- only validation is being changed, data being saved is the same (saved in format 2023-09-19).

[MDS-5056](https://bcmines.atlassian.net/browse/MDS-5056)