### PR TITLE
[FIX] - VC Doc Refs Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ This application was originally developed in Javascript, and is being migrated t
 
 ## Verifiable Credentials
 
-This project support verifiable credential features compatible with [AnonCreds](https://www.hyperledger.org/projects/anoncreds) and [Hyperledger Aries](https://www.hyperledger.org/projects/aries) and serves as the [Administering Authority for the BC Mines Act Permit](https://github.com/bcgov/bc-vcpedia/blob/main/credentials/credential-bc-mines-act-permit.md#15-administering-authority).
+This project support verifiable credential features compatible with [AnonCreds](https://www.hyperledger.org/projects/anoncreds) and [Hyperledger Aries](https://www.hyperledger.org/projects/aries) and serves as the [Administering Authority for the BC Mines Act Permit](https://github.com/bcgov/bc-vcpedia/blob/main/credentials/bc-mines-act-permit/1.1.1/governance.md#15-administering-authority).
 
 See the [Verifiable Credential doc](docs/verifiable_credentials.md) for more detail.
 

--- a/docs/verifiable_credentials.md
+++ b/docs/verifiable_credentials.md
@@ -8,7 +8,7 @@ The core-api is enabled to send credential-offer messages to connected wallets a
 
 ## Governance Documentation
 
-The Mines Act Permit Verifiable Credentials has public [governance documentation](https://github.com/bcgov/bc-vcpedia/blob/main/credentials/credential-bc-mines-act-permit.md) that should be kept up-to-date with any technical or process changes.
+The Mines Act Permit Verifiable Credentials has public [governance documentation](https://github.com/bcgov/bc-vcpedia/blob/main/credentials/bc-mines-act-permit/1.1.1/governance.md) that should be kept up-to-date with any technical or process changes.
 
 ### Connection Establishment
 
@@ -51,7 +51,7 @@ Current Limitations:
 
 The Overlay Capture Architechture (OCA) bundle for this credential is hosted [here](https://github.com/bcgov/aries-oca-bundles/tree/main/OCABundles/schema). The OCA bundle provides infomation on how the credential should be presented, including backgroun colors, labels, data-typing, and localization. If the credential is updated, the OCA bundle may need to be updated to match.
 
-OCA bundles hosted here can be previewed on the [OCA Explorer](https://bcgov.github.io/aries-oca-bundles/)
+OCA bundles hosted here can be previewed on the [OCA Explorer](https://bcgov.github.io/aries-oca-explorer/)
 
 ### Permit Amendments and Revocation
 


### PR DESCRIPTION
Some VC documentation moves so some links in our readmes are broken. 

Found in https://github.com/bcgov/mds/issues/2847. 

Fixed here. 