### PR TITLE
[MDS-5641] Added GH Actions to deploy permit service to test and prod, parameterized elasticsearch settings

### DIFF
--- a/.github/workflows/permit-service.build.deploy.dev.yaml
+++ b/.github/workflows/permit-service.build.deploy.dev.yaml
@@ -19,6 +19,8 @@ jobs:
   build-backend:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/permit-service.build.deploy.dev.yaml
+++ b/.github/workflows/permit-service.build.deploy.dev.yaml
@@ -29,7 +29,7 @@ jobs:
         name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          reguistry: ${{ secrets.CLUSTER_REGISTRY }}
+          registry: ${{ secrets.CLUSTER_REGISTRY }}
           username: ${{ secrets.CLUSTER_REGISTRY_USER }}
           password: ${{ secrets.BUILD_TOKEN }}
       -

--- a/.github/workflows/permit-service.build.deploy.dev.yaml
+++ b/.github/workflows/permit-service.build.deploy.dev.yaml
@@ -28,16 +28,16 @@ jobs:
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       -
-        name: Login to Docker Hub
+        name: Login to Openshift iamge registry
         uses: docker/login-action@v3
         with:
-          registry: ${{ secrets.CLUSTER_REGISTRY }}
-          username: ${{ secrets.CLUSTER_REGISTRY_USER }}
-          password: ${{ secrets.BUILD_TOKEN }}
+          registry: ${{ secrets.ARTIFACTORY_CLUSTER_REGISTRY }}
+          username: ${{ secrets.ARTIFACTORY_USER }}
+          password: ${{ secrets.ARTIFACTORY_PASSWORD }}
       -
         name: Build and push
         uses: docker/build-push-action@v5
         with:
           push: true
-          tags: ${{ secrets.CLUSTER_REGISTRY }}/${{ secrets.NS_TOOLS }}/${{ env.NAME }}:${{ env.INITIAL_TAG }},${{ secrets.CLUSTER_REGISTRY }}/${{ secrets.NS_TOOLS }}/${{ env.NAME }}:${{ env.TAG }}
+          tags: ${{ secrets.ARTIFACTORY_CLUSTER_REGISTRY }}/${{ secrets.ARTIFACTORY_PROJECT_NAME }}/${{ env.NAME }}:${{ env.INITIAL_TAG }},${{ secrets.ARTIFACTORY_CLUSTER_REGISTRY }}/${{ secrets.ARTIFACTORY_PROJECT_NAME }}/${{ env.NAME }}:${{ env.TAG }}
           context: ${{ env.CONTEXT }}

--- a/.github/workflows/permit-service.build.deploy.dev.yaml
+++ b/.github/workflows/permit-service.build.deploy.dev.yaml
@@ -28,7 +28,7 @@ jobs:
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       -
-        name: Login to Openshift iamge registry
+        name: Login to Openshift image registry
         uses: docker/login-action@v3
         with:
           registry: ${{ secrets.ARTIFACTORY_CLUSTER_REGISTRY }}

--- a/.github/workflows/permit-service.build.deploy.dev.yaml
+++ b/.github/workflows/permit-service.build.deploy.dev.yaml
@@ -16,7 +16,7 @@ env:
   CONTEXT: services/permits/
 
 jobs:
-  build-backend:
+  build-service:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -41,3 +41,32 @@ jobs:
           push: true
           tags: ${{ secrets.ARTIFACTORY_CLUSTER_REGISTRY }}/${{ secrets.ARTIFACTORY_PROJECT_NAME }}/${{ env.NAME }}:${{ env.INITIAL_TAG }},${{ secrets.ARTIFACTORY_CLUSTER_REGISTRY }}/${{ secrets.ARTIFACTORY_PROJECT_NAME }}/${{ env.NAME }}:${{ env.TAG }}
           context: ${{ env.CONTEXT }}
+  trigger-gitops:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: [build-service]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Git Ops Push
+        run: ./gitops/commit.sh permits dev dev ${{ github.actor }} ${{ secrets.GH_TOKEN }}
+      - name: Install oc
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: "4.7"
+      - name: Setup ArgoCD CLI
+        uses: imajeetyadav/argocd-cli@v1
+        with:
+          version: v2.7.9 # optional
+      - name: oc login
+        run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
+      - name: Wait for deployment to complete
+        run: ./gitops/watch-deployment.sh permits dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGO_CD_CLI_JWT }}
+
+  run-if-failed:
+    runs-on: ubuntu-latest
+    needs: [trigger-gitops]
+    if: failure()
+    steps:
+      - name: Notify Discord of Rollout failure
+        run: ./gitops/notify_discord.sh permits dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} 1

