### PR TITLE
[MDS-5725] fixed sorting bug, and set status to INI by default instead of NRQ

### DIFF
--- a/services/core-api/app/api/mines/reports/resources/mine_reports.py
+++ b/services/core-api/app/api/mines/reports/resources/mine_reports.py
@@ -129,7 +129,7 @@ class MineReportListResource(Resource, UserMixin):
             submission = submissions[-1]
             if len(submission.get('documents')) > 0:
                 submission_status = data.get('mine_report_submission_status') if data.get(
-                    'mine_report_submission_status') else 'NRQ'
+                    'mine_report_submission_status') else 'INI'
                 report_submission = MineReportSubmission(
                     mine_report_submission_status_code=submission_status,
                     submission_date=datetime.utcnow())

--- a/services/minespace-web/src/components/dashboard/mine/reports/ReportsTable.tsx
+++ b/services/minespace-web/src/components/dashboard/mine/reports/ReportsTable.tsx
@@ -148,7 +148,7 @@ export const ReportsTable: FC<ReportsTableProps> = (props) => {
 
       return {
         ...report,
-        status: latestSubmission?.mine_report_submission_status_code,
+        status: latestSubmission?.mine_report_submission_status_code ?? "",
       };
     });
 


### PR DESCRIPTION
## Objective 

[MDS-5725](https://bcmines.atlassian.net/browse/MDS-5725)

- fixed a blank screen bug when trying to sort if a report status is null (edge case as this shouldn't happen in the future)
- Defaulted report status to INI if none is sent instead of NRQ
