### PR TITLE
[MDS-5746] Fix issue when uploading multiple files in parallel

### DIFF
--- a/services/common/src/components/forms/RenderFileUpload.tsx
+++ b/services/common/src/components/forms/RenderFileUpload.tsx
@@ -164,6 +164,7 @@ export const FileUpload = (props: FileUploadProps) => {
         clearInterval(intervalId);
         if (response.data.status === "Success") {
           load(documentGuid);
+
           props.onFileLoad(file.name, documentGuid, versionGuid);
 
           if (props?.afterSuccess?.action) {
@@ -463,6 +464,7 @@ export const FileUpload = (props: FileUploadProps) => {
           allowMultiple={props.allowMultiple}
           onaddfilestart={props.addFileStart}
           allowReorder={props.allowReorder}
+          maxParallelUploads={1}
           maxFileSize={props.maxFileSize}
           // maxFiles={props.maxFiles || undefined}
           allowFileTypeValidation={acceptedFileTypes.length > 0}
@@ -470,7 +472,7 @@ export const FileUpload = (props: FileUploadProps) => {
           onaddfile={handleFileAdd}
           onprocessfiles={props.onProcessFiles}
           onprocessfileabort={props.onAbort}
-          // oninit={props.onInit}
+          oninit={props.onInit}
           labelIdle={props?.labelIdle}
           itemInsertLocation={props?.itemInsertLocation}
           credits={null}


### PR DESCRIPTION
## Objective 

[MDS-5746](https://bcmines.atlassian.net/browse/MDS-5746)

This fixes an issue with parallel file uploads where sometimes files would not appear in the list of submitted files after  being submitted. 
This happens when file upload are completed too close together, and are caused by how we handle updating the state with newly uploaded files (common pattern across the system).

![image](https://github.com/bcgov/mds/assets/66635118/ebb0fd9c-4e1b-4176-8fca-111c615939a7)

The `setUploadedFiles(...)` is actually performed `async` (as with all state updates), so if you call them two times in short order, `uploadedFiles` might not have had time to finish updating before the second call, so an old value is read, causing files to be missed
