### PR TITLE
[MDS-5737] Fixed opening of document viewer from action menu and other Document Viewer issues

### DIFF
--- a/services/common/src/components/documents/DocumentTable.tsx
+++ b/services/common/src/components/documents/DocumentTable.tsx
@@ -182,7 +182,7 @@ export const DocumentTable: FC<DocumentTableProps> = ({
       label: FileOperations.View,
       icon: <FileOutlined />,
       clickFunction: (_event, record: MineDocument) =>
-        dispatch(openDocument(record.document_manager_guid, record.mine_document_guid)),
+        dispatch(openDocument(record.document_manager_guid, record.document_name)),
     },
     {
       key: "download",

--- a/services/core-web/src/components/common/DocumentTable.tsx
+++ b/services/core-web/src/components/common/DocumentTable.tsx
@@ -180,7 +180,7 @@ export const DocumentTable: FC<DocumentTableProps> = ({
       label: FileOperations.View,
       icon: <FileOutlined />,
       clickFunction: (_event, record: MineDocument) =>
-        dispatch(openDocument(record.document_manager_guid, record.mine_document_guid)),
+        dispatch(openDocument(record.document_manager_guid, record.document_name)),
     },
     {
       key: "download",

--- a/services/minespace-web/src/components/syncfusion/DocumentViewer.js
+++ b/services/minespace-web/src/components/syncfusion/DocumentViewer.js
@@ -5,7 +5,10 @@ import PropTypes from "prop-types";
 import { ENVIRONMENT } from "@mds/common";
 import { createRequestHeader } from "@common/utils/RequestHeaders";
 import { Modal, Skeleton } from "antd";
-import { closeDocumentViewer, openDocumentViewer } from "@mds/common/redux/actions/documentViewerActions";
+import {
+  closeDocumentViewer,
+  openDocumentViewer,
+} from "@mds/common/redux/actions/documentViewerActions";
 import {
   getDocumentPath,
   getDocumentName,
@@ -113,10 +116,10 @@ export class DocumentViewer extends Component {
         >
           <Suspense fallback={<Skeleton />}>
             <PdfViewer
-              serviceUrl={this.pdfViewerServiceUrl}
+              pdfViewerServiceUrl={this.pdfViewerServiceUrl}
               documentPath={this.props.documentPath}
-              ajaxRequestSettings={ajaxRequestSettings}>
-            </PdfViewer>
+              ajaxRequestSettings={ajaxRequestSettings}
+            ></PdfViewer>
           </Suspense>
         </Modal>
       </>


### PR DESCRIPTION
## Objective 

[MDS-5737](https://bcmines.atlassian.net/browse/MDS-5737)

Fixed a couple of issues around the document viewer
- The "Open in Document Viewer" action button downloads the document instead of opening in the document viewer in both minespace and core: Second param to `openDocument` is the document name, not guid
- The Document Viewer fails with an error in Minespace: PDF Viewer service url param name was wrong
- Document Viewer doesn't work locally: Newly uploaded files didn't have the S3_PREFIX appended for multipart uploads
