### PR TITLE
[MDS-5525] Remove Actions menu from Bond document table (#2710)

### DIFF
--- a/services/core-web/src/components/Forms/ExplosivesPermit/ExplosivesPermitForm.tsx
+++ b/services/core-web/src/components/Forms/ExplosivesPermit/ExplosivesPermitForm.tsx
@@ -119,7 +119,9 @@ export const ExplosivesPermitForm: FC<ExplosivesPermitFormProps &
     "now_application_guid"
   );
 
-  const [isHistoric, setIsHistoric] = useState<boolean>(!initialValues?.explosives_permit_id && props.isPermitTab);
+  const [isHistoric, setIsHistoric] = useState<boolean>(
+    !initialValues?.explosives_permit_id && props.isPermitTab
+  );
   const isESUP = props.userRoles.includes(USER_ROLES[Permission.EDIT_EXPLOSIVES_PERMITS]);
   // eslint-disable-next-line no-unused-vars
   const hasEditPermission = isESUP;
@@ -134,12 +136,12 @@ export const ExplosivesPermitForm: FC<ExplosivesPermitFormProps &
   const handleRadioChange = (e) => {
     setRadioSelection(e.target.value);
     setIsHistoric(e.target.value == 1);
-    setIsAmend(e.target.value==3);
+    setIsAmend(e.target.value == 3);
   };
 
   const handleOpenAddExplosivesPermitModal = () => {
-    setParentView(false)
-  }
+    setParentView(false);
+  };
 
   const descriptionListElement = (
     <div>
@@ -148,19 +150,22 @@ export const ExplosivesPermitForm: FC<ExplosivesPermitFormProps &
           <li>
             <Typography.Text strong>Add an existing permit </Typography.Text>
             <Typography.Text>
-              that was previously issued but does not exist in CORE and Minespace. This will help you keep track of your
-              past permits and activities.
+              that was previously issued but does not exist in CORE and Minespace. This will help
+              you keep track of your past permits and activities.
             </Typography.Text>
           </li>
           <li>
             <Typography.Text strong>Create a new permit </Typography.Text>
-            <Typography.Text>this is meant for new explosive storage and use permits.</Typography.Text>
+            <Typography.Text>
+              this is meant for new explosive storage and use permits.
+            </Typography.Text>
           </li>
           <li>
             <Typography.Text strong>Amend an existing permit </Typography.Text>
             <Typography.Text>
-              that has already been added to CORE and Minespace. This will allow you to make changes to your permit
-              conditions, such as the dates, amount of explosives.</Typography.Text>
+              that has already been added to CORE and Minespace. This will allow you to make changes
+              to your permit conditions, such as the dates, amount of explosives.
+            </Typography.Text>
           </li>
         </ul>
       </Typography.Paragraph>
@@ -172,33 +177,44 @@ export const ExplosivesPermitForm: FC<ExplosivesPermitFormProps &
       To make changes to an existing explosive storage and use permit, follow these steps:
       <br />
       <ul className="landing-list">
-        <li>Open the permit that you want to amend from the applications page of the mine in CORE.</li>
-        <li>Click on the “Amend Permit” button at the top right corner of the permit details page.</li>
+        <li>
+          Open the permit that you want to amend from the applications page of the mine in CORE.
+        </li>
+        <li>
+          Click on the “Amend Permit” button at the top right corner of the permit details page.
+        </li>
         <li>Fill out the amendment form with the required information and documents.</li>
         <li>Complete the amendment and issue the permit.</li>
       </ul>
     </div>
   );
 
