### PR TITLE
[MDS-5445] Minespace - include ESUPs on permit table

### DIFF
--- a/services/common/src/utils/featureFlag.ts
+++ b/services/common/src/utils/featureFlag.ts
@@ -10,6 +10,7 @@ export enum Feature {
   FLAGSMITH = "flagsmith",
   TSF_V2 = "tsf_v2",
   VERIFIABLE_CREDENTIALS = "verifiable_credentials",
+  MINESPACE_ESUPS = "minespace_esups",
 }
 
 export const initializeFlagsmith = async (flagsmithUrl, flagsmithKey) => {

--- a/services/core-web/src/components/common/CoreTableCommonColumns.tsx
+++ b/services/core-web/src/components/common/CoreTableCommonColumns.tsx
@@ -18,7 +18,11 @@ export const renderTextColumn = (
     title,
     dataIndex,
     key: dataIndex,
-    render: (text: string) => <div title={title}>{text ?? placeHolder}</div>,
+    render: (text: string) => (
+      <div title={title} className={`${dataIndex}-column`}>
+        {text ?? placeHolder}
+      </div>
+    ),
     ...(width !== undefined ? { width } : null),
     ...(sortable ? { sorter: nullableStringSorter(dataIndex) } : null),
   };

--- a/services/core-web/src/components/common/buttons/LinkButton.js
+++ b/services/core-web/src/components/common/buttons/LinkButton.js
@@ -5,8 +5,8 @@ const propTypes = {
   onClick: PropTypes.func.isRequired,
   tabIndex: PropTypes.number,
   style: PropTypes.objectOf(PropTypes.any),
-  // eslint-disable-next-line react/forbid-prop-types
   children: PropTypes.any,
+  title: PropTypes.string,
 };
 
 const defaultProps = {

--- a/services/minespace-web/src/components/common/CoreTableCommonColumns.tsx
+++ b/services/minespace-web/src/components/common/CoreTableCommonColumns.tsx
@@ -18,7 +18,11 @@ export const renderTextColumn = (
     title,
     dataIndex,
     key: dataIndex,
-    render: (text: string) => <div title={title}>{text ?? placeHolder}</div>,
+    render: (text: string) => (
+      <div title={title} className={`${dataIndex}-column`}>
+        {text ?? placeHolder}
+      </div>
+    ),
     ...(width !== undefined ? { width } : null),
     ...(sortable ? { sorter: nullableStringSorter(dataIndex) } : null),
   };

--- a/services/minespace-web/src/components/common/LinkButton.js
+++ b/services/minespace-web/src/components/common/LinkButton.js
@@ -4,9 +4,9 @@ import PropTypes from "prop-types";
 const propTypes = {
   onClick: PropTypes.func.isRequired,
   tabIndex: PropTypes.number,
-  // eslint-disable-next-line  react/forbid-prop-types
   children: PropTypes.any,
   disabled: PropTypes.bool,
+  title: PropTypes.string,
 };
 
 const defaultProps = {

--- a/services/minespace-web/src/components/dashboard/mine/permits/Permits.tsx
+++ b/services/minespace-web/src/components/dashboard/mine/permits/Permits.tsx
@@ -1,27 +1,33 @@
 import React, { FC, useEffect, useState } from "react";
 import { connect } from "react-redux";
 import { Row, Col, Typography, Button, Badge } from "antd";
-
 import { fetchPermits } from "@mds/common/redux/actionCreators/permitActionCreator";
+import { fetchExplosivesPermits } from "@mds/common/redux/actionCreators/explosivesPermitActionCreator";
 import { openModal } from "@mds/common/redux/actions/modalActions";
 import { getPermits } from "@mds/common/redux/selectors/permitSelectors";
+import { getExplosivesPermits } from "@mds/common/redux/selectors/explosivesPermitSelectors";
 import PermitsTable from "@/components/dashboard/mine/permits/PermitsTable";
-import { Feature, IMine, IPermit, VC_CONNECTION_STATES, isFeatureEnabled } from "@mds/common";
+import { Feature, IExplosivesPermit, IMine, IPermit, VC_CONNECTION_STATES, isFeatureEnabled } from "@mds/common";
 import { ActionCreator } from "@mds/common/interfaces/actionCreator";
 import modalConfig from "@/components/modalContent/config";
 
 interface PermitsProps {
   mine: IMine;
   permits: IPermit[];
+  explosivesPermits: IExplosivesPermit[];
   fetchPermits: ActionCreator<typeof fetchPermits>;
+  fetchExplosivesPermits: ActionCreator<typeof fetchExplosivesPermits>;
   openModal: (payload) => any;
 }
-export const Permits: FC<PermitsProps> = ({ mine, permits, ...props }) => {
+export const Permits: FC<PermitsProps> = ({ mine, permits, explosivesPermits, ...props }) => {
   const [isLoaded, setIsLoaded] = useState<boolean>(false);
 
   useEffect(() => {
     if (!isLoaded) {
-      props.fetchPermits(mine.mine_guid).then(() => {
+      Promise.all([
+        props.fetchPermits(mine.mine_guid),
+        props.fetchExplosivesPermits(mine.mine_guid),
+      ]).then(() => {
         setIsLoaded(true);
       });
     }
@@ -162,10 +168,12 @@ export const Permits: FC<PermitsProps> = ({ mine, permits, ...props }) => {
 
 const mapStateToProps = (state) => ({
   permits: getPermits(state),
+  explosivesPermits: getExplosivesPermits(state),
 });
 
 const mapDispatchToProps = {
   fetchPermits,
+  fetchExplosivesPermits,
   openModal,
 };
 

--- a/services/minespace-web/src/components/dashboard/mine/permits/Permits.tsx
+++ b/services/minespace-web/src/components/dashboard/mine/permits/Permits.tsx
@@ -144,10 +144,12 @@ export const Permits: FC<PermitsProps> = ({ mine, permits, explosivesPermits, ..
         <Typography.Title level={4}>Permits</Typography.Title>
 
         <Typography.Paragraph>
-          The below table displays all of the permit applications associated with this mine.
+          The below table displays all of the <strong>permit applications</strong> associated with
+          this mine.
           {mine.major_mine_ind && isFeatureEnabled(Feature.VERIFIABLE_CREDENTIALS) && (
             <>
               <Typography.Text>
+                {" "}
                 Major mines operators in B.C. can now use digital credentials to prove that they
                 hold a valid Mines Act Permit from the Government of B.C.
               </Typography.Text>
@@ -158,6 +160,7 @@ export const Permits: FC<PermitsProps> = ({ mine, permits, explosivesPermits, ..
         <PermitsTable
           isLoaded={isLoaded}
           permits={permits}
+          explosivesPermits={explosivesPermits}
           majorMineInd={mine.major_mine_ind}
           openVCWalletInvitationModal={openVCWalletInvitationModal}
         />

--- a/services/minespace-web/src/components/dashboard/mine/permits/PermitsTable.tsx
+++ b/services/minespace-web/src/components/dashboard/mine/permits/PermitsTable.tsx
@@ -210,7 +210,13 @@ export const PermitsTable: FC<PermitsTableProps> = (props) => {
 
   const esupRowData = props.explosivesPermits.map((esup) => transformEsupData(esup));
   const permitRowData = props.permits.map((permit) => transformRowData(permit));
-  const rowData = [...esupRowData, ...permitRowData];
+
+  let rowData: any[];
+  if (isFeatureEnabled(Feature.MINESPACE_ESUPS)) {
+    rowData = [...esupRowData, ...permitRowData];
+  } else {
+    rowData = permitRowData;
+  }
 
   const expandedColumns = [
     renderTextColumn("amendmentNumber", "Amendment No."),

--- a/services/minespace-web/src/components/dashboard/mine/permits/PermitsTable.tsx
+++ b/services/minespace-web/src/components/dashboard/mine/permits/PermitsTable.tsx
@@ -29,6 +29,11 @@ import { SortOrder } from "antd/lib/table/interface";
 
 const draftAmendment = "DFT";
 
+const permitTypes = {
+  ESUP: "Explosive Storage and Use",
+  Permit: "Mines Act Permit",
+};
+
 interface PermitsTableProps {
   isLoaded: boolean;
   permits: IPermit[];
@@ -104,7 +109,14 @@ export const PermitsTable: FC<PermitsTableProps> = (props) => {
         clickFunction: openIssuanceModal,
       },
     ];
-    const actionColumn = renderActionsColumn(actions);
+
+    const filterActions = (record, actionList) => {
+      if (record.permit_type !== permitTypes.Permit) {
+        return actionList.filter((a) => a.key !== "vc_issue");
+      }
+      return actionList;
+    };
+    const actionColumn = renderActionsColumn(actions, filterActions);
     columns.splice(3, 0, issuanceStateColumn);
     columns.push(actionColumn);
   }
@@ -140,7 +152,7 @@ export const PermitsTable: FC<PermitsTableProps> = (props) => {
     return {
       ...permit,
       key: permit.permit_guid,
-      permit_type: "Mines Act Permit",
+      permit_type: permitTypes.Permit,
       majorMineInd: props.majorMineInd,
       authorization_end_date: latestAmendment?.authorization_end_date,
       firstIssued: firstAmendment?.issue_date,
@@ -167,7 +179,7 @@ export const PermitsTable: FC<PermitsTableProps> = (props) => {
         description: amendment.description,
         authorization_end_date: amendment.expiry_date,
         related_documents: amendment.documents,
-        permit_type: "Explosive Storage and Use",
+        permit_type: permitTypes.ESUP,
       };
     };
 

--- a/services/minespace-web/src/components/dashboard/mine/permits/PermitsTable.tsx
+++ b/services/minespace-web/src/components/dashboard/mine/permits/PermitsTable.tsx
@@ -25,6 +25,7 @@ import {
   renderTextColumn,
 } from "@/components/common/CoreTableCommonColumns";
 import IssuePermitDigitalCredential from "@/components/modalContent/verifiableCredentials/IssuePermitDigitalCredential";
+import { SortOrder } from "antd/lib/table/interface";
 
 const draftAmendment = "DFT";
 
@@ -50,7 +51,10 @@ export const PermitsTable: FC<PermitsTableProps> = (props) => {
     renderCategoryColumn("permit_status_code", "Permit Status", { C: "Closed", O: "Open" }, true),
     renderDateColumn("authorization_end_date", "Authorization End Date", true),
     renderDateColumn("firstIssued", "First Issued", true),
-    renderDateColumn("lastAmended", "Last Amended", true),
+    {
+      ...renderDateColumn("lastAmended", "Last Amended", true),
+      defaultSortOrder: "descend" as SortOrder,
+    },
   ];
 
   if (
@@ -135,6 +139,7 @@ export const PermitsTable: FC<PermitsTableProps> = (props) => {
 
     return {
       ...permit,
+      key: permit.permit_guid,
       permit_type: "Mines Act Permit",
       majorMineInd: props.majorMineInd,
       authorization_end_date: latestAmendment?.authorization_end_date,
@@ -155,7 +160,7 @@ export const PermitsTable: FC<PermitsTableProps> = (props) => {
     ) => {
       return {
         permit_no: amendment.permit_number,
-        amendmentNumber: index + 1, //amendment.explosives_permit_amendment_id ?? 'first', //index + 1,
+        amendmentNumber: index + 1,
         current_permittee: amendment.permittee_name,
         permit_status_code: amendment.is_closed ? "C" : "O",
         issue_date: amendment.issue_date,
@@ -183,6 +188,7 @@ export const PermitsTable: FC<PermitsTableProps> = (props) => {
 
     return {
       ...firstAmendment,
+      key: esup.explosives_permit_guid,
       permit_status_code: isClosed ? "C" : "O",
       firstIssued: esup.issue_date,
       lastAmended: lastAmended,
@@ -248,7 +254,6 @@ export const PermitsTable: FC<PermitsTableProps> = (props) => {
       loading={!props.isLoaded}
       columns={columns}
       dataSource={rowData}
-      rowKey="permit_no"
       emptyText="This mine has no permit data."
       expandProps={{
         getDataSource: (record) => record.permit_amendments,

--- a/services/minespace-web/src/styles/components/PermitsTable.scss
+++ b/services/minespace-web/src/styles/components/PermitsTable.scss
@@ -1,0 +1,4 @@
+.description-column {
+    text-wrap: wrap;
+    max-width: "300px";
+}

--- a/services/minespace-web/src/styles/index.scss
+++ b/services/minespace-web/src/styles/index.scss
@@ -37,6 +37,7 @@
 @import "./components/Incidents.scss";
 @import "./components/FileReplace.scss";
 @import "./components/DocumentTableWithExpandedRows.scss";
+@import "./components/PermitsTable.scss";
 
 // UTILITIES - utilities and helper classes. This layer has the highest specificity.
 @import "./generic/helpers.scss";


### PR DESCRIPTION
## Objective 
- include ESUPs on the permits table on Minespace

### Notes
- did not allow issue VC on ESUPs
- changes from mockups on columns
   - will get approval before merging
- did not filter out ESUP applications from table
   - the plan is to put them there eventually I believe
   - on prod, only a handful of records are applications (have no permit number, issue date, application_status != "APP(roved)"

[MDS-5445](https://bcmines.atlassian.net/browse/MDS-5445)

_Why are you making this change? Provide a short explanation and/or screenshots_
