### PR TITLE
[MDS-5498] NoW app revert to display message when section is empty

### DIFF
--- a/services/core-web/src/components/noticeOfWork/applications/ScrollContentWrapper.tsx
+++ b/services/core-web/src/components/noticeOfWork/applications/ScrollContentWrapper.tsx
@@ -43,7 +43,7 @@ export const ScrollContentWrapper: FC<ScrollContentWrapperProps> = (props) => {
 
   useEffect(() => {
     if (props.data !== undefined && isEmpty(props.data)) {
-      // setIsVisible(false);
+      setIsVisible(false);
     }
   }, []);
 


### PR DESCRIPTION
## Objective 

[MDS-5498](https://bcmines.atlassian.net/browse/MDS-5498)

After some discussions, it sounds like this ticket will be parked for the time being as the decision to remove the requirement for the input "Describe how explosives will get to the site" needs to be looked at further. 

In the mean time, this revert in the PR makes it so when a section inside a NoW application is empty, it will display a message instead of the section.

![image](https://github.com/bcgov/mds/assets/127789479/3cfdfff3-c5c6-4eda-a051-e9af8420c1f7)

