### PR TITLE
 [MDS-5590] Adjusting esup creation flow for permit and application sections

### DIFF
--- a/services/core-web/src/components/Forms/ExplosivesPermit/ExplosivesPermitFormNew.tsx
+++ b/services/core-web/src/components/Forms/ExplosivesPermit/ExplosivesPermitFormNew.tsx
@@ -1,7 +1,14 @@
 import React, { FC, useEffect, useState } from "react";
 import { connect } from "react-redux";
 import { compose } from "redux";
-import { Field, formValueSelector, getFormValues, InjectedFormProps, reduxForm } from "redux-form";
+import {
+  Field,
+  formValueSelector,
+  getFormValues,
+  InjectedFormProps,
+  reduxForm,
+  change,
+} from "redux-form";
 import { Form } from "@ant-design/compatible";
 import "@ant-design/compatible/assets/index.css";
 import { Alert, Button, Col, Popconfirm, Row, Table, Typography, Radio } from "antd";
@@ -52,6 +59,7 @@ interface ExplosivesPermitFormProps {
   isAmendment?: boolean;
   inspectors: IGroupedDropdownList[];
   documents: IExplosivesPermitDocument[];
+  dispatch: any;
 }
 
 interface StateProps {
@@ -120,15 +128,21 @@ export const ExplosivesPermitFormNew: FC<ExplosivesPermitFormProps &
     "now_application_guid"
   );
 
-  const [isHistoric, setIsHistoric] = useState<boolean>(
-    !initialValues?.explosives_permit_id && props.isPermitTab
-  );
+  const [isHistoric, setIsHistoric] = useState<boolean>(!initialValues?.explosives_permit_id);
 
   const disabled = isProcessed;
 
   const [radioSelection, setRadioSelection] = useState<number>(props.isPermitTab ? 1 : 2);
   const [parentView, setParentView] = useState<boolean>(!isAmendment);
   const [isAmendSelected, setIsAmend] = useState<boolean>(false);
+
+  useEffect(() => {
+    props.dispatch(change(FORM.EXPLOSIVES_PERMIT_NEW, "is_historic", isHistoric));
+  }, [isHistoric]);
+
+  useEffect(() => {
+    setIsHistoric(radioSelection === 1);
+  }, []);
 
   const handleRadioChange = (e) => {
     setRadioSelection(e.target.value);
@@ -294,7 +308,7 @@ export const ExplosivesPermitFormNew: FC<ExplosivesPermitFormProps &
           <Typography.Title level={3} className="purple">
             Explosives Permit Details
           </Typography.Title>
-          {props.isPermitTab && (
+          {isHistoric && (
             <>
               <Row gutter={6}>
                 <Col span={12}>
@@ -341,7 +355,7 @@ export const ExplosivesPermitFormNew: FC<ExplosivesPermitFormProps &
             </>
           )}
           <Row gutter={6}>
-            {props.isPermitTab && (
+            {isHistoric && (
               <Col span={12}>
                 <Form.Item>
                   <Field
@@ -356,7 +370,7 @@ export const ExplosivesPermitFormNew: FC<ExplosivesPermitFormProps &
                 </Form.Item>
               </Col>
             )}
-            <Col span={props.isPermitTab ? 12 : 24}>
+            <Col span={isHistoric ? 12 : 24}>
               <Form.Item>
                 <Field
                   id="permit_guid"
@@ -389,11 +403,11 @@ export const ExplosivesPermitFormNew: FC<ExplosivesPermitFormProps &
                 <Field
                   id="mine_manager_mine_party_appt_id"
                   name="mine_manager_mine_party_appt_id"
-                  label={props.isPermitTab ? "Mine Manager" : "Mine Manager*"}
+                  label={isHistoric ? "Mine Manager" : "Mine Manager*"}
                   placeholder="Select Mine Manager"
                   partyLabel="Mine Manager"
                   validate={
-                    props.isPermitTab
+                    isHistoric
                       ? [validateSelectOptions(mineManagersDropdown, true)]
                       : [required, validateSelectOptions(mineManagersDropdown, true)]
                   }
@@ -562,7 +576,7 @@ const mapStateToProps = (state) => ({
 });
 
 export default compose(
-  connect(mapStateToProps, null),
+  connect(mapStateToProps),
   reduxForm({
     form: FORM.EXPLOSIVES_PERMIT_NEW,
     touchOnBlur: true,

--- a/services/core-web/src/components/mine/ExplosivesPermit/ExplosivesPermit.tsx
+++ b/services/core-web/src/components/mine/ExplosivesPermit/ExplosivesPermit.tsx
@@ -115,7 +115,7 @@ export const ExplosivesPermit: FC<ExplosivesPermitProps> = ({
   };
 
   const handleAddExplosivesPermit = (values) => {
-    const system = values.permit_tab ? "MMS" : "Core";
+    const system = values.is_historic ? "MMS" : "Core";
     const payload = {
       originating_system: system,
       ...values,
@@ -157,7 +157,7 @@ export const ExplosivesPermit: FC<ExplosivesPermitProps> = ({
   };
 
   const handleOpenAddExplosivesPermitModal = (event, permitTab, record = null) => {
-    const initialValues = record || { permit_tab: permitTab };
+    const initialValues = record || {};
     const isProcessed = record !== null && record?.application_status !== "REC";
     event.preventDefault();
     props.openModal({

--- a/services/core-web/src/components/modalContent/AddExplosivesPermitModal.tsx
+++ b/services/core-web/src/components/modalContent/AddExplosivesPermitModal.tsx
@@ -16,6 +16,7 @@ interface ExplosivesPermitModalProps {
   closeModal: () => void;
   isProcessed: boolean;
   isAmendment: boolean;
+  dispatch: any;
 }
 
 export const AddExplosivesPermitModal: FC<ExplosivesPermitModalProps> = (props) => (


### PR DESCRIPTION
## Objective 

[MDS-5590](https://bcmines.atlassian.net/browse/MDS-5590)

- Change so when creating a new permit, either in applications tab or permits tab, the modal opens to create a new permit
- Change so when creating a historic permit, either in applications tab or permits tab, the modal opens to create a historic permit record
