### PR TITLE
[CHORE] - update language in VC modals

### DIFF
--- a/services/minespace-web/src/components/dashboard/mine/permits/Permits.tsx
+++ b/services/minespace-web/src/components/dashboard/mine/permits/Permits.tsx
@@ -122,7 +122,7 @@ export const Permits: FC<PermitsProps> = ({ mine, permits, ...props }) => {
                     )
                   }
                 >
-                  Generate Digital Wallet Connection
+                  Generate Connection Invitation
                 </Button>
               )}
             </Col>

--- a/services/minespace-web/src/components/dashboard/mine/permits/PermitsTable.tsx
+++ b/services/minespace-web/src/components/dashboard/mine/permits/PermitsTable.tsx
@@ -77,7 +77,7 @@ export const PermitsTable: FC<PermitsTableProps> = (props) => {
       event.preventDefault();
       props.openModal({
         props: {
-          title: "Issue Permit as Digital Credential",
+          title: "Issue Digital Credential",
           issuanceState: permit.lastAmendedVC,
           connectionState: permit.current_permittee_digital_wallet_connection_state,
           permitAmendmentGuid: permit.lastAmendedGuid,

--- a/services/minespace-web/src/components/modalContent/verifiableCredentials/IssuePermitDigitalCredential.tsx
+++ b/services/minespace-web/src/components/modalContent/verifiableCredentials/IssuePermitDigitalCredential.tsx
@@ -75,17 +75,16 @@ export const IssuePermitDigitalCredential: FC<IssuePermitDigitalCredentialProps>
   const content = {
     alertTitle: {
       noWallet:
-        "Your digital wallet needs to be set up before you can add this permit to your digital wallet.",
+        "Your digital wallet needs to be set up before you can add this credential to your digital wallet.",
       issueReady: `Issue Digital Credential for ${current_permittee}.`,
-      pending:
-        "The digital credential for this permit has already been offered to your digital wallet.",
+      pending: "This digital credential has already been offered.",
       active: "This digital credential has been accepted.",
     },
     alertMessage: {
       noWallet:
         "Digital wallets must be connected in order to send and receive digital credentials. Please establish a digital wallet connection by clicking on the 'Generate Digital Wallet Connection' button below.",
-      issueReady: `Receive your permit as a digital credential by clicking the button below. The digital credential will be offered from the Chief Permitting Officer of B.C. for you to review, accept, and store in the digital wallet of ${current_permittee}.`,
-      pending: `Please review and verify this digital credential in the digital wallet of ${current_permittee}. If all data is accurate, accept the credential for it to be stored in your digital wallet.`,
+      issueReady: `Receive your digital credential by clicking the button below. The digital credential will be offered from the Chief Permitting Officer of B.C. for you to review, accept, and store in the digital wallet of ${current_permittee}.`,
+      pending: `Please review this digital credential in the digital wallet of ${current_permittee}. If all data is accurate, accept the credential for it to be stored in your digital wallet.`,
       active: `Please review the details in the digital wallet of ${current_permittee}.`,
     },
     modalBody: {
@@ -105,7 +104,7 @@ export const IssuePermitDigitalCredential: FC<IssuePermitDigitalCredentialProps>
     },
     issueButton: {
       issueReady: `Issue Digital Credential for Permit ${permit_no}`,
-      pending: `Digital Credential for Permit ${permit_no} has been issued`,
+      pending: `Digital Credential for Permit ${permit_no} has been offered`,
       active: `Digital Credential for Permit ${permit_no} accepted`,
     },
     credentialStatusText: {

--- a/services/minespace-web/src/components/modalContent/verifiableCredentials/IssuePermitDigitalCredential.tsx
+++ b/services/minespace-web/src/components/modalContent/verifiableCredentials/IssuePermitDigitalCredential.tsx
@@ -76,7 +76,7 @@ export const IssuePermitDigitalCredential: FC<IssuePermitDigitalCredentialProps>
     alertTitle: {
       noWallet:
         "Your digital wallet needs to be set up before you can add this permit to your digital wallet.",
-      issueReady: "Option to Issue Permit as a Digital Credential.",
+      issueReady: `Issue Digital Credential for ${current_permittee}.`,
       pending:
         "The digital credential for this permit has already been offered to your digital wallet.",
       active: "This digital credential has been accepted.",
@@ -84,7 +84,7 @@ export const IssuePermitDigitalCredential: FC<IssuePermitDigitalCredentialProps>
     alertMessage: {
       noWallet:
         "Digital wallets must be connected in order to send and receive digital credentials. Please establish a digital wallet connection by clicking on the 'Generate Digital Wallet Connection' button below.",
-      issueReady: `Receive your permit as a digital credential by clicking the button below. A request will be sent to the Chief Permitting Officer of B.C. who will then issue your permit as a digital credential for you to review, accept, and store in the digital wallet of ${current_permittee}.`,
+      issueReady: `Receive your permit as a digital credential by clicking the button below. The digital credential will be offered from the Chief Permitting Officer of B.C. for you to review, accept, and store in the digital wallet of ${current_permittee}.`,
       pending: `Please review and verify this digital credential in the digital wallet of ${current_permittee}. If all data is accurate, accept the credential for it to be stored in your digital wallet.`,
       active: `Please review the details in the digital wallet of ${current_permittee}.`,
     },
@@ -93,10 +93,9 @@ export const IssuePermitDigitalCredential: FC<IssuePermitDigitalCredentialProps>
       issueReady: (
         <>
           <Typography.Paragraph>
-            By generating this request, you are requesting your permit to be sent as a digital
-            credential. Please monitor the digital wallet of {current_permittee} to review and
-            accept any incoming offers being sent from the Chief Permitting Officer of B.C.&apos;s
-            digital wallet.
+            By generating this request, you are requesting your digital credential. Please monitor
+            the digital wallet of {current_permittee} to review and accept any incoming offers from
+            the Chief Permitting Officer of B.C.&apos;s digital wallet.
           </Typography.Paragraph>
           <Typography.Paragraph strong>
             Click below to add permit {permit_no} to the digital wallet of {current_permittee}
@@ -105,9 +104,9 @@ export const IssuePermitDigitalCredential: FC<IssuePermitDigitalCredentialProps>
       ),
     },
     issueButton: {
-      issueReady: `Issue Digital Credential for permit ${permit_no}`,
-      pending: `Digital Credential for permit ${permit_no} has been issued`,
-      active: `Digital Credential for permit ${permit_no} accepted`,
+      issueReady: `Issue Digital Credential for Permit ${permit_no}`,
+      pending: `Digital Credential for Permit ${permit_no} has been issued`,
+      active: `Digital Credential for Permit ${permit_no} accepted`,
     },
     credentialStatusText: {
       pending: (


### PR DESCRIPTION
With the digital credential not being legally equivalent to the permit PDF, we need to remove language that implies they are. 
