### PR TITLE
[MDS-5515] SchemaSpy updates

### DIFF
--- a/.github/workflows/core-api.build.deploy.dev.yaml
+++ b/.github/workflows/core-api.build.deploy.dev.yaml
@@ -52,6 +52,9 @@ jobs:
       - name: Push
         run: |
           docker push --all-tags ${{ secrets.CLUSTER_REGISTRY }}/${{ secrets.NS_TOOLS }}/${{ env.MIG }}
+      - name: SchemaSpy Rollout
+        uses: ./.github/workflows/schemaspy-rollout-dev.yaml
+        
 
   trigger-gitops:
     runs-on: ubuntu-20.04
@@ -77,8 +80,8 @@ jobs:
 
   run-if-failed:
     runs-on: ubuntu-20.04
-    needs: [trigger-gitops]
-    if: always() && (needs.trigger-gitops.result == 'failure')
+    needs: [build-backend, build-flyway, trigger-gitops]
+    if: ${{ always() && contains(needs.*.result, 'failure') }}
     steps:
       - name: Notification
         run: ./gitops/watch-deployment.sh core-api dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} 1

--- a/.github/workflows/core-api.build.deploy.dev.yaml
+++ b/.github/workflows/core-api.build.deploy.dev.yaml
@@ -52,8 +52,10 @@ jobs:
       - name: Push
         run: |
           docker push --all-tags ${{ secrets.CLUSTER_REGISTRY }}/${{ secrets.NS_TOOLS }}/${{ env.MIG }}
-      - name: SchemaSpy Rollout
-        uses: ./.github/workflows/schemaspy-rollout-dev.yaml
+
+  schemaspy-rollout:
+    uses: ./.github/workflows/schemaspy-rollout-dev.yaml
+    secrets: inherit
         
 
   trigger-gitops:

--- a/.github/workflows/core-api.build.deploy.dev.yaml
+++ b/.github/workflows/core-api.build.deploy.dev.yaml
@@ -55,6 +55,7 @@ jobs:
 
   schemaspy-rollout:
     uses: ./.github/workflows/schemaspy-rollout-dev.yaml
+    needs: [build-flyway]
     secrets: inherit
         
 

--- a/.github/workflows/core-api.deploy.prod.yaml
+++ b/.github/workflows/core-api.deploy.prod.yaml
@@ -33,6 +33,10 @@ jobs:
           ${{ secrets.NS_TOOLS }}/flyway:${{ env.ORIG_TAG }} \
           ${{ secrets.NS_TOOLS }}/flyway:${{ env.PROMOTE_TAG }}
 
+      - name: Restart SchemaSpy pods
+        run: |
+          oc -n 4c2ba9-prod rollout restart deployment/schemaspy
+
   trigger-gitops:
     runs-on: ubuntu-20.04
     timeout-minutes: 10

--- a/.github/workflows/core-api.deploy.prod.yaml
+++ b/.github/workflows/core-api.deploy.prod.yaml
@@ -35,6 +35,7 @@ jobs:
 
   schemaspy-rollout:
     uses: ./.github/workflows/schemaspy-rollout-prod.yaml
+    needs: [promote-image-to-prod]
     secrets: inherit
 
   trigger-gitops:

--- a/.github/workflows/core-api.deploy.prod.yaml
+++ b/.github/workflows/core-api.deploy.prod.yaml
@@ -33,9 +33,8 @@ jobs:
           ${{ secrets.NS_TOOLS }}/flyway:${{ env.ORIG_TAG }} \
           ${{ secrets.NS_TOOLS }}/flyway:${{ env.PROMOTE_TAG }}
 
-      - name: Restart SchemaSpy pods
-        run: |
-          oc -n 4c2ba9-prod rollout restart deployment/schemaspy
+      - name: SchemaSpy Rollout
+        uses: ./.github/workflows/schemaspy-rollout-prod.yaml
 
   trigger-gitops:
     runs-on: ubuntu-20.04
@@ -61,8 +60,8 @@ jobs:
 
   run-if-failed:
     runs-on: ubuntu-20.04
-    needs: [trigger-gitops]
-    if: always() && (needs.trigger-gitops.result == 'failure')
+    needs: [promote-image-to-prod, trigger-gitops]
+    if: ${{ always() && contains(needs.*.result, 'failure') }}
     steps:
       - name: Notification
         run: ./gitops/watch-deployment.sh core-api prod ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} 1

