### PR TITLE
[FIX] - Allow DB writes without JWT Authentication

### DIFF
--- a/services/core-api/app/__init__.py
+++ b/services/core-api/app/__init__.py
@@ -188,10 +188,7 @@ def register_routes(app):
     root_api_namespace.add_namespace(notice_of_departure_api)
     root_api_namespace.add_namespace(activity_api)
     root_api_namespace.add_namespace(dams_api)
-    # THIS DOES NOT WORK AS EXPECTED, AND ONLY CHECKS FEATURE FLAG ON APP START
-    # POD RESTART IS REQUIRED FOR FEATURE FLAG CHANGE TO TAKE EFFECT
-    if is_feature_enabled(Feature.TRACTION_VERIFIABLE_CREDENTIALS):
-        root_api_namespace.add_namespace(verifiable_credential_api)
+    root_api_namespace.add_namespace(verifiable_credential_api)
 
     @root_api_namespace.route('/version/')
     class VersionCheck(Resource):

--- a/services/core-api/app/api/utils/include/user_info.py
+++ b/services/core-api/app/api/utils/include/user_info.py
@@ -1,6 +1,6 @@
 from app.extensions import jwt
 from jose import jwt as jwt_jose
-from flask import has_request_context
+from flask import has_request_context, request
 
 VALID_REALM = ['idir']
 
@@ -37,7 +37,7 @@ class User:
             return raw_info['preferred_username'].lower()
 
     def get_user_username(self):
-        if has_request_context():
+        if has_request_context() and "authorization" in request.headers:
 
             raw_info = self.get_user_raw_info()
             realms = list(set(VALID_REALM) & set(raw_info.get('client_roles') or []))

--- a/services/core-api/app/api/verifiable_credentials/resources/verifiable_credential.py
+++ b/services/core-api/app/api/verifiable_credentials/resources/verifiable_credential.py
@@ -7,7 +7,7 @@ from app.api.utils.resources_mixins import UserMixin
 from app.api.services.traction_service import TractionService
 
 class VerifiableCredentialResource(Resource, UserMixin):
-    @api.doc(description='', params={})
+    @api.doc(description='test authorization with traction', params={})
     @requires_any_of([VIEW_ALL, MINESPACE_PROPONENT])
     def get(self):
         traction_svc=TractionService()

--- a/services/core-api/app/api/verifiable_credentials/resources/verifiable_credential_connections.py
+++ b/services/core-api/app/api/verifiable_credentials/resources/verifiable_credential_connections.py
@@ -1,6 +1,6 @@
 from flask import current_app
 from flask_restplus import Resource
-from werkzeug.exceptions import NotFound
+from werkzeug.exceptions import NotFound, NotImplemented
 from app.extensions import api
 from app.api.utils.access_decorators import requires_any_of, EDIT_PARTY, MINESPACE_PROPONENT
 
@@ -9,19 +9,18 @@ from app.api.verifiable_credentials.models.connection import PartyVerifiableCred
 from app.api.services.traction_service import TractionService
 from app.api.verifiable_credentials.response_models import PARTY_VERIFIABLE_CREDENTIAL_CONNECTION
 from app.api.utils.resources_mixins import UserMixin
+from app.api.utils.feature_flag import Feature, is_feature_enabled
 
 class VerifiableCredentialConnectionResource(Resource, UserMixin):
     @api.doc(description='Create a connection invitation for a party by guid', params={})
     @requires_any_of([EDIT_PARTY, MINESPACE_PROPONENT])
     def post(self, party_guid: str):
-        #mine_guid will be param. just easy this way for development
+        if not is_feature_enabled(Feature.TRACTION_VERIFIABLE_CREDENTIALS):
+            raise NotImplemented()
         party = Party.find_by_party_guid(party_guid)
         if not party:
             raise NotFound(f"party not found with party_guid {party_guid}")
         
-        #TODO Validate the party is an organization? 
-        #TODO Validate the party is related to orgbook entity?
-
         traction_svc=TractionService()
         invitation = traction_svc.create_oob_connection_invitation(party)
         
@@ -32,6 +31,8 @@ class VerifiableCredentialConnectionResource(Resource, UserMixin):
     @requires_any_of([EDIT_PARTY, MINESPACE_PROPONENT])
     @api.marshal_with(PARTY_VERIFIABLE_CREDENTIAL_CONNECTION, code=200, envelope='records')
     def get(self, party_guid: str):