-  return (
-    isFeatureEnabled(Feature.ONE_WINDOW_FOR_CREATING_NEW_OR_HISTORICAL_ESUP) && parentView ? (
+  return isFeatureEnabled(Feature.ONE_WINDOW_FOR_CREATING_NEW_OR_HISTORICAL_ESUP) && parentView ? (
     <>
       <Form layout="vertical">
         <Typography.Title level={3}>Add Permit</Typography.Title>
         <div>
-          <Typography.Paragraph>Let's get your permit started, in CORE you can...</Typography.Paragraph>
+          <Typography.Paragraph>
+            Let&apos;s get your permit started, in CORE you can...
+          </Typography.Paragraph>
           {descriptionListElement}
         </div>
-        <div  className="landing-list">
-          <h4 className="uppercase">DEFAULT TO "ADD EXISTING" FROM PERMIT PAGE / "CREATE NEW" FROM APPLICATION PAGE</h4><br/>
+        <div className="landing-list">
+          <h4 className="uppercase">
+            DEFAULT TO &quot;ADD EXISTING&quot; FROM PERMIT PAGE / &quot;CREATE NEW&quot; FROM
+            APPLICATION PAGE
+          </h4>
+          <br />
           <Typography.Text>Select an action below to get started:</Typography.Text>
-          <div  className="landing-list">
-            <Radio.Group className="vertical-radio-group"
+          <div className="landing-list">
+            <Radio.Group
+              className="vertical-radio-group"
               value={radioSelection}
-              onChange={handleRadioChange}>
-                  <Radio value={1}>Add an existing explosive storage and use permit</Radio>
-                  <Radio value={2}>Create new explosive storage and use permit</Radio>
-                  <Radio value={3}>Amend an existing explosive storage and use permit</Radio>
+              onChange={handleRadioChange}
+            >
+              <Radio value={1}>Add an existing explosive storage and use permit</Radio>
+              <Radio value={2}>Create new explosive storage and use permit</Radio>
+              <Radio value={3}>Amend an existing explosive storage and use permit</Radio>
             </Radio.Group>
           </div>
         </div>
@@ -220,282 +236,289 @@ export const ExplosivesPermitForm: FC<ExplosivesPermitFormProps &
             cancelText="No"
             onConfirm={props.closeModal}
           >
-            <Button className="full-mobile">
-              Cancel
-            </Button>
+            <Button className="full-mobile">Cancel</Button>
           </Popconfirm>
-          <Button disabled={isAmend} type="primary" onClick={(e) => handleOpenAddExplosivesPermitModal()}>
+          <Button
+            disabled={isAmend}
+            type="primary"
+            onClick={() => handleOpenAddExplosivesPermitModal()}
+          >
             Next
           </Button>
         </div>
       </Form>
-    </>)
-    :
-    (<>
-    <Form layout="vertical" onSubmit={props.handleSubmit}>
-      {isHistoric && (
-        <Alert
-          message="Adding a Historic Explosives Storage & Use Permit"
-          description="By creating an Explosives Permit on the Permit Tab, the permit will be created with a status of Approved and an Originating System of MMS. If you would like to create an Explosives Permit Application, navigate to the Application Tab."
-          type="info"
-          showIcon
-        />
-      )}
-      {disabled && (
-        <Alert
-          message="Editing Disabled"
-          description="If details of this permit need to be cleaned up for data quality purposes, contact the MDS administrators at mds@gov.bc.ca"
-          type="info"
-          showIcon
-        />
-      )}
-      <br />
-      <Row gutter={48}>
-        <Col md={12} sm={24}>
-          <h4>Explosives Permit Details</h4>
-          {props.isPermitTab && (
-            <>
-              <Row gutter={6}>
-                <Col span={12}>
-                  <Form.Item>
-                    <Field
-                      id="issue_date"
-                      name="issue_date"
-                      label="Issue Date*"
-                      component={renderConfig.DATE}
-                      validate={[required, dateNotInFuture]}
-                      disabled={disabled}
-                    />
-                  </Form.Item>
-                </Col>
-                <Col span={12}>
-                  <Form.Item>
-                    <Field
-                      id="expiry_date"
-                      name="expiry_date"
-                      label="Expiry Date*"
-                      component={renderConfig.DATE}
-                      validate={[required]}
-                      disabled={disabled}
-                    />
-                  </Form.Item>
-                </Col>
-              </Row>
-              <Row gutter={6}>
-                <Col span={24}>
-                  <Form.Item>
-                    <Field
-                      id="issuing_inspector_party_guid"
-                      name="issuing_inspector_party_guid"
-                      label="Issuing Inspector*"
-                      component={renderConfig.GROUPED_SELECT}
-                      placeholder="Start typing the Issuing Inspector's name"
-                      validate={[required]}
-                      data={props.inspectors}
-                      disabled={disabled}
-                    />
-                  </Form.Item>
-                </Col>
-              </Row>
-            </>
-          )}
-          <Row gutter={6}>
+    </>
+  ) : (
+    <>
+      <Form layout="vertical" onSubmit={props.handleSubmit}>
+        {isHistoric && (
+          <Alert
+            message="Adding a Historic Explosives Storage & Use Permit"
+            description="By creating an Explosives Permit on the Permit Tab, the permit will be created with a status of Approved and an Originating System of MMS. If you would like to create an Explosives Permit Application, navigate to the Application Tab."
+            type="info"
+            showIcon
+          />
+        )}
+        {disabled && (
+          <Alert
+            message="Editing Disabled"
+            description="If details of this permit need to be cleaned up for data quality purposes, contact the MDS administrators at mds@gov.bc.ca"
+            type="info"
+            showIcon
+          />
+        )}
+        <br />
+        <Row gutter={48}>
+          <Col md={12} sm={24}>
+            <h4>Explosives Permit Details</h4>
             {props.isPermitTab && (
-              <Col span={12}>
+              <>
+                <Row gutter={6}>
+                  <Col span={12}>
+                    <Form.Item>
+                      <Field
+                        id="issue_date"
+                        name="issue_date"
+                        label="Issue Date*"
+                        component={renderConfig.DATE}
+                        validate={[required, dateNotInFuture]}
+                        disabled={disabled}
+                      />
+                    </Form.Item>
+                  </Col>
+                  <Col span={12}>
+                    <Form.Item>
+                      <Field
+                        id="expiry_date"
+                        name="expiry_date"
+                        label="Expiry Date*"
+                        component={renderConfig.DATE}
+                        validate={[required]}
+                        disabled={disabled}
+                      />
+                    </Form.Item>
+                  </Col>
+                </Row>
+                <Row gutter={6}>
+                  <Col span={24}>
+                    <Form.Item>
+                      <Field
+                        id="issuing_inspector_party_guid"
+                        name="issuing_inspector_party_guid"
+                        label="Issuing Inspector*"
+                        component={renderConfig.GROUPED_SELECT}
+                        placeholder="Start typing the Issuing Inspector's name"
+                        validate={[required]}
+                        data={props.inspectors}
+                        disabled={disabled}
+                      />
+                    </Form.Item>
+                  </Col>
+                </Row>
+              </>
+            )}
+            <Row gutter={6}>
+              {props.isPermitTab && (
+                <Col span={12}>
+                  <Form.Item>
+                    <Field
+                      id="permit_number"
+                      name="permit_number"
+                      placeholder="Explosives Permit Number"
+                      label="Explosives Permit Number*"
+                      component={renderConfig.FIELD}
+                      validate={[required]}
+                      disabled={disabled}
+                    />
+                  </Form.Item>
+                </Col>
+              )}
+              <Col span={props.isPermitTab ? 12 : 24}>
                 <Form.Item>
                   <Field
-                    id="permit_number"
-                    name="permit_number"
-                    placeholder="Explosives Permit Number"
-                    label="Explosives Permit Number*"
-                    component={renderConfig.FIELD}
-                    validate={[required]}
+                    id="permit_guid"
+                    name="permit_guid"
+                    placeholder="Select a Permit"
+                    label="Mines Act Permit*"
+                    component={renderConfig.SELECT}
+                    data={permitDropdown}
+                    validate={[required, validateSelectOptions(permitDropdown, true)]}
                     disabled={disabled}
                   />
                 </Form.Item>
               </Col>
+            </Row>
+            <Form.Item>
+              <Field
+                id="now_application_guid"
+                name="now_application_guid"
+                placeholder="Select a NoW"
+                label="Notice of Work Number"
+                component={renderConfig.SELECT}
+                validate={[validateSelectOptions(nowDropdown, true)]}
+                data={nowDropdown}
+                disabled={disabled}
+              />
+            </Form.Item>
+            <Row gutter={6}>
+              <Col span={12}>
+                <Form.Item>
+                  <Field
+                    id="mine_manager_mine_party_appt_id"
+                    name="mine_manager_mine_party_appt_id"
+                    label={props.isPermitTab ? "Mine Manager" : "Mine Manager*"}
+                    placeholder="Select Mine Manager"
+                    partyLabel="Mine Manager"
+                    validate={
+                      props.isPermitTab
+                        ? [validateSelectOptions(mineManagersDropdown, true)]
+                        : [required, validateSelectOptions(mineManagersDropdown, true)]
+                    }
+                    component={renderConfig.SELECT}
+                    data={mineManagersDropdown}
+                    disabled={disabled}
+                  />
+                </Form.Item>
+              </Col>
+              <Col span={12}>
+                <Form.Item>
+                  <Field
+                    id="permittee_mine_party_appt_id"
+                    name="permittee_mine_party_appt_id"
+                    label="Permittee*"
+                    component={renderConfig.SELECT}
+                    placeholder="Select Permittee"
+                    validate={[required, validateSelectOptions(permitteeDropdown, true)]}
+                    data={permitteeDropdown}
+                    disabled={disabled || !mines_permit_guid}
+                  />
+                </Form.Item>
+              </Col>
+            </Row>
+            <Form.Item>
+              <Field
+                id="application_date"
+                name="application_date"
+                label="Application Date*"
+                component={renderConfig.DATE}
+                validate={[required, dateNotInFuture]}
+                disabled={disabled}
+              />
+            </Form.Item>
+            <Form.Item>
+              <Field
+                id="description"
+                name="description"
+                label="Other Information"
+                component={renderConfig.AUTO_SIZE_FIELD}
+                disabled={disabled}
+              />
+            </Form.Item>
+            <h4>Storage Details</h4>
+            <Row gutter={6}>
+              <Col span={12}>
+                <Form.Item>
+                  <Field
+                    id="latitude"
+                    name="latitude"
+                    label="Latitude*"
+                    validate={[number, maxLength(10), lat, required]}
+                    component={renderConfig.FIELD}
+                    disabled={disabled}
+                  />
+                </Form.Item>
+              </Col>
+              <Col span={12}>
+                <Form.Item>
+                  <Field
+                    id="longitude"
+                    name="longitude"
+                    label="Longitude*"
+                    validate={[number, maxLength(12), lon, required, lonNegative]}
+                    component={renderConfig.FIELD}
+                    disabled={disabled}
+                  />
+                </Form.Item>
+              </Col>
+            </Row>
+            <ExplosivesPermitMap pin={[props.formValues?.latitude, props.formValues?.longitude]} />
+            <br />
+            <DocumentCategoryForm
+              categories={props.documentTypeDropdownOptions}
+              mineGuid={props.mineGuid}
+              isProcessed={disabled}
+              infoText="Please upload any documents that support this explosives storage and use permit. Documents uploaded here will be viewable by Minespace users."
+            />
+          </Col>
+          <Col md={12} sm={24} className="border--left--layout">
+            {isHistoric && (
+              <>
+                <Row gutter={16}>
+                  <Col span={12}>
+                    <Form.Item>
+                      <Field
+                        id="is_closed"
+                        name="is_closed"
+                        label="Permit Status*"
+                        component={renderConfig.RADIO}
+                        customOptions={closedOptions}
+                        validate={[requiredRadioButton]}
+                      />
+                    </Form.Item>
+                  </Col>
+                  <Col span={12}>
+                    <Form.Item>
+                      <Field
+                        id="closed_timestamp"
+                        name="closed_timestamp"
+                        label="Date Permit was Closed"
+                        component={renderConfig.DATE}
+                        disabled={disabled}
+                      />
+                    </Form.Item>
+                  </Col>
+                </Row>
+                <Row gutter={16}>
+                  <Col span={24}>
+                    <Form.Item>
+                      <Field
+                        id="closed_reason"
+                        name="closed_reason"
+                        label="Reason for Closure"
+                        component={renderConfig.AUTO_SIZE_FIELD}
+                      />
+                    </Form.Item>
+                  </Col>
+                </Row>
+              </>
             )}
-            <Col span={props.isPermitTab ? 12 : 24}>
-              <Form.Item>
-                <Field
-                  id="permit_guid"
-                  name="permit_guid"
-                  placeholder="Select a Permit"
-                  label="Mines Act Permit*"
-                  component={renderConfig.SELECT}
-                  data={permitDropdown}
-                  validate={[required, validateSelectOptions(permitDropdown, true)]}
-                  disabled={disabled}
-                />
-              </Form.Item>
-            </Col>
-          </Row>
-          <Form.Item>
-            <Field
-              id="now_application_guid"
-              name="now_application_guid"
-              placeholder="Select a NoW"
-              label="Notice of Work Number"
-              component={renderConfig.SELECT}
-              validate={[validateSelectOptions(nowDropdown, true)]}
-              data={nowDropdown}
-              disabled={disabled}
-            />
-          </Form.Item>
-          <Row gutter={6}>
-            <Col span={12}>
-              <Form.Item>
-                <Field
-                  id="mine_manager_mine_party_appt_id"
-                  name="mine_manager_mine_party_appt_id"
-                  label={props.isPermitTab ? "Mine Manager" : "Mine Manager*"}
-                  placeholder="Select Mine Manager"
-                  partyLabel="Mine Manager"
-                  validate={
-                    props.isPermitTab
-                      ? [validateSelectOptions(mineManagersDropdown, true)]
-                      : [required, validateSelectOptions(mineManagersDropdown, true)]
-                  }
-                  component={renderConfig.SELECT}
-                  data={mineManagersDropdown}
-                  disabled={disabled}
-                />
-              </Form.Item>
-            </Col>
-            <Col span={12}>
-              <Form.Item>
-                <Field
-                  id="permittee_mine_party_appt_id"
-                  name="permittee_mine_party_appt_id"
-                  label="Permittee*"
-                  component={renderConfig.SELECT}
-                  placeholder="Select Permittee"
-                  validate={[required, validateSelectOptions(permitteeDropdown, true)]}
-                  data={permitteeDropdown}
-                  disabled={disabled || !mines_permit_guid}
-                />
-              </Form.Item>
-            </Col>
-          </Row>
-          <Form.Item>
-            <Field
-              id="application_date"
-              name="application_date"
-              label="Application Date*"
-              component={renderConfig.DATE}
-              validate={[required, dateNotInFuture]}
-              disabled={disabled}
-            />
-          </Form.Item>
-          <Form.Item>
-            <Field
-              id="description"
-              name="description"
-              label="Other Information"
-              component={renderConfig.AUTO_SIZE_FIELD}
-              disabled={disabled}
-            />
-          </Form.Item>
-          <h4>Storage Details</h4>
-          <Row gutter={6}>
-            <Col span={12}>
-              <Form.Item>
-                <Field
-                  id="latitude"
-                  name="latitude"
-                  label="Latitude*"
-                  validate={[number, maxLength(10), lat, required]}
-                  component={renderConfig.FIELD}
-                  disabled={disabled}
-                />
-              </Form.Item>
-            </Col>
-            <Col span={12}>
-              <Form.Item>
-                <Field
-                  id="longitude"
-                  name="longitude"
-                  label="Longitude*"
-                  validate={[number, maxLength(12), lon, required, lonNegative]}
-                  component={renderConfig.FIELD}
-                  disabled={disabled}
-                />
-              </Form.Item>
-            </Col>
-          </Row>
-          <ExplosivesPermitMap pin={[props.formValues?.latitude, props.formValues?.longitude]} />
-          <br />
-          <DocumentCategoryForm
-            categories={props.documentTypeDropdownOptions}
-            mineGuid={props.mineGuid}
-            isProcessed={disabled}
-            infoText="Please upload any documents that support this explosives storage and use permit. Documents uploaded here will be viewable by Minespace users."
-          />
-        </Col>
-        <Col md={12} sm={24} className="border--left--layout">
-          {isHistoric && (
-            <>
-              <Row gutter={16}>
-                <Col span={12}>
-                  <Form.Item>
-                    <Field
-                      id="is_closed"
-                      name="is_closed"
-                      label="Permit Status*"
-                      component={renderConfig.RADIO}
-                      customOptions={closedOptions}
-                      validate={[requiredRadioButton]}
-                    />
-                  </Form.Item>
-                </Col>
-                <Col span={12}>
-                  <Form.Item>
-                    <Field
-                      id="closed_timestamp"
-                      name="closed_timestamp"
-                      label="Date Permit was Closed"
-                      component={renderConfig.DATE}
-                      disabled={disabled}
-                    />
-                  </Form.Item>
-                </Col>
-              </Row>
-              <Row gutter={16}>
-                <Col span={24}>
-                  <Form.Item>
-                    <Field
-                      id="closed_reason"
-                      name="closed_reason"
-                      label="Reason for Closure"
-                      component={renderConfig.AUTO_SIZE_FIELD}
-                    />
-                  </Form.Item>
-                </Col>
-              </Row>
-            </>
-          )}
-          <br />
-          <MagazineForm isProcessed={disabled} />
-        </Col>
-      </Row>
-      <div className="right center-mobile" style={{ paddingTop: "14px" }}>
-        <Popconfirm
-          placement="topRight"
-          title="Are you sure you want to cancel?"
-          onConfirm={props.closeModal}
-          okText="Yes"
-          cancelText="No"
-        >
-          <Button className="full-mobile" type="default">
-            Cancel
+            <br />
+            <MagazineForm isProcessed={disabled} />
+          </Col>
+        </Row>
+        <div className="right center-mobile" style={{ paddingTop: "14px" }}>
+          <Popconfirm
+            placement="topRight"
+            title="Are you sure you want to cancel?"
+            onConfirm={props.closeModal}
+            okText="Yes"
+            cancelText="No"
+          >
+            <Button className="full-mobile" type="default">
+              Cancel
+            </Button>
+          </Popconfirm>
+          <Button
+            type="primary"
+            className="full-mobile"
+            htmlType="submit"
+            loading={props.submitting}
+          >
+            Submit
           </Button>
-        </Popconfirm>
-        <Button type="primary" className="full-mobile" htmlType="submit" loading={props.submitting}>
-          Submit
-        </Button>
-      </div>
-    </Form>
-    </>)
+        </div>
+      </Form>
+    </>
   );
 };
 

