### PR TITLE
[MDS-5495] Remove Actions Menu from IRT template upload (#2684)

### DIFF
--- a/.github/workflows/minespace.unit.yaml
+++ b/.github/workflows/minespace.unit.yaml
@@ -25,6 +25,12 @@ jobs:
         with:
           node-version: 14.x
 
+      - name: Set Fontawesome token
+        run: |
+          yarn config set 'npmScopes["fortawesome"].npmAuthToken' "${{ secrets.FONT_AWESOME_PACKAGE_TOKEN }}"
+          yarn config set 'npmScopes["fortawesome"].npmAlwaysAuth' true
+          yarn config set 'npmScopes["fortawesome"].npmRegistryServer' "https://npm.fontawesome.com/"
+
       - name: Install Dependencies
         run: yarn install
 

--- a/services/core-web/src/components/common/DocumentTable.tsx
+++ b/services/core-web/src/components/common/DocumentTable.tsx
@@ -53,7 +53,6 @@ interface DocumentTableProps {
   defaultSortKeys: string[];
   excludedColumnKeys: string[];
   additionalColumnProps: { key: string; colProps: any }[];
-  fileOperationPermissionMap: { operation: FileOperations; permission: string | boolean }[];
   userRoles: string[];
   handleRowSelectionChange: (arg1: MineDocument[]) => void;
   replaceAlertMessage?: string;
@@ -83,7 +82,6 @@ export const DocumentTable = ({
   const [rowSelection, setRowSelection] = useState([]);
   const [isCompressionModal, setCompressionModal] = useState(false);
   const [isCompressionInProgress, setCompressionInProgress] = useState(false);
-  const [documentTypeCode, setDocumentTypeCode] = useState("");
   const [documentsCanBulkDropDown, setDocumentsCanBulkDropDown] = useState(false);
 
   const { isFeatureEnabled } = useFeatureFlag();
@@ -182,7 +180,6 @@ export const DocumentTable = ({
     });
   };
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const actions = [
     {
       key: "view",
@@ -327,22 +324,22 @@ export const DocumentTable = ({
 
   const bulkActionsProps = enableBulkActions
     ? {
-      rowSelection: {
-        type: "checkbox",
-        ...rowSelectionObject,
-      },
-    }
+        rowSelection: {
+          type: "checkbox",
+          ...rowSelectionObject,
+        },
+      }
     : {};
 
   const versionProps = showVersionHistory
     ? {
-      expandProps: {
-        childrenColumnName: "versions",
-        matchChildColumnsToParent: true,
-        recordDescription: "version history",
-        rowExpandable: (record) => record.number_prev_versions > 0,
-      },
-    }
+        expandProps: {
+          childrenColumnName: "versions",
+          matchChildColumnsToParent: true,
+          recordDescription: "version history",
+          rowExpandable: (record) => record.number_prev_versions > 0,
+        },
+      }
     : {};
 
   const coreTableProps = {
@@ -387,7 +384,7 @@ export const DocumentTable = ({
   return (
     <div>
       <DocumentCompression
-        documentType={documentTypeCode}
+        documentType=""
         rows={rowSelection}
         setCompressionModalVisible={setCompressionModal}
         isCompressionModalVisible={isCompressionModal}

--- a/services/minespace-web/Dockerfile.ci
+++ b/services/minespace-web/Dockerfile.ci
@@ -4,10 +4,16 @@ FROM node:14.21.3 as builder
 RUN mkdir /app
 WORKDIR /app
 
+ARG FONT_AWESOME_PACKAGE_TOKEN
+
 # Install app dependencies
 COPY . .
 
 ENV NODE_OPTIONS="--max-old-space-size=6144"
+
+RUN yarn config set 'npmScopes["fortawesome"].npmAuthToken' "$FONT_AWESOME_PACKAGE_TOKEN"
+RUN yarn config set 'npmScopes["fortawesome"].npmAlwaysAuth' true
+RUN yarn config set 'npmScopes["fortawesome"].npmRegistryServer' "https://npm.fontawesome.com/"
 
 # Install Dependencies
 RUN yarn

--- a/services/minespace-web/src/HOC/AuthenticationGuard.js
+++ b/services/minespace-web/src/HOC/AuthenticationGuard.js
@@ -9,6 +9,7 @@ import { useKeycloak } from "@react-keycloak/web";
 import { KEYCLOAK } from "@mds/common";
 import { isAuthenticated } from "@/selectors/authenticationSelectors";
 import { authenticateUser } from "@/actionCreators/authenticationActionCreator";
+import { storeUserAccessData } from "@common/actions/authenticationActions";
 import UnauthenticatedNotice from "@/components/common/UnauthenticatedNotice";
 import Loading from "@/components/common/Loading";
 import * as route from "@/constants/routes";
@@ -22,6 +23,7 @@ import * as ENV from "@/constants/environment";
 const propTypes = {
   isAuthenticated: PropTypes.bool.isRequired,
   authenticateUser: PropTypes.func.isRequired,
+  storeUserAccessData: PropTypes.func.isRequired,
 };
 
 export const AuthenticationGuard = (isPublic) => (WrappedComponent) => {
@@ -50,15 +52,18 @@ export const AuthenticationGuard = (isPublic) => (WrappedComponent) => {
       const authenticationInProgressFlag = localStorage.getItem("authenticationInProgressFlag");
       const token = keycloak.tokenParsed ?? null;
       const { type } = queryString.parse(window.location.search);
+      const clientRoles = token?.client_roles || [];
 
       if (keycloak.authenticated && !authenticationInProgressFlag && !type) {
         localStorage.setItem("authenticationInProgressFlag", true);
         props.authenticateUser(token);
+        props.storeUserAccessData(clientRoles);
       }
       // standard Authentication flow on initial load,
       // if token exists, authenticate user.
       if (token && !props.isAuthenticated) {
         props.authenticateUser(token);
+        props.storeUserAccessData(clientRoles);
       }
     };
 
@@ -89,6 +94,7 @@ export const AuthenticationGuard = (isPublic) => (WrappedComponent) => {
     bindActionCreators(
       {
         authenticateUser,
+        storeUserAccessData,
       },
       dispatch
     );

--- a/services/minespace-web/src/components/Forms/projects/informationRequirementsTable/IRTFileImport.js
+++ b/services/minespace-web/src/components/Forms/projects/informationRequirementsTable/IRTFileImport.js
@@ -121,6 +121,7 @@ export class IRTFileImport extends Component {
                 documents={documents}
                 documentParent="Information Requirements Table"
                 documentColumns={documentColumns}
+                isViewOnly
               />
               <br />
               {this.props.project?.information_requirements_table?.status_code === "SUB" && (


### PR DESCRIPTION
## Objective 
- made the instance of the table view only, which will disallow non-viewing actions
- the actions menu is still there but only contains "Download" (for the excel files expected to be there)
- also cleaned up some unused/undefined variables
- fixed getUserAccessData by calling it at the same point we do on core, so that the data exists.
- bonus: CI/CD changes for font-awesome on MS

[MDS-5495](https://bcmines.atlassian.net/browse/MDS-5495)