### PR TITLE
[MDS-5587] - Fix ESUP amendment document flow

### DIFF
--- a/services/core-api/app/api/mines/explosives_permit/models/explosives_permit.py
+++ b/services/core-api/app/api/mines/explosives_permit/models/explosives_permit.py
@@ -79,7 +79,7 @@ class ExplosivesPermit(SoftDeleteMixin, AuditMixin, PermitMixin, Base):
     def update(self, permit_guid, now_application_guid, issuing_inspector_party_guid, mine_manager_mine_party_appt_id,
                permittee_mine_party_appt_id, application_status, issue_date, expiry_date, decision_reason, is_closed,
                closed_reason, closed_timestamp, latitude, longitude, application_date, description, letter_date,
-               letter_body, explosive_magazines=[], detonator_magazines=[], documents=[], add_to_session=True):
+               letter_body, explosive_magazines=[], detonator_magazines=[], documents=[], generate_documents=False, add_to_session=True):
 
         # Update simple properties.
         self.permit_guid = permit_guid
@@ -205,11 +205,11 @@ class ExplosivesPermit(SoftDeleteMixin, AuditMixin, PermitMixin, Base):
                 if self.application_status == 'REC' and application_status == 'APP':
                     self.permit_number = ExplosivesPermit.get_next_permit_number()
 
-                # If the permit documents have not already been generated, generate them.
-                if not self.mine_documents:
+                current_app.logger.debug(f'generate_documents: {generate_documents}')
+
+                if generate_documents:
                     create_permit_enclosed_letter()
                     create_issued_permit()
-
 
             self.application_status = application_status
 

--- a/services/core-api/app/api/mines/explosives_permit/models/explosives_permit.py
+++ b/services/core-api/app/api/mines/explosives_permit/models/explosives_permit.py
@@ -205,8 +205,6 @@ class ExplosivesPermit(SoftDeleteMixin, AuditMixin, PermitMixin, Base):
                 if self.application_status == 'REC' and application_status == 'APP':
                     self.permit_number = ExplosivesPermit.get_next_permit_number()
 
-                current_app.logger.debug(f'generate_documents: {generate_documents}')
-
                 if generate_documents:
                     create_permit_enclosed_letter()
                     create_issued_permit()

--- a/services/core-api/app/api/mines/explosives_permit/resources/explosives_permit.py
+++ b/services/core-api/app/api/mines/explosives_permit/resources/explosives_permit.py
@@ -150,6 +150,12 @@ class ExplosivesPermitResource(Resource, UserMixin):
         store_missing=False,
         required=False,
     )
+    parser.add_argument(
+        'generate_documents',
+        type=inputs.boolean,
+        store_missing=False,
+        required=False,
+    )
 
     @api.doc(
         description='Get an Explosives Permit.',
@@ -189,6 +195,9 @@ class ExplosivesPermitResource(Resource, UserMixin):
         if letter_body is None:
             letter_body = ""
 
+        current_app.logger.debug('generate_documents')
+        current_app.logger.debug(data.get('generate_documents'))
+
         explosives_permit.update(
             data.get('permit_guid'), data.get('now_application_guid'),
             data.get('issuing_inspector_party_guid'), data.get('mine_manager_mine_party_appt_id'),
@@ -200,7 +209,10 @@ class ExplosivesPermitResource(Resource, UserMixin):
             letter_date,
             letter_body,
             data.get('explosive_magazines', []),
-            data.get('detonator_magazines', []), data.get('documents', []))
+            data.get('detonator_magazines', []),
+            data.get('documents', []),
+            data.get('generate_documents', False)
+        )
         
 
         explosives_permit.save()

--- a/services/core-api/app/api/mines/explosives_permit/resources/explosives_permit.py
+++ b/services/core-api/app/api/mines/explosives_permit/resources/explosives_permit.py
@@ -195,9 +195,6 @@ class ExplosivesPermitResource(Resource, UserMixin):
         if letter_body is None:
             letter_body = ""
 
