### PR TITLE
[MDS-5562] add required data for revocation

### DIFF
--- a/migrations/sql/V2023.11.09.14.07__add_rev_reg_vc_columns.sql
+++ b/migrations/sql/V2023.11.09.14.07__add_rev_reg_vc_columns.sql
@@ -1,0 +1,5 @@
+ALTER TABLE party_verifiable_credential_mines_act_permit
+    ADD COLUMN IF NOT EXISTS rev_reg_id character varying(150); 
+
+ALTER TABLE party_verifiable_credential_mines_act_permit
+    ADD COLUMN IF NOT EXISTS cred_rev_id character varying(150); 

--- a/services/core-api/app/api/services/traction_service.py
+++ b/services/core-api/app/api/services/traction_service.py
@@ -69,7 +69,6 @@ class TractionService():
 
         payload = {
             "auto_issue": True,
-            "auto_remove": True,
             "comment": "VC to provide proof of a permit and some basic details",
             "connection_id": str(connection_id),
             "cred_def_id": Config.CRED_DEF_ID_MINES_ACT_PERMIT,

--- a/services/core-api/app/api/verifiable_credentials/models/credentials.py
+++ b/services/core-api/app/api/verifiable_credentials/models/credentials.py
@@ -12,7 +12,9 @@ class PartyVerifiableCredentialMinesActPermit(AuditMixin, Base):
     cred_exch_id = db.Column(db.String, primary_key=True)
     party_guid = db.Column(UUID(as_uuid=True), db.ForeignKey('party.party_guid'), nullable=False)
     permit_amendment_guid = db.Column(UUID(as_uuid=True), db.ForeignKey('permit_amendment.permit_amendment_guid'), nullable=False)
-    cred_exch_state =db.Column(db.String, nullable=True)
+    cred_exch_state = db.Column(db.String, nullable=True)
+    rev_reg_id = db.Column(db.String, nullable=True)
+    cred_rev_id = db.Column(db.String, nullable=True)
 
     def __repr__(self):
         return '<PartyVerifiableCredentialMinesActPermit cred_exch_id=%r, party_guid=%r, permit_amendment_id=%r>' % self.cred_exch_id, self.party_guid, self.permit_amendment_id

--- a/services/core-api/app/api/verifiable_credentials/resources/verifiable_credential_webhook.py
+++ b/services/core-api/app/api/verifiable_credentials/resources/verifiable_credential_webhook.py
@@ -43,9 +43,13 @@ class VerifiableCredentialWebhookResource(Resource, UserMixin):
             new_state = webhook_body["state"]
             if new_state != cred_exch_record.cred_exch_state:
                 cred_exch_record.cred_exch_state=new_state
+                if new_state == "credential_acked":
+                    current_app.logger.info(f"cred_acked, save revokation details {webhook_body}")
+                    cred_exch_record.rev_reg_id = webhook_body["rev_reg_id"]
+                    cred_exch_record.cred_rev_id = webhook_body["cred_rev_id"]
+
                 cred_exch_record.save()
                 current_app.logger.info(f"Updated cred_exch_record cred_exch_id={cred_exch_id} with state={new_state}")
-                # 'deleted' or 'credential_acked' should both be considered successful
         elif topic == PING:
                 current_app.logger.info(f"TrustPing received={request.get_json()}")
         else:


### PR DESCRIPTION
## Objective 

[MDS-5562](https://bcmines.atlassian.net/browse/MDS-5562)

This will not enable revocation, but it will ensure we have the right data to revoke any credential at a later date when we do have the functionality. Revocation could be done manually in the traction wallet, but this will be needed if we want to enable controls in minespace or MDS, and will work even if the credential exchange record in traction is deleted.

This may require a follow up, but this is the best way to test the webhook exchange between MDS and Traction. 