### PR TITLE
[MDS-5508] Fix ESUP edit document modal overlap

### DIFF
--- a/services/core-web/src/components/Forms/DocumentCategoryForm.tsx
+++ b/services/core-web/src/components/Forms/DocumentCategoryForm.tsx
@@ -1,55 +1,55 @@
-import React, { Component } from "react";
-import PropTypes from "prop-types";
+import React, { FC } from "react";
 import { connect } from "react-redux";
 import { remove } from "lodash";
 import { bindActionCreators } from "redux";
-import { Col, Row, Popconfirm, Typography } from "antd";
+import { Button, Col, Popconfirm, Row, Typography } from "antd";
 import { Form } from "@ant-design/compatible";
 import "@ant-design/compatible/assets/index.css";
-import { Field, FieldArray, change, formValueSelector, arrayPush } from "redux-form";
+import { arrayPush, change, Field, FieldArray, formValueSelector } from "redux-form";
 import { required } from "@common/utils/Validate";
 import { renderConfig } from "@/components/common/config";
 import { TRASHCAN } from "@/constants/assets";
 import * as FORM from "@/constants/forms";
 import ExplosivesPermitFileUpload from "@/components/Forms/ExplosivesPermit/ExplosivesPermitFileUpload";
+import { IExplosivesPermitDocument, IOption } from "@mds/common";
 
-import CustomPropTypes from "@/customPropTypes";
+interface DocumentCategoryFormProps {
+  documents: IExplosivesPermitDocument[];
+  categories: IOption[];
+  isProcessed: boolean;
+  mineGuid: string;
+  change: (form: string, field: string, value: any) => void;
+  arrayPush: (form: string, field: string, value: any) => void;
+  infoText: string;
+}
 
-const propTypes = {
-  documents: PropTypes.arrayOf(CustomPropTypes.mineDocument),
-  categories: CustomPropTypes.options.isRequired,
-  isProcessed: PropTypes.bool.isRequired,
-  mineGuid: PropTypes.string.isRequired,
-  change: PropTypes.func.isRequired,
-  arrayPush: PropTypes.func.isRequired,
-  infoText: PropTypes.string,
-};
-
-const defaultProps = {
-  documents: [],
-};
-
-export class DocumentCategoryForm extends Component {
+export const DocumentCategoryForm: FC<DocumentCategoryFormProps> = ({
+  documents = [],
+  categories,
+  isProcessed,
+  mineGuid,
+  infoText,
+  ...props
+}) => {
   // File upload handlers
-  onFileLoad = (fileName, document_manager_guid) => {
-    this.props.arrayPush(FORM.EXPLOSIVES_PERMIT, "documents", {
+  const onFileLoad = (fileName, document_manager_guid) => {
+    props.arrayPush(FORM.EXPLOSIVES_PERMIT, "documents", {
       document_name: fileName,
       document_manager_guid,
     });
   };
 
-  onRemoveFile = (err, fileItem) => {
-    remove(this.props.documents, { document_manager_guid: fileItem.serverId });
-    return this.props.change(FORM.EXPLOSIVES_PERMIT, "documents", this.props.documents);
+  const onRemoveFile = (err, fileItem) => {
+    remove(documents, { document_manager_guid: fileItem.serverId });
+    return props.change(FORM.EXPLOSIVES_PERMIT, "documents", documents);
   };
 
-  DocumentCategories = ({ fields }) => {
+  const DocumentCategories = ({ fields }) => {
     return (
       <>
         {fields.map((field, index) => {
           const documentExists = fields.get(index) && fields.get(index).mine_document_guid;
           return (
-            // eslint-disable-next-line react/no-array-index-key
             <div className="padding-sm margin-small" key={index}>
               <Row gutter={16}>
                 <Col span={10}>
@@ -72,14 +72,14 @@ export class DocumentCategoryForm extends Component {
                       placeholder="Select a Document Category"
                       label="Document Category*"
                       component={renderConfig.SELECT}
-                      data={this.props.categories}
+                      data={categories}
                       validate={[required]}
-                      disabled={documentExists && this.props.isProcessed}
+                      disabled={documentExists && isProcessed}
                     />
                   </Form.Item>
                 </Col>
                 <Col span={4} className="right">
-                  {documentExists && !this.props.isProcessed && (
+                  {documentExists && !isProcessed && (
                     <Popconfirm
                       placement="top"
                       title={[
@@ -92,9 +92,9 @@ export class DocumentCategoryForm extends Component {
                         fields.remove(index);
                       }}
                     >
-                      <button ghost type="button">
-                        <img name="remove" src={TRASHCAN} alt="Remove Document" />
-                      </button>
+                      <Button ghost>
+                        <img src={TRASHCAN} alt="Remove Document" />
+                      </Button>
                     </Popconfirm>
                   )}
                 </Col>
@@ -106,31 +106,26 @@ export class DocumentCategoryForm extends Component {
     );
   };
 
-  render() {
-    return (
-      <div className="document-container">
-        <Form.Item label="Select Files/Upload files*">
-          <div className="inputs">
-            <FieldArray name="documents" component={this.DocumentCategories} />
-          </div>
-          <Typography.Text>{this.props.infoText}</Typography.Text>
-          <Field
-            id="DocumentFileUpload"
-            name="DocumentFileUpload"
-            onFileLoad={this.onFileLoad}
-            onRemoveFile={this.onRemoveFile}
-            mineGuid={this.props.mineGuid}
-            component={ExplosivesPermitFileUpload}
-            allowMultiple
-          />
-        </Form.Item>
-      </div>
-    );
-  }
-}
-
-DocumentCategoryForm.propTypes = propTypes;
-DocumentCategoryForm.defaultProps = defaultProps;
+  return (
+    <div className="document-container">
+      <Form.Item label="Select Files/Upload files*">
+        <div className="inputs">
+          <FieldArray props={{}} name="documents" component={DocumentCategories} />
+        </div>
+        <Typography.Text>{infoText}</Typography.Text>
+        <Field
+          id="DocumentFileUpload"
+          name="DocumentFileUpload"
+          onFileLoad={onFileLoad}
+          onRemoveFile={onRemoveFile}
+          mineGuid={mineGuid}
+          component={ExplosivesPermitFileUpload}
+          allowMultiple
+        />
+      </Form.Item>
+    </div>
+  );
+};
 
 const selector = formValueSelector(FORM.EXPLOSIVES_PERMIT);
 const mapStateToProps = (state) => ({

--- a/services/core-web/src/styles/generic/layout.scss
+++ b/services/core-web/src/styles/generic/layout.scss
@@ -646,10 +646,6 @@ img.lessOpacity {
   border: 1px solid #f0f0f0;
   border-radius: 5px;
   padding: 10px;
-
-  .inputs {
-    max-height: 300px;
-  }
 }
 
 .hidden {

--- a/services/core-web/src/tests/components/Forms/__snapshots__/DocumentCategoryForm.spec.js.snap
+++ b/services/core-web/src/tests/components/Forms/__snapshots__/DocumentCategoryForm.spec.js.snap
@@ -14,6 +14,7 @@ exports[`DocumentCategoryForm renders properly 1`] = `
       <FieldArray
         component={[Function]}
         name="documents"
+        props={Object {}}
       />
     </div>
     <ForwardRef(Text)>


### PR DESCRIPTION
Fixed overlap in esup edit documents modal.
Converted DocumentCategoryForm to a functional typescript component.

## Objective 

[MDS-5508](https://bcmines.atlassian.net/browse/MDS-5508)

<img width="1478" alt="image" src="https://github.com/bcgov/mds/assets/83598933/845e001e-0bf2-4c12-8e6c-13b2a7c91264">