-        current_app.logger.debug('generate_documents')
-        current_app.logger.debug(data.get('generate_documents'))
-
         explosives_permit.update(
             data.get('permit_guid'), data.get('now_application_guid'),
             data.get('issuing_inspector_party_guid'), data.get('mine_manager_mine_party_appt_id'),

--- a/services/core-api/app/api/mines/explosives_permit/response_models.py
+++ b/services/core-api/app/api/mines/explosives_permit/response_models.py
@@ -105,7 +105,6 @@ EXPLOSIVES_PERMIT_MODEL = api.model(
         'mines_permit_number': fields.String(attribute='mines_act_permit.permit_no'),
         'now_number': fields.String(attribute='now_application_identity.now_number'),
         'closed_by': fields.String,
-        'now_number': fields.String(attribute='now_application_identity.now_number'),
         'explosives_permit_amendments': fields.List(fields.Nested(EXPLOSIVES_PERMIT_AMENDMENT_MODEL))
     })
 

--- a/services/core-api/app/api/mines/explosives_permit_amendment/models/explosives_permit_amendment.py
+++ b/services/core-api/app/api/mines/explosives_permit_amendment/models/explosives_permit_amendment.py
@@ -224,6 +224,7 @@ class ExplosivesPermitAmendment(SoftDeleteMixin, AuditMixin, PermitMixin, Base):
                explosive_magazines=[],
                detonator_magazines=[],
                documents=[],
+               generate_documents=False,
                add_to_session=True):
 
         # Update simple properties.
@@ -356,8 +357,9 @@ class ExplosivesPermitAmendment(SoftDeleteMixin, AuditMixin, PermitMixin, Base):
                         token, True, False, False)
 
                 permit_number = ExplosivesPermit.find_permit_number_by_explosives_permit_id(explosives_permit_id)
-                create_permit_enclosed_letter()
-                create_issued_permit()
+                if generate_documents:
+                    create_permit_enclosed_letter()
+                    create_issued_permit()
 
         self.application_status = application_status
 

--- a/services/core-api/app/api/mines/explosives_permit_amendment/resources/explosives_permit_amendment.py
+++ b/services/core-api/app/api/mines/explosives_permit_amendment/resources/explosives_permit_amendment.py
@@ -3,6 +3,7 @@ from datetime import datetime
 
 from werkzeug.exceptions import NotFound
 from flask_restplus import Resource, inputs
+from flask import current_app
 
 from app.api.mines.explosives_permit.response_models import EXPLOSIVES_PERMIT_AMENDMENT_MODEL
 from app.api.mines.mine.models.mine import Mine
@@ -148,6 +149,12 @@ class ExplosivesPermitAmendmentResource(Resource, UserMixin):
         store_missing=False,
         required=False,
     )
+    parser.add_argument(
+        'generate_documents',
+        type=inputs.boolean,
+        store_missing=False,
+        required=False,
+    )
 
     @api.doc(
         description='Get an Explosives Permit Amendment.',
@@ -178,7 +185,8 @@ class ExplosivesPermitAmendmentResource(Resource, UserMixin):
             raise NotFound('Explosives Permit Amendment not found')
 
         data = self.parser.parse_args()
-
+        current_app.logger.debug('DOCUMENTS')
+        current_app.logger.debug(data.get('documents', []))
         explosives_permit_amendment.update(
             data.get('explosives_permit_id'),
             data.get('permit_guid'), data.get('now_application_guid'),
@@ -190,7 +198,10 @@ class ExplosivesPermitAmendmentResource(Resource, UserMixin):
             data.get('description'),data.get('letter_date'),
             data.get('letter_body'),
             data.get('explosive_magazines', []),
-            data.get('detonator_magazines', []), data.get('documents', []))
+            data.get('detonator_magazines', []),
+            data.get('documents', []),
+            data.get('generate_documents', [])
+        )
 
         explosives_permit_amendment.save()
         return explosives_permit_amendment

