### PR TITLE
[MDS-5438] Remove file handler.

### DIFF
--- a/services/document-manager/backend/app/config.py
+++ b/services/document-manager/backend/app/config.py
@@ -147,24 +147,16 @@ class Config(object):
                 'stream': 'ext://sys.stdout',
                 'formatter': 'default',
                 'level': 'DEBUG'
-            },
-            'file': {
-                'class': 'logging.handlers.RotatingFileHandler',
-                'mode': 'a',
-                'backupCount': 0,
-                'maxBytes': 100000000,
-                'filename': '/var/log/document-manager.log',
-                'formatter': 'default',
             }
         },
         'root': {
             'level': FLASK_LOGGING_LEVEL,
-            'handlers': ['file', 'console']
+            'handlers': ['console']
         },
         'loggers': {
             'werkzeug': {
                 'level': WERKZEUG_LOGGING_LEVEL,
-                'handlers': ['file', 'console'],
+                'handlers': ['console'],
                 'propagate': DISPLAY_WERKZEUG_LOG
             }
         }


### PR DESCRIPTION
## Objective 

[MDS-5438](https://bcmines.atlassian.net/browse/MDS-5438)

Remove file logging handler as it is redundant.
