### PR TITLE
[MDS-5684] Removed extract css webpack plugin

### DIFF
--- a/services/minespace-web/package.json
+++ b/services/minespace-web/package.json
@@ -113,7 +113,6 @@
     "file-loader": "4.3.0",
     "fsevents": "2.3.2",
     "hard-source-webpack-plugin": "0.13.1",
-    "html-critical-webpack-plugin": "2.1.0",
     "http-server-spa": "1.3.0",
     "jest": "24.8.0",
     "less": "4.1.3",

--- a/services/minespace-web/webpack.config.ts
+++ b/services/minespace-web/webpack.config.ts
@@ -9,7 +9,6 @@ const dotenv = require("dotenv").config({ path: `${__dirname}/.env` });
 const SpeedMeasurePlugin = require("speed-measure-webpack-plugin");
 const threadLoader = require("thread-loader");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
-const HtmlCriticalWebpackPlugin = require("html-critical-webpack-plugin");
 
 const parts = require("./webpack.parts");
 
@@ -260,19 +259,6 @@ const prodConfig = merge([
   parts.copy(PATHS.public, path.join(PATHS.build, "public")),
   {
     plugins: [
-      new HtmlCriticalWebpackPlugin({
-        base: PATHS.build,
-        src: "index.html",
-        dest: "index.html",
-        inline: true,
-        minify: true,
-        extract: true,
-        width: 375,
-        height: 565,
-        penthouse: {
-          blockJSRequests: false,
-        },
-      }),
       new BundleAnalyzerPlugin({
         analyzerMode: "static",
         generateStatsFile: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2670,7 +2670,6 @@ __metadata:
     fsevents: 2.3.2
     hard-source-webpack-plugin: 0.13.1
     hoist-non-react-statics: 3.3.1
-    html-critical-webpack-plugin: 2.1.0
     http-server-spa: 1.3.0
     jest: 24.8.0
     jest-canvas-mock: 2.1.0


### PR DESCRIPTION
## Objective 

[MDS-5684](https://bcmines.atlassian.net/browse/MDS-5684)

The `HtmlCriticalWebpackPlugin` injects an inline JS snippet into `index.html` to dynamically load CSS. This inline snippet prevents us from writing an effective Content Security Policy, as we have to allow inline JS which nullifies some of the XSS protection the CSP can give us.

Tradeoff: A minor loading time increase.