+        if not is_feature_enabled(Feature.TRACTION_VERIFIABLE_CREDENTIALS):
+            raise NotImplemented()
         party_vc_conn = PartyVerifiableCredentialConnection.find_by_party_guid(party_guid=party_guid)
         return party_vc_conn
  

--- a/services/core-api/app/api/verifiable_credentials/resources/verifiable_credential_map.py
+++ b/services/core-api/app/api/verifiable_credentials/resources/verifiable_credential_map.py
@@ -12,6 +12,7 @@ from app.api.verifiable_credentials.models.credentials import PartyVerifiableCre
 from app.api.services.traction_service import TractionService
 from app.api.utils.resources_mixins import UserMixin
 from app.api.utils.access_decorators import requires_any_of, MINESPACE_PROPONENT, EDIT_PARTY
+from app.api.utils.feature_flag import Feature, is_feature_enabled
 
 
 
@@ -29,6 +30,8 @@ class VerifiableCredentialMinesActPermitResource(Resource, UserMixin):
     @api.doc(description="Create a connection invitation for a party by guid", params={"party_guid":"guid for party with wallet connection","permit_amendment_guid":"parmit_amendment that will be offered as a credential to the indicated party"})
     @requires_any_of([EDIT_PARTY, MINESPACE_PROPONENT])
     def post(self):
+        if not is_feature_enabled(Feature.TRACTION_VERIFIABLE_CREDENTIALS):
+            raise NotImplemented()
         data = self.parser.parse_args()
         current_app.logger.warning(data)
         party_guid = data["party_guid"]

--- a/services/core-api/app/api/verifiable_credentials/resources/verifiable_credential_webhook.py
+++ b/services/core-api/app/api/verifiable_credentials/resources/verifiable_credential_webhook.py
@@ -25,7 +25,6 @@ class VerifiableCredentialWebhookResource(Resource, UserMixin):
         if request.headers.get("x-api-key") != Config.TRACTION_WEBHOOK_X_API_KEY:
              return Forbidden("bad x-api-key")
 
-        User._test_mode = True  #webhook handling has no row level auth
         webhook_body = request.get_json()
         current_app.logger.debug(f"TRACTION WEBHOOK <topic={topic}>: {webhook_body}")
         current_app.logger.debug(f"TRACTION WEBHOOK request.__dict__ {request.__dict__}")

--- a/services/core-api/app/api/verifiable_credentials/resources/verifiable_credential_webhook.py
+++ b/services/core-api/app/api/verifiable_credentials/resources/verifiable_credential_webhook.py
@@ -12,6 +12,8 @@ from app.api.services.traction_service import TractionService
 from app.api.verifiable_credentials.models.connection import PartyVerifiableCredentialConnection
 from app.api.verifiable_credentials.models.credentials import PartyVerifiableCredentialMinesActPermit
 
+from app.api.utils.feature_flag import Feature, is_feature_enabled
+
 PRESENT_PROOF = "present_proof"
 CONNECTIONS = "connections"
 CREDENTIAL_OFFER = "issue_credential"
@@ -21,13 +23,15 @@ PING = "ping"
 class VerifiableCredentialWebhookResource(Resource, UserMixin):
     @api.doc(description='Endpoint to recieve webhooks from Traction.', params={})
     def post(self, topic):
+        if not is_feature_enabled(Feature.TRACTION_VERIFIABLE_CREDENTIALS):
+            raise NotImplemented()
+        
         #custom auth for traction
         if request.headers.get("x-api-key") != Config.TRACTION_WEBHOOK_X_API_KEY:
              return Forbidden("bad x-api-key")
 
         webhook_body = request.get_json()
         current_app.logger.debug(f"TRACTION WEBHOOK <topic={topic}>: {webhook_body}")
-        current_app.logger.debug(f"TRACTION WEBHOOK request.__dict__ {request.__dict__}")
         if topic == CONNECTIONS:
             invitation_id = webhook_body['invitation_msg_id']
             vc_conn = PartyVerifiableCredentialConnection.query.unbound_unsafe().filter_by(invitation_id=invitation_id).first()


### PR DESCRIPTION
authorization should be handled well before this. this is to allow non-OIDC JWT's to write to the db if needed. Specifically verifiable credential webhook handler to receive calls from Traction

## Objective 

core-api needs to receive webhooks calls from traction and make database changes. 

If the request handling is reading for a username, but there is no `authorization` don't crash use the string `system` instead.

more feature flagging from namespace registration on app startup, to request time checks. 