--- a/services/core-web/src/components/Forms/Securities/ReclamationInvoiceForm.js
+++ b/services/core-web/src/components/Forms/Securities/ReclamationInvoiceForm.js
@@ -15,6 +15,12 @@ import CustomPropTypes from "@/customPropTypes";
 import FileUpload from "@/components/common/FileUpload";
 import RenderAutoSizeField from "@/components/common/RenderAutoSizeField";
 import { DOCUMENT, EXCEL } from "@/constants/fileTypes";
+import {
+  documentNameColumn,
+  removeFunctionColumn,
+  uploadDateColumn,
+} from "@/components/common/DocumentColumns";
+import { renderTextColumn } from "@/components/common/CoreTableCommonColumns";
 
 const propTypes = {
   onSubmit: PropTypes.func.isRequired,
@@ -53,6 +59,8 @@ export class ReclamationInvoiceForm extends Component {
     }));
   };
 
+  // TODO: this function will have to remove the file through a BE call
+  // before it can be used with the Actions menu. Currently only on submit, and unlikely they're deleted
   onRemoveExistingFile = (event, mineDocumentGuid) => {
     event.preventDefault();
     this.setState((prevState) => ({
@@ -80,10 +88,18 @@ export class ReclamationInvoiceForm extends Component {
       []
     );
 
+    const documentColumns = [
+      documentNameColumn(),
+      renderTextColumn("category", "Category"),
+      uploadDateColumn(),
+      removeFunctionColumn(this.onRemoveExistingFile),
+    ];
+
     return (
       <Form
         layout="vertical"
         onSubmit={this.props.handleSubmit((values) => {
+          // TODO: move document deletion to BE call in onRemoveExistingFile
           // Create the invoice's new document list by removing deleted documents and adding uploaded documents.
           const currentDocuments = this.props.invoice.documents || [];
           const newDocuments = currentDocuments
@@ -157,7 +173,8 @@ export class ReclamationInvoiceForm extends Component {
           <Col xs={24}>
             <DocumentTable
               documents={documentTableRecords}
-              removeDocument={this.onRemoveExistingFile}
+              documentColumns={documentColumns}
+              excludedColumnKeys={["actions"]}
             />
           </Col>
         </Row>

--- a/services/core-web/src/components/common/ActionMenu.tsx
+++ b/services/core-web/src/components/common/ActionMenu.tsx
@@ -1,5 +1,5 @@
-import { Button, Dropdown, MenuProps } from "antd";
-import { CARAT, EDIT_OUTLINE_VIOLET } from "@/constants/assets";
+import { Button, Dropdown } from "antd";
+import { CARAT } from "@/constants/assets";
 import React, { FC } from "react";
 import { ITableAction } from "@/components/common/CoreTableCommonColumns";
 

--- a/services/core-web/src/components/mine/ExplosivesPermit/ExplosivesPermit.tsx
+++ b/services/core-web/src/components/mine/ExplosivesPermit/ExplosivesPermit.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState } from "react";
+import React, { FC } from "react";
 import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
 import {

--- a/services/core-web/src/components/mine/ExplosivesPermit/MineExplosivesPermitTable.tsx
+++ b/services/core-web/src/components/mine/ExplosivesPermit/MineExplosivesPermitTable.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from "react";
 import { RouteComponentProps, withRouter } from "react-router-dom";
-import { Badge, Button, Dropdown, Popconfirm, Tooltip, Menu } from "antd";
+import { Badge, Button, Dropdown, Popconfirm, Tooltip } from "antd";
 import { EyeOutlined, WarningOutlined } from "@ant-design/icons";
 import { dateSorter, formatDate } from "@common/utils/helpers";
 import * as Strings from "@common/constants/strings";
@@ -240,7 +240,7 @@ const MineExplosivesPermitTable: FC<RouteComponentProps & MineExplosivesPermitTa
       title: "",
       key: "addEditButton",
       align: "right",
-      render: (text, record) => {
+      render: (record) => {
         const isApproved = record.application_status === "APP";
         const isProcessed = record.application_status !== "REC";
         const hasDocuments =

--- a/services/core-web/src/tests/components/Forms/Securities/__snapshots__/BondForm.spec.js.snap
+++ b/services/core-web/src/tests/components/Forms/Securities/__snapshots__/BondForm.spec.js.snap
@@ -314,8 +314,40 @@ exports[`BondForm renders properly 1`] = `
       xs={24}
     >
       <Connect(DocumentTable)
+        documentColumns={
+          Array [
+            Object {
+              "dataIndex": "document_name",
+              "key": "document_name",
+              "render": [Function],
+              "sorter": [Function],
+              "title": "File Name",
+            },
+            Object {
+              "dataIndex": "category",
+              "key": "category",
+              "render": [Function],
+              "title": "Category",
+            },
+            Object {
+              "dataIndex": "upload_date",
+              "key": "upload_date",
+              "render": [Function],
+              "sorter": [Function],
+              "title": "Uploaded",
+            },
+            Object {
+              "key": "remove",
+              "render": [Function],
+            },
+          ]
+        }
         documents={Array []}
-        removeDocument={[Function]}
+        excludedColumnKeys={
+          Array [
+            "actions",
+          ]
+        }
       />
     </Col>
   </Row>

--- a/services/core-web/src/tests/components/Forms/Securities/__snapshots__/ReclamationInvoiceForm.spec.js.snap
+++ b/services/core-web/src/tests/components/Forms/Securities/__snapshots__/ReclamationInvoiceForm.spec.js.snap
@@ -122,8 +122,40 @@ exports[`ReclamationInvoiceForm renders properly 1`] = `
       xs={24}
     >
       <Connect(DocumentTable)
+        documentColumns={
+          Array [
+            Object {
+              "dataIndex": "document_name",
+              "key": "document_name",
+              "render": [Function],
+              "sorter": [Function],
+              "title": "File Name",
+            },
+            Object {
+              "dataIndex": "category",
+              "key": "category",
+              "render": [Function],
+              "title": "Category",
+            },
+            Object {
+              "dataIndex": "upload_date",
+              "key": "upload_date",
+              "render": [Function],
+              "sorter": [Function],
+              "title": "Uploaded",
+            },
+            Object {
+              "key": "remove",
+              "render": [Function],
+            },
+          ]
+        }
         documents={Array []}
-        removeDocument={[Function]}
+        excludedColumnKeys={
+          Array [
+            "actions",
+          ]
+        }
       />
     </Col>
   </Row>

--- a/services/minespace-web/src/components/common/DocumentTable.tsx
+++ b/services/minespace-web/src/components/common/DocumentTable.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useState, useEffect, FC } from "react";
 import CoreTable from "@/components/common/CoreTable";
 import {
   documentNameColumn,
@@ -27,38 +27,36 @@ import {
 import { openDocument } from "../syncfusion/DocumentViewer";
 import { downloadFileFromDocumentManager } from "@common/utils/actionlessNetworkCalls";
 import { getUserAccessData } from "@common/selectors/authenticationSelectors";
-import { useFeatureFlag } from "@common/providers/featureFlags/useFeatureFlag";
 import { Dropdown, Button, MenuProps } from "antd";
 import { DownOutlined } from "@ant-design/icons";
+import { useFeatureFlag } from "@common/providers/featureFlags/useFeatureFlag";
 
 interface DocumentTableProps {
-  enableBulkActions: boolean;
   documents: MineDocument[];
-  isLoaded: boolean;
-  isViewOnly: boolean;
-  canArchiveDocuments: boolean;
-  showVersionHistory: boolean;
-  documentParent: string;
-  view: string;
+  isLoaded?: boolean;
+  isViewOnly?: boolean;
+  canArchiveDocuments?: boolean;
+  showVersionHistory?: boolean;
+  enableBulkActions?: boolean;
+  documentParent?: string;
+  view?: "standard" | "minimal";
   openModal: (arg) => void;
   openDocument: any;
   closeModal: () => void;
   removeDocument: (event, doc_guid: string, mine_guid: string) => void;
   archiveMineDocuments: (mineGuid: string, mineDocumentGuids: string[]) => void;
-  onArchivedDocuments: (docs?: MineDocument[]) => void;
-  documentColumns: ColumnType<unknown>[];
-  additionalColumns: ColumnType<MineDocument>[];
-  defaultSortKeys: string[];
-  excludedColumnKeys: string[];
-  additionalColumnProps: { key: string; colProps: any }[];
-  fileOperationPermissionMap: { operation: FileOperations; permission: string | boolean }[];
+  onArchivedDocuments?: (docs?: MineDocument[]) => void;
+  documentColumns?: ColumnType<unknown>[];
+  additionalColumns?: ColumnType<MineDocument>[];
+  defaultSortKeys?: string[];
+  excludedColumnKeys?: string[];
+  additionalColumnProps?: { key: string; colProps: any }[];
   userRoles: string[];
   replaceAlertMessage?: string;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-shadow
-export const DocumentTable = ({
-  enableBulkActions = false,
+export const DocumentTable: FC<DocumentTableProps> = ({
   isViewOnly = false,
   excludedColumnKeys = [],
   additionalColumnProps = [],
@@ -67,6 +65,7 @@ export const DocumentTable = ({
   documentParent = null,
   isLoaded = true,
   showVersionHistory = false,
+  enableBulkActions = false,
   defaultSortKeys = ["upload_date", "dated", "update_timestamp"],
   view = "standard",
   canArchiveDocuments = false,
@@ -75,15 +74,16 @@ export const DocumentTable = ({
   removeDocument,
   openDocument,
   replaceAlertMessage = "The replaced file will not reviewed as part of the submission.  The new file should be in the same format as the original file.",
-
   ...props
 }: DocumentTableProps) => {
+  const [rowSelection, setRowSelection] = useState([]);
   const { isFeatureEnabled } = useFeatureFlag();
 
   const allowedTableActions = {
     [FileOperations.View]: true,
     [FileOperations.Download]: true,
-    [FileOperations.Replace]: !isViewOnly,
+    // don't allow changes to version history where history is not shown
+    [FileOperations.Replace]: !isViewOnly && showVersionHistory,
     [FileOperations.Archive]:
       !isViewOnly && canArchiveDocuments && isFeatureEnabled(Feature.MAJOR_PROJECT_ARCHIVE_FILE),
     [FileOperations.Delete]: !isViewOnly && removeDocument !== undefined,
@@ -92,7 +92,6 @@ export const DocumentTable = ({
   const isMinimalView: boolean = view === "minimal";
 
   const parseDocuments = (docs: any[]): MineDocument[] => {
-    if (!docs) return [];
     let parsedDocs: MineDocument[];
     if (docs.length && docs[0] instanceof MineDocument) {
       parsedDocs = docs;
@@ -105,8 +104,7 @@ export const DocumentTable = ({
     });
   };
 
-  const [documents, setDocuments] = useState<MineDocument[]>();
-  const [rowSelection, setRowSelection] = useState([]);
+  const [documents, setDocuments] = useState<MineDocument[]>(parseDocuments(props.documents ?? []));
 
   useEffect(() => {
     setDocuments(parseDocuments(props.documents ?? []));
@@ -168,16 +166,6 @@ export const DocumentTable = ({
     });
   };
 
-  const handleRowSelectionChange = (value) => {
-    setRowSelection(value);
-  };
-
-  const rowSelectionObject: any = {
-    onChange: (selectedRowKeys: React.Key[], selectedRows: any) => {
-      handleRowSelectionChange(selectedRows);
-    },
-  };
-
   const actions = [
     {
       key: "view",
@@ -214,44 +202,6 @@ export const DocumentTable = ({
       clickFunction: (event, record: MineDocument) => openDeleteModal(event, [record]),
     },
   ].filter((action) => allowedTableActions[action.label]);
-
-  const bulkItems: MenuProps["items"] = [
-    {
-      key: "0",
-      icon: <InboxOutlined />,
-      label: (
-        <button
-          type="button"
-          className="full actions-dropdown-button"
-          onClick={(e) => {
-            openArchiveModal(e, rowSelection);
-          }}
-        >
-          <div>Archive File(s)</div>
-        </button>
-      ),
-    },
-  ];
-
-  const renderBulkActions = () => {
-    const element = (
-      <Dropdown
-        menu={{ items: bulkItems }}
-        placement="bottomLeft"
-        disabled={rowSelection.length === 0}
-      >
-        <Button className="ant-btn ant-btn-primary">
-          Action
-          <DownOutlined />
-        </Button>
-      </Dropdown>
-    );
-    return (
-      enableBulkActions && (
-        <div style={{ float: "right", marginBottom: 8, marginRight: 8 }}>{element}</div>
-      )
-    );
-  };
 
   const filterActions = (record: MineDocument, tableActions: ITableAction[]) => {
     const allowedDocumentActions: string[] = record.allowed_actions;
@@ -314,6 +264,54 @@ export const DocumentTable = ({
   const minimalProps = isMinimalView
     ? { size: "small" as SizeType, rowClassName: "ant-table-row-minimal" }
     : null;
+
+  const bulkItems: MenuProps["items"] = [
+    {
+      key: "0",
+      icon: <InboxOutlined />,
+      label: (
+        <button
+          type="button"
+          className="full actions-dropdown-button"
+          onClick={(e) => {
+            openArchiveModal(e, rowSelection);
+          }}
+        >
+          <div>Archive File(s)</div>
+        </button>
+      ),
+    },
+  ];
+
+  const renderBulkActions = () => {
+    const element = (
+      <Dropdown
+        menu={{ items: bulkItems }}
+        placement="bottomLeft"
+        disabled={rowSelection.length === 0}
+      >
+        <Button className="ant-btn ant-btn-primary">
+          Action
+          <DownOutlined />
+        </Button>
+      </Dropdown>
+    );
+    return (
+      enableBulkActions && (
+        <div style={{ float: "right", marginBottom: 8, marginRight: 8 }}>{element}</div>
+      )
+    );
+  };
+
+  const handleRowSelectionChange = (value) => {
+    setRowSelection(value);
+  };
+
+  const rowSelectionObject: any = {
+    onChange: (selectedRowKeys: React.Key[], selectedRows: any) => {
+      handleRowSelectionChange(selectedRows);
+    },
+  };
 
   const bulkActionsProps = enableBulkActions
     ? {


### PR DESCRIPTION
## Objective 
- get delete functionality working on the Securities/Bonds/Edit Bond form again: actions menu replace & delete functions don't work on this form
- on merge to develop, eslint had a ton of work to do in correcting whitespace and complaining about unused vars, cleaned those up
- trying to keep the DocumentTable in Core & MS as similar as possible, reordered things in both files so structure matches

[MDS-5525](https://bcmines.atlassian.net/browse/MDS-5525)

_Why are you making this change? Provide a short explanation and/or screenshots_
![image](https://github.com/bcgov/mds/assets/102187683/7cb1516d-9c2c-45a3-8ce0-5808e40d9374)
- I was fully intending to alter how the DocumentTable interprets rather than the parent elements to fix the problem
- and for getting rid of replace functionality where it's not wanted, that was what I did (I have decided that version history + replace are interconnected and if you aren't showing the resulting version history from a replace, don't allow replace)
- but as it turns out, 2 forms (BondForm, ReclamationInvoice) and _only 2 forms_ were outliers with delete functions that don't delete (they add files to a list that will not be included when the user submits the form to delete the association)
   - the only other components with delete document functionality are either project/application components where we implemented Actions menu, and Variance-related files that have a proper delete function that calls the BE 
- previously, this worked. But with the delete document modal, the user is not returned to the form when they click delete, so this delete function + delete modal can't work together
- in the future, we should fix the delete functions used on these forms. 
- refactoring the modal to not replace modal content on open new modal would also be nice (see modalReducer)