### PR TITLE
[MDS-5530] Automatically close an ESUP if a new amendment is issued

### DIFF
--- a/services/core-api/app/api/mines/explosives_permit_amendment/models/explosives_permit_amendment.py
+++ b/services/core-api/app/api/mines/explosives_permit_amendment/models/explosives_permit_amendment.py
@@ -14,7 +14,9 @@ from app.api.mines.explosives_permit_amendment.models.explosives_permit_amendmen
 from app.api.mines.explosives_permit_amendment.models.explosives_permit_amendment_magazine import \
     ExplosivesPermitAmendmentMagazine
 from app.api.utils.models_mixins import Base, SoftDeleteMixin, AuditMixin, PermitMixin
-from sqlalchemy import func
+from sqlalchemy import func, and_
+from sqlalchemy.sql import update
+from app.api.utils.include.user_info import User
 
 from app.extensions import db
 
@@ -72,6 +74,31 @@ class ExplosivesPermitAmendment(SoftDeleteMixin, AuditMixin, PermitMixin, Base):
         sequence = Sequence('explosives_permit_application_number_sequence')
         next_value = sequence.next_value()
         return func.concat(next_value, f'-{year}-{month}')
+
+    @classmethod
+    def update_amendment_status_by_explosives_permit_id(cls, explosives_permit_id, is_closed_status, amendment_guid_to_exclude = None):
+
+        and_clause = None
+
+        if amendment_guid_to_exclude is not None:
+            and_clause = and_(
+                cls.explosives_permit_id == explosives_permit_id,
+                cls.is_closed != is_closed_status,
+                cls.explosives_permit_amendment_guid != amendment_guid_to_exclude
+            )
+        else:
+            and_clause = and_(
+                cls.explosives_permit_id == explosives_permit_id,
+                cls.is_closed != is_closed_status,
+            )
+
+        update_stmt = update(cls)\
+            .where(and_clause)\
+            .values(is_closed = is_closed_status)
+
+        update_result = db.session.execute(update_stmt)
+        db.session.commit()
+        return update_result.rowcount
 
     @classmethod
     def create(cls,

--- a/services/core-api/app/api/mines/explosives_permit_amendment/resources/explosives_permit_amendment_list.py
+++ b/services/core-api/app/api/mines/explosives_permit_amendment/resources/explosives_permit_amendment_list.py
@@ -9,7 +9,7 @@ from app.api.utils.resources_mixins import UserMixin
 from app.api.utils.custom_reqparser import CustomReqparser
 from app.api.utils.access_decorators import requires_role_edit_explosives_permit
 from app.api.mines.mine.models.mine import Mine
-
+from app.api.mines.explosives_permit.models.explosives_permit import ExplosivesPermit
 
 
 class ExplosivesPermitAmendmentListResource(Resource, UserMixin):
@@ -164,5 +164,13 @@ class ExplosivesPermitAmendmentListResource(Resource, UserMixin):
             data.get('documents', []),
             data.get('now_application_guid'))
         explosives_permit_amendment.save()
+
+        # Updating the previous amendments' is_closed status to True.
+        updated_columns = ExplosivesPermitAmendment.update_amendment_status_by_explosives_permit_id(
+            data.get('explosives_permit_id'), True,
+            explosives_permit_amendment.explosives_permit_amendment_guid)
+
+        if updated_columns == 0: #Explosive Permit status need to be updated.
+            ExplosivesPermit.update_permit_status(explosives_permit_amendment.explosives_permit_id, True)
 
         return explosives_permit_amendment, 201


### PR DESCRIPTION
## Objective 

[MDS-5530](https://bcmines.atlassian.net/browse/MDS-5530)

Backend updated to:
- Close the ESUP permit (amendment or permit) when a new amendment is issued to an existing ESUP.
- The metadata for the person who issued the new amendment will be recorded as the person who closed the previous record.
