### PR TITLE
[MDS-5597] Fix ESUP "Created By" column to show the username

### DIFF
--- a/services/core-api/app/api/utils/models_mixins.py
+++ b/services/core-api/app/api/utils/models_mixins.py
@@ -426,6 +426,7 @@ class PermitDocumentMixin(object):
     document_manager_guid = association_proxy('mine_document', 'document_manager_guid')
     document_name = association_proxy('mine_document', 'document_name')
     upload_date = association_proxy('mine_document', 'upload_date')
+    create_user = association_proxy('mine_document', 'create_user')
 
 class PermitMagazineMixin(object):
     type_no = db.Column(db.String, nullable=False)

--- a/services/core-web/src/components/mine/ExplosivesPermit/MineExplosivesPermitTable.tsx
+++ b/services/core-web/src/components/mine/ExplosivesPermit/MineExplosivesPermitTable.tsx
@@ -653,7 +653,7 @@ const MineExplosivesPermitTable: FC<RouteComponentProps & MineExplosivesPermitTa
           ? {
               rowExpandable: (record: IExplosivesPermit) =>
                 record.explosives_permit_amendments?.length > 1,
-              recordDescription: "document details",
+              recordDescription: "amendment details",
               getDataSource: (record: IExplosivesPermit) => {
                 const totalAmendments = record.explosives_permit_amendments.length;
                 return record.explosives_permit_amendments.map((amendment) => {


### PR DESCRIPTION
## Objective 
- added the create_user field to the Mixin that ESUP docs use
- the tooltip text was bothering me and it was a quick fix so did that too

[MDS-5597](https://bcmines.atlassian.net/browse/MDS-5597)

_Why are you making this change? Provide a short explanation and/or screenshots_
![image](https://github.com/bcgov/mds/assets/102187683/c85b88c8-32ed-4e05-ab03-7c835e2874fd)
