### PR TITLE
[MDS-5664] Fix ESUPs amendment number

### DIFF
--- a/services/core-api/app/api/mines/explosives_permit/models/explosives_permit_document_type.py
+++ b/services/core-api/app/api/mines/explosives_permit/models/explosives_permit_document_type.py
@@ -118,8 +118,8 @@ class ExplosivesPermitDocumentType(AuditMixin, Base):
             template_data['issue_date'] = format_letter_date(issue_date)
             template_data['expiry_date'] = format_letter_date(expiry_date)
 
-            if 'amendment_count' in template_data:
-                amendment_info = self.get_amendment_info(template_data['amendment_count'],
+            if 'amendment_no' in template_data:
+                amendment_info = self.get_amendment_info(template_data['amendment_no'],
                                                          issue_date)
                 template_data['amendment'] = amendment_info['amendment']
 
@@ -182,8 +182,8 @@ class ExplosivesPermitDocumentType(AuditMixin, Base):
         def transform_letter(template_data, explosives_permit):
             template_data['letter_date'] = format_letter_date(template_data['letter_date'])
 
-            if 'amendment_count' in template_data:
-                amendment_info = self.get_amendment_info(template_data['amendment_count'],
+            if 'amendment_no' in template_data:
+                amendment_info = self.get_amendment_info(template_data['amendment_no'],
                                                          template_data['issue_date'])
                 template_data['amendment_with_date'] = amendment_info['amendment_with_date']
 
@@ -215,10 +215,10 @@ class ExplosivesPermitDocumentType(AuditMixin, Base):
             return after_permit_generated(template_data, explosives_permit_doc, explosives_permit)
 
     @classmethod
-    def get_amendment_info(self, amendment_count, issue_date):
+    def get_amendment_info(self, amendment_no, issue_date):
         amendment_info_payload = {}
-        amendment_info_payload['amendment'] = f'Amendment {amendment_count}'
+        amendment_info_payload['amendment'] = f'Amendment {amendment_no}'
         amendment_info_payload[
-            'amendment_with_date'] = f'(Amendment {amendment_count}) issued {format_letter_date(issue_date)}'
+            'amendment_with_date'] = f'(Amendment {amendment_no}) issued {format_letter_date(issue_date)}'
 
         return amendment_info_payload

--- a/services/core-api/app/api/mines/explosives_permit_amendment/models/explosives_permit_amendment.py
+++ b/services/core-api/app/api/mines/explosives_permit_amendment/models/explosives_permit_amendment.py
@@ -216,7 +216,7 @@ class ExplosivesPermitAmendment(SoftDeleteMixin, AuditMixin, PermitMixin, Base):
             explosives_permit_amendment_guid=explosives_permit_amendment_guid, deleted_ind=False).one_or_none()
 
     def update(self,
-               amendment_count,
+               amendment_no,
                explosives_permit_id,
                permit_guid,
                now_application_guid,
@@ -329,7 +329,7 @@ class ExplosivesPermitAmendment(SoftDeleteMixin, AuditMixin, PermitMixin, Base):
                     or self.application_status == 'APP') and application_status == 'APP':
                 from app.api.document_generation.resources.explosives_permit_amendment_document_resource import ExplosivesPermitAmendmentDocumentResource
                 from app.api.mines.explosives_permit.resources.explosives_permit_document_type import ExplosivesPermitDocumentGenerateResource
-                amendment_info = ExplosivesPermitDocumentType.get_amendment_info(amendment_count, str(issue_date))
+                amendment_info = ExplosivesPermitDocumentType.get_amendment_info(amendment_no, str(issue_date))
 
                 def create_permit_enclosed_letter():
                     mine = self.mine