--- a/.github/workflows/permit-service.deploy.prod.yaml
+++ b/.github/workflows/permit-service.deploy.prod.yaml
@@ -1,0 +1,59 @@
+name: Permit Service - Promote Prod
+
+on:
+  workflow_dispatch:
+
+env:
+  ORIG_TAG: test
+  PROMOTE_TAG: prod
+  IMAGE: permits
+
+jobs:
+  promote-image:
+    name: promote-image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install oc
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: "4.7"
+
+      - name: oc login
+        run: |
+          oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
+
+      - name: Promote from test to prod
+        run: |
+          oc -n ${{secrets.NS_TOOLS}} tag \
+          ${{ secrets.NS_TOOLS }}/${{ env.IMAGE }}:${{ env.ORIG_TAG }} \
+          ${{ secrets.NS_TOOLS }}/${{ env.IMAGE }}:${{ env.PROMOTE_TAG }}
+
+  trigger-gitops:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: promote-image
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Git Ops Push
+        run: ./gitops/commit.sh ${{ env.IMAGE }} test prod ${{ github.actor }} ${{ secrets.GH_TOKEN }}
+      - name: Install oc
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: "4.7"
+      - name: Setup ArgoCD CLI
+        uses: imajeetyadav/argocd-cli@v1
+        with:
+          version: v2.7.9 # optional
+      - name: oc login
+        run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
+      - name: Notification
+        run: ./gitops/watch-deployment.sh permits prod ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGO_CD_CLI_JWT }}
+
+  run-if-failed:
+    runs-on: ubuntu-latest
+    needs: [trigger-gitops]
+    if: failure()
+    steps:
+      - name: Notification
+        run: ./gitops/watch-deployment.sh permits prod ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} 1

--- a/.github/workflows/permit-service.deploy.prod.yaml
+++ b/.github/workflows/permit-service.deploy.prod.yaml
@@ -56,4 +56,4 @@ jobs:
     if: failure()
     steps:
       - name: Notification
-        run: ./gitops/watch-deployment.sh permits prod ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} 1
+        run: ./gitops/notify_discord.sh permits prod ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} 1

--- a/.github/workflows/permit-service.deploy.test.yaml
+++ b/.github/workflows/permit-service.deploy.test.yaml
@@ -1,0 +1,59 @@
+name: Permit Service - Promote TEST
+
+on:
+  workflow_dispatch:
+
+env:
+  ORIG_TAG: dev
+  PROMOTE_TAG: test
+  IMAGE: permits
+
+jobs:
+  promote-image:
+    name: promote-image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install oc
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: "4.7"
+
+      - name: oc login
+        run: |
+          oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
+
+      - name: Promote from dev to test
+        run: |
+          oc -n ${{secrets.NS_TOOLS}} tag \
+          ${{ secrets.NS_TOOLS }}/${{ env.IMAGE }}:${{ env.ORIG_TAG }} \
+          ${{ secrets.NS_TOOLS }}/${{ env.IMAGE }}:${{ env.PROMOTE_TAG }}
+
+  trigger-gitops:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: promote-image
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Git Ops Push
+        run: ./gitops/commit.sh ${{ env.IMAGE }} dev test ${{ github.actor }} ${{ secrets.GH_TOKEN }}
+      - name: Install oc
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: "4.7"
+      - name: Setup ArgoCD CLI
+        uses: imajeetyadav/argocd-cli@v1
+        with:
+          version: v2.7.9 # optional
+      - name: oc login
+        run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
+      - name: Notification
+        run: ./gitops/watch-deployment.sh permits test ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGO_CD_CLI_JWT }}
+
+  run-if-failed:
+    runs-on: ubuntu-latest
+    needs: [trigger-gitops]
+    if: failure()
+    steps:
+      - name: Notification
+        run: ./gitops/watch-deployment.sh permits test ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} 1

