### PR TITLE
[FIX] Add trailing slash to webhook endpoint (#2695)

### DIFF
--- a/services/core-api/app/api/verifiable_credentials/namespace.py
+++ b/services/core-api/app/api/verifiable_credentials/namespace.py
@@ -7,5 +7,5 @@ from app.api.verifiable_credentials.resources.verifiable_credential_webhook impo
 api = Namespace('verifiable-credentials', description='Variances actions/options')
 
 api.add_resource(VerifiableCredentialResource, '')
-api.add_resource(VerifiableCredentialWebhookResource, '/webhook/topic/<string:topic>')
+api.add_resource(VerifiableCredentialWebhookResource, '/webhook/topic/<string:topic>/')
 api.add_resource(VerifiableCredentialConnectionResource, '/oob-invitation/<string:party_guid>')

--- a/services/core-web/common/components/tailings/EngineerOfRecord.tsx
+++ b/services/core-web/common/components/tailings/EngineerOfRecord.tsx
@@ -315,7 +315,9 @@ export const EngineerOfRecord: FC<EngineerOfRecordProps> = (props) => {
           {!formValues?.engineer_of_record?.mine_party_appt_guid && (
             <>
               <div className="margin-large--top margin-large--bottom">
-                <Typography.Title level={4}>{!fieldsDisabled? "Upload Acceptance Letter *" : "Upload Acceptance Letter"}</Typography.Title>
+                <Typography.Title level={4}>
+                  {!fieldsDisabled ? "Upload Acceptance Letter *" : "Upload Acceptance Letter"}
+                </Typography.Title>
                 <Typography.Text>
                   Letter must be officially signed. A notification will be sent to the Mine Manager
                   upon upload.
@@ -353,7 +355,7 @@ export const EngineerOfRecord: FC<EngineerOfRecordProps> = (props) => {
               <Field
                 id="engineer_of_record.start_date"
                 name="engineer_of_record.start_date"
-                label={!fieldsDisabled? "Start Date *" : "Start Date"}
+                label={!fieldsDisabled ? "Start Date *" : "Start Date"}
                 disabled={fieldsDisabled}
                 component={renderConfig.DATE}
                 validate={

--- a/services/minespace-web/common/components/tailings/EngineerOfRecord.tsx
+++ b/services/minespace-web/common/components/tailings/EngineerOfRecord.tsx
@@ -315,7 +315,9 @@ export const EngineerOfRecord: FC<EngineerOfRecordProps> = (props) => {
           {!formValues?.engineer_of_record?.mine_party_appt_guid && (
             <>
               <div className="margin-large--top margin-large--bottom">
-                <Typography.Title level={4}>{!fieldsDisabled? "Upload Acceptance Letter *" : "Upload Acceptance Letter"}</Typography.Title>
+                <Typography.Title level={4}>
+                  {!fieldsDisabled ? "Upload Acceptance Letter *" : "Upload Acceptance Letter"}
+                </Typography.Title>
                 <Typography.Text>
                   Letter must be officially signed. A notification will be sent to the Mine Manager
                   upon upload.
@@ -353,7 +355,7 @@ export const EngineerOfRecord: FC<EngineerOfRecordProps> = (props) => {
               <Field
                 id="engineer_of_record.start_date"
                 name="engineer_of_record.start_date"
-                label={!fieldsDisabled? "Start Date *" : "Start Date"}
+                label={!fieldsDisabled ? "Start Date *" : "Start Date"}
                 disabled={fieldsDisabled}
                 component={renderConfig.DATE}
                 validate={


### PR DESCRIPTION
* update state based on webhooks

* don't use enum inheritance

* trailing slash

* add trailing slash

## Objective 

[MDS-5486](https://bcmines.atlassian.net/browse/MDS-5486)

_Why are you making this change? Provide a short explanation and/or screenshots_
