### PR TITLE
[MDS-5589] Adjustment to have same order in esup history and esup table

### DIFF
--- a/services/core-web/src/components/mine/ExplosivesPermit/MineExplosivesPermitTable.tsx
+++ b/services/core-web/src/components/mine/ExplosivesPermit/MineExplosivesPermitTable.tsx
@@ -605,7 +605,7 @@ const MineExplosivesPermitTable: FC<RouteComponentProps & MineExplosivesPermitTa
       title: "Amendment",
       key: "explosives_permit_amendment_id",
       render: (_, record, index) => {
-        const amendmentIndex = record.totalAmendments - index;
+        const amendmentIndex = record.totalAmendments - 1 - index;
         return <Typography.Text>{amendmentIndex}</Typography.Text>;
       },
     },

--- a/services/core-web/src/components/modalContent/ExplosivesPermitViewModal.tsx
+++ b/services/core-web/src/components/modalContent/ExplosivesPermitViewModal.tsx
@@ -140,7 +140,7 @@ export const ExplosivesPermitViewModal: FC<ExplosivesPermitViewModalProps> = (pr
 
     return permitHistory
       .map((amendment, index) => {
-        return { ...amendment, amendment_order: index + 1 };
+        return { ...amendment, amendment_order: index };
       })
       .reverse();
   };

--- a/services/core-web/src/components/modalContent/ExplosivesPermitViewModal.tsx
+++ b/services/core-web/src/components/modalContent/ExplosivesPermitViewModal.tsx
@@ -102,7 +102,9 @@ export const ExplosivesPermitViewModal: FC<ExplosivesPermitViewModalProps> = (pr
       title: "Amendment",
       key: "amendment_order",
       dataIndex: "amendment_order",
-      render: (text) => <div>{text}</div>,
+      render: (text) => {
+        return <div>{text}</div>;
+      },
     },
     {
       title: "",
@@ -133,12 +135,14 @@ export const ExplosivesPermitViewModal: FC<ExplosivesPermitViewModalProps> = (pr
   const transformPermitHistoryData = () => {
     const permitHistory: any[] = [
       permitAmendmentLike(parentPermit),
-      ...parentPermit.explosives_permit_amendments,
+      ...parentPermit?.explosives_permit_amendments?.sort(
+        (a, b) => a.explosives_permit_amendment_id - b.explosives_permit_amendment_id
+      ),
     ];
 
     return permitHistory
       .map((amendment, index) => {
-        return { ...amendment, amendment_order: index };
+        return { ...amendment, amendment_order: index + 1 };
       })
       .reverse();
   };

--- a/services/core-web/src/components/modalContent/ExplosivesPermitViewModal.tsx
+++ b/services/core-web/src/components/modalContent/ExplosivesPermitViewModal.tsx
@@ -102,9 +102,7 @@ export const ExplosivesPermitViewModal: FC<ExplosivesPermitViewModalProps> = (pr
       title: "Amendment",
       key: "amendment_order",
       dataIndex: "amendment_order",
-      render: (text) => {
-        return <div>{text}</div>;
-      },
+      render: (text) => <div>{text}</div>,
     },
     {
       title: "",


### PR DESCRIPTION
## Objective 

[MDS-5589](https://bcmines.atlassian.net/browse/MDS-5589)

- Change to make index and order the same between esup table and esup history table

![image](https://github.com/bcgov/mds/assets/127789479/f74dc8c9-93ff-44c8-b9a3-8a2d1dc4225c)
