### PR TITLE
[MDS-5620] NoW Signatures fix aspect ratio

### DIFF
--- a/services/core-api/app/api/mines/explosives_permit/models/explosives_permit_document_type.py
+++ b/services/core-api/app/api/mines/explosives_permit/models/explosives_permit_document_type.py
@@ -1,15 +1,10 @@
-import base64
-from io import BytesIO
-
-from PIL import Image
-from flask import current_app
 from sqlalchemy.schema import FetchedValue
 
-from app.extensions import db
-from app.api.utils.models_mixins import AuditMixin, Base
-from app.api.parties.party.models.party import Party
-from app.api.parties.party_appt.models.mine_party_appt import MinePartyAppointment
 from app.api.document_generation.models.document_template import format_letter_date
+from app.api.parties.party.models.party import Party
+from app.api.utils.helpers import create_image_with_aspect_ratio
+from app.api.utils.models_mixins import AuditMixin, Base
+from app.extensions import db
 
 PERMIT_SIGNATURE_IMAGE_HEIGHT_INCHES = 0.8
 LETTER_SIGNATURE_IMAGE_HEIGHT_INCHES = 0.8
@@ -50,30 +45,6 @@ class ExplosivesPermitDocumentType(AuditMixin, Base):
                 raise Exception('No Issuing Inspector has been assigned')
             if not explosives_permit.issuing_inspector.signature:
                 raise Exception('No signature for the Issuing Inspector has been provided')
-
-        def create_image(source, width=None, height=None):
-
-            # If there is a prefix in the source, remove it
-            base64_source = source
-            if ';base64,' in base64_source:
-                prefix, base64_source = base64_source.split(';base64,', 1)
-
-            # Convert base64 string to PIL Image to get dimensions
-            img_data = base64.b64decode(base64_source)
-            img = Image.open(BytesIO(img_data))
-
-            # Use aspect ratio of image to calculate width if not provided
-            if height and not width:
-                aspect_ratio = img.width / img.height
-                # Convert height from inches to pixels (Word assumes 96 DPI)
-                height_in_pixels = height * 96
-
-                # Calculate width while maintaining aspect ratio
-                width = height_in_pixels * aspect_ratio
-                # Convert width from pixels back to inches
-                width = width / 96
-
-            return {'source': source, 'width': width, 'height': height}
 
         is_draft = template_data.get('is_draft', True)
         template_data['is_draft'] = is_draft
@@ -149,7 +120,7 @@ class ExplosivesPermitDocumentType(AuditMixin, Base):
 
             if 'amendment_count' in template_data:
                 amendment_info = self.get_amendment_info(template_data['amendment_count'],
-                                                                              issue_date)
+                                                         issue_date)
                 template_data['amendment'] = amendment_info['amendment']
 
             def transform_magazines(magazines):
@@ -201,8 +172,8 @@ class ExplosivesPermitDocumentType(AuditMixin, Base):
             if not is_draft:
                 template_data['images'] = {
                     'issuing_inspector_signature':
-                    create_image(
-                        issuing_inspector.signature, height=PERMIT_SIGNATURE_IMAGE_HEIGHT_INCHES)
+                        create_image_with_aspect_ratio(
+                            issuing_inspector.signature, height=PERMIT_SIGNATURE_IMAGE_HEIGHT_INCHES)
                 }
 
             return template_data
@@ -219,8 +190,8 @@ class ExplosivesPermitDocumentType(AuditMixin, Base):
             if not is_draft:
                 template_data['images'] = {
                     'issuing_inspector_signature':
-                    create_image(
-                        issuing_inspector.signature, height=LETTER_SIGNATURE_IMAGE_HEIGHT_INCHES)
+                        create_image_with_aspect_ratio(
+                            issuing_inspector.signature, height=LETTER_SIGNATURE_IMAGE_HEIGHT_INCHES)
                 }
 
             return template_data
@@ -247,6 +218,7 @@ class ExplosivesPermitDocumentType(AuditMixin, Base):
     def get_amendment_info(self, amendment_count, issue_date):
         amendment_info_payload = {}
         amendment_info_payload['amendment'] = f'Amendment {amendment_count}'
-        amendment_info_payload['amendment_with_date'] = f'(Amendment {amendment_count}) issued {format_letter_date(issue_date)}'
+        amendment_info_payload[
+            'amendment_with_date'] = f'(Amendment {amendment_count}) issued {format_letter_date(issue_date)}'
 
         return amendment_info_payload

--- a/services/core-api/app/api/now_applications/models/now_application_document_type.py
+++ b/services/core-api/app/api/now_applications/models/now_application_document_type.py
@@ -1,7 +1,7 @@
 import re
 from sqlalchemy.schema import FetchedValue
 from flask_restplus import marshal
