### PR TITLE
[MDS-5672] -BUGFIX - restored previous incident loading functionality

### DIFF
--- a/services/core-web/src/components/mine/Incidents/MineIncident.tsx
+++ b/services/core-web/src/components/mine/Incidents/MineIncident.tsx
@@ -172,39 +172,25 @@ export const MineIncident = (props) => {
     featureUrlRouteArguments: sideBarRoute.params,
   };
 
+  const handleScroll = () => {
+    if (window.pageYOffset > 170 && !fixedTop) {
+      setIsFixedTop(true);
+    } else if (window.pageYOffset <= 170 && fixedTop) {
+      setIsFixedTop(false);
+    }
+  };
+
   useEffect(() => {
-    let isMounted = true;
+    handleFetchData().then(() => {
+      setIsLoaded(true);
 
-    const handleFetchData = async (): Promise<void> => {
-      if (mineGuid && mineIncidentGuid) {
-        setIsNewIncident(false);
-        setIsLoaded(false);
-        await dispatch(fetchMineIncident(mineGuid, mineIncidentGuid));
-        if (isMounted) {
-          setIsLoaded(true);
-        }
-      }
-      return Promise.resolve();
-    };
-
-    const handleScroll = () => {
-      if (window.pageYOffset > 170 && !fixedTop) {
-        setIsFixedTop(true);
-      } else if (window.pageYOffset <= 170 && fixedTop) {
-        setIsFixedTop(false);
-      }
-    };
-
-    window.addEventListener("scroll", handleScroll);
-    handleFetchData();
+      return () => {
+        window.removeEventListener("scroll", handleScroll);
+        props.clearMineIncident();
+      };
+    });
     handleScroll();
-
-    return () => {
-      window.removeEventListener("scroll", handleScroll);
-      isMounted = false;
-      dispatch(clearMineIncident());
-    };
-  }, [pathname, mineGuid, mineIncidentGuid]);
+  }, [pathname]);
 
   return isLoaded ? (
     <>

--- a/services/core-web/src/tests/components/mine/Incidents/MineIncident.spec.tsx
+++ b/services/core-web/src/tests/components/mine/Incidents/MineIncident.spec.tsx
@@ -1,11 +1,11 @@
 import React from "react";
 import { render } from "@testing-library/react";
-import { MineIncident, MineIncidentProps } from "@/components/mine/Incidents/MineIncident";
+import { MineIncident } from "@/components/mine/Incidents/MineIncident";
 import * as MOCK from "@/tests/mocks/dataMocks";
 import { store } from "@/App";
 import { Provider } from "react-redux";
 
-const props: MineIncidentProps = {
+const props: any = {
   incident: MOCK.INCIDENT,
   formErrors: {},
   formValues: {


### PR DESCRIPTION
## Objective 

Had reworked the loading of the incident form on Core, but it turns out that broke loading when it was a newly created incident.  Restored the previous flow.

[MDS-5672](https://bcmines.atlassian.net/browse/MDS-5672)
