### PR TITLE
[MDS-5828] Run cypress tests against local DB

### DIFF
--- a/.github/workflows/core-web.cypress.yaml
+++ b/.github/workflows/core-web.cypress.yaml
@@ -1,0 +1,87 @@
+name: CORE WEB - Cypress Tests
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - services/common/**
+      - services/core-web/**
+      - services/core-api/**
+      - services/document-manager/**
+
+jobs:
+  run-cypress:
+    name: run-cypress
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+        name: checkout
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20.x
+      - name: Install oc
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: "4.7"
+
+      - name: oc login
+        run: |
+          oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
+
+      - name: Set up env variables
+        run: |
+          INPUT=yes LOAD_EXTERNAL=yes make env
+          # Run app in production mode
+          sed -i "s/NODE_ENV=.*/NODE_ENV=production/g" ./services/core-web/.env
+      - name: Run keycloak
+        run: |
+          make keycloak
+      - name: Install Dependencies
+        run: |
+          yarn
+      - name: Run app
+        run: |
+          ARTIFACTORY_TOKEN=${{ secrets.ARTIFACTORY_TOKEN }} EXTRA_SERVICES=frontend make be-minimal
+      - name: Seed database
+        run: |
+          make ENTRIES=10 seeddb
+      - name: Run cypress tests
+        run: yarn workspace @mds/core-web cypress run
+        env:
+          CYPRESS_TEST_USER: core-admin
+          CYPRESS_TEST_PASSWORD: cypress
+          CYPRESS_CORE_WEB_TEST_URL: http://localhost:3000
+          CYPRESS_BACKEND: mds-python-backend
+          CYPRESS_API_URL: http://localhost:5000
+          CYPRESS_KEYCLOAK_URL: http://localhost:8080/auth
+          CYPRESS_ENVIRONMENT: local
+          CYPRESS_DOC_MAN_URL: http://localhost:5001
+          CYPRESS_MATOMO_URL: https://matomo-4c2ba9-test.apps.silver.devops.gov.bc.ca/
+          CYPRESS_KEYCLOAK_CLIENT_ID: mines-digital-services-mds-public-client-4414
+          CYPRESS_KEYCLOAK_RESOURCE: mines-digital-services-mds-public-client-4414
+          CYPRESS_KEYCLOAK_IDP_HINT: idir
+          CYPRESS_FILE_SYSTEM_PROVIDER_URL: https://mds-dev.apps.silver.devops.gov.bc.ca/file-api/AmazonS3Provider/
+          CYPRESS_FLAGSMITH_URL: https://mds-flags-dev.apps.silver.devops.gov.bc.ca/api/v1/
+          CYPRESS_FLAGSMITH_KEY: 4Eu9eEMDmWVEHKDaKoeWY7
+      - name: Upload cypress video
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: cypress-recording
+          path: services/core-web/cypress/videos
+      - name: Collect docker logs on failure
+        if: failure()
+        uses: jwalton/gh-docker-logs@v2
+        with:
+          dest: "./logs"
+      - name: Tar logs
+        if: failure()
+        run: tar cvzf ./logs.tgz ./logs
+      - name: Upload logs to GitHub
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: logs.tgz
+          path: ./logs.tgz

--- a/.github/workflows/core-web.unit.yaml
+++ b/.github/workflows/core-web.unit.yaml
@@ -40,38 +40,6 @@ jobs:
 
       - name: Run frontend tests
         run: cd services/core-web/ && yarn && yarn test
