### PR TITLE
[MDS-5541] Fix for filtering issue in mines search

### DIFF
--- a/services/core-api/app/api/mines/mine/models/mine.py
+++ b/services/core-api/app/api/mines/mine/models/mine.py
@@ -216,6 +216,13 @@ class Mine(SoftDeleteMixin, AuditMixin, Base):
             return self.mine_work_informations[0].work_status
         return "Unknown"
 
+    @hybrid_property
+    def latest_mine_status(self):
+        if self.mine_status:
+            latest_status = max(self.mine_status, key=lambda x: x.update_timestamp)
+            return latest_status
+        return None
+
     @work_status.expression
     def work_status(cls):
         return func.coalesce(

--- a/services/core-api/app/api/mines/response_models.py
+++ b/services/core-api/app/api/mines/response_models.py
@@ -430,7 +430,8 @@ MINES_MODEL = api.model(
         'verified_status': fields.Nested(MINE_VERIFIED_MODEL, skip_none=True),
         'has_minespace_users': fields.Boolean,
         'mms_alias': fields.String,
-        'mine_work_information': fields.Nested(MINE_WORK_INFORMATION_MODEL, skip_none=True)
+        'mine_work_information': fields.Nested(MINE_WORK_INFORMATION_MODEL, skip_none=True),
+        'latest_mine_status': fields.Nested(STATUS_MODEL)
     })
 
 MINE_MODEL = api.inherit(


### PR DESCRIPTION
## Objective 

[MDS-5541](https://bcmines.atlassian.net/browse/MDS-5541)

_Why are you making this change? Provide a short explanation and/or screenshots_

- While fixing, new property (hybrid) was added to represent the latest status of the mine, in to the Mine model. In addition to the fix, this property is added to the API response model.
- Tested recreating the issue in local environment.