### PR TITLE
[MDS-5509] Fixing Error: object of type NoneType has no len() on letter_date

### DIFF
--- a/services/core-api/app/api/mines/explosives_permit/resources/explosives_permit.py
+++ b/services/core-api/app/api/mines/explosives_permit/resources/explosives_permit.py
@@ -181,6 +181,14 @@ class ExplosivesPermitResource(Resource, UserMixin):
 
         data = self.parser.parse_args()
 
+        letter_date = data.get('letter_date')
+        if letter_date is None:
+            letter_date = str(datetime.utcnow())
+
+        letter_body = data.get('letter_body')
+        if letter_body is None:
+            letter_body = ""
+
         explosives_permit.update(
             data.get('permit_guid'), data.get('now_application_guid'),
             data.get('issuing_inspector_party_guid'), data.get('mine_manager_mine_party_appt_id'),
@@ -189,8 +197,8 @@ class ExplosivesPermitResource(Resource, UserMixin):
             data.get('is_closed'), data.get('closed_reason'), data.get('closed_timestamp'),
             data.get('latitude'), data.get('longitude'), data.get('application_date'),
             data.get('description'),
-            data.get('letter_date'),
-            data.get('letter_body'),
+            letter_date,
+            letter_body,
             data.get('explosive_magazines', []),
             data.get('detonator_magazines', []), data.get('documents', []))
         


### PR DESCRIPTION
## Objective 

[MDS-5509](https://bcmines.atlassian.net/browse/MDS-5509)

_Why are you making this change? Provide a short explanation and/or screenshots_

letter related arguments (`letter_date` and `letter_body`) are applicable in application flow only. Hence assigning default values (which was used earlier) to resolve the issue.

Related resources:
https://github.com/bcgov/mds/pull/2679/files