-
-      - name: build-core-web
-        run: |
-          NODE_OPTIONS=--max-old-space-size=5024 yarn workspace @mds/core-web build
-
-      - name: start-core-web
-        run: yarn workspace @mds/core-web run http-server-spa build /index.html 3000 &
-
-      - name: Run cypress tests
-        run: yarn workspace @mds/core-web cypress run
-        env:
-          CYPRESS_TEST_USER: ${{ secrets.CYPRESS_CORE_USER }}
-          CYPRESS_TEST_PASSWORD: ${{ secrets.CYPRESS_CORE_PASSWORD }}
-          CYPRESS_CORE_WEB_TEST_URL: ${{ secrets.CYPRESS_CORE_WEB_TEST_URL }}
-          CYPRESS_BACKEND: ${{ secrets.CYPRESS_BACKEND }}
-          CYPRESS_API_URL: ${{ secrets.CYPRESS_API_URL }}
-          CYPRESS_KEYCLOAK_URL: ${{ secrets.CYPRESS_KEYCLOAK_URL }}
-          CYPRESS_ENVIRONMENT: ${{ secrets.CYPRESS_ENVIRONMENT }}
-          CYPRESS_DOC_MAN_URL: ${{ secrets.CYPRESS_DOC_MAN_URL }}
-          CYPRESS_FILE_SYSTEM_PROVIDER_URL: ${{ secrets.CYPRESS_FILE_SYSTEM_PROVIDER_URL }}
-          CYPRESS_MATOMO_URL: ${{ secrets.CYPRESS_MATOMO_URL }}
-          CYPRESS_KEYCLOAK_CLIENT_ID: ${{ secrets.CYPRESS_KEYCLOAK_CLIENT_ID }}
-          CYPRESS_KEYCLOAK_IDP_HINT: ${{ secrets.CYPRESS_KEYCLOAK_IDP_HINT }}
-          CYPRESS_KEYCLOAK_RESOURCE: ${{ secrets.CYPRESS_KEYCLOAK_RESOURCE }}
-          CYPRESS_FLAGSMITH_URL: ${{ secrets.CYPRESS_FLAGSMITH_URL }}
-          CYPRESS_FLAGSMITH_KEY: ${{ secrets.CYPRESS_FLAGSMITH_KEY }}
-      - name: Upload cypress video
-        uses: actions/upload-artifact@v3
-        if: failure()
-        with:
-          name: cypress-recording
-          path: services/core-web/cypress/videos
   run-sonar-scan:
     name: Run SonarCloud Scan
     if: success()

--- a/.github/workflows/minespace.cypress.yaml
+++ b/.github/workflows/minespace.cypress.yaml
@@ -1,0 +1,87 @@
+name: Minespace WEB - Cypress Tests
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - services/common/**
+      - services/minespace-web/**
+      - services/core-api/**
+      - services/document-manager/**
+
+jobs:
+  run-cypress-minespace:
+    name: run-cypress-minespace
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+        name: checkout
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20.x
+      - name: Install oc
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: "4.7"
+
+      - name: oc login
+        run: |
+          oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
+
+      - name: Set up env variables
+        run: |
+          INPUT=yes LOAD_EXTERNAL=yes make env
+          sed -i "s/NODE_ENV=.*/NODE_ENV=production/g" ./services/minespace-web/.env
+
+      - name: Run keycloak
+        run: |
+          make keycloak
+      - name: Install Dependencies
+        run: |
+          yarn
+      - name: Run app
+        run: |
+          ARTIFACTORY_TOKEN=${{ secrets.ARTIFACTORY_TOKEN }} EXTRA_SERVICES=minespace make be-minimal
+      - name: Seed database
+        run: |
+          make ENTRIES=10 seeddb
+      - name: Run cypress tests
+        run: yarn workspace @mds/minespace-web cypress run
+        env:
+          CYPRESS_TEST_USER: minespace-admin
+          CYPRESS_TEST_PASSWORD: cypress
+          CYPRESS_MINESPACE_WEB_TEST_URL: http://localhost:3020
+          CYPRESS_BACKEND: mds-python-backend
+          CYPRESS_API_URL: http://localhost:5000
+          CYPRESS_KEYCLOAK_URL: http://localhost:8080/auth
+          CYPRESS_ENVIRONMENT: local
+          CYPRESS_DOC_MAN_URL: http://localhost:5001
+          CYPRESS_MATOMO_URL: https://matomo-4c2ba9-test.apps.silver.devops.gov.bc.ca/
+          CYPRESS_KEYCLOAK_CLIENT_ID: mines-digital-services-mds-public-client-4414
+          CYPRESS_KEYCLOAK_RESOURCE: mines-digital-services-mds-public-client-4414
+          CYPRESS_KEYCLOAK_IDP_HINT: idir
+          CYPRESS_FILE_SYSTEM_PROVIDER_URL: https://mds-dev.apps.silver.devops.gov.bc.ca/file-api/AmazonS3Provider/
+          CYPRESS_FLAGSMITH_URL: https://mds-flags-dev.apps.silver.devops.gov.bc.ca/api/v1/
+          CYPRESS_FLAGSMITH_KEY: 4Eu9eEMDmWVEHKDaKoeWY7
+      - name: Upload cypress video
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: cypress-recording
+          path: services/minespace-web/cypress/videos
+      - name: Collect docker logs on failure
+        if: failure()
+        uses: jwalton/gh-docker-logs@v2
+        with:
+          dest: "./logs"
+      - name: Tar logs
+        if: failure()
+        run: tar cvzf ./logs.tgz ./logs
+      - name: Upload logs to GitHub
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: logs.tgz
+          path: ./logs.tgz