--- a/.github/workflows/permit-service.deploy.test.yaml
+++ b/.github/workflows/permit-service.deploy.test.yaml
@@ -56,4 +56,4 @@ jobs:
     if: failure()
     steps:
       - name: Notification
-        run: ./gitops/watch-deployment.sh permits test ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} 1
+        run: ./gitops/notify_discord.sh permits dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} 1

--- a/services/permits/app/pipelines.py
+++ b/services/permits/app/pipelines.py
@@ -8,11 +8,12 @@ from haystack.nodes import BM25Retriever
 from haystack.nodes import FARMReader
 import os
 
+ca_cert = os.environ.get('ELASTICSEARCH_CA_CERT', None)
 host = os.environ.get('ELASTICSEARCH_HOST', 'elasticsearch')
 username = os.environ.get('ELASTICSEARCH_USERNAME', '')
 password = os.environ.get('ELASTICSEARCH_PASSWORD', '')
 
-document_store = ElasticsearchDocumentStore(host=host, username=username, password=password, index="permits", embedding_dim=384)
+document_store = ElasticsearchDocumentStore(host=host, username=username, password=password, index="permits", embedding_dim=384, ca_certs=ca_cert)
 
 def query_pipeline():
     """

--- a/services/permits/app/pipelines.py
+++ b/services/permits/app/pipelines.py
@@ -6,8 +6,13 @@ from rest_api.controller.utils import RequestLimiter
 from haystack.document_stores import ElasticsearchDocumentStore
 from haystack.nodes import BM25Retriever
 from haystack.nodes import FARMReader
+import os
 
-document_store = ElasticsearchDocumentStore(host='elasticsearch', username="", password="", index="permits", embedding_dim=384)
+host = os.environ.get('ELASTICSEARCH_HOST', 'elasticsearch')
+username = os.environ.get('ELASTICSEARCH_USERNAME', '')
+password = os.environ.get('ELASTICSEARCH_PASSWORD', '')
+
+document_store = ElasticsearchDocumentStore(host=host, username=username, password=password, index="permits", embedding_dim=384)
 
 def query_pipeline():
     """

--- a/services/permits/app/pipelines.py
+++ b/services/permits/app/pipelines.py
@@ -13,7 +13,16 @@ host = os.environ.get('ELASTICSEARCH_HOST', 'elasticsearch')
 username = os.environ.get('ELASTICSEARCH_USERNAME', '')
 password = os.environ.get('ELASTICSEARCH_PASSWORD', '')
 
-document_store = ElasticsearchDocumentStore(host=host, username=username, password=password, index="permits", embedding_dim=384, ca_certs=ca_cert)
+document_store = ElasticsearchDocumentStore(
+    host=host,
+    username=username,
+    password=password,
+    index="permits",
+    embedding_dim=384,
+    ca_certs=ca_cert,
+    verify_certs=True if ca_cert else False,
+    secheme='https' if ca_cert else 'http'
+)
 
 def query_pipeline():
     """

--- a/services/permits/app/pipelines.py
+++ b/services/permits/app/pipelines.py
@@ -21,7 +21,7 @@ document_store = ElasticsearchDocumentStore(
     embedding_dim=384,
     ca_certs=ca_cert,
     verify_certs=True if ca_cert else False,
-    secheme='https' if ca_cert else 'http'
+    scheme='https' if ca_cert else 'http'
 )
 
 def query_pipeline():

--- a/services/permits/requirements.txt
+++ b/services/permits/requirements.txt
@@ -2,4 +2,5 @@ fastapi==0.103.2
 uvicorn==0.24.0.post1
 farm-haystack[elasticsearch8,pdf,inference]==1.22.1
 git+https://github.com/deepset-ai/haystack.git@v1.22.1#egg=rest_api&subdirectory=rest_api
+--extra-index-url https://download.pytorch.org/whl/cpu
 torch==2.1.1


### PR DESCRIPTION
## Objective 

[MDS-5641](https://bcmines.atlassian.net/browse/MDS-5641)

- Added Github actions for deploying the permit service to test and prod
- Push permit service image to Artifactory instead of internal openshift registry due to size of image
- Parameterized connection details for Elasticsearch so the service can connect to the existing Elasticsearch instance
- Only install dependencies for running Haystack on a CPU as the GPU dependencies added 2GB to the final image.
