### PR TITLE
[MDS-5729] BUG FIX: Multiselect width

### DIFF
--- a/services/common/src/components/forms/RenderMultiSelect.tsx
+++ b/services/common/src/components/forms/RenderMultiSelect.tsx
@@ -30,7 +30,6 @@ export const RenderMultiSelect: FC<MultiSelectProps> = (props) => {
     <FormConsumer>
       {(value: IFormContext) => {
         const { isEditMode, isModal } = value;
-
         if (!isEditMode) {
           const stringValue = "";
           return <BaseViewInput value={stringValue} label={label} />;
@@ -38,7 +37,7 @@ export const RenderMultiSelect: FC<MultiSelectProps> = (props) => {
 
         const extraProps = isModal ? null : { getPopupContainer: (trigger) => trigger.parentNode };
         return (
-          <div>
+          <div className="form-multiselect">
             <Form.Item
               name={input.name}
               required={props.required}

--- a/services/common/src/components/projects/ProjectLinks.tsx
+++ b/services/common/src/components/projects/ProjectLinks.tsx
@@ -60,7 +60,7 @@ const ProjectLinkInput = ({ unrelatedProjects = [], mineGuid, projectGuid }) => 
           id="linked-projects"
           name="linked-projects"
           props={{
-            label: "Select one or more related projects (optional)",
+            label: "Select one or more related projects",
             data: transformUnrelatedProjects(unrelatedProjects),
           }}
           component={RenderMultiSelect}

--- a/services/minespace-web/src/styles/overrides/antd-overrides.scss
+++ b/services/minespace-web/src/styles/overrides/antd-overrides.scss
@@ -534,6 +534,10 @@ th.ant-descriptions-item.vertical-description {
   padding: 5px;
 }
 
+.form-multiselect .ant-col.ant-form-item-control {
+  width: 100%;
+}
+
 // DATE PICKER
 .ant-picker {
   width: 100%;


### PR DESCRIPTION
## Objective 
- make multiselect take up the whole width
  - there's some row business going on that I don't think was there before, and from what I can tell, it put the select in a column with no span
- take out "optional" that is duplicated. 
   - I did check, and it's pretty much just ReportDetailsForm using new inputs, there was nowhere else for me to fix it. 👍 

[MDS-5729](https://bcmines.atlassian.net/browse/MDS-5729)

_Why are you making this change? Provide a short explanation and/or screenshots_
![image](https://github.com/bcgov/mds/assets/102187683/7ef80f8e-f234-4267-b937-70b412155010)
Perhaps a bit odd that it expands so wide when you select an option, but at least it's perfectly functional
![image](https://github.com/bcgov/mds/assets/102187683/0fb0eb57-8d32-4026-806c-7e07b8345c4e)