-from app.api.utils.helpers import format_datetime_to_string, format_currency
+from app.api.utils.helpers import format_datetime_to_string, format_currency, create_image_with_aspect_ratio
 
 from app.extensions import db
 from app.api.utils.models_mixins import AuditMixin, Base
@@ -145,9 +145,6 @@ class NOWApplicationDocumentType(AuditMixin, Base):
                                                 'reclamation_cost', True),
             }
 
-        def create_image(source, width=None, height=None):
-            return {'source': source, 'width': width, 'height': height}
-
         def validate_issuing_inspector(now_application):
             if not now_application.issuing_inspector:
                 raise Exception('No Issuing Inspector has been assigned')
@@ -188,7 +185,7 @@ class NOWApplicationDocumentType(AuditMixin, Base):
             if not is_draft:
                 template_data['images'] = {
                     'issuing_inspector_signature':
-                    create_image(
+                    create_image_with_aspect_ratio(
                         now_application.issuing_inspector.signature,
                         height=SIGNATURE_IMAGE_HEIGHT_INCHES)
                 }
@@ -248,7 +245,7 @@ class NOWApplicationDocumentType(AuditMixin, Base):
 
             template_data['images'] = {
                 'issuing_inspector_signature':
-                create_image(
+                create_image_with_aspect_ratio(
                     now_application.issuing_inspector.signature,
                     height=SIGNATURE_IMAGE_HEIGHT_INCHES)
             }

--- a/services/core-api/app/api/utils/helpers.py
+++ b/services/core-api/app/api/utils/helpers.py
@@ -1,6 +1,10 @@
+import base64
+from io import BytesIO
 import re
 from datetime import datetime
 from pytz import timezone, utc
+from PIL import Image
+from flask import current_app
 
 
 def clean_HTML_string(raw_html):
@@ -45,3 +49,33 @@ def get_preamble_text(description):
            f"Reclamation Program, including the deposit of reclamation securities. Nothing in this permit limits the authority of "\
            f"other government agencies to set additional requirements or to act independently under their respective authorizations "\
            f"and legislation."
+
+def create_image_with_aspect_ratio(source, width=None, height=None):
+
+    # If there is a prefix in the source, remove it
+    base64_source = source
+    if ';base64,' in base64_source:
+        prefix, base64_source = base64_source.split(';base64,', 1)
+
+    # Pad base64_source if it's not correctly padded
+    missing_padding = len(base64_source) % 4
+    if missing_padding:
+        current_app.logger.debug('Padding base64 string with {} ='.format(missing_padding))
+        base64_source += '=' * (4 - missing_padding)
+
+    # Convert base64 string to PIL Image to get dimensions
+    img_data = base64.b64decode(base64_source)
+    img = Image.open(BytesIO(img_data))
+
+    # Use aspect ratio of image to calculate width if not provided
+    if height and not width:
+        aspect_ratio = img.width / img.height
+        # Convert height from inches to pixels (Word assumes 96 DPI)
+        height_in_pixels = height * 96
+
+        # Calculate width while maintaining aspect ratio
+        width = height_in_pixels * aspect_ratio
+        # Convert width from pixels back to inches
+        width = width / 96
+
+    return {'source': source, 'width': width, 'height': height}

--- a/services/core-api/tests/now_applications/resources/test_now_application_document_type_resource.py
+++ b/services/core-api/tests/now_applications/resources/test_now_application_document_type_resource.py
@@ -78,7 +78,7 @@ class TestGetNOWApplicationDocumentTypeResource:
         """Should return the a token for successful generation"""
         now_application = NOWApplicationFactory()
         now_application_identity = NOWApplicationIdentityFactory(now_application=now_application)
-        now_application.issuing_inspector.signature = 'data:image/png;base64,'
+        now_application.issuing_inspector.signature = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNgYAAAAAMAASsJTYQAAAAASUVORK5CYII="
 
         data = {
             'now_application_guid': now_application_identity.now_application_guid,
@@ -99,7 +99,7 @@ class TestGetNOWApplicationDocumentTypeResource:
         """Should return the a token for successful generation"""
         now_application = NOWApplicationFactory()
         now_application_identity = NOWApplicationIdentityFactory(now_application=now_application)
-        now_application.issuing_inspector.signature = 'data:image/png;base64,'
+        now_application.issuing_inspector.signature = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNgYAAAAAMAASsJTYQAAAAASUVORK5CYII="
 
         changed_mine_no = str(now_application_identity.mine.mine_no + '1')
         data = {


### PR DESCRIPTION
Moved the create_image function to properly capture the aspect ratio of an image into the utils/helpers file and utilized it in creating the image for now document signatures

## Objective 

[MDS-5620](https://bcmines.atlassian.net/browse/MDS-5620)