--- a/.github/workflows/core-api.deploy.prod.yaml
+++ b/.github/workflows/core-api.deploy.prod.yaml
@@ -33,8 +33,9 @@ jobs:
           ${{ secrets.NS_TOOLS }}/flyway:${{ env.ORIG_TAG }} \
           ${{ secrets.NS_TOOLS }}/flyway:${{ env.PROMOTE_TAG }}
 
-      - name: SchemaSpy Rollout
-        uses: ./.github/workflows/schemaspy-rollout-prod.yaml
+  schemaspy-rollout:
+    uses: ./.github/workflows/schemaspy-rollout-prod.yaml
+    secrets: inherit
 
   trigger-gitops:
     runs-on: ubuntu-20.04

--- a/.github/workflows/core-api.deploy.test.yaml
+++ b/.github/workflows/core-api.deploy.test.yaml
@@ -32,6 +32,10 @@ jobs:
           oc -n ${{secrets.NS_TOOLS}} tag \
           ${{ secrets.NS_TOOLS }}/flyway:${{ env.ORIG_TAG }} \
           ${{ secrets.NS_TOOLS }}/flyway:${{ env.PROMOTE_TAG }}
+      
+      - name: Restart SchemaSpy pods
+        run: |
+          oc -n 4c2ba9-test rollout restart deployment/schemaspy
 
   trigger-gitops:
     runs-on: ubuntu-20.04

--- a/.github/workflows/core-api.deploy.test.yaml
+++ b/.github/workflows/core-api.deploy.test.yaml
@@ -33,8 +33,9 @@ jobs:
           ${{ secrets.NS_TOOLS }}/flyway:${{ env.ORIG_TAG }} \
           ${{ secrets.NS_TOOLS }}/flyway:${{ env.PROMOTE_TAG }}
       
-      - name: SchemaSpy Rollout
-        uses: ./.github/workflows/schemaspy-rollout-test.yaml
+  schemaspy-rollout:
+    uses: ./.github/workflows/schemaspy-rollout-dev.yaml
+    secrets: inherit
 
   trigger-gitops:
     runs-on: ubuntu-20.04

--- a/.github/workflows/core-api.deploy.test.yaml
+++ b/.github/workflows/core-api.deploy.test.yaml
@@ -34,7 +34,8 @@ jobs:
           ${{ secrets.NS_TOOLS }}/flyway:${{ env.PROMOTE_TAG }}
       
   schemaspy-rollout:
-    uses: ./.github/workflows/schemaspy-rollout-dev.yaml
+    uses: ./.github/workflows/schemaspy-rollout-test.yaml
+    needs: [promote-image-to-test]
     secrets: inherit
 
   trigger-gitops:

--- a/.github/workflows/core-api.deploy.test.yaml
+++ b/.github/workflows/core-api.deploy.test.yaml
@@ -33,9 +33,8 @@ jobs:
           ${{ secrets.NS_TOOLS }}/flyway:${{ env.ORIG_TAG }} \
           ${{ secrets.NS_TOOLS }}/flyway:${{ env.PROMOTE_TAG }}
       
-      - name: Restart SchemaSpy pods
-        run: |
-          oc -n 4c2ba9-test rollout restart deployment/schemaspy
+      - name: SchemaSpy Rollout
+        uses: ./.github/workflows/schemaspy-rollout-test.yaml
 
   trigger-gitops:
     runs-on: ubuntu-20.04
@@ -64,8 +63,8 @@ jobs:
 
   run-if-failed:
     runs-on: ubuntu-20.04
-    needs: [trigger-gitops]
-    if: always() && (needs.trigger-gitops.result == 'failure')
+    needs: [promote-image-to-test, trigger-gitops]
+    if: ${{ always() && contains(needs.*.result, 'failure') }}
     steps:
       - name: Notification
         run: ./gitops/watch-deployment.sh core-api test ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} 1

--- a/.github/workflows/schemaspy-rollout-dev.yaml
+++ b/.github/workflows/schemaspy-rollout-dev.yaml
@@ -3,11 +3,10 @@ name: SchemaSpy - DEV restart rollout
 on:
   workflow_call:
   workflow_dispatch:
-  pull_request:
 
 jobs:
   dev-schemaspy-rollout:
     uses: ./.github/workflows/schemaspy-rollout.yaml    
     with: 
       environment: dev
-    # secrets: inherit
+    secrets: inherit

--- a/.github/workflows/schemaspy-rollout-dev.yaml
+++ b/.github/workflows/schemaspy-rollout-dev.yaml
@@ -1,0 +1,17 @@
+name: SchemaSpy - DEV restart rollout
+
+on:
+  pull_request:
+  workflow_dispatch:
+  push:
+    branches:
+      - develop
+    paths:
+      - migrations/sql
+
+jobs:
+  dev-schemaspy-rollout:
+    uses: ./.github/workflows/schemaspy-rollout.yaml    
+    with: 
+      environment: dev
+    secrets: inherit

--- a/.github/workflows/schemaspy-rollout-dev.yaml
+++ b/.github/workflows/schemaspy-rollout-dev.yaml
@@ -3,10 +3,11 @@ name: SchemaSpy - DEV restart rollout
 on:
   workflow_call:
   workflow_dispatch:
+  pull_request:
 
 jobs:
   dev-schemaspy-rollout:
     uses: ./.github/workflows/schemaspy-rollout.yaml    
     with: 
       environment: dev
-    secrets: inherit
+    # secrets: inherit

--- a/.github/workflows/schemaspy-rollout-prod.yaml
+++ b/.github/workflows/schemaspy-rollout-prod.yaml
@@ -1,4 +1,4 @@
-name: SchemaSpy - DEV restart rollout
+name: SchemaSpy - PROD restart rollout
 
 on:
   workflow_call:
@@ -8,5 +8,5 @@ jobs:
   dev-schemaspy-rollout:
     uses: ./.github/workflows/schemaspy-rollout.yaml    
     with: 
-      environment: dev
+      environment: prod
     secrets: inherit

--- a/.github/workflows/schemaspy-rollout-test.yaml
+++ b/.github/workflows/schemaspy-rollout-test.yaml
@@ -1,4 +1,4 @@
-name: SchemaSpy - DEV restart rollout
+name: SchemaSpy - TEST restart rollout
 
 on:
   workflow_call:
@@ -8,5 +8,5 @@ jobs:
   dev-schemaspy-rollout:
     uses: ./.github/workflows/schemaspy-rollout.yaml    
     with: 
-      environment: dev
+      environment: test
     secrets: inherit

--- a/.github/workflows/schemaspy-rollout.yaml
+++ b/.github/workflows/schemaspy-rollout.yaml
@@ -1,4 +1,4 @@
-name: Testing this as part of a workflow
+name: SchemaSpy Rollout
 
 on:
   workflow_call:

--- a/.github/workflows/schemaspy-rollout.yaml
+++ b/.github/workflows/schemaspy-rollout.yaml
@@ -1,10 +1,11 @@
 name: Testing this as part of a workflow
 
 on:
-  pull_request:
-
-env:
-  ENVIRONMENT: dev
+  workflow_call:
+    inputs:
+      environment:
+        required: true
+        type: string
 
 jobs:
   test-schemaspy-rollout:
@@ -25,17 +26,17 @@ jobs:
 
       - name: Restart SchemaSpy pods
         run: |
-          oc -n 4c2ba9-${{ env.ENVIRONMENT }} rollout restart deployment/schemaspy
+          oc -n 4c2ba9-${{ inputs.environment }} rollout restart deployment/schemaspy
 
       - name: Watch Rollout Status        
         run: |
-          oc -n 4c2ba9-${{ env.ENVIRONMENT }} rollout status deployment/schemaspy
+          oc -n 4c2ba9-${{ inputs.environment }} rollout status deployment/schemaspy
         timeout-minutes: 10
       
       - name: Notify Discord of Rollout success
         if: ${{ success() }} 
-        run: ./gitops/notify_discord.sh schemaspy ${{ env.ENVIRONMENT }} ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} 0
+        run: ./gitops/notify_discord.sh schemaspy ${{ inputs.environment }} ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} 0
 
       - name: Notify Discord of Rollout failure
         if: ${{ failure() }} 
-        run: ./gitops/notify_discord.sh schemaspy ${{ env.ENVIRONMENT }} ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} 1
+        run: ./gitops/notify_discord.sh schemaspy ${{ inputs.environment }} ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} 1

--- a/.github/workflows/schemaspy-rollout.yaml
+++ b/.github/workflows/schemaspy-rollout.yaml
@@ -8,8 +8,8 @@ on:
         type: string
 
 jobs:
-  test-schemaspy-rollout:
-    name: test-schemaspy-rollout    
+  schemaspy-rollout:
+    name: schemaspy-rollout    
     runs-on: ubuntu-20.04
     steps:
       - name: Install oc

--- a/.github/workflows/schemaspy-rollout.yaml
+++ b/.github/workflows/schemaspy-rollout.yaml
@@ -25,20 +25,18 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Restart SchemaSpy pods
-        if: false
         run: |
           oc -n 4c2ba9-${{ inputs.environment }} rollout restart deployment/schemaspy
 
       - name: Watch Rollout Status
-        if: false     
         run: |
           oc -n 4c2ba9-${{ inputs.environment }} rollout status deployment/schemaspy
         timeout-minutes: 10
       
       - name: Notify Discord of Rollout success
-        if: false
+        if: ${{ success() }}
         run: ./gitops/notify_discord.sh schemaspy ${{ inputs.environment }} ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} 0
 
       - name: Notify Discord of Rollout failure
-        if: false
+        if: ${{ failure() }}
         run: ./gitops/notify_discord.sh schemaspy ${{ inputs.environment }} ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} 1

--- a/.github/workflows/schemaspy-rollout.yaml
+++ b/.github/workflows/schemaspy-rollout.yaml
@@ -25,18 +25,20 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Restart SchemaSpy pods
+        if: false
         run: |
           oc -n 4c2ba9-${{ inputs.environment }} rollout restart deployment/schemaspy
 
-      - name: Watch Rollout Status        
+      - name: Watch Rollout Status
+        if: false     
         run: |
           oc -n 4c2ba9-${{ inputs.environment }} rollout status deployment/schemaspy
         timeout-minutes: 10
       
       - name: Notify Discord of Rollout success
-        if: ${{ success() }} 
+        if: false
         run: ./gitops/notify_discord.sh schemaspy ${{ inputs.environment }} ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} 0
 
       - name: Notify Discord of Rollout failure
-        if: ${{ failure() }} 
+        if: false
         run: ./gitops/notify_discord.sh schemaspy ${{ inputs.environment }} ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} 1

--- a/.github/workflows/testing-workflow.yaml
+++ b/.github/workflows/testing-workflow.yaml
@@ -17,6 +17,9 @@ jobs:
         run: |
           oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
 
+      - name: Checkout
+        uses: actions/checkout@v3
+        
       - name: Restart SchemaSpy pods
         run: |
           oc -n 4c2ba9-dev rollout restart deployment/schemaspy

--- a/.github/workflows/testing-workflow.yaml
+++ b/.github/workflows/testing-workflow.yaml
@@ -20,3 +20,6 @@ jobs:
       - name: Restart SchemaSpy pods
         run: |
           oc -n 4c2ba9-dev rollout restart deployment/schemaspy
+      
+      - name: Notification
+        run: ./gitops/watch-deployment.sh schemaspy dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGO_CD_CLI_JWT }}

--- a/.github/workflows/testing-workflow.yaml
+++ b/.github/workflows/testing-workflow.yaml
@@ -3,9 +3,12 @@ name: Testing this as part of a workflow
 on:
   pull_request:
 
+env:
+  ENVIRONMENT: dev
+
 jobs:
   test-schemaspy-rollout:
-    name: test-schemaspy-rollout
+    name: test-schemaspy-rollout    
     runs-on: ubuntu-20.04
     steps:
       - name: Install oc
@@ -22,11 +25,17 @@ jobs:
 
       - name: Restart SchemaSpy pods
         run: |
-          oc -n 4c2ba9-dev rollout restart deployment/schemaspy
+          oc -n 4c2ba9-${{ env.ENVIRONMENT }} rollout restart deployment/schemaspy
 
-      - name: Watch Rollout Status
+      - name: Watch Rollout Status        
         run: |
-          oc -n 4c2ba9-dev rollout status deployment/schemaspy
+          oc -n 4c2ba9-{{ env.ENVIRONMENT }} rollout status deployment/schemaspy
+        timeout-minutes: 10
       
-      - name: Notification
-        run: ./gitops/notify_discord.sh schemaspy dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} 0
+      - name: Notify Discord of Rollout success
+        if: ${{ success() }} 
+        run: ./gitops/notify_discord.sh schemaspy {{ env.ENVIRONMENT }} ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} 0
+
+      - name: Notify Discord of Rollout failure
+        if: ${{ failure() }} 
+        run: ./gitops/notify_discord.sh schemaspy {{ env.ENVIRONMENT }} ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} 1

