### PR TITLE
[MDS-5437] Implement KeyCloak logging

### DIFF
--- a/services/core-api/app/config.py
+++ b/services/core-api/app/config.py
@@ -83,14 +83,14 @@ class Config(object):
                 'formatter': 'default',
             }
         },
+        'root': {
+            'level': FLASK_LOGGING_LEVEL,
+            'handlers': ['file', 'console']
+        },
         'loggers': {
-            '': {
-                'level': FLASK_LOGGING_LEVEL,
-                'handlers': ['file', 'console']
-            },
             'werkzeug': {
-                'level': 'ERROR',  # Set the level to ERROR to disable logging
-                'propagate': False  # Prevent the log messages from being propagated to the root logger
+                'level': 'CRITICAL',
+                'propagate': False
             }
         }
     }

--- a/services/core-api/app/config.py
+++ b/services/core-api/app/config.py
@@ -58,6 +58,10 @@ class Config(object):
     # Environment config
     FLASK_LOGGING_LEVEL = os.environ.get('FLASK_LOGGING_LEVEL',
                                          'INFO')                # ['DEBUG','INFO','WARN','ERROR','CRITICAL']
+    WERKZEUG_LOGGING_LEVEL = os.environ.get('WERKZEUG_LOGGING_LEVEL',
+                                         'CRITICAL')  # ['DEBUG','INFO','WARN','ERROR','CRITICAL']
+    DISPLAY_WERKZEUG_LOG = os.environ.get('DISPLAY_WERKZEUG_LOG',
+                                            False)
 
     LOGGING_DICT_CONFIG = {
         'version': 1,
@@ -89,8 +93,8 @@ class Config(object):
         },
         'loggers': {
             'werkzeug': {
-                'level': 'CRITICAL',
-                'propagate': False
+                'level': WERKZEUG_LOGGING_LEVEL,
+                'propagate': DISPLAY_WERKZEUG_LOG
             }
         }
     }

--- a/services/core-api/app/config.py
+++ b/services/core-api/app/config.py
@@ -83,9 +83,15 @@ class Config(object):
                 'formatter': 'default',
             }
         },
-        'root': {
-            'level': FLASK_LOGGING_LEVEL,
-            'handlers': ['file', 'console']
+        'loggers': {
+            '': {
+                'level': FLASK_LOGGING_LEVEL,
+                'handlers': ['file', 'console']
+            },
+            'werkzeug': {
+                'level': 'ERROR',  # Set the level to ERROR to disable logging
+                'propagate': False  # Prevent the log messages from being propagated to the root logger
+            }
         }
     }
 


### PR DESCRIPTION
## Objective 

[MDS-5437](https://bcmines.atlassian.net/browse/MDS-5437)

I have configured the **werkzeug** logger's logging level to **CRITICAL** and propagate to **False** in order to prevent the propagation of **INFO** logs. The **werkzeug** logger is the default logger responsible for displaying logs when the core-api is running in development, testing, and production environments. To replicate this logger locally, I added a new section to the LOGGING_DICT_CONFIG configuration setup and set the level attribute to **INFO** and the propagate attribute to True. 
I
This fix can only be tested after merging and testing it in the development environment.
