### PR TITLE
[MDS-5646]  Minespace project coordinated review radio button error

### DIFF
--- a/services/minespace-web/src/components/pages/Project/ProjectSummaryPage.tsx
+++ b/services/minespace-web/src/components/pages/Project/ProjectSummaryPage.tsx
@@ -177,8 +177,8 @@ export const ProjectSummaryPage: FC<ProjectSummaryPageProps> = (props) => {
       payload,
       message
     )
-      .then(() => {
-        updateProject(
+      .then(async () => {
+        await updateProject(
           { projectGuid },
           { mrc_review_required: payload.mrc_review_required, contacts: payload.contacts },
           "Successfully updated project.",


### PR DESCRIPTION
## Objective 

[MDS-5646](https://bcmines.atlassian.net/browse/MDS-5646)

- The issue was the Minespace project coordinated review radio button not showing up as user selection
- One cause of the issue was the missing await for the async function `updateProject`. It would attempt to fetch the data before the project data was finished updating
- Another part of the issue was the Minespace radio button options were setup as strings "True"/"False" and this caused the radio selection to be yes even though user selects no. I have another PR open that makes the change to boolean True/False for the Minespace radio button (https://github.com/bcgov/mds/pull/2845)
