### PR TITLE
[MDS-5737] Fixed incosistent path on new file uploads

### DIFF
--- a/services/filesystem-provider/.env-example
+++ b/services/filesystem-provider/.env-example
@@ -8,5 +8,5 @@ S3_PREFIX=/
 
 SYNCFUSION_LICENSE_KEY=
 
-JWT_OIDC_AUTHORITY=https://test.loginproxy.gov.bc.ca/auth/realms/standard/.well-known/openid-configuration
+JWT_OIDC_AUTHORITY=https://test.loginproxy.gov.bc.ca/auth/realms/standard/
 JWT_OIDC_AUDIENCE=mines-digital-services-mds-public-client-4414

--- a/services/minespace-web/src/components/common/DocumentTable.tsx
+++ b/services/minespace-web/src/components/common/DocumentTable.tsx
@@ -147,7 +147,7 @@ export const DocumentTable: FC<DocumentTableProps> = ({
       label: FileOperations.View,
       icon: <FileOutlined />,
       clickFunction: (_event, record: MineDocument) =>
-        openDocument(record.document_manager_guid, record.mine_document_guid),
+        openDocument(record.document_manager_guid, record.document_name),
     },
     {
       key: "download",


### PR DESCRIPTION
## Objective 

[MDS-5737](https://bcmines.atlassian.net/browse/MDS-5737)

The new file upload logic didn't append the S3_PREFIX when saving the `object_store_path`, just when copying the file there, making the saved path referencing a file that doesn't exist.

![image](https://github.com/bcgov/mds/assets/66635118/54516688-abef-462c-affe-3a44ac71a356)

A couple of other changes:
- Leftover fix for Viewing documents in document viewer when using the action menu in Minespace
- Updated filesystem_manager env variable to match what's expected. Syncfusion should now work out of the box when running the project locally as long as the `filesystem_provider` pod is running
