### PR TITLE
[MDS-5437] keycloak access log fix

### DIFF
--- a/services/core-api/app/__init__.py
+++ b/services/core-api/app/__init__.py
@@ -64,9 +64,10 @@ def create_app(test_config=None):
         # Get request information
         method = request.method
         path = request.path
+        ip_address = request.remote_addr
 
         # Log combined request and response information
-        current_app.logger.info(f"Received {method} request to {path} | Response status code: {response.status_code}")
+        current_app.logger.info(f"Received {method} request to {path} from {ip_address} | Response status code: {response.status_code}")
 
         return response
 

--- a/services/core-api/app/__init__.py
+++ b/services/core-api/app/__init__.py
@@ -9,6 +9,8 @@ from flask_cors import CORS
 from flask_restplus import Resource, apidoc
 from opentelemetry.instrumentation.flask import FlaskInstrumentor
 from sqlalchemy.exc import SQLAlchemyError
+
+from app.date_time_helper import get_formatted_current_time
 from app.flask_jwt_oidc_local.exceptions import AuthError
 from werkzeug.exceptions import Forbidden
 import traceback
@@ -65,9 +67,10 @@ def create_app(test_config=None):
         method = request.method
         path = request.path
         ip_address = request.remote_addr
+        http_version = request.environ.get('SERVER_PROTOCOL', 'HTTP/1.1')
 
         # Log combined request and response information
-        current_app.logger.info(f"Received {method} request to {path} from {ip_address} | Response status code: {response.status_code}")
+        current_app.logger.info(f'{ip_address} - - [{get_formatted_current_time()}] "{method} {path} {http_version}" {response.status_code} -')
 
         return response
 

--- a/services/core-api/app/__init__.py
+++ b/services/core-api/app/__init__.py
@@ -8,7 +8,6 @@ from flask import Flask, request, current_app
 from flask_cors import CORS
 from flask_restplus import Resource, apidoc
 from opentelemetry.instrumentation.flask import FlaskInstrumentor
-from opentelemetry.instrumentation.logging import LoggingInstrumentor
 from sqlalchemy.exc import SQLAlchemyError
 from app.flask_jwt_oidc_local.exceptions import AuthError
 from werkzeug.exceptions import Forbidden
@@ -59,6 +58,17 @@ def create_app(test_config=None):
     trace.set_tracer_provider(TracerProvider())
 
     FlaskInstrumentor().instrument_app(app)
+
+    @app.after_request
+    def log_response_info(response):
+        # Get request information
+        method = request.method
+        path = request.path
+
+        # Log combined request and response information
+        current_app.logger.info(f"Received {method} request to {path} | Response status code: {response.status_code}")
+
+        return response
 
     if test_config is None:
         # load the instance config, if it exists, when not testing

--- a/services/core-api/app/config.py
+++ b/services/core-api/app/config.py
@@ -59,7 +59,7 @@ class Config(object):
     FLASK_LOGGING_LEVEL = os.environ.get('FLASK_LOGGING_LEVEL',
                                          'INFO')                # ['DEBUG','INFO','WARN','ERROR','CRITICAL']
     WERKZEUG_LOGGING_LEVEL = os.environ.get('WERKZEUG_LOGGING_LEVEL',
-                                         'INFO')  # ['DEBUG','INFO','WARN','ERROR','CRITICAL']
+                                         'CRITICAL')  # ['DEBUG','INFO','WARN','ERROR','CRITICAL']
     DISPLAY_WERKZEUG_LOG = os.environ.get('DISPLAY_WERKZEUG_LOG',
                                             True)
 

--- a/services/core-api/app/config.py
+++ b/services/core-api/app/config.py
@@ -25,8 +25,8 @@ class CustomFormatter(logging.Formatter):
                     if getJwtManager().audience:
                         return getJwtManager().audience
             except Exception as e:
-                # Handle the exception here (e.g., log it)
-                print(f"An error occurred: {e}")
+                # The exception is caught, but no error message is printed or logged
+                pass
 
             return None
 

--- a/services/core-api/app/config.py
+++ b/services/core-api/app/config.py
@@ -61,7 +61,7 @@ class Config(object):
     WERKZEUG_LOGGING_LEVEL = os.environ.get('WERKZEUG_LOGGING_LEVEL',
                                          'INFO')  # ['DEBUG','INFO','WARN','ERROR','CRITICAL']
     DISPLAY_WERKZEUG_LOG = os.environ.get('DISPLAY_WERKZEUG_LOG',
-                                            False)
+                                            True)
 
     LOGGING_DICT_CONFIG = {
         'version': 1,

--- a/services/core-api/app/config.py
+++ b/services/core-api/app/config.py
@@ -61,7 +61,7 @@ class Config(object):
     WERKZEUG_LOGGING_LEVEL = os.environ.get('WERKZEUG_LOGGING_LEVEL',
                                          'INFO')  # ['DEBUG','INFO','WARN','ERROR','CRITICAL']
     DISPLAY_WERKZEUG_LOG = os.environ.get('DISPLAY_WERKZEUG_LOG',
-                                            True)
+                                            False)
 
     LOGGING_DICT_CONFIG = {
         'version': 1,

--- a/services/core-api/app/config.py
+++ b/services/core-api/app/config.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import traceback
 
 from dotenv import load_dotenv, find_dotenv
 from celery.schedules import crontab
@@ -22,11 +23,16 @@ class CustomFormatter(logging.Formatter):
                 # Check if the request is a valid HTTP request
                 if current_app and hasattr(current_app, 'extensions'):
                     from app.extensions import getJwtManager
-                    if getJwtManager().audience:
-                        return getJwtManager().audience
+                    from flask import request
+
+                    # Check if the request has a bearer token
+                    bearer_token = request.headers.get('Authorization')
+                    if bearer_token and bearer_token.startswith('Bearer '):
+                        if getJwtManager().audience:
+                            return getJwtManager().audience
             except Exception as e:
-                # The exception is caught, but no error message is printed or logged
-                pass
+                #print error only when there is a major error with implementation of getJwtManager()
+                print(traceback.format_exc())
 
             return None
 

--- a/services/core-api/app/date_time_helper.py
+++ b/services/core-api/app/date_time_helper.py
@@ -1,5 +1,8 @@
 from dateutil.relativedelta import relativedelta
+from datetime import datetime
 
+def get_formatted_current_time():
+    return datetime.now().strftime("%d/%b/%Y %H:%M:%S")
 
 def get_duration_text(start_date, end_date):
     def get_duration_text_or_default(duration, unit):


### PR DESCRIPTION
## Objective 

[MDS-5437](https://bcmines.atlassian.net/browse/MDS-5437)

- Improvised a way to display and format access logs similar to the way werkzeug logger works. This was done to be able to add traceid and client to the logs displayed. For some reason this is not possible (getting traceid and client information) with werkzeug logger.
- Set the werkzeug access logger level to CRITICAL.
- Removed the print error message that was getting displayed.

Sample screenshot of how the access logs now look.

![image](https://github.com/bcgov/mds/assets/72251620/c3f8a9d7-b11e-455a-9c34-9870419befe3)


