### PR TITLE
[MDS-4259] ESUP permit Amendment without issuing new permit

### DIFF
--- a/services/core-api/app/api/mines/explosives_permit_amendment/models/explosives_permit_amendment.py
+++ b/services/core-api/app/api/mines/explosives_permit_amendment/models/explosives_permit_amendment.py
@@ -183,7 +183,6 @@ class ExplosivesPermitAmendment(SoftDeleteMixin, AuditMixin, PermitMixin, Base):
                mine_manager_mine_party_appt_id,
                permittee_mine_party_appt_id,
                application_status,
-               issue_date,
                expiry_date,
                decision_reason,
                is_closed,
@@ -208,7 +207,6 @@ class ExplosivesPermitAmendment(SoftDeleteMixin, AuditMixin, PermitMixin, Base):
         self.permittee_mine_party_appt_id = permittee_mine_party_appt_id
         self.application_date = application_date
         self.description = description
-        self.issue_date = issue_date
         self.expiry_date = expiry_date
         self.latitude = latitude
         self.longitude = longitude

--- a/services/core-api/app/api/mines/explosives_permit_amendment/resources/explosives_permit_amendment.py
+++ b/services/core-api/app/api/mines/explosives_permit_amendment/resources/explosives_permit_amendment.py
@@ -62,12 +62,6 @@ class ExplosivesPermitAmendmentResource(Resource, UserMixin):
         required=False,
     )
     parser.add_argument(
-        'issue_date',
-        type=lambda x: inputs.datetime_from_iso8601(x) if x else None,
-        store_missing=False,
-        required=False,
-    )
-    parser.add_argument(
         'expiry_date',
         type=lambda x: inputs.datetime_from_iso8601(x) if x else None,
         store_missing=False,
@@ -190,7 +184,7 @@ class ExplosivesPermitAmendmentResource(Resource, UserMixin):
             data.get('permit_guid'), data.get('now_application_guid'),
             data.get('issuing_inspector_party_guid'), data.get('mine_manager_mine_party_appt_id'),
             data.get('permittee_mine_party_appt_id'), data.get('application_status'),
-            data.get('issue_date'), data.get('expiry_date'), data.get('decision_reason'),
+            data.get('expiry_date'), data.get('decision_reason'),
             data.get('is_closed'), data.get('closed_reason'), data.get('closed_timestamp'),
             data.get('latitude'), data.get('longitude'), data.get('application_date'),
             data.get('description'),data.get('letter_date'),


### PR DESCRIPTION
## Objective 

[MDS-4259](https://bcmines.atlassian.net/browse/MDS-4259)

The purpose of this fix is to prevent the issue date from being updated when an ESUP amendment is updated as part of the attributes.
