### PR TITLE
[MDS-5684] Allow manual trigger of core test pipeline

### DIFF
--- a/.github/workflows/core-web.unit.yaml
+++ b/.github/workflows/core-web.unit.yaml
@@ -1,6 +1,7 @@
 name: CORE WEB - Unit Tests
 
 on:
+  workflow_dispatch:
   pull_request:
     paths:
       - services/common/**


### PR DESCRIPTION
## Objective 

[MDS-5684](https://bcmines.atlassian.net/browse/MDS-5684)

Enable workflow_dispatch of the core web test action. Will make it a whole lot easier to test changes to the pipeline. 