--- a/.github/workflows/minespace.unit.yaml
+++ b/.github/workflows/minespace.unit.yaml
@@ -36,44 +36,6 @@ jobs:
 
       - name: Run minespace tests
         run: yarn workspace @mds/minespace-web test
-
-      - name: build-minespace-web
-        run: |
-          NODE_OPTIONS=--max-old-space-size=5024 yarn workspace @mds/minespace-web build
-
-      - name: start-minespace-web
-        run: yarn workspace @mds/minespace-web run http-server-spa build /index.html 3020 &
-
-      - name: Run cypress tests
-        run: yarn workspace @mds/minespace-web cypress run
-        env:
-          CYPRESS_TEST_USER: ${{ secrets.CYPRESS_MINESPACE_USER }}
-          CYPRESS_TEST_PASSWORD: ${{ secrets.CYPRESS_MINESPACE_PASSWORD }}
-          CYPRESS_MINESPACE_WEB_TEST_URL: ${{ secrets.CYPRESS_MINESPACE_WEB_TEST_URL }}
-          CYPRESS_BACKEND: ${{ secrets.CYPRESS_BACKEND }}
-          CYPRESS_API_URL: ${{ secrets.CYPRESS_API_URL }}
-          CYPRESS_KEYCLOAK_URL: ${{ secrets.CYPRESS_KEYCLOAK_URL }}
-          CYPRESS_ENVIRONMENT: ${{ secrets.CYPRESS_ENVIRONMENT }}
-          CYPRESS_DOC_MAN_URL: ${{ secrets.CYPRESS_DOC_MAN_URL }}
-          CYPRESS_FILE_SYSTEM_PROVIDER_URL: ${{ secrets.CYPRESS_FILE_SYSTEM_PROVIDER_URL }}
-          CYPRESS_MATOMO_URL: ${{ secrets.CYPRESS_MATOMO_URL }}
-          CYPRESS_KEYCLOAK_CLIENT_ID: ${{ secrets.CYPRESS_KEYCLOAK_CLIENT_ID }}
-          CYPRESS_KEYCLOAK_IDP_HINT: ${{ secrets.CYPRESS_KEYCLOAK_IDP_HINT }}
-          CYPRESS_KEYCLOAK_RESOURCE: ${{ secrets.CYPRESS_KEYCLOAK_RESOURCE }}
-          CYPRESS_FLAGSMITH_URL: ${{ secrets.CYPRESS_FLAGSMITH_URL }}
-          CYPRESS_FLAGSMITH_KEY: ${{ secrets.CYPRESS_FLAGSMITH_KEY }}
-
-      - name: Upload cypress video
-        uses: actions/upload-artifact@v3
-        if: failure()
-        with:
-          name: cypress-recording
-          path: services/minespace-web/cypress/videos
-      - name: Upload stats file
-        uses: actions/upload-artifact@v3
-        with:
-          name: stats
-          path: services/minespace-web/build/stats.json
   run-sonar-scan:
     name: Run SonarCloud Scan
     if: success()

--- a/cypress/realm-export.json
+++ b/cypress/realm-export.json
@@ -751,6 +751,7 @@
                 "core_environmental_reports",
                 "core_edit_permits",
                 "nris_view_all",
+                "core_admin",
                 "idir",
                 "core_edit_reports",
                 "core_edit_submissions",

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -162,15 +162,17 @@ services:
     user: 1000:1000
     container_name: mds_frontend
     build:
