### PR TITLE
[CHORE] - Listen for connection webhooks from traction. 

### DIFF
--- a/services/core-api/app/api/services/traction_service.py
+++ b/services/core-api/app/api/services/traction_service.py
@@ -57,7 +57,7 @@ class TractionService():
         oob_create_resp = requests.post(traction_oob_create_invitation, json=payload,headers=self.get_headers())
 
         response = oob_create_resp.json()
-        current_app.logger.info(response)
+        current_app.logger.info(f"oob invitation create reponse from traction = {response}")
         new_traction_connection = PartyVerifiableCredentialConnection(party_guid = party.party_guid, invitation_id = response["invitation"]["@id"])
         new_traction_connection.save()
 

--- a/services/core-api/app/api/verifiable_credentials/models/connection.py
+++ b/services/core-api/app/api/verifiable_credentials/models/connection.py
@@ -25,3 +25,6 @@ class PartyVerifiableCredentialConnection(AuditMixin, Base):
     def find_by_party_guid(cls, party_guid) -> "PartyVerifiableCredentialConnection":
         return cls.query.filter_by(party_guid=party_guid).all()
         
+    @classmethod
+    def find_by_invitation_id(cls, invitation_id) -> "PartyVerifiableCredentialConnection":
+        return cls.query.filter_by(invitation_id=invitation_id).one_or_none()

--- a/services/core-api/app/api/verifiable_credentials/namespace.py
+++ b/services/core-api/app/api/verifiable_credentials/namespace.py
@@ -7,5 +7,5 @@ from app.api.verifiable_credentials.resources.verifiable_credential_webhook impo
 api = Namespace('verifiable-credentials', description='Variances actions/options')
 
 api.add_resource(VerifiableCredentialResource, '')
-api.add_resource(VerifiableCredentialWebhookResource, '/webhook/<string:topic>')
+api.add_resource(VerifiableCredentialWebhookResource, '/webhook/topic/<string:topic>')
 api.add_resource(VerifiableCredentialConnectionResource, '/oob-invitation/<string:party_guid>')

--- a/services/core-api/app/api/verifiable_credentials/resources/verifiable_credential_connections.py
+++ b/services/core-api/app/api/verifiable_credentials/resources/verifiable_credential_connections.py
@@ -22,6 +22,5 @@ class VerifiableCredentialConnectionResource(Resource, UserMixin):
         traction_svc=TractionService()
         invitation = traction_svc.create_oob_connection_invitation(party)
         
-        current_app.logger.warn(invitation)
         return invitation
  

--- a/services/core-api/app/api/verifiable_credentials/resources/verifiable_credential_webhook.py
+++ b/services/core-api/app/api/verifiable_credentials/resources/verifiable_credential_webhook.py
@@ -1,3 +1,4 @@
+import enum
 from flask import current_app, request
 from flask_restplus import Resource
 
@@ -6,8 +7,21 @@ from app.extensions import api
 from app.api.utils.resources_mixins import UserMixin
 from app.api.services.traction_service import TractionService
 
+from app.api.verifiable_credentials.models.connection import PartyVerifiableCredentialConnection
+
+class ACAPY_WEBHOOK_TOPICS(enum, str):
+    PRESENT_PROOF = "present_proof"
 
 class VerifiableCredentialWebhookResource(Resource, UserMixin):
     @api.doc(description='Endpoint to recieve webhooks from Traction.', params={})
     def post(self, topic):
         current_app.logger.warning(f"TRACTION WEBHOOK: {request.__dict__}")
+        invitation_id = request["invi_msg_id"]
+        if topic == ACAPY_WEBHOOK_TOPICS.PRESENT_PROOF:
+            vc_conn = PartyVerifiableCredentialConnection.find_by_invitation_id(invitation_id)
+            assert vc_conn, f"{invitation_id} not found"
+            new_state = request["state"]
+            if new_state != vc_conn.connection_state:
+                vc_conn.connection_state=new_state
+                vc_conn.save()
+                current_app.logger.debug(f"Updated party_vc_conn invitation_id={invitation_id} with state={new_state}")

--- a/services/core-api/app/api/verifiable_credentials/resources/verifiable_credential_webhook.py
+++ b/services/core-api/app/api/verifiable_credentials/resources/verifiable_credential_webhook.py
@@ -9,15 +9,15 @@ from app.api.services.traction_service import TractionService
 
 from app.api.verifiable_credentials.models.connection import PartyVerifiableCredentialConnection
 
-class ACAPY_WEBHOOK_TOPICS(enum, str):
-    PRESENT_PROOF = "present_proof"
+PRESENT_PROOF = "present_proof"
+CONNECTIONS = "connections"
 
 class VerifiableCredentialWebhookResource(Resource, UserMixin):
     @api.doc(description='Endpoint to recieve webhooks from Traction.', params={})
     def post(self, topic):
         current_app.logger.warning(f"TRACTION WEBHOOK: {request.__dict__}")
         invitation_id = request["invi_msg_id"]
-        if topic == ACAPY_WEBHOOK_TOPICS.PRESENT_PROOF:
+        if topic == CONNECTIONS:
             vc_conn = PartyVerifiableCredentialConnection.find_by_invitation_id(invitation_id)
             assert vc_conn, f"{invitation_id} not found"
             new_state = request["state"]
@@ -25,3 +25,5 @@ class VerifiableCredentialWebhookResource(Resource, UserMixin):
                 vc_conn.connection_state=new_state
                 vc_conn.save()
                 current_app.logger.debug(f"Updated party_vc_conn invitation_id={invitation_id} with state={new_state}")
+        else:
+            current_app.logger.info(f"unknown topic={topic} received, payload ={request}")


### PR DESCRIPTION
## Objective 

acapy sends webhooks when things happen. So far we are only listening for 'connections' but will need to listen for 'present_proof' in the future. 

When things happen to the connection, update the record in MDS for brevity and speed. 

We will need to key off of pending vs active connections to allow/enable actions.
