### PR TITLE
[MDS-4990] Fixing broken link to TSF page

### DIFF
--- a/services/core-api/app/api/mines/tailings/models/tailings.py
+++ b/services/core-api/app/api/mines/tailings/models/tailings.py
@@ -166,6 +166,6 @@ class MineTailingsStorageFacility(AuditMixin, Base):
         recipients = MINESPACE_TSF_UPDATE_EMAIL
         subject = f'TSF Information Update for {self.mine.mine_name}'
         body = f'<p>{self.mine.mine_name} (Mine No.: {self.mine.mine_no}) has requested to update their TSF information.</p>'
-        link = f'{Config.CORE_PRODUCTION_URL}/mine-dashboard/{self.mine.mine_guid}/reports/permits-and-approvals/tailings'
+        link = f'{Config.CORE_PRODUCTION_URL}/mine-dashboard/{self.mine.mine_guid}/permits-and-approvals/tailings'
         body += f'<p>View updates in Core: <a href="{link}" target="_blank">{link}</a></p>'
         EmailService.send_email(subject, recipients, body)


### PR DESCRIPTION
## Objective 

[MDS-4990](https://bcmines.atlassian.net/browse/MDS-4990)

Removed the `/reports` part of the link to provide the correct link to TSF page.
