### PR TITLE
[MDS-5538] Bug when opening view permit with no previous amendments

### DIFF
--- a/services/core-web/src/components/mine/ExplosivesPermit/ExplosivesPermit.tsx
+++ b/services/core-web/src/components/mine/ExplosivesPermit/ExplosivesPermit.tsx
@@ -173,7 +173,7 @@ export const ExplosivesPermit: FC<ExplosivesPermitProps> = ({
       props: {
         title: "View Explosives Storage & Use Permit",
         explosivesPermit: record,
-        parentPermit,
+        parentPermit: { explosives_permit_amendments: [], ...parentPermit },
         mine,
         closeModal: props.closeModal,
         handleOpenExplosivesPermitCloseModal,


### PR DESCRIPTION
## Objective 

- set the array to be empty array instead of undefined so that .map, etc, will work.

[MDS-5538](https://bcmines.atlassian.net/browse/MDS-5538)

_Why are you making this change? Provide a short explanation and/or screenshots_
