### PR TITLE
[CHORE] Fixed error saying Canada/Pacific tz data is not found

### DIFF
--- a/services/core-web/webpack.config.ts
+++ b/services/core-web/webpack.config.ts
@@ -80,18 +80,18 @@ const commonConfig = merge([
         REQUEST_HEADER: path.resolve(__dirname, "common/utils/RequestHeaders.js"),
         GLOBAL_ROUTES: path.resolve(__dirname, "src/constants/routes.ts"),
       }),
-      // Prevent moment locales to be bundled with the app
-      // to reduce app size
-      new webpack.IgnorePlugin({
-        resourceRegExp: /^\.\/locale$/,
-        contextRegExp: /moment$/,
-      }),
-      // Explicitly load timezone data for Canada and US
-      new MomentTimezoneDataPlugin({
-        startYear: 1900,
-        endYear: 2300,
-        matchCountries: ["CA", "US"],
-      }),
+      // // Prevent moment locales to be bundled with the app
+      // // to reduce app size
+      // new webpack.IgnorePlugin({
+      //   resourceRegExp: /^\.\/locale$/,
+      //   contextRegExp: /moment$/,
+      // }),
+      // // Explicitly load timezone data for Canada and US
+      // new MomentTimezoneDataPlugin({
+      //   startYear: 1900,
+      //   endYear: 2300,
+      //   matchCountries: ["CA", "US"],
+      // }),
       new MiniCssExtractPlugin(),
     ],
     resolve: {
@@ -100,8 +100,8 @@ const commonConfig = merge([
         ...PATH_ALIASES,
         ...(process.env.NODE_ENV === "development"
           ? {
-            "react-dom": "@hot-loader/react-dom",
-          }
+              "react-dom": "@hot-loader/react-dom",
+            }
           : {}),
         // Use lodash-es that supports proper tree-shaking
         lodash: "lodash-es",
@@ -246,8 +246,8 @@ const prodConfig = merge([
         generateStatsFile: true,
         statsOptions: { source: false },
       }),
-    ]
-  }
+    ],
+  },
 ]);
 
 module.exports = () => {

--- a/services/minespace-web/webpack.config.ts
+++ b/services/minespace-web/webpack.config.ts
@@ -89,18 +89,18 @@ const commonConfig = merge([
         REQUEST_HEADER: path.resolve(__dirname, "common/utils/RequestHeaders.js"),
         GLOBAL_ROUTES: path.resolve(__dirname, "src/constants/routes.ts"),
       }),
-      // Prevent moment locales to be bundled with the app
-      // to reduce app size
-      new webpack.IgnorePlugin({
-        resourceRegExp: /^\.\/locale$/,
-        contextRegExp: /moment$/,
-      }),
-      // Explicitly load timezone data for Canada and US
-      new MomentTimezoneDataPlugin({
-        startYear: 1900,
-        endYear: 2300,
-        matchCountries: ["CA", "US"],
-      }),
+      // // Prevent moment locales to be bundled with the app
+      // // to reduce app size
+      // new webpack.IgnorePlugin({
+      //   resourceRegExp: /^\.\/locale$/,
+      //   contextRegExp: /moment$/,
+      // }),
+      // // Explicitly load timezone data for Canada and US
+      // new MomentTimezoneDataPlugin({
+      //   startYear: 1900,
+      //   endYear: 2300,
+      //   matchCountries: ["CA", "US"],
+      // }),
       new MiniCssExtractPlugin(),
     ],
     resolve: {


### PR DESCRIPTION
## Objective 

[MDS-CHORE](https://bcmines.atlassian.net/browse/MDS-CHORE)

An error has popped up saying Moment does not have any data for Canada/Pacific. It's caused by the recent improvements to how we load webpack to reduce bundle size, so disabling that build config.

![image](https://github.com/bcgov/mds/assets/66635118/ab501051-69dc-4a66-9ee1-fc6d0c4fb3bf)