--- a/services/core-web/common/actionCreators/explosivesPermitActionCreator.ts
+++ b/services/core-web/common/actionCreators/explosivesPermitActionCreator.ts
@@ -60,7 +60,8 @@ export const fetchExplosivesPermits = (
 export const updateExplosivesPermit = (
   mineGuid: string,
   explosivesPermitGuid: string,
-  payload: Partial<IExplosivesPermit>
+  payload: Partial<IExplosivesPermit>,
+  generate_documents = false
 ): AppThunk<Promise<AxiosResponse<IExplosivesPermit>>> => (
   dispatch
 ): Promise<AxiosResponse<IExplosivesPermit>> => {
@@ -69,7 +70,7 @@ export const updateExplosivesPermit = (
   return CustomAxios()
     .put(
       ENVIRONMENT.apiUrl + API.EXPLOSIVES_PERMIT(mineGuid, explosivesPermitGuid),
-      payload,
+      { ...payload, generate_documents },
       createRequestHeader()
     )
     .then((response) => {

--- a/services/core-web/common/actionCreators/explosivesPermitAmendmentActionCreator.ts
+++ b/services/core-web/common/actionCreators/explosivesPermitAmendmentActionCreator.ts
@@ -12,7 +12,8 @@ import { AxiosResponse } from "axios";
 export const updateExplosivesPermitAmendment = (
   mineGuid: string,
   explosivesPermitAmendmentGuid: string,
-  payload: Partial<IExplosivesPermit>
+  payload: Partial<IExplosivesPermit>,
+  generate_documents = false
 ): AppThunk<Promise<AxiosResponse<IExplosivesPermit>>> => (
   dispatch
 ): Promise<AxiosResponse<IExplosivesPermitAmendment>> => {
@@ -21,7 +22,7 @@ export const updateExplosivesPermitAmendment = (
   return CustomAxios()
     .put(
       ENVIRONMENT.apiUrl + API.EXPLOSIVES_PERMIT_AMENDMENT(mineGuid, explosivesPermitAmendmentGuid),
-      payload,
+      { ...payload, generate_documents },
       createRequestHeader()
     )
     .then((response) => {

--- a/services/core-web/src/components/Forms/DocumentCategoryForm.tsx
+++ b/services/core-web/src/components/Forms/DocumentCategoryForm.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from "react";
+import React, { FC, useEffect } from "react";
 import { connect } from "react-redux";
 import { remove } from "lodash";
 import { bindActionCreators } from "redux";
@@ -18,6 +18,7 @@ interface DocumentCategoryFormProps {
   categories: IOption[];
   isProcessed: boolean;
   mineGuid: string;
+  isAmendment: boolean;
   change: (form: string, field: string, value: any) => void;
   arrayPush: (form: string, field: string, value: any) => void;
   infoText: string;
@@ -29,6 +30,7 @@ export const DocumentCategoryForm: FC<DocumentCategoryFormProps> = ({
   isProcessed,
   mineGuid,
   infoText,
+  isAmendment,
   ...props
 }) => {
   // File upload handlers
@@ -56,11 +58,18 @@ export const DocumentCategoryForm: FC<DocumentCategoryFormProps> = ({
     );
   };
 
+  useEffect(() => {
+    console.log("isAmendment", isAmendment);
+  }, [isAmendment]);
+
   const DocumentCategories = ({ fields }) => {
     return (
       <>
         {fields.map((field, index) => {
           const documentExists = fields.get(index) && fields.get(index).mine_document_guid;
+          const fieldId = isAmendment
+            ? `${field}explosives_permit_amendment_document_type_code`
+            : `${field}explosives_permit_document_type_code`;
           return (
             <div className="padding-sm margin-small" key={index}>
               <Row gutter={16}>
@@ -79,8 +88,8 @@ export const DocumentCategoryForm: FC<DocumentCategoryFormProps> = ({
                 <Col span={10}>
                   <Form.Item>
                     <Field
-                      id={`${field}explosives_permit_document_type_code`}
-                      name={`${field}explosives_permit_document_type_code`}
+                      id={fieldId}
+                      name={fieldId}
                       placeholder="Select a Document Category"
                       label="Document Category*"
                       component={renderConfig.SELECT}

--- a/services/core-web/src/components/Forms/DocumentCategoryForm.tsx
+++ b/services/core-web/src/components/Forms/DocumentCategoryForm.tsx
@@ -58,10 +58,6 @@ export const DocumentCategoryForm: FC<DocumentCategoryFormProps> = ({
     );
   };
 
-  useEffect(() => {
-    console.log("isAmendment", isAmendment);
-  }, [isAmendment]);
-
   const DocumentCategories = ({ fields }) => {
     return (
       <>

--- a/services/core-web/src/components/Forms/DocumentCategoryForm.tsx
+++ b/services/core-web/src/components/Forms/DocumentCategoryForm.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect } from "react";
+import React, { FC } from "react";
 import { connect } from "react-redux";
 import { remove } from "lodash";
 import { bindActionCreators } from "redux";

--- a/services/core-web/src/components/Forms/ExplosivesPermit/ExplosivesPermitFormNew.tsx
+++ b/services/core-web/src/components/Forms/ExplosivesPermit/ExplosivesPermitFormNew.tsx
@@ -48,6 +48,7 @@ interface ExplosivesPermitFormProps {
   initialValues: any;
   mineGuid: string;
   isProcessed: boolean;
+  isAmendment: boolean;
   documentTypeDropdownOptions: IOption[];
   isPermitTab: boolean;
   inspectors: IGroupedDropdownList[];
@@ -72,6 +73,7 @@ export const ExplosivesPermitFormNew: FC<ExplosivesPermitFormProps &
   initialValues = {},
   mines_permit_guid = null,
   isProcessed = false,
+  isAmendment = false,
   ...props
 }) => {
   const [generatedDocs, setGeneratedDocs] = useState([]);
@@ -487,6 +489,7 @@ export const ExplosivesPermitFormNew: FC<ExplosivesPermitFormProps &
               mineGuid={props.mineGuid}
               isProcessed={disabled}
               infoText="Please upload any documents that support this explosives storage and use permit. Documents uploaded here will be viewable by Minespace users."
+              isAmendment={isAmendment}
             />
           </Col>
           <Col md={12} sm={24} className="border--left--layout">

--- a/services/core-web/src/components/mine/ExplosivesPermit/ExplosivesPermit.tsx
+++ b/services/core-web/src/components/mine/ExplosivesPermit/ExplosivesPermit.tsx
@@ -109,6 +109,7 @@ export const ExplosivesPermit: FC<ExplosivesPermitProps> = ({
         documentTypeDropdownOptions: explosivesPermitDocumentTypeDropdownOptions,
         isPermitTab: permitTab,
         inspectors,
+        isAmendment: !!record?.explosives_permit_amendment_guid,
       },
       content: modalConfig.EXPLOSIVES_PERMIT_MODAL,
       width: "75vw",
@@ -187,7 +188,7 @@ export const ExplosivesPermit: FC<ExplosivesPermitProps> = ({
   const handleIssueExplosivesPermit = (values, record) => {
     const payload = { ...record, ...values, application_status: "APP" };
     return props
-      .updateExplosivesPermit(mineGuid, record.explosives_permit_guid, payload)
+      .updateExplosivesPermit(mineGuid, record.explosives_permit_guid, payload, true)
       .then(() => {
         props.fetchExplosivesPermits(mineGuid);
         props.closeModal();

--- a/services/core-web/src/components/modalContent/AddExplosivesPermitModal.tsx
+++ b/services/core-web/src/components/modalContent/AddExplosivesPermitModal.tsx
@@ -14,6 +14,7 @@ interface ExplosivesPermitModalProps {
   inspectors: IGroupedDropdownList[];
   closeModal: () => void;
   isProcessed: boolean;
+  isAmendment: boolean;
 }
 
 export const AddExplosivesPermitModal: FC<ExplosivesPermitModalProps> = (props) => (

--- a/services/core-web/src/tests/actionCreators/explosivesPermitActionCreator.spec.js
+++ b/services/core-web/src/tests/actionCreators/explosivesPermitActionCreator.spec.js
@@ -81,18 +81,18 @@ describe("`updateExplosivesPermit` action creator", () => {
   const mine_guid = "12345-6789";
   const permit_guid = "12345-6789";
   const url = `${ENVIRONMENT.apiUrl}${API.EXPLOSIVES_PERMIT(mine_guid, permit_guid)}`;
-
   const permit_status_code = "C";
   const description = "test description";
 
-  const mockPayload = { permit_status_code, description };
+  const mockPayload = { permit_status_code, description, generate_documents: true };
   it("Request successful, dispatches `success` with correct response", () => {
     const mockResponse = { data: { success: true } };
     mockAxios.onPut(url, mockPayload).reply(200, mockResponse);
     return updateExplosivesPermit(
       mine_guid,
       permit_guid,
-      mockPayload
+      mockPayload,
+      true
     )(dispatch).then(() => {
       expect(requestSpy).toHaveBeenCalledTimes(1);
       expect(successSpy).toHaveBeenCalledTimes(1);

--- a/services/minespace-web/common/actionCreators/explosivesPermitActionCreator.ts
+++ b/services/minespace-web/common/actionCreators/explosivesPermitActionCreator.ts
@@ -60,7 +60,8 @@ export const fetchExplosivesPermits = (
 export const updateExplosivesPermit = (
   mineGuid: string,
   explosivesPermitGuid: string,
-  payload: Partial<IExplosivesPermit>
+  payload: Partial<IExplosivesPermit>,
+  generate_documents = false
 ): AppThunk<Promise<AxiosResponse<IExplosivesPermit>>> => (
   dispatch
 ): Promise<AxiosResponse<IExplosivesPermit>> => {
@@ -69,7 +70,7 @@ export const updateExplosivesPermit = (
   return CustomAxios()
     .put(
       ENVIRONMENT.apiUrl + API.EXPLOSIVES_PERMIT(mineGuid, explosivesPermitGuid),
-      payload,
+      { ...payload, generate_documents },
       createRequestHeader()
     )
     .then((response) => {

--- a/services/minespace-web/common/actionCreators/explosivesPermitAmendmentActionCreator.ts
+++ b/services/minespace-web/common/actionCreators/explosivesPermitAmendmentActionCreator.ts
@@ -12,7 +12,8 @@ import { AxiosResponse } from "axios";
 export const updateExplosivesPermitAmendment = (
   mineGuid: string,
   explosivesPermitAmendmentGuid: string,
-  payload: Partial<IExplosivesPermit>
+  payload: Partial<IExplosivesPermit>,
+  generate_documents = false
 ): AppThunk<Promise<AxiosResponse<IExplosivesPermit>>> => (
   dispatch
 ): Promise<AxiosResponse<IExplosivesPermitAmendment>> => {
@@ -21,7 +22,7 @@ export const updateExplosivesPermitAmendment = (
   return CustomAxios()
     .put(
       ENVIRONMENT.apiUrl + API.EXPLOSIVES_PERMIT_AMENDMENT(mineGuid, explosivesPermitAmendmentGuid),
-      payload,
+      { ...payload, generate_documents },
       createRequestHeader()
     )
     .then((response) => {


### PR DESCRIPTION
The code was updated to allow optional generation of ESUP documents. Previously, every update to the permit or amendment would trigger regeneration of related documents, which should only happen when a permit or amendment is processed.

Also added an `isAmendment` property to several areas of ESUPS, to allow for handling of differences between ESUPs and amendments (particularly with field names for amendment documents vs esup documents)

## Objective 

[MDS-5587](https://bcmines.atlassian.net/browse/MDS-5587)