-      context: services/core-web
-    command: [ "npm", "run", "serve" ]
+      context: .
+      dockerfile: services/core-web/Dockerfile.ci
+      args:
+        ARTIFACTORY_TOKEN: $ARTIFACTORY_TOKEN
+
     volumes:
       - ./services/core-web/src:/app/src
     ports:
       - 3000:3000
-    depends_on:
-      - backend
     env_file: ./services/core-web/.env
+    network_mode: "host"
     healthcheck:
       test: [ "CMD", "curl", "localhost:3000/health" ]
       interval: 15s
@@ -184,20 +186,23 @@ services:
     user: 1000:1000
     container_name: mds_minespace
     build:
-      context: services/minespace-web
-    command: [ "npm", "run", "serve" ]
+      context: .
+      dockerfile: services/minespace-web/Dockerfile.ci
+      args:
+        ARTIFACTORY_TOKEN: $ARTIFACTORY_TOKEN
+    environment:
+      - NODE_ENV=production
     volumes:
       - ./services/minespace-web/src:/app/src
     ports:
       - 3020:3020
-    depends_on:
-      - backend
     env_file: ./services/minespace-web/.env
     healthcheck:
       test: [ "CMD", "curl", "localhost:3020/health" ]
       interval: 5s
       timeout: 5s
       retries: 5
+    network_mode: "host"
 
   ####################### NRIS_BACKEND Definition #######################
   nris_backend:

--- a/services/core-api/app/commands.py
+++ b/services/core-api/app/commands.py
@@ -57,6 +57,7 @@ def register_commands(app):
     def _create_data(num):
         User._test_mode = True
         with app.app_context():
+            MineFactory(major_mine_ind=True) # Ensure there is at least one major mine
             for _ in range(int(num)):
                 mine = MineFactory()
                 MinePartyAppointmentFactory(mine=mine, mine_party_appt_type_code='EOR')

--- a/services/core-web/cypress.config.ts
+++ b/services/core-web/cypress.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
   viewportHeight: 1080,
   videoUploadOnPasses: false,
   supportFolder: "cypress/support",