--- a/.github/workflows/testing-workflow.yaml
+++ b/.github/workflows/testing-workflow.yaml
@@ -22,4 +22,7 @@ jobs:
           oc -n 4c2ba9-dev rollout restart deployment/schemaspy
       
       - name: Notification
-        run: ./gitops/watch-deployment.sh schemaspy dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGO_CD_CLI_JWT }}
+        run: |
+          pwd
+          ls -a
+          ./gitops/watch-deployment.sh schemaspy dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGO_CD_CLI_JWT }}

--- a/.github/workflows/testing-workflow.yaml
+++ b/.github/workflows/testing-workflow.yaml
@@ -19,13 +19,16 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v3
-        
+
       - name: Restart SchemaSpy pods
         run: |
           oc -n 4c2ba9-dev rollout restart deployment/schemaspy
       
+      - name: Setup ArgoCD CLI
+        uses: imajeetyadav/argocd-cli@v1
+        with:
+          version: v2.7.9 # optional
+          
       - name: Notification
         run: |
-          pwd
-          ls -a
           ./gitops/watch-deployment.sh schemaspy dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGO_CD_CLI_JWT }}

--- a/.github/workflows/testing-workflow.yaml
+++ b/.github/workflows/testing-workflow.yaml
@@ -1,0 +1,22 @@
+name: Testing this as part of a workflow
+
+on:
+  pull_request:
+
+jobs:
+  test-schemaspy-rollout:
+    name: test-schemaspy-rollout
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Install oc
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: "4.7"
+
+      - name: oc login
+        run: |
+          oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
+
+      - name: Restart SchemaSpy pods
+        run: |
+          oc -n 4c2ba9-dev rollout restart deployment/schemaspy

--- a/.github/workflows/testing-workflow.yaml
+++ b/.github/workflows/testing-workflow.yaml
@@ -23,12 +23,10 @@ jobs:
       - name: Restart SchemaSpy pods
         run: |
           oc -n 4c2ba9-dev rollout restart deployment/schemaspy
-      
-      - name: Setup ArgoCD CLI
-        uses: imajeetyadav/argocd-cli@v1
-        with:
-          version: v2.7.9 # optional
-          
-      - name: Notification
+
+      - name: Watch Rollout Status
         run: |
-          ./gitops/watch-deployment.sh schemaspy dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGO_CD_CLI_JWT }}
+          oc -n 4c2ba9-dev rollout status deployment/schemaspy
+      
+      - name: Notification
+        run: ./gitops/notify_discord.sh schemaspy dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} 0

--- a/.github/workflows/testing-workflow.yaml
+++ b/.github/workflows/testing-workflow.yaml
@@ -29,13 +29,13 @@ jobs:
 
       - name: Watch Rollout Status        
         run: |
-          oc -n 4c2ba9-{{ env.ENVIRONMENT }} rollout status deployment/schemaspy
+          oc -n 4c2ba9-${{ env.ENVIRONMENT }} rollout status deployment/schemaspy
         timeout-minutes: 10
       
       - name: Notify Discord of Rollout success
         if: ${{ success() }} 
-        run: ./gitops/notify_discord.sh schemaspy {{ env.ENVIRONMENT }} ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} 0
+        run: ./gitops/notify_discord.sh schemaspy ${{ env.ENVIRONMENT }} ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} 0
 
       - name: Notify Discord of Rollout failure
         if: ${{ failure() }} 
-        run: ./gitops/notify_discord.sh schemaspy {{ env.ENVIRONMENT }} ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} 1
+        run: ./gitops/notify_discord.sh schemaspy ${{ env.ENVIRONMENT }} ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} 1


### PR DESCRIPTION
## Objective 
- restart the schemaspy deployment in openshift so that new pods are created with updated info
- have it be automatic so we don't have to do it manually
   - tied it into core-api deploys 
- it's not identical (doesn't run flyway first), but I setup a temporary workflow to run on PR to make sure it can run (will delete once verified) <-- DELETED, verified that reusable workflow is called successfully
- attempted to fix the run-if-failed in the core-api deployment workflows. Based on SO answer found here https://stackoverflow.com/questions/71430668/how-to-run-a-github-actions-job-on-workflow-failure by Yann Thomas-Gérard
   - if one of those executes sometime for us we can put it in other places 

[MDS-5515](https://bcmines.atlassian.net/browse/MDS-5515)

_Why are you making this change? Provide a short explanation and/or screenshots_
