### PR TITLE
[MDS-5579] purple highlight bug

### DIFF
--- a/services/core-web/src/styles/components/ExplosivesPermits.scss
+++ b/services/core-web/src/styles/components/ExplosivesPermits.scss
@@ -40,6 +40,10 @@
   border: 2px solid $violet;
 }
 
+.esup-history-button:focus {
+  background-color: white;
+}
+
 .esup-alert .ant-alert-content .ant-alert-description div button {
   position: absolute;
   right: 0;


### PR DESCRIPTION
## Objective 

The `View History` button on esups was showing a purple background colour on focus.  Changed it to white.

[MDS-5579](https://bcmines.atlassian.net/browse/MDS-5579)

<img width="952" alt="image" src="https://github.com/bcgov/mds/assets/83598933/fc0043e8-0438-4f6d-8586-0c62f7693e53">
