### PR TITLE
[MDS-5638] - Permit Service auth

### DIFF
--- a/services/permits/Dockerfile
+++ b/services/permits/Dockerfile
@@ -2,8 +2,7 @@ FROM python:3.9
 
 WORKDIR /code
 
-COPY ./requirements.txt /code/requirements.txt
-COPY ./.env /.env
+COPY . /code
 
 RUN apt-get update \
     && apt-get -y install tesseract-ocr # required for pytesseract
@@ -11,7 +10,5 @@ RUN apt-get update \
 ENV TESSDATA_PREFIX /usr/share/tesseract-ocr/5/tessdata
 
 RUN pip install --no-cache-dir --upgrade -r /code/requirements.txt
-
-COPY ./app /code/app
 
 CMD ["uvicorn", "app.app:mds", "--reload", "--host", "0.0.0.0", "--port", "80"]


### PR DESCRIPTION
## Objective 

Updated the dockerfile to copy all files so that it doesn't fail if the .env isn't present

[MDS-5638](https://bcmines.atlassian.net/browse/MDS-5638)
