### PR TITLE
[MDS-5601] - add security for traction webhook endpoint

### DIFF
--- a/services/core-api/app/api/verifiable_credentials/resources/verifiable_credential_webhook.py
+++ b/services/core-api/app/api/verifiable_credentials/resources/verifiable_credential_webhook.py
@@ -1,8 +1,9 @@
-import enum
 from flask import current_app, request
+from werkzeug.exceptions import Forbidden
 from flask_restplus import Resource
 from app.api.utils.include.user_info import User
 
+from app.config import Config
 from app.extensions import api
 
 from app.api.utils.resources_mixins import UserMixin
@@ -20,6 +21,10 @@ PING = "ping"
 class VerifiableCredentialWebhookResource(Resource, UserMixin):
     @api.doc(description='Endpoint to recieve webhooks from Traction.', params={})
     def post(self, topic):
+        #custom auth for traction
+        if request.headers.get("x-api-key") != Config.TRACTION_WEBHOOK_X_API_KEY:
+             return Forbidden("bad x-api-key")
+
         User._test_mode = True  #webhook handling has no row level auth
         webhook_body = request.get_json()
         current_app.logger.debug(f"TRACTION WEBHOOK <topic={topic}>: {webhook_body}")

--- a/services/core-api/app/config.py
+++ b/services/core-api/app/config.py
@@ -249,7 +249,7 @@ class Config(object):
     TRACTION_HOST = os.environ.get("TRACTION_HOST","https://traction-tenant-proxy-dev.apps.silver.devops.gov.bc.ca")
     TRACTION_TENANT_ID = os.environ.get("TRACTION_TENANT_ID","GET_TENANT_ID_FROM_TRACTION")
     TRACTION_WALLET_API_KEY = os.environ.get("TRACTION_WALLET_API_KEY","GET_WALLET_API_KEY_FROM_TRACTION")
-
+    TRACTION_WEBHOOK_X_API_KEY = os.environ.get("TRACTION_WEBHOOK_X_API_KEY","NO_X_API_KEY")
     CRED_DEF_ID_MINES_ACT_PERMIT = os.environ.get("CRED_DEF_ID_MINES_ACT_PERMIT","CRED_DEF_ID_MINES_ACT_PERMIT")
 
 class TestConfig(Config):


### PR DESCRIPTION
Traction is already providing them, but we will need new env vars.

## Objective 

[MDS-5601](https://bcmines.atlassian.net/browse/MDS-5601)

Only traction should be allowed to call this endpoint.

`TRACTION_WEBHOOK_X_API_KEY` is now a new environment variables for all environments.