### PR TITLE
[MDS-5711] Enabled remote desktop to run Cypress in GH codespaces + added default keycloak users for running Cypress tests

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,7 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/universal:2",
+  "features": {
+    "ghcr.io/devcontainers/features/desktop-lite:1": {}
+  },
+  "forwardPorts": [6080, 5901]
+}

--- a/cypress/keycloak-users.json
+++ b/cypress/keycloak-users.json
@@ -1,0 +1,93 @@
+[
+  {
+    "realm": "standard",
+    "users": [
+      {
+        "id": "1d5eb1c9-fd6a-486d-8fdd-ec8e084c0456",
+        "createdTimestamp": 1704392219309,
+        "username": "core-admin",
+        "enabled": true,
+        "totp": false,
+        "emailVerified": true,
+        "firstName": "core",
+        "lastName": "admin",
+        "email": "core-admin@gov.bc.ca",
+        "credentials": [
+          {
+            "id": "5c68c25a-22cc-4d9f-8e32-13203c2c7589",
+            "type": "password",
+            "createdDate": 1704392265075,
+            "secretData": "{\"value\":\"FyuUgMOD82UZqd+cnbu7yV2WGEh9x7ren0M6WqbB6S/QJuTjan3SOvnMJOr1w9NgOs7njGaKxXJXUajxSxdc8A==\",\"salt\":\"RGnbF6k+xlZV6BbeD9N3AQ==\",\"additionalParameters\":{}}",
+            "credentialData": "{\"hashIterations\":27500,\"algorithm\":\"pbkdf2-sha256\",\"additionalParameters\":{}}"
+          }
+        ],
+        "disableableCredentialTypes": [],
+        "requiredActions": [],
+        "realmRoles": ["default-roles-standard"],
+        "clientRoles": {
+          "mines-digital-services-mds-public-client-4414": ["core_full_permissions"]
+        },
+        "notBefore": 0,
+        "groups": []
+      },
+      {
+        "id": "a28dfc3a-5e5c-4501-ab2f-399d8e64f2c8",
+        "createdTimestamp": 1704402112321,
+        "username": "minespace-admin",
+        "enabled": true,
+        "totp": false,
+        "emailVerified": true,
+        "firstName": "minespace",
+        "lastName": "admin",
+        "email": "minespace-admin@test.com",
+        "credentials": [
+          {
+            "id": "f399d41d-47cb-4b97-9cc8-8cffe74dc3d7",
+            "type": "password",
+            "createdDate": 1704402132451,
+            "secretData": "{\"value\":\"W9ZFXFoLX0+JOQWZB7dOiyk3Weh0xxp9Ytqi2TF/hpYMPFj6Suh6kfQTVdbXisk8HtB7EaJ9vuwKsJwDXKcwmA==\",\"salt\":\"JkUxZvapXLKuoJNx8Ws9CQ==\",\"additionalParameters\":{}}",
+            "credentialData": "{\"hashIterations\":27500,\"algorithm\":\"pbkdf2-sha256\",\"additionalParameters\":{}}"
+          }
+        ],
+        "disableableCredentialTypes": [],
+        "requiredActions": [],
+        "realmRoles": ["default-roles-standard"],
+        "clientRoles": {
+          "mines-digital-services-mds-public-client-4414": [
+            "core_view_all",
+            "mds_minespace_proponents"
+          ]
+        },
+        "notBefore": 0,
+        "groups": []
+      }
+    ]
+  },
+  {
+    "realm": "master",
+    "users": [
+      {
+        "id": "94b2d91c-64b7-427d-b202-2bf366316a03",
+        "createdTimestamp": 1704392039635,
+        "username": "admin",
+        "enabled": true,
+        "totp": false,
+        "emailVerified": false,
+        "credentials": [
+          {
+            "id": "05c1a3d7-0745-4cc4-82f5-febf26091898",
+            "type": "password",
+            "createdDate": 1704392039650,
+            "secretData": "{\"value\":\"ceGCjWsDc88YxgcyanDysz3NahYlsqsn7SmA/hbYQofdZ0tOJJqfpq4A7ZfsM5hig1+43tlDmthVQVKwZVvo4g==\",\"salt\":\"vZ+jWSlcPrj2xudvhkjgsA==\",\"additionalParameters\":{}}",
+            "credentialData": "{\"hashIterations\":27500,\"algorithm\":\"pbkdf2-sha256\",\"additionalParameters\":{}}"
+          }
+        ],
+        "disableableCredentialTypes": [],
+        "requiredActions": [],
+        "realmRoles": ["default-roles-master", "admin"],
+        "notBefore": 0,
+        "groups": []
+      }
+    ]
+  }
+]

--- a/services/minespace-web/README.md
+++ b/services/minespace-web/README.md
@@ -33,30 +33,35 @@ Contributors to this codebase are expected to follow the testing standards set o
 
 _If coverage is lower than before writing a new feature, the tests **need** to be updated, and the feature is considered **incomplete**_
 
+#### Cypress tests
+
 **Setup Cypress test**
-Add the following cypress related environment variables from env-example.
 
-CYPRESS_TEST_USER
-CYPRESS_TEST_PASSWORD
-CYPRESS_MINESPACE_WEB_TEST_URL
-CYPRESS_BACKEND
-CYPRESS_API_URL
-CYPRESS_KEYCLOAK_URL
-CYPRESS_ENVIRONMENT
-CYPRESS_DOC_MAN_URL
-CYPRESS_MATOMO_URL
-CYPRESS_KEYCLOAK_CLIENT_ID
-CYPRESS_KEYCLOAK_RESOURCE
-CYPRESS_KEYCLOAK_IDP_HINT
-CYPRESS_FILE_SYSTEM_PROVIDER_URL
-
-run the command `docker-compose up -d keycloak`
-
-Navigate to `http://localhost:8080` to check if keycloak was successfully installed.
+1. Make sure you've run `make env` which will configure env variables cypress need to run successfully. Most are prefixed with `CYPRESS_` and found in `.env-example` files in services/minespace-web and services/core-web
+2. Start a local version of `keycloak`: `docker-compose up -d keycloak`. This will start a keycloak instance at http://localhost:8080, admin credentials if you ever need to log into it for debugging purposes is `admin/admin`.
 
 **Run Cypress test**
 To run your cypress tests with a browser, type the command `yarn run cypress open`.
 To run your cypress tests in headless mode, type the command `yarn cypress run`.
+
+**Keycloak Realm configuration**
+A keycloak realm named `standard` is created when Keycloak is started. The configuration of the realm is found in `cypress/realm-export.json`. This is where you can configure roles that should be available for users
+
+**Keycloak user configuration**
+Keycloak will automatically create the following users for cypress to use (defined in `cypress/keycloak-users.json`).
+
+`core-admin` - Used by core cypress tests. Roles: the composite `core_full_permissions` role defined in `cypress/realm-export.json`. Password: cypress
+`minespace-admin` - Used by minespace cypress tests. Roles: core_view_all and mds_minespace_proponents. Password: cypress
+`admin` - Used to log into the Keycloak admin interface. Password: admin
+
+#### Running cypress tests in Codespaces
+
+Cypress tests can be run in github codespaces following the instructions above. If you want to run your cypress tests in a headful browser
+
+1. Run cypress: `yarn run cypress open`
+2. Access a remote desktop at http://localhost:6080 - password `vscode`
+
+This is made possible by the [desktop-lite](https://github.com/devcontainers/features/tree/main/src/desktop-lite) Codespaces feature, and configured in `.devcontainer/devcontainer.json`
 
 ### Running
 


### PR DESCRIPTION
## Objective 

[MDS-5711](https://bcmines.atlassian.net/browse/MDS-5711)

![image](https://github.com/bcgov/mds/assets/66635118/e90f0e26-4a42-411a-9e47-6fb4877756d4)

Enabled the [desktop-lite](https://github.com/devcontainers/features/tree/main/src/desktop-lite) codespaces feature, so we can run Cypress in codespaces. Updated README with instructions on how to use it.

Added `cypress/keycloak-users.json` that contains default users Cypress can use that are created when Keycloak starts up.