### PR TITLE
[MDS-5522] Major project application status only showing SUBMITTED or NOT SUBMITTED

### DIFF
--- a/services/core-web/src/components/common/CoreTooltip.tsx
+++ b/services/core-web/src/components/common/CoreTooltip.tsx
@@ -36,7 +36,7 @@ export const NOWFieldOriginTooltip = () => (
 interface NOWOriginalValueTooltipProps {
   originalValue: string;
   isVisible: boolean;
-  style: any;
+  style?: any;
 }
 
 export const NOWOriginalValueTooltip: FC<NOWOriginalValueTooltipProps> = ({

--- a/services/core-web/src/components/mine/Projects/ProjectStagesTable.js
+++ b/services/core-web/src/components/mine/Projects/ProjectStagesTable.js
@@ -43,7 +43,7 @@ export class ProjectStagesTable extends Component {
           label = text;
         } else {
           label =
-            record.key && record.stage_status?.toUpperCase() === "SUB"
+            record.key && record.stage_status
               ? `[${record.stage_status_hash[text]}]` || "N/A"
               : "[Not submitted]";
         }


### PR DESCRIPTION
## Objective 

[MDS-5522](https://bcmines.atlassian.net/browse/MDS-5522)

- change to make major project application status appear as is in the final application page

![image](https://github.com/bcgov/mds/assets/127789479/c7fe8066-87eb-47f9-895f-6c5aed93392c)


![image](https://github.com/bcgov/mds/assets/127789479/26de55a8-6d03-40d1-be6f-8facc5172976)