+  defaultCommandTimeout: 15000,
   e2e: {
     // We've imported your old cypress plugins here.
     // You may want to clean this up later by importing these.

--- a/services/core-web/cypress/e2e/createproject.cy.ts
+++ b/services/core-web/cypress/e2e/createproject.cy.ts
@@ -8,10 +8,14 @@ describe("Major Projects", () => {
 
     // Navigate to the mines page
     cy.get('[data-cy="mines-button"]', { timeout: 10000 }).click({ force: true });
+    cy.get('[data-cy="expand-filters-button"]').click({ force: true });
+    cy.contains("Select Mine Classification").click({ force: true });
+    cy.get('[title="Major Mine"]').click({ force: true });
+    cy.contains("Apply Filters").click({ force: true });
 
-    // Navigate to the second mine
+    // // Navigate to the second mine
     cy.get('[data-cy="mine-link"]', { timeout: 10000 })
-      .eq(4)
+      .first()
       .click({ force: true });
 
     // Hover over the permits and approvals menu
@@ -47,14 +51,14 @@ describe("Major Projects", () => {
     // Navigate back to major projects
     cy.get('[data-cy="back-to-major-project-link"]').click({ force: true });
     // wait for table to load data
-    cy.wait(15000);
+    cy.wait(15000); // wait for table to load data
     // Find the newly created project in the table and assert
-    // cy.get("[data-cy=project-name-column]", { timeout: 10000 })
-    //   .contains(uniqueProjectName)
-    //   .closest("tr")
-    //   .as("targetRow");
-    //
+    cy.get("[data-cy=project-name-column]", { timeout: 10000 })
+      .contains(uniqueProjectName)
+      .closest("tr")
+      .as("targetRow");
+
     // // Assert that the row contains the expected data
-    // cy.get("@targetRow", { timeout: 10000 }).should("contain", uniqueProjectName);
+    cy.get("@targetRow", { timeout: 10000 }).should("contain", uniqueProjectName);
   });
 });

--- a/services/core-web/cypress/e2e/majorprojects.cy.ts
+++ b/services/core-web/cypress/e2e/majorprojects.cy.ts
@@ -46,7 +46,7 @@ describe("Major Projects", () => {
 
       cy.intercept(
         "PATCH",
-        /.*\/(api\/)?document-manager\/documents\/332d6f13-cd09-4b55-93d7-52bd7e557fa4\/complete-upload$/,
+        /.*\/(api\/)?(document-manager\/)?documents\/332d6f13-cd09-4b55-93d7-52bd7e557fa4\/complete-upload$/,
         {
           statusCode: 204,
         }

--- a/services/core-web/cypress/support/commands.ts
+++ b/services/core-web/cypress/support/commands.ts
@@ -25,7 +25,7 @@ Cypress.Commands.add("login", () => {
     keycloak_idpHint: Cypress.env("CYPRESS_KEYCLOAK_IDP_HINT"),
     environment: Cypress.env("CYPRESS_ENVIRONMENT"),
     flagsmithUrl: Cypress.env("CYPRESS_FLAGSMITH_URL"),
-    flagsmithKey: Cypress.env("CYPRESS_FLAGSMITH_KEY")
+    flagsmithKey: Cypress.env("CYPRESS_FLAGSMITH_KEY"),
   };
 
   cy.intercept("GET", environmentUrl, (req) => {

--- a/services/core-web/src/components/Forms/AdvancedMineSearchForm.js
+++ b/services/core-web/src/components/Forms/AdvancedMineSearchForm.js
@@ -166,7 +166,11 @@ export class AdvancedMineSearchForm extends Component {
           </div>
         )}
         <div className="left center-mobile">
-          <Button className="btn--dropdown" onClick={this.toggleIsAdvancedSearch}>
+          <Button
+            className="btn--dropdown"
+            onClick={this.toggleIsAdvancedSearch}
+            data-cy="expand-filters-button"
+          >
             {this.state.expandAdvancedSearch ? "Collapse Filters" : "Expand Filters"}
             {this.state.expandAdvancedSearch ? <UpOutlined /> : <DownOutlined />}
           </Button>

--- a/services/core-web/src/tests/components/Forms/__snapshots__/AdvancedSearchForm.spec.js.snap
+++ b/services/core-web/src/tests/components/Forms/__snapshots__/AdvancedSearchForm.spec.js.snap
@@ -29,6 +29,7 @@ exports[`AdvancedMineSearchForm renders properly 1`] = `
   >
     <Button
       className="btn--dropdown"
+      data-cy="expand-filters-button"
       onClick={[Function]}
     >
       Expand Filters

--- a/services/minespace-web/cypress.config.ts
+++ b/services/minespace-web/cypress.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   viewportWidth: 1960,
   viewportHeight: 1080,
   videoUploadOnPasses: false,
+  defaultCommandTimeout: 15000,
   e2e: {
     // We've imported your old cypress plugins here.
     // You may want to clean this up later by importing these.

--- a/services/minespace-web/cypress/e2e/homepage.cy.ts
+++ b/services/minespace-web/cypress/e2e/homepage.cy.ts
@@ -7,7 +7,7 @@ describe("Mines Page", () => {
   it("should navigate to the mines page successfully", () => {
     cy.visit(`${url}/mines`);
     // Assert that landing on the home page is successful
-    cy.url({ timeout: 10000 }).should("include", "/mines");
+    cy.url({ timeout: 15000 }).should("include", "/mines");
     cy.get("h1.ant-typography").should("have.text", "My Mines");
     cy.get("h4.ant-typography").should("have.text", "Welcome, cypress@bceid.");
   });


### PR DESCRIPTION
## Objective 

[MDS-5828](https://bcmines.atlassian.net/browse/MDS-5828)

Run Cypress tests against local DB instead of dev environment. This will make them a bit more robust and prevent backend changes that break the tests to make its way into the codebase.

**Changes**
- Split Cypress tests into separate actions for Minespace and Core
- Added `make be-minimal` command that spins up a minimal version of the backend required for the cypress tests to run
- Upload container logs as artifact that you can download if tests fail
- Updated tests to run against minespace/core docker containers instead of manually running `yarn` to make it as close to the deployed version as possible + enables parallel building of the frontend and backend
- Moved full rebuilding of the backend container into `make be-rebuild` instead of having as part of `make be`, seeing as a full rebuild is rarely needed.
- `make seeddb` can now take a param specifying how many entities to seed the database with: `make ENTRIES=10 seeddb`
- Always seed the DB with a major mine as to make sure major project tests don't fail