### PR TITLE
[MDS-5550] Bug: Actions in menu don't do anything (#2723)

### DIFF
--- a/services/core-web/src/components/common/ActionMenu.tsx
+++ b/services/core-web/src/components/common/ActionMenu.tsx
@@ -8,8 +8,9 @@ interface ActionMenuProps {
   actionItems: ITableAction[];
   category: string;
 }
-const ActionMenu: FC<ActionMenuProps> = ({ record, actionItems, category }) => {
-  const items = actionItems.map((action) => {
+
+export const generateActionMenuItems = (actionItems: ITableAction[], record) => {
+  return actionItems.map((action) => {
     return {
       key: action.key,
       icon: action.icon,
@@ -24,6 +25,10 @@ const ActionMenu: FC<ActionMenuProps> = ({ record, actionItems, category }) => {
       ),
     };
   });
+};
+
+const ActionMenu: FC<ActionMenuProps> = ({ record, actionItems, category }) => {
+  const items = generateActionMenuItems(actionItems, record);
   return (
     <Dropdown menu={{ items }} placement="bottomLeft">
       <Button

--- a/services/core-web/src/components/common/CoreTableCommonColumns.tsx
+++ b/services/core-web/src/components/common/CoreTableCommonColumns.tsx
@@ -4,6 +4,7 @@ import { dateSorter, formatDate, nullableStringSorter } from "@common/utils/help
 import { ColumnType } from "antd/lib/table";
 import { Button, Dropdown } from "antd";
 import { CARAT } from "@/constants/assets";
+import { generateActionMenuItems } from "./ActionMenu";
 
 export const renderTextColumn = (
   dataIndex: string,
@@ -84,30 +85,13 @@ export const renderActionsColumn = (
   recordActionsFilter: (record, actions) => ITableAction[],
   isRowSelected = false,
   text = "Actions",
-  classPrefix = "",
   dropdownAltText = "Menu"
 ) => {
-  const labelClass = classPrefix ? `${classPrefix}-dropdown-button` : "actions-dropdown-button";
-
   return {
     key: "actions",
     render: (record) => {
       const filteredActions = recordActionsFilter ? recordActionsFilter(record, actions) : actions;
-      const items = filteredActions.map((action) => {
-        return {
-          key: action.key,
-          icon: action.icon,
-          label: (
-            <button
-              type="button"
-              className={`full ${labelClass}`}
-              onClick={(event) => action.clickFunction(event, record)}
-            >
-              <div>{action.label}</div>
-            </button>
-          ),
-        };
-      });
+      const items = generateActionMenuItems(filteredActions, record);
 
       return (
         <div>

--- a/services/core-web/src/components/mine/ExplosivesPermit/MineExplosivesPermitTable.tsx
+++ b/services/core-web/src/components/mine/ExplosivesPermit/MineExplosivesPermitTable.tsx
@@ -20,7 +20,7 @@ import { ColumnType } from "antd/lib/table";
 import moment from "moment-timezone";
 import { ITableAction } from "@/components/common/CoreTableCommonColumns";
 import VioletEditIcon from "@/assets/icons/violet-edit";
-import ActionMenu from "@/components/common/ActionMenu";
+import ActionMenu, { generateActionMenuItems } from "@/components/common/ActionMenu";
 
 interface MineExplosivesPermitTableProps {
   data: IExplosivesPermit[];
@@ -387,7 +387,11 @@ const MineExplosivesPermitTable: FC<RouteComponentProps & MineExplosivesPermitTa
                 ) : (
                   <Dropdown
                     className="full-height full-mobile"
-                    menu={isApproved ? { items: approvedMenu } : { items: menu }}
+                    menu={
+                      isApproved
+                        ? { items: generateActionMenuItems(approvedMenu, record) }
+                        : { items: generateActionMenuItems(menu, record) }
+                    }
                     placement="bottomLeft"
                   >
                     <Button className="permit-table-button">


### PR DESCRIPTION
## Objective 
- make the actions do actions again
- little mix up here between our ActionMenu and the antd Dropdown menu and the ITableAction.
- ITableAction was made by us for the action menu and can't be passed directly to the Dropdown without processing it first
- extracted and exported the function that did the processing
- put it in the CoreTableCommonColumns too because why not (and removed a parameter that wasn't used anywhere)

[MDS-5550](https://bcmines.atlassian.net/browse/MDS-5550)

_Why are you making this change? Provide a short explanation and/or screenshots_