--- a/services/core-api/app/api/mines/explosives_permit_amendment/resources/explosives_permit_amendment.py
+++ b/services/core-api/app/api/mines/explosives_permit_amendment/resources/explosives_permit_amendment.py
@@ -15,7 +15,7 @@ from app.api.mines.explosives_permit_amendment.models.explosives_permit_amendmen
 class ExplosivesPermitAmendmentResource(Resource, UserMixin):
     parser = CustomReqparser()
     parser.add_argument(
-        'amendment_count',
+        'amendment_no',
         type=int,
         store_missing=False,
         required=False,
@@ -186,7 +186,7 @@ class ExplosivesPermitAmendmentResource(Resource, UserMixin):
     @api.doc(
         description='Update an Explosives Permit Amendment.',
         params={
-            'amendment_count': 'Number of amendments created.',
+            'amendment_no': 'Number of amendments created.',
             'mine_guid': 'The GUID of the mine the Explosives Permit belongs to.',
             'explosives_permit_amendment_guid': 'The GUID of the Explosives Permit Amendment to update.'
         })
@@ -201,7 +201,7 @@ class ExplosivesPermitAmendmentResource(Resource, UserMixin):
         current_app.logger.debug('DOCUMENTS')
         current_app.logger.debug(data.get('documents', []))
         explosives_permit_amendment.update(
-            data.get('amendment_count'),
+            data.get('amendment_no'),
             data.get('explosives_permit_id'),
             data.get('permit_guid'), data.get('now_application_guid'),
             data.get('issuing_inspector_party_guid'), data.get('mine_manager_mine_party_appt_id'),

--- a/services/core-web/src/components/mine/ExplosivesPermit/ExplosivesPermit.tsx
+++ b/services/core-web/src/components/mine/ExplosivesPermit/ExplosivesPermit.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from "react";
+import React, { FC, useState } from "react";
 import { connect } from "react-redux";
 import {
   createExplosivesPermit,
@@ -91,9 +91,7 @@ export const ExplosivesPermit: FC<ExplosivesPermitProps> = ({
   };
 
   const handleDocumentPreview = (documentTypeCode, values: any, record) => {
-    if (record.isAmendment) {
-      values.amendment_no = record.amendment_no;
-    }
+    if (record.isAmendment) values.amendment_no = record.amendment_no;
     const payload = {
       explosives_permit_guid: record.explosives_permit_guid,
       template_data: values,
@@ -185,7 +183,11 @@ export const ExplosivesPermit: FC<ExplosivesPermitProps> = ({
     return props.createExplosivesPermitAmendment(payload).then((newPermit) => {
       fetchExplosivesPermits(mineGuid);
       if (issueAfter) {
-        handleOpenExplosivesPermitDecisionModal(null, { ...newPermit.data, isAmendment: true });
+        handleOpenExplosivesPermitDecisionModal(null, {
+          ...newPermit.data,
+          isAmendment: true,
+          amendment_no: amendment_count,
+        });
       } else {
         closeModal();
       }

--- a/services/core-web/src/components/mine/ExplosivesPermit/ExplosivesPermit.tsx
+++ b/services/core-web/src/components/mine/ExplosivesPermit/ExplosivesPermit.tsx
@@ -91,6 +91,9 @@ export const ExplosivesPermit: FC<ExplosivesPermitProps> = ({
   };
 
   const handleDocumentPreview = (documentTypeCode, values: any, record) => {
+    if (record.isAmendment) {
+      values.amendment_no = record.amendment_no;
+    }
     const payload = {
       explosives_permit_guid: record.explosives_permit_guid,
       template_data: values,


### PR DESCRIPTION
## Objective 

[MDS-5664](https://bcmines.atlassian.net/browse/MDS-5664)

Addressed a bug that prevented the display of ESUPs amendment numbers in generated ESUP letters and certificates.

**Preview Mode**

![image](https://github.com/bcgov/mds/assets/72251620/d09673c3-a540-4aab-a2b4-d4a633c76d93)


![image](https://github.com/bcgov/mds/assets/72251620/2ad4a992-0735-4fdf-b364-75d4b5d5924a)


**Full Mode**

![image](https://github.com/bcgov/mds/assets/72251620/14cde5d9-3a6d-4601-b935-0650c0285f99)


![image](https://github.com/bcgov/mds/assets/72251620/9bc07b25-69df-476b-84f1-9bed6220f491)




