### PR TITLE
[MDS-5675] Allow manual builds of docman to be deployed to dev

### DIFF
--- a/.github/workflows/docman.build.deploy.dev.yaml
+++ b/.github/workflows/docman.build.deploy.dev.yaml
@@ -1,6 +1,7 @@
 name: DOCMAN - Build & Deploy To DEV
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - develop


### PR DESCRIPTION
## Objective 

[MDS-5675](https://bcmines.atlassian.net/browse/MDS-5675)

Enabled trigger of manual builds of Docman. Currently in the process of debugging CORS issues with the new File Upload flow, and want to do a quick test of it 🙃 