### PR TITLE
[MDS-5456] adding soft deletion of now_application_document_identity_xref

### DIFF
--- a/migrations/sql/V2023.10.04.12.13__add_now_document_identity_xref_delete_ind.sql
+++ b/migrations/sql/V2023.10.04.12.13__add_now_document_identity_xref_delete_ind.sql
@@ -1,0 +1,11 @@
+ALTER TABLE
+    now_application_document_identity_xref
+ADD
+    COLUMN IF NOT EXISTS deleted_ind boolean DEFAULT false NOT NULL;
+
+UPDATE
+    now_application_document_identity_xref as x
+SET deleted_ind = d.deleted_ind
+FROM mine_document d
+WHERE
+    d.mine_document_guid = x.mine_document_guid;

--- a/migrations/sql/V2023.10.06.10.36__add_now_submissions_document_delete_ind.sql
+++ b/migrations/sql/V2023.10.06.10.36__add_now_submissions_document_delete_ind.sql
@@ -1,0 +1,4 @@
+ALTER TABLE
+    now_submissions.document
+ADD
+    COLUMN IF NOT EXISTS deleted_ind boolean DEFAULT false NOT NULL;

--- a/services/core-api/app/api/now_applications/models/now_application.py
+++ b/services/core-api/app/api/now_applications/models/now_application.py
@@ -179,7 +179,7 @@ class NOWApplication(Base, AuditMixin):
         secondary=
         'join(NOWApplicationIdentity, Document, foreign(NOWApplicationIdentity.messageid)==remote(Document.messageid))',
         primaryjoin=
-        'and_(NOWApplication.now_application_id==NOWApplicationIdentity.now_application_id, foreign(NOWApplicationIdentity.messageid)==remote(Document.messageid))',
+        'and_(NOWApplication.now_application_id==NOWApplicationIdentity.now_application_id, foreign(NOWApplicationIdentity.messageid)==remote(Document.messageid), remote(Document.deleted_ind)==False)',
         secondaryjoin='foreign(NOWApplicationIdentity.messageid)==remote(Document.messageid)',
         viewonly=True,
         order_by='asc(Document.id)')

--- a/services/core-api/app/api/now_applications/models/now_application.py
+++ b/services/core-api/app/api/now_applications/models/now_application.py
@@ -188,7 +188,7 @@ class NOWApplication(Base, AuditMixin):
         'NOWApplicationDocumentIdentityXref',
         lazy='selectin',
         primaryjoin=
-        'and_(NOWApplicationDocumentIdentityXref.now_application_id==NOWApplication.now_application_id)',
+        'and_(NOWApplicationDocumentIdentityXref.now_application_id==NOWApplication.now_application_id, NOWApplicationDocumentIdentityXref.deleted_ind==False)',
         order_by='asc(NOWApplicationDocumentIdentityXref.create_timestamp)')
 
     contacts = db.relationship(

--- a/services/core-api/app/api/now_applications/models/now_application_document_identity_xref.py
+++ b/services/core-api/app/api/now_applications/models/now_application_document_identity_xref.py
@@ -3,13 +3,13 @@ from sqlalchemy.schema import FetchedValue
 from sqlalchemy.orm import backref
 from sqlalchemy.ext.hybrid import hybrid_property
 
-from app.api.utils.models_mixins import AuditMixin, Base
+from app.api.utils.models_mixins import AuditMixin, Base, SoftDeleteMixin
 from app.extensions import db
 from app.api.constants import NOW_APPLICATION_EDIT_GROUP
 from app.api.mines.documents.models.mine_document import MineDocument
 
 
-class NOWApplicationDocumentIdentityXref(AuditMixin, Base):
+class NOWApplicationDocumentIdentityXref(SoftDeleteMixin, AuditMixin, Base):
     __tablename__ = 'now_application_document_identity_xref'
     _edit_groups = [NOW_APPLICATION_EDIT_GROUP]
 
@@ -53,3 +53,7 @@ class NOWApplicationDocumentIdentityXref(AuditMixin, Base):
     @classmethod
     def find_by_guid(cls, guid):
         return cls.query.filter_by(now_application_document_xref_guid=guid).one_or_none()
+    
+    def delete(self, commit=True):
+        self.mine_document.delete(commit)
+        super(NOWApplicationDocumentIdentityXref, self).delete(commit)

--- a/services/core-api/app/api/now_submissions/models/document.py
+++ b/services/core-api/app/api/now_submissions/models/document.py
@@ -1,12 +1,12 @@
 from sqlalchemy.schema import FetchedValue
 
-from app.api.utils.models_mixins import Base
+from app.api.utils.models_mixins import Base, SoftDeleteMixin
 from app.extensions import db
 from sqlalchemy.dialects.postgresql import UUID
 from app.api.constants import *
 
 
-class Document(Base):
+class Document(SoftDeleteMixin, Base):
     __tablename__ = "document"
     __table_args__ = {"schema": "now_submissions"}
     _edit_groups = [NOW_APPLICATION_EDIT_GROUP]
@@ -24,3 +24,10 @@ class Document(Base):
     @classmethod
     def find_by_id(cls, id):
         return cls.query.filter_by(id=id).one_or_none()
+    
+    @classmethod
+    def find_by_messageid_and_filename(cls, messageid, filename):
+        return cls.query.filter_by(messageid=messageid, filename=filename).first()
+    
+    def delete(self, commit=True):
+        super(Document, self).delete(commit)


### PR DESCRIPTION
## Objective 

[MDS-5456](https://bcmines.atlassian.net/browse/MDS-5456)

- Changes for making imported submission documents in NoW soft deletable instead of giving error _None Type object has no attribute now_application_.

- The issue is because documents with import status Success do not have a record in the now_application_document_xref database table, instead they can be found in the now_application_document_identity_xref table.

- Database changes made to add deleted_ind column inside now_application_document_identity_xref and now_submissions.document tables.

