### PR TITLE
[MDS-5552]replacing now manage doc and admin with zip download

### DIFF
--- a/services/core-web/src/components/common/CompressionNotificationProgressBar.tsx
+++ b/services/core-web/src/components/common/CompressionNotificationProgressBar.tsx
@@ -17,7 +17,7 @@ export const CompressionNotificationProgressBar: FC<CompressionNotificationProgr
     trailColor="#d9d9d9"
     className="compressionProgressBar"
     style={{
-      top: `${props.notificationTopPosition - 10}px`,
+      top: `${props.notificationTopPosition - 11}px`,
     }}
   />
 );

--- a/services/core-web/src/components/common/DocumentCompression.tsx
+++ b/services/core-web/src/components/common/DocumentCompression.tsx
@@ -21,7 +21,7 @@ interface DocumentCompressionProps {
   documentsCompression: ActionCreator<typeof documentsCompression>;
   pollDocumentsCompressionProgress: ActionCreator<typeof pollDocumentsCompressionProgress>;
   startFilesCompression: () => void;
-  showArchiveDownloadWarning: boolean;
+  showDownloadWarning: boolean;
 }
 
 export const DocumentCompression: FC<DocumentCompressionProps> = (props) => {
@@ -121,14 +121,14 @@ export const DocumentCompression: FC<DocumentCompressionProps> = (props) => {
   };
 
   useEffect(() => {
-    if (!props.showArchiveDownloadWarning && props.isCompressionModalVisible) {
+    if (!props.showDownloadWarning && props.isCompressionModalVisible) {
       startFilesCompression();
     }
   }, [props.isCompressionModalVisible]);
 
   return (
     <div>
-      {props.showArchiveDownloadWarning && (
+      {props.showDownloadWarning && (
         <DocumentCompressionWarningModal
           isModalVisible={props.isCompressionModalVisible}
           filesCompression={startFilesCompression}

--- a/services/core-web/src/components/common/DocumentCompression.tsx
+++ b/services/core-web/src/components/common/DocumentCompression.tsx
@@ -1,8 +1,8 @@
-import React, { FC, useState, useRef } from "react";
+import React, { FC, useState, useRef, useEffect } from "react";
 import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
 import { notification } from "antd";
-import DocumentCompressionModal from "../modalContent/DocumentCompressionModal";
+import DocumentCompressionWarningModal from "../modalContent/DocumentCompressionWarningModal";
 import DocumentCompressedDownloadModal from "../modalContent/DocumentCompressedDownloadModal";
 import CompressionNotificationProgressBar from "./CompressionNotificationProgressBar";
 import {
@@ -21,6 +21,7 @@ interface DocumentCompressionProps {
   documentsCompression: ActionCreator<typeof documentsCompression>;
   pollDocumentsCompressionProgress: ActionCreator<typeof pollDocumentsCompressionProgress>;
   startFilesCompression: () => void;
+  showArchiveDownloadWarning: boolean;
 }
 
 export const DocumentCompression: FC<DocumentCompressionProps> = (props) => {
@@ -64,7 +65,7 @@ export const DocumentCompression: FC<DocumentCompressionProps> = (props) => {
       .filter((row) => row.is_latest_version && !row.is_archived)
       .map((filteredRows) => filteredRows.document_manager_guid);
 
-    setEntityTitle(props.rows[0].entity_title);
+    setEntityTitle(props.rows[0].entity_title || "");
     if (documentManagerGuids.length === 0) {
       setTimeout(() => {
         const description =
@@ -119,13 +120,21 @@ export const DocumentCompression: FC<DocumentCompressionProps> = (props) => {
     }
   };
 
+  useEffect(() => {
+    if (!props.showArchiveDownloadWarning && props.isCompressionModalVisible) {
+      startFilesCompression();
+    }
+  }, [props.isCompressionModalVisible]);
+
   return (
     <div>
-      <DocumentCompressionModal
-        isModalVisible={props.isCompressionModalVisible}
-        filesCompression={startFilesCompression}
-        setModalVisible={props.setCompressionModalVisible}
-      />
+      {props.showArchiveDownloadWarning && (
+        <DocumentCompressionWarningModal
+          isModalVisible={props.isCompressionModalVisible}
+          filesCompression={startFilesCompression}
+          setModalVisible={props.setCompressionModalVisible}
+        />
+      )}
       {isProgressBarVisible && (
         <CompressionNotificationProgressBar
           compressionProgress={compressionProgress}

--- a/services/core-web/src/components/common/DocumentTable.tsx
+++ b/services/core-web/src/components/common/DocumentTable.tsx
@@ -366,6 +366,7 @@ export const DocumentTable: FC<DocumentTableProps> = ({
         setCompressionModalVisible={setCompressionModal}
         isCompressionModalVisible={isCompressionModal}
         compressionInProgress={setCompressionInProgress}
+        showArchiveDownloadWarning={true}
       />
       {renderBulkActions()}
       {<CoreTable {...coreTableProps} />}

--- a/services/core-web/src/components/common/DocumentTable.tsx
+++ b/services/core-web/src/components/common/DocumentTable.tsx
@@ -366,7 +366,7 @@ export const DocumentTable: FC<DocumentTableProps> = ({
         setCompressionModalVisible={setCompressionModal}
         isCompressionModalVisible={isCompressionModal}
         compressionInProgress={setCompressionInProgress}
-        showArchiveDownloadWarning={true}
+        showDownloadWarning={showVersionHistory || canArchiveDocuments}
       />
       {renderBulkActions()}
       {<CoreTable {...coreTableProps} />}

--- a/services/core-web/src/components/mine/Projects/MajorMineApplicationTab.js
+++ b/services/core-web/src/components/mine/Projects/MajorMineApplicationTab.js
@@ -284,7 +284,7 @@ export class MajorMineApplicationTab extends Component {
             rows={documents}
             setCompressionModalVisible={(state) => this.setState({ isCompressionModal: state })}
             isCompressionModalVisible={this.state.isCompressionModal}
-            showArchiveDownloadWarning={true}
+            showDownloadWarning={true}
           />
           <Button
             style={{ float: "right" }}

--- a/services/core-web/src/components/mine/Projects/MajorMineApplicationTab.js
+++ b/services/core-web/src/components/mine/Projects/MajorMineApplicationTab.js
@@ -284,6 +284,7 @@ export class MajorMineApplicationTab extends Component {
             rows={documents}
             setCompressionModalVisible={(state) => this.setState({ isCompressionModal: state })}
             isCompressionModalVisible={this.state.isCompressionModal}
+            showArchiveDownloadWarning={true}
           />
           <Button
             style={{ float: "right" }}

--- a/services/core-web/src/components/modalContent/DocumentCompressionWarningModal.tsx
+++ b/services/core-web/src/components/modalContent/DocumentCompressionWarningModal.tsx
@@ -1,13 +1,15 @@
 import React, { FC } from "react";
 import { Modal, Typography } from "antd";
 
-interface DocumentCompressionModalProps {
+interface DocumentCompressionWarningModalProps {
   isModalVisible: boolean;
   filesCompression: () => void;
   setModalVisible: (arg1: boolean) => void;
 }
 
-export const DocumentCompressionModal: FC<DocumentCompressionModalProps> = (props) => (
+export const DocumentCompressionWarningModal: FC<DocumentCompressionWarningModalProps> = (
+  props
+) => (
   <Modal
     title=""
     open={props.isModalVisible}
@@ -26,4 +28,4 @@ export const DocumentCompressionModal: FC<DocumentCompressionModalProps> = (prop
   </Modal>
 );
 
-export default DocumentCompressionModal;
+export default DocumentCompressionWarningModal;

--- a/services/core-web/src/components/modalContent/ManageDocumentsDownloadPackageModal.js
+++ b/services/core-web/src/components/modalContent/ManageDocumentsDownloadPackageModal.js
@@ -1,49 +1,19 @@
 import React, { useState } from "react";
-import { connect } from "react-redux";
 import PropTypes from "prop-types";
 import { DownloadOutlined } from "@ant-design/icons";
-import { Button, Progress, Popconfirm } from "antd";
-import { getDocumentDownloadState } from "@common/selectors/noticeOfWorkSelectors";
+import { Button, Popconfirm } from "antd";
 import NOWSubmissionDocuments from "@/components/noticeOfWork/applications/NOWSubmissionDocuments";
-import { COLOR } from "@/constants/styles";
-import CustomPropTypes from "@/customPropTypes";
 
 const propTypes = {
   nowDocuments: PropTypes.arrayOf(PropTypes.objectOf(PropTypes.any)).isRequired,
   noticeOfWorkGuid: PropTypes.string.isRequired,
   onSubmit: PropTypes.func.isRequired,
-  cancelDownload: PropTypes.func.isRequired,
   closeModal: PropTypes.func.isRequired,
-  documentDownloadState: CustomPropTypes.documentDownloadState,
-};
-
-const defaultProps = {
-  documentDownloadState: {
-    downloading: false,
-    currentFile: 0,
-    totalFiles: 0,
-  },
 };
 
 export const ManageDocumentsDownloadPackageModal = (props) => {
   const [selectedDocumentRows, setSelectedDocumentRows] = useState(props.nowDocuments);
-
-  return props.documentDownloadState.downloading ? (
-    <div className="inline-flex flex-flow-column horizontal-center">
-      <h4>Downloading Selected Files...</h4>
-      <Progress
-        className="padding-md--top padding-lg--bottom"
-        strokeColor={COLOR.violet}
-        type="circle"
-        percent={Math.round(
-          (props.documentDownloadState.currentFile / props.documentDownloadState.totalFiles) * 100
-        )}
-      />
-      <Button className="full-mobile" type="secondary" onClick={() => props.cancelDownload()}>
-        Cancel
-      </Button>
-    </div>
-  ) : (
+  return (
     <>
       <div>
         <h4>All NoW Documents</h4>
@@ -105,11 +75,6 @@ export const ManageDocumentsDownloadPackageModal = (props) => {
   );
 };
 
-const mapStateToProps = (state) => ({
-  documentDownloadState: getDocumentDownloadState(state),
-});
-
 ManageDocumentsDownloadPackageModal.propTypes = propTypes;
-ManageDocumentsDownloadPackageModal.defaultProps = defaultProps;
 
-export default connect(mapStateToProps)(ManageDocumentsDownloadPackageModal);
+export default ManageDocumentsDownloadPackageModal;

--- a/services/core-web/src/components/noticeOfWork/applications/FinalPermitDocuments.js
+++ b/services/core-web/src/components/noticeOfWork/applications/FinalPermitDocuments.js
@@ -2,9 +2,7 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { FormSection } from "redux-form";
 import { connect } from "react-redux";
-import { Button, Progress } from "antd";
-import { getDocumentDownloadState, getNOWProgress } from "@common/selectors/noticeOfWorkSelectors";
-import { COLOR } from "@/constants/styles";
+import { getNOWProgress } from "@common/selectors/noticeOfWorkSelectors";
 import CustomPropTypes from "@/customPropTypes";
 import PermitPackage from "@/components/noticeOfWork/applications/PermitPackage";
 import NOWDocuments from "@/components/noticeOfWork/applications/NOWDocuments";
@@ -18,7 +16,6 @@ const propTypes = {
   mineGuid: PropTypes.string.isRequired,
   noticeOfWork: CustomPropTypes.importedNOWApplication.isRequired,
   importNowSubmissionDocumentsJob: PropTypes.objectOf(PropTypes.any),
-  documentDownloadState: CustomPropTypes.documentDownloadState.isRequired,
   progress: PropTypes.objectOf(PropTypes.string).isRequired,
   adminView: PropTypes.bool,
   showPreambleFileMetadata: PropTypes.bool,
@@ -37,14 +34,6 @@ const defaultProps = {
 };
 
 export class FinalPermitDocuments extends Component {
-  state = {
-    cancelDownload: false,
-  };
-
-  cancelDownload = () => {
-    this.setState({ cancelDownload: true });
-  };
-
   render() {
     const permitDocuments = this.props.noticeOfWork.documents.filter(
       ({ is_final_package }) => is_final_package
@@ -122,24 +111,7 @@ export class FinalPermitDocuments extends Component {
       );
     }
 
-    return this.props.documentDownloadState.downloading ? (
-      <div className="inline-flex flex-flow-column horizontal-center">
-        <h4>Downloading Selected Files...</h4>
-        <Progress
-          className="padding-md--top padding-lg--bottom"
-          strokeColor={COLOR.violet}
-          type="circle"
-          percent={Math.round(
-            (this.props.documentDownloadState.currentFile /
-              this.props.documentDownloadState.totalFiles) *
-              100
-          )}
-        />
-        <Button className="full-mobile" type="secondary" onClick={() => this.cancelDownload()}>
-          Cancel
-        </Button>
-      </div>
-    ) : (
+    return (
       <div>
         <div className="inline-flex between">
           <div>
@@ -185,7 +157,6 @@ export class FinalPermitDocuments extends Component {
 }
 
 const mapStateToProps = (state) => ({
-  documentDownloadState: getDocumentDownloadState(state),
   progress: getNOWProgress(state),
 });
 

--- a/services/core-web/src/components/noticeOfWork/applications/PermitPackage.js
+++ b/services/core-web/src/components/noticeOfWork/applications/PermitPackage.js
@@ -170,7 +170,7 @@ export class PermitPackage extends Component {
           setCompressionModalVisible={(state) => this.setState({ isCompressionModal: state })}
           isCompressionModalVisible={this.state.isCompressionModal}
           compressionInProgress={(state) => this.setState({ isCompressionInProgress: state })}
-          showArchiveDownloadWarning={false}
+          showDownloadWarning={false}
         />
         <Button
           type="secondary"

--- a/services/core-web/src/components/noticeOfWork/applications/manageDocuments/ManageDocumentsTab.js
+++ b/services/core-web/src/components/noticeOfWork/applications/manageDocuments/ManageDocumentsTab.js
@@ -162,7 +162,7 @@ export class ManageDocumentsTab extends Component {
             rows={this.state.documents}
             setCompressionModalVisible={(state) => this.setState({ isCompressionModal: state })}
             isCompressionModalVisible={this.state.isCompressionModal}
-            showArchiveDownloadWarning={false}
+            showDownloadWarning={false}
           />
           <NOWApplicationManageDocuments
             mineGuid={this.props.noticeOfWork.mine_guid}

--- a/services/core-web/src/tests/components/common/__snapshots__/CompressionNotificationProgressBar.spec.tsx.snap
+++ b/services/core-web/src/tests/components/common/__snapshots__/CompressionNotificationProgressBar.spec.tsx.snap
@@ -9,7 +9,7 @@ exports[`CompressionNotificationProgressBar renders properly 1`] = `
   strokeLinecap="square"
   style={
     Object {
-      "top": "-10px",
+      "top": "-11px",
     }
   }
   trailColor="#d9d9d9"

--- a/services/core-web/src/tests/components/noticeOfWork/applications/__snapshots__/PreviousAmendmentDocuments.spec.js.snap
+++ b/services/core-web/src/tests/components/noticeOfWork/applications/__snapshots__/PreviousAmendmentDocuments.spec.js.snap
@@ -2,8 +2,17 @@
 
 exports[`PermitPackage renders properly 1`] = `
 <div>
+  <Connect(DocumentCompression)
+    compressionInProgress={[Function]}
+    documentType="all"
+    isCompressionModalVisible={false}
+    rows={Array []}
+    setCompressionModalVisible={[Function]}
+    showArchiveDownloadWarning={false}
+  />
   <Button
     className="full-mobile"
+    disabled={false}
     onClick={[Function]}
     type="secondary"
   >

--- a/services/core-web/src/tests/components/noticeOfWork/applications/__snapshots__/PreviousAmendmentDocuments.spec.js.snap
+++ b/services/core-web/src/tests/components/noticeOfWork/applications/__snapshots__/PreviousAmendmentDocuments.spec.js.snap
@@ -8,7 +8,7 @@ exports[`PermitPackage renders properly 1`] = `
     isCompressionModalVisible={false}
     rows={Array []}
     setCompressionModalVisible={[Function]}
-    showArchiveDownloadWarning={false}
+    showDownloadWarning={false}
   />
   <Button
     className="full-mobile"

--- a/services/core-web/src/tests/components/noticeOfWork/applications/documents/__snapshots__/ManageDocumentsTab.spec.js.snap
+++ b/services/core-web/src/tests/components/noticeOfWork/applications/documents/__snapshots__/ManageDocumentsTab.spec.js.snap
@@ -426,6 +426,13 @@ exports[`ManageDocumentsTab renders properly 1`] = `
   <div
     className="side-menu--content"
   >
+    <Connect(DocumentCompression)
+      documentType="all"
+      isCompressionModalVisible={false}
+      rows={Array []}
+      setCompressionModalVisible={[Function]}
+      showArchiveDownloadWarning={false}
+    />
     <NOWApplicationManageDocuments
       handleSaveNOWEdit={[Function]}
       importNowSubmissionDocumentsJob={false}

--- a/services/core-web/src/tests/components/noticeOfWork/applications/documents/__snapshots__/ManageDocumentsTab.spec.js.snap
+++ b/services/core-web/src/tests/components/noticeOfWork/applications/documents/__snapshots__/ManageDocumentsTab.spec.js.snap
@@ -431,7 +431,7 @@ exports[`ManageDocumentsTab renders properly 1`] = `
       isCompressionModalVisible={false}
       rows={Array []}
       setCompressionModalVisible={[Function]}
-      showArchiveDownloadWarning={false}
+      showDownloadWarning={false}
     />
     <NOWApplicationManageDocuments
       handleSaveNOWEdit={[Function]}


### PR DESCRIPTION
## Objective 

[MDS-5552](https://bcmines.atlassian.net/browse/MDS-5552)

- Replaces the existing download of NoW documents and Permit Package documents in NoW Manage Documents tab with download zip, similar to Major projects.

- Replaces the existing download of Permit Package documents in NoW Administrative tab with download zip, similar to Major projects.

![image](https://github.com/bcgov/mds/assets/127789479/fc3225fa-ba75-455a-870b-ca3a41be32fb)

![image](https://github.com/bcgov/mds/assets/127789479/589eea29-2122-4301-bff5-e2b78bb707e4)
