### PR TITLE
[MDS-5744] Save Draft validation on MS projects stepped form

### DIFF
--- a/services/core-web/cypress/e2e/majorprojects.cy.ts
+++ b/services/core-web/cypress/e2e/majorprojects.cy.ts
@@ -1,4 +1,4 @@
-describe.skip("Major Projects", () => {
+describe("Major Projects", () => {
   beforeEach(() => {
     cy.login();
 

--- a/services/minespace-web/src/components/pages/Project/ProjectSummaryPage.tsx
+++ b/services/minespace-web/src/components/pages/Project/ProjectSummaryPage.tsx
@@ -246,8 +246,8 @@ export const ProjectSummaryPage: FC<ProjectSummaryPageProps> = (props) => {
       if (projectGuid && projectSummaryGuid) {
         handleUpdateProjectSummary(values, message);
       }
+      handleTabChange(newActiveTab);
     }
-    handleTabChange(newActiveTab);
   };
 
   const mineName = isEditMode


### PR DESCRIPTION
## Objective 
- missed the save draft functionality earlier with same bug on save changes
  - don't change tabs when there are errors when user clicks save (fixed earlier), and don't change tabs if they clicked save draft either
- this is going up as a draft because it's done but testing will block it

[MDS-5744](https://bcmines.atlassian.net/browse/MDS-5744)

_Why are you making this change? Provide a short explanation and/or screenshots_
errors on save draft!
![image](https://github.com/bcgov/mds/assets/102187683/d9016072-a3ba-402a-a147-95e66d072335)
