### PR TITLE
[MDS-5409] Fixed SQLAlchemy relationship warnings in Core

### DIFF
--- a/services/core-api/app/api/incidents/models/mine_incident.py
+++ b/services/core-api/app/api/incidents/models/mine_incident.py
@@ -134,7 +134,8 @@ class MineIncident(SoftDeleteMixin, AuditMixin, Base):
         'MineDocument',
         lazy='selectin',
         secondary='mine_incident_document_xref',
-        secondaryjoin='and_(foreign(MineIncidentDocumentXref.mine_document_guid) == remote(MineDocument.mine_document_guid),MineDocument.deleted_ind == False)'
+        secondaryjoin='and_(foreign(MineIncidentDocumentXref.mine_document_guid) == remote(MineDocument.mine_document_guid),MineDocument.deleted_ind == False)',
+        overlaps='_documents'
     )
 
     categories = db.relationship(
@@ -146,7 +147,7 @@ class MineIncident(SoftDeleteMixin, AuditMixin, Base):
         primaryjoin='and_(MineIncidentNote.mine_incident_guid == MineIncident.mine_incident_guid, MineIncidentNote.deleted_ind == False)'
     )
 
-    mine_table = db.relationship('Mine', lazy='joined')
+    mine_table = db.relationship('Mine', lazy='joined', back_populates='mine_incidents', overlaps='mine,mine_incidents')
     mine_name = association_proxy('mine_table', 'mine_name')
     mine_region = association_proxy('mine_table', 'mine_region')
     major_mine_ind = association_proxy('mine_table', 'major_mine_ind')

--- a/services/core-api/app/api/mines/alerts/models/mine_alert.py
+++ b/services/core-api/app/api/mines/alerts/models/mine_alert.py
@@ -1,6 +1,7 @@
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.schema import FetchedValue
+from sqlalchemy.orm import backref
 from app.api.utils.models_mixins import SoftDeleteMixin, AuditMixin, Base
 from app.extensions import db
 from sqlalchemy_filters import apply_pagination
@@ -19,7 +20,7 @@ class MineAlert(SoftDeleteMixin, AuditMixin, Base):
 
     end_date = db.Column(db.DateTime)
 
-    mine_table = db.relationship('MineMapViewLocation', lazy='joined', primaryjoin='and_(foreign(MineAlert.mine_guid) == remote(MineMapViewLocation.mine_guid))')
+    mine_table = db.relationship('MineMapViewLocation', lazy='joined', primaryjoin='and_(foreign(MineAlert.mine_guid) == remote(MineMapViewLocation.mine_guid))', overlaps='alerts')
     mine_name = association_proxy('mine_table', 'mine_name')
     mine_no = association_proxy('mine_table', 'mine_no')
 

--- a/services/core-api/app/api/mines/explosives_permit/models/explosives_permit.py
+++ b/services/core-api/app/api/mines/explosives_permit/models/explosives_permit.py
@@ -57,11 +57,14 @@ class ExplosivesPermit(SoftDeleteMixin, AuditMixin, PermitMixin, Base):
     explosive_magazines = db.relationship('ExplosivesPermitMagazine', lazy='select',
         primaryjoin='and_(ExplosivesPermitMagazine.explosives_permit_id == ExplosivesPermit.explosives_permit_id, ExplosivesPermitMagazine.explosives_permit_magazine_type_code == "EXP", ExplosivesPermitMagazine.deleted_ind == False)')
     detonator_magazines = db.relationship('ExplosivesPermitMagazine', lazy='select',
-        primaryjoin='and_(ExplosivesPermitMagazine.explosives_permit_id == ExplosivesPermit.explosives_permit_id, ExplosivesPermitMagazine.explosives_permit_magazine_type_code == "DET", ExplosivesPermitMagazine.deleted_ind == False)')
+        primaryjoin='and_(ExplosivesPermitMagazine.explosives_permit_id == ExplosivesPermit.explosives_permit_id, ExplosivesPermitMagazine.explosives_permit_magazine_type_code == "DET", ExplosivesPermitMagazine.deleted_ind == False)',
+        overlaps='explosive_magazines')
 
     documents = db.relationship('ExplosivesPermitDocumentXref', lazy='select')
     mine_documents = db.relationship('MineDocument', lazy='select', secondary='explosives_permit_document_xref',
-        secondaryjoin='and_(foreign(ExplosivesPermitDocumentXref.mine_document_guid) == remote(MineDocument.mine_document_guid), MineDocument.deleted_ind == False)')
+        secondaryjoin='and_(foreign(ExplosivesPermitDocumentXref.mine_document_guid) == remote(MineDocument.mine_document_guid), MineDocument.deleted_ind == False)',
+        overlaps='mine_document, documents'
+    )
 
     mines_act_permit = db.relationship('Permit', lazy='select')
     now_application_identity = db.relationship('NOWApplicationIdentity', lazy='select')

--- a/services/core-api/app/api/mines/explosives_permit_amendment/models/explosives_permit_amendment.py
+++ b/services/core-api/app/api/mines/explosives_permit_amendment/models/explosives_permit_amendment.py
@@ -49,7 +49,8 @@ class ExplosivesPermitAmendment(SoftDeleteMixin, AuditMixin, PermitMixin, Base):
         'MineDocument',
         lazy='select',
         secondary='explosives_permit_amendment_document_xref',
-        secondaryjoin='and_(foreign(ExplosivesPermitAmendmentDocumentXref.mine_document_guid) == remote(MineDocument.mine_document_guid), MineDocument.deleted_ind == False)'
+        secondaryjoin='and_(foreign(ExplosivesPermitAmendmentDocumentXref.mine_document_guid) == remote(MineDocument.mine_document_guid), MineDocument.deleted_ind == False)',
+        overlaps='mine_document,documents'
     )
 
     mines_act_permit = db.relationship('Permit', lazy='select')
@@ -63,7 +64,8 @@ class ExplosivesPermitAmendment(SoftDeleteMixin, AuditMixin, PermitMixin, Base):
     detonator_magazines = db.relationship(
         'ExplosivesPermitAmendmentMagazine',
         lazy='select',
-        primaryjoin='and_(ExplosivesPermitAmendmentMagazine.explosives_permit_amendment_id == ExplosivesPermitAmendment.explosives_permit_amendment_id, ExplosivesPermitAmendmentMagazine.explosives_permit_amendment_magazine_type_code == "DET", ExplosivesPermitAmendmentMagazine.deleted_ind == False)'
+        primaryjoin='and_(ExplosivesPermitAmendmentMagazine.explosives_permit_amendment_id == ExplosivesPermitAmendment.explosives_permit_amendment_id, ExplosivesPermitAmendmentMagazine.explosives_permit_amendment_magazine_type_code == "DET", ExplosivesPermitAmendmentMagazine.deleted_ind == False)',
+        overlaps='explosive_magazines'
     )
 
     def __repr__(self):

--- a/services/core-api/app/api/mines/incidents/models/mine_incident_document_xref.py
+++ b/services/core-api/app/api/mines/incidents/models/mine_incident_document_xref.py
@@ -18,7 +18,7 @@ class MineIncidentDocumentXref(Base):
         db.String,
         db.ForeignKey('mine_incident_document_type_code.mine_incident_document_type_code'),
         nullable=False)
-    mine_document = db.relationship('MineDocument', lazy='joined')
+    mine_document = db.relationship('MineDocument', lazy='joined', overlaps="mine_documents")
 
     mine_guid = association_proxy('mine_document', 'mine_guid')
     document_manager_guid = association_proxy('mine_document', 'document_manager_guid')

--- a/services/core-api/app/api/mines/mine/models/mine.py
+++ b/services/core-api/app/api/mines/mine/models/mine.py
@@ -64,11 +64,13 @@ class Mine(SoftDeleteMixin, AuditMixin, Base):
         order_by='desc(Permit.create_timestamp)',
         lazy='select',
         secondary='mine_permit_xref',
-        secondaryjoin='and_(foreign(MinePermitXref.permit_id) == remote(Permit.permit_id),Permit.deleted_ind == False,MinePermitXref.deleted_ind == False)'
+        secondaryjoin='and_(foreign(MinePermitXref.permit_id) == remote(Permit.permit_id),Permit.deleted_ind == False,MinePermitXref.deleted_ind == False)',
+        back_populates='_all_mines',
+        overlaps='_mine_associations,all_mine_permit_xref,mine_permit_xref,mine'
     )
 
     # across all permit_identities
-    _mine_permit_amendments = db.relationship('PermitAmendment', lazy='selectin')
+    _mine_permit_amendments = db.relationship('PermitAmendment', lazy='selectin', back_populates='mine')
 
     mine_type = db.relationship(
         'MineType',
@@ -91,7 +93,7 @@ class Mine(SoftDeleteMixin, AuditMixin, Base):
         lazy='select',
         primaryjoin='and_(MineIncident.mine_guid == Mine.mine_guid, MineIncident.deleted_ind == False)')
 
-    mine_reports = db.relationship('MineReport', lazy='select')
+    mine_reports = db.relationship('MineReport', lazy='select', back_populates='mine')
 
     explosives_permits = db.relationship(
         'ExplosivesPermit',
@@ -115,7 +117,8 @@ class Mine(SoftDeleteMixin, AuditMixin, Base):
         'MineWorkInformation',
         lazy='selectin',
         order_by='desc(MineWorkInformation.created_timestamp)',
-        primaryjoin='and_(MineWorkInformation.mine_guid == Mine.mine_guid, MineWorkInformation.deleted_ind == False)'
+        primaryjoin='and_(MineWorkInformation.mine_guid == Mine.mine_guid, MineWorkInformation.deleted_ind == False)',
+        back_populates='mine'
     )
 
     comments = db.relationship(

--- a/services/core-api/app/api/mines/permits/permit/models/permit.py
+++ b/services/core-api/app/api/mines/permits/permit/models/permit.py
@@ -40,7 +40,7 @@ class Permit(SoftDeleteMixin, AuditMixin, Base):
         order_by='desc(PermitAmendment.issue_date), desc(PermitAmendment.permit_amendment_id)',
         lazy='select')
 
-    _all_mines = db.relationship('Mine', lazy='select', secondary='mine_permit_xref')
+    _all_mines = db.relationship('Mine', lazy='select', secondary='mine_permit_xref', back_populates='_permit_identities', overlaps='mine,mine_permit_xref,all_mine_permit_xref')
 
     permittee_appointments = db.relationship(
         'MinePartyAppointment',
@@ -48,12 +48,14 @@ class Permit(SoftDeleteMixin, AuditMixin, Base):
         'and_(MinePartyAppointment.permit_id == Permit.permit_id, MinePartyAppointment.deleted_ind==False, MinePartyAppointment.mine_party_appt_type_code=="PMT")',
         lazy='select',
         order_by=
-        'desc(MinePartyAppointment.start_date), desc(MinePartyAppointment.mine_party_appt_id)')
+        'desc(MinePartyAppointment.start_date), desc(MinePartyAppointment.mine_party_appt_id)',
+        overlaps='permit,permitt_appointments')
     permit_appointments = db.relationship(
         'MinePartyAppointment',
         lazy='select',
         order_by=
-        'desc(MinePartyAppointment.start_date), desc(MinePartyAppointment.mine_party_appt_id)')
+        'desc(MinePartyAppointment.start_date), desc(MinePartyAppointment.mine_party_appt_id)',
+        overlaps='permittee_appointments,permit')
     permit_status = db.relationship('PermitStatusCode', lazy='select')
     permit_status_code_description = association_proxy('permit_status', 'description')
 
@@ -61,8 +63,8 @@ class Permit(SoftDeleteMixin, AuditMixin, Base):
     is_exploration = db.Column(db.Boolean)
 
     bonds = db.relationship(
-        'Bond', lazy='select', secondary='bond_permit_xref', order_by='desc(Bond.issue_date)')
-    reclamation_invoices = db.relationship('ReclamationInvoice', lazy='select')
+        'Bond', lazy='select', secondary='bond_permit_xref', order_by='desc(Bond.issue_date)', back_populates='permit')
+    reclamation_invoices = db.relationship('ReclamationInvoice', lazy='select', back_populates='permit')
     exemption_fee_status_code = db.Column(
         db.String, db.ForeignKey('exemption_fee_status.exemption_fee_status_code'))
     exemption_fee_status_note = db.Column(db.String)
@@ -72,7 +74,7 @@ class Permit(SoftDeleteMixin, AuditMixin, Base):
         lazy='select',
         primaryjoin='and_(Permit.permit_guid == MineType.permit_guid, MineType.active_ind==True)')
 
-    _mine_associations = db.relationship('MinePermitXref')
+    _mine_associations = db.relationship('MinePermitXref', overlaps='_all_mines,all_mine_permit_xref,mine_permit_xref')
 
     # Liability on permit after permit is closed
     remaining_static_liability = db.Column(db.Numeric(16, 2))

--- a/services/core-api/app/api/mines/permits/permit_conditions/models/permit_conditions.py
+++ b/services/core-api/app/api/mines/permits/permit_conditions/models/permit_conditions.py
@@ -27,7 +27,7 @@ class PermitConditions(SoftDeleteMixin, AuditMixin, Base):
     permit_condition_id = db.Column(db.Integer, primary_key=True)
     permit_amendment_id = db.Column(
         db.Integer, db.ForeignKey('permit_amendment.permit_amendment_id'), nullable=False)
-    permit_amendment = db.relationship('PermitAmendment', lazy='select')
+    permit_amendment = db.relationship('PermitAmendment', lazy='select', back_populates='conditions')
     permit_condition_guid = db.Column(UUID(as_uuid=True), server_default=FetchedValue())
     condition = db.Column(db.String, nullable=False)
     condition_category_code = db.Column(

--- a/services/core-api/app/api/mines/reports/models/mine_report.py
+++ b/services/core-api/app/api/mines/reports/models/mine_report.py
@@ -36,7 +36,7 @@ class MineReport(SoftDeleteMixin, AuditMixin, Base):
     submitter_email = db.Column(db.String, nullable=False)
 
     mine_guid = db.Column(UUID(as_uuid=True), db.ForeignKey('mine.mine_guid'), nullable=False)
-    mine = db.relationship('Mine', lazy='joined')
+    mine = db.relationship('Mine', lazy='joined', back_populates='mine_reports')
     mine_name = association_proxy('mine', 'mine_name')
     mine_region = association_proxy('mine', 'mine_region')
     major_mine_ind = association_proxy('mine', 'major_mine_ind')
@@ -54,7 +54,8 @@ class MineReport(SoftDeleteMixin, AuditMixin, Base):
         'MineReportSubmission',
         lazy='joined',
         order_by='asc(MineReportSubmission.mine_report_submission_id)',
-        uselist=True)
+        uselist=True,
+        back_populates='report')
 
     mine_report_contacts = db.relationship(
         'MineReportContact',

--- a/services/core-api/app/api/mines/reports/models/mine_report_submission.py
+++ b/services/core-api/app/api/mines/reports/models/mine_report_submission.py
@@ -26,7 +26,7 @@ class MineReportSubmission(Base, AuditMixin):
         order_by='MineReportComment.comment_datetime',
         primaryjoin="and_(MineReportComment.mine_report_submission_id == MineReportSubmission.mine_report_submission_id, MineReportComment.deleted_ind==False)",
         lazy='joined')
-    report = db.relationship('MineReport', lazy='joined')
+    report = db.relationship('MineReport', lazy='joined', back_populates='mine_report_submissions')
 
     mine_report_guid = association_proxy('report', 'mine_report_guid')
 

--- a/services/core-api/app/api/mines/tailings/models/tailings.py
+++ b/services/core-api/app/api/mines/tailings/models/tailings.py
@@ -63,7 +63,8 @@ class MineTailingsStorageFacility(AuditMixin, Base):
         'MineTailingsStorageFacility.mine_tailings_storage_facility_guid, '
         'MinePartyAppointment.mine_party_appt_type_code == "EOR", MinePartyAppointment.deleted_ind == False)',
         order_by=
-        'nullslast(desc(MinePartyAppointment.start_date)), nullsfirst(desc(MinePartyAppointment.end_date))'
+        'nullslast(desc(MinePartyAppointment.start_date)), nullsfirst(desc(MinePartyAppointment.end_date))',
+        overlaps="mine_tailings_storage_facility"
     )
     dams = db.relationship(
         'Dam',
@@ -81,7 +82,8 @@ class MineTailingsStorageFacility(AuditMixin, Base):
         primaryjoin=
         'and_(MinePartyAppointment.mine_tailings_storage_facility_guid == MineTailingsStorageFacility.mine_tailings_storage_facility_guid, MinePartyAppointment.mine_party_appt_type_code == "TQP", MinePartyAppointment.deleted_ind == False)',
         order_by=
-        'nullslast(desc(MinePartyAppointment.start_date)), nullsfirst(desc(MinePartyAppointment.end_date))'
+        'nullslast(desc(MinePartyAppointment.start_date)), nullsfirst(desc(MinePartyAppointment.end_date))',
+        overlaps="engineer_of_records,mine_tailings_storage_facility"
     )
 
     @hybrid_property

--- a/services/core-api/app/api/mines/work_information/models/mine_work_information.py
+++ b/services/core-api/app/api/mines/work_information/models/mine_work_information.py
@@ -33,7 +33,7 @@ class MineWorkInformation(SoftDeleteMixin, AuditMixin, Base):
     updated_by = db.Column(db.String, default=User().get_user_username, nullable=False)
     updated_timestamp = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
 
-    mine = db.relationship('Mine')
+    mine = db.relationship('Mine', back_populates='mine_work_informations')
 
     def __repr__(self):
         return f'<{self.__class__.__name__} {self.mine_work_information_id}>'

--- a/services/core-api/app/api/notice_of_departure/models/notice_of_departure_document_xref.py
+++ b/services/core-api/app/api/notice_of_departure/models/notice_of_departure_document_xref.py
@@ -22,7 +22,7 @@ class NoticeOfDepartureDocumentXref(SoftDeleteMixin, AuditMixin, Base):
         db.ForeignKey('notice_of_departure.nod_guid'),
         server_default=FetchedValue())
     document_type = db.Column(db.Enum(DocumentType), nullable=False, default=DocumentType.checklist)
-    mine_document = db.relationship('MineDocument', lazy='joined')
+    mine_document = db.relationship('MineDocument', lazy='joined', overlaps="mine_documents,notice_of_departure")
 
     mine_guid = association_proxy('mine_document', 'mine_guid')
     document_manager_guid = association_proxy('mine_document', 'document_manager_guid')

--- a/services/core-api/app/api/now_applications/models/activity_detail/activity_detail_base.py
+++ b/services/core-api/app/api/now_applications/models/activity_detail/activity_detail_base.py
@@ -43,10 +43,10 @@ class ActivityDetailBase(AuditMixin, Base):
     water_quantity = db.Column(db.Numeric(14, 2))
     water_quantity_unit_type_code = db.Column(db.String, db.ForeignKey('unit_type.unit_type_code'))
 
-    _etl_activity_details = db.relationship('ETLActivityDetail', load_on_pending=True)
+    _etl_activity_details = db.relationship('ETLActivityDetail', load_on_pending=True, back_populates='activity_detail')
     
-    activitySummaryBuildingDetailXrefChild = db.relationship('ActivitySummaryBuildingDetailXref', backref='activity_detail', cascade='all,delete-orphan')
-    activitySummaryStagingAreaDetailXrefChild = db.relationship('ActivitySummaryStagingAreaDetailXref', backref='activity_detail', cascade='all,delete-orphan')
+    activitySummaryBuildingDetailXrefChild = db.relationship('ActivitySummaryBuildingDetailXref', backref='activity_detail', cascade='all,delete-orphan', overlaps='building_detail_associations,building_details,detail')
+    activitySummaryStagingAreaDetailXrefChild = db.relationship('ActivitySummaryStagingAreaDetailXref', backref='activity_detail', cascade='all,delete-orphan', overlaps='detail,staging_area_detail_associations,staging_area_details')
 
     activity_type_code = db.column_property(
         func.coalesce(

--- a/services/core-api/app/api/now_applications/models/activity_detail/activity_summary_building_detail_xref.py
+++ b/services/core-api/app/api/now_applications/models/activity_detail/activity_summary_building_detail_xref.py
@@ -10,6 +10,6 @@ class ActivitySummaryBuildingDetailXref(Base):
         db.Integer, db.ForeignKey('activity_detail.activity_detail_id', ondelete='CASCADE'), primary_key=True)
 
     summary = db.relationship(
-        'ActivitySummaryBase', backref='building_summary_associations', load_on_pending=True)
+        'ActivitySummaryBase', backref='building_summary_associations', load_on_pending=True, overlaps='building_summary_associations,summary')
     detail = db.relationship(
-        'ActivityDetailBase', backref='building_detail_associations', load_on_pending=True)
+        'ActivityDetailBase', backref='building_detail_associations', load_on_pending=True, overlaps='building_summary_associations,summary')

--- a/services/core-api/app/api/now_applications/models/activity_detail/activity_summary_staging_area_detail_xref.py
+++ b/services/core-api/app/api/now_applications/models/activity_detail/activity_summary_staging_area_detail_xref.py
@@ -11,6 +11,6 @@ class ActivitySummaryStagingAreaDetailXref(Base):
         db.Integer, db.ForeignKey('activity_detail.activity_detail_id', ondelete='CASCADE'), primary_key=True)
 
     summary = db.relationship(
-        'ActivitySummaryBase', backref='staging_area_summary_associations', load_on_pending=True)
+        'ActivitySummaryBase', backref='staging_area_summary_associations', load_on_pending=True, overlaps='building_detail_associations,building_details,detail')
     detail = db.relationship(
-        'ActivityDetailBase', backref='staging_area_detail_associations', load_on_pending=True)
+        'ActivityDetailBase', backref='staging_area_detail_associations', load_on_pending=True, overlaps='detail,staging_area_detail_associations,staging_area_details')

--- a/services/core-api/app/api/now_applications/models/activity_detail/etl_activity_detail.py
+++ b/services/core-api/app/api/now_applications/models/activity_detail/etl_activity_detail.py
@@ -10,4 +10,4 @@ class ETLActivityDetail(Base):
     placeractivityid = db.Column(db.Integer)
     settlingpondid = db.Column(db.Integer)
 
-    activity_detail = db.relationship('ActivityDetailBase', uselist=False, load_on_pending=True)
+    activity_detail = db.relationship('ActivityDetailBase', uselist=False, load_on_pending=True, back_populates='_etl_activity_details')

--- a/services/core-api/app/api/now_applications/models/activity_summary/camp.py
+++ b/services/core-api/app/api/now_applications/models/activity_summary/camp.py
@@ -25,13 +25,14 @@ class Camp(ActivitySummaryBase):
     volume_fuel_stored = db.Column(db.Numeric(14, 2))
 
     details = db.relationship(
-        'CampDetail', secondary='activity_summary_detail_xref', load_on_pending=True)
+        'CampDetail', secondary='activity_summary_detail_xref', load_on_pending=True, overlaps='building_detail_associations,detail,detail_associations,summary,summary_associations')
     staging_area_details = db.relationship(
         'StagingAreaDetail',
         secondary='activity_summary_staging_area_detail_xref',
-        load_on_pending=True)
+        load_on_pending=True,
+        overlaps='staging_area_detail_associations,staging_area_summary_associations,summary')
     building_details = db.relationship(
-        'BuildingDetail', secondary='activity_summary_building_detail_xref', load_on_pending=True)
+        'BuildingDetail', secondary='activity_summary_building_detail_xref', load_on_pending=True, overlaps='building_detail_associations,detail,building_summary_associations,summary')
 
     @hybrid_property
     def calculated_total_disturbance_camp(self):

--- a/services/core-api/app/api/now_applications/models/activity_summary/cut_lines_polarization_survey.py
+++ b/services/core-api/app/api/now_applications/models/activity_summary/cut_lines_polarization_survey.py
@@ -18,7 +18,8 @@ class CutLinesPolarizationSurvey(ActivitySummaryBase):
     details = db.relationship(
         'CutLinesPolarizationSurveyDetail',
         secondary='activity_summary_detail_xref',
-        load_on_pending=True)
+        load_on_pending=True,
+        overlaps='detail,detail_associations,summary,summary_associations')
 
     @hybrid_property
     def calculated_total_disturbance(self):

--- a/services/core-api/app/api/now_applications/models/activity_summary/exploration_access.py
+++ b/services/core-api/app/api/now_applications/models/activity_summary/exploration_access.py
@@ -21,7 +21,7 @@ class ExplorationAccess(ActivitySummaryBase):
     bridge_culvert_crossing_description = db.Column(db.String)
 
     details = db.relationship(
-        'ExplorationAccessDetail', secondary='activity_summary_detail_xref', load_on_pending=True)
+        'ExplorationAccessDetail', secondary='activity_summary_detail_xref', load_on_pending=True, overlaps='detail,detail_associations,summary,summary_associations')
 
     @hybrid_property
     def calculated_total_disturbance(self):

--- a/services/core-api/app/api/now_applications/models/activity_summary/exploration_surface_drilling.py
+++ b/services/core-api/app/api/now_applications/models/activity_summary/exploration_surface_drilling.py
@@ -22,7 +22,8 @@ class ExplorationSurfaceDrilling(ActivitySummaryBase):
     details = db.relationship(
         'ExplorationSurfaceDrillingDetail',
         secondary='activity_summary_detail_xref',
-        load_on_pending=True)
+        load_on_pending=True,
+        overlaps='detail,detail_associations,summary,summary_associations')
     @hybrid_property
     def calculated_total_disturbance(self):
         return self.calculate_total_disturbance_area(self.details)

--- a/services/core-api/app/api/now_applications/models/activity_summary/mechanical_trenching.py
+++ b/services/core-api/app/api/now_applications/models/activity_summary/mechanical_trenching.py
@@ -16,7 +16,7 @@ class MechanicalTrenching(ActivitySummaryBase):
 
     ## NO TABLE FOR THIS TYPE
     details = db.relationship(
-        'MechanicalTrenchingDetail', secondary='activity_summary_detail_xref', load_on_pending=True)
+        'MechanicalTrenchingDetail', secondary='activity_summary_detail_xref', load_on_pending=True, overlaps='detail,detail_associations,summary,summary_associations')
 
     @hybrid_property
     def calculated_total_disturbance(self):

--- a/services/core-api/app/api/now_applications/models/activity_summary/placer_operation.py
+++ b/services/core-api/app/api/now_applications/models/activity_summary/placer_operation.py
@@ -30,7 +30,7 @@ class PlacerOperation(ActivitySummaryBase):
                                                    db.ForeignKey('unit_type.unit_type_code'))
 
     details = db.relationship(
-        'PlacerOperationDetail', secondary='activity_summary_detail_xref', load_on_pending=True)
+        'PlacerOperationDetail', secondary='activity_summary_detail_xref', load_on_pending=True, overlaps='detail,detail_associations,summary,summary_associations')
 
     @hybrid_property
     def calculated_total_disturbance(self):

--- a/services/core-api/app/api/now_applications/models/activity_summary/sand_gravel_quarry_operation.py
+++ b/services/core-api/app/api/now_applications/models/activity_summary/sand_gravel_quarry_operation.py
@@ -65,7 +65,8 @@ class SandGravelQuarryOperation(ActivitySummaryBase):
     details = db.relationship(
         'SandGravelQuarryOperationDetail',
         secondary='activity_summary_detail_xref',
-        load_on_pending=True)
+        load_on_pending=True,
+        overlaps='detail,detail_associations,summary,summary_associations')
 
     # TODO replace with value from vFCBC
     # If the other description is provided, the other option has been selected.

--- a/services/core-api/app/api/now_applications/models/activity_summary/settling_pond.py
+++ b/services/core-api/app/api/now_applications/models/activity_summary/settling_pond.py
@@ -30,7 +30,7 @@ class SettlingPond(ActivitySummaryBase):
     is_ponds_discharged = db.Column(db.Boolean)
 
     details = db.relationship(
-        'SettlingPondDetail', secondary='activity_summary_detail_xref', load_on_pending=True)
+        'SettlingPondDetail', secondary='activity_summary_detail_xref', load_on_pending=True, overlaps='detail,detail_associations,summary,summary_associations')
 
     @hybrid_property
     def calculated_total_disturbance(self):

--- a/services/core-api/app/api/now_applications/models/activity_summary/surface_bulk_sample.py
+++ b/services/core-api/app/api/now_applications/models/activity_summary/surface_bulk_sample.py
@@ -24,7 +24,7 @@ class SurfaceBulkSample(ActivitySummaryBase):
     has_bedrock_excavation = db.Column(db.Boolean)
 
     details = db.relationship(
-        'SurfaceBulkSampleDetail', secondary='activity_summary_detail_xref', load_on_pending=True)
+        'SurfaceBulkSampleDetail', secondary='activity_summary_detail_xref', load_on_pending=True, overlaps='detail,detail_associations,summary,summary_associations')
 
     @hybrid_property
     def calculated_total_disturbance(self):

--- a/services/core-api/app/api/now_applications/models/activity_summary/underground_exploration.py
+++ b/services/core-api/app/api/now_applications/models/activity_summary/underground_exploration.py
@@ -37,7 +37,9 @@ class UndergroundExploration(ActivitySummaryBase):
     details = db.relationship(
         'UndergroundExplorationDetail',
         secondary='activity_summary_detail_xref',
-        load_on_pending=True)
+        load_on_pending=True,
+        overlaps='detail,detail_associations,summary,summary_associations'
+    )
     
     @hybrid_property
     def calculated_total_disturbance(self):

--- a/services/core-api/app/api/now_applications/models/activity_summary/water_supply.py
+++ b/services/core-api/app/api/now_applications/models/activity_summary/water_supply.py
@@ -15,7 +15,7 @@ class WaterSupply(ActivitySummaryBase):
     }
 
     ## NO TABLE FOR THIS TYPE
-    details = db.relationship('WaterSupplyDetail', secondary='activity_summary_detail_xref')
+    details = db.relationship('WaterSupplyDetail', secondary='activity_summary_detail_xref', overlaps='detail,detail_associations,summary,summary_associations')
 
     def __repr__(self):
         return '<WaterSupply %r>' % self.activity_summary_id

--- a/services/core-api/app/api/now_applications/models/applications_view.py
+++ b/services/core-api/app/api/now_applications/models/applications_view.py
@@ -82,13 +82,16 @@ class ApplicationsView(Base):
         lazy='selectin',
         primaryjoin=
         'and_(foreign(NOWApplicationDocumentXref.now_application_id)==ApplicationsView.now_application_id, NOWApplicationDocumentXref.now_application_review_id==None)',
-        order_by='desc(NOWApplicationDocumentXref.create_timestamp)')
+        order_by='desc(NOWApplicationDocumentXref.create_timestamp)',
+        overlaps='documents'
+    )
 
     permit_amendments = db.relationship(
         'PermitAmendment',
         lazy='select',
         primaryjoin=
-        'and_(foreign(PermitAmendment.now_application_guid)==ApplicationsView.now_application_guid )'
+        'and_(foreign(PermitAmendment.now_application_guid)==ApplicationsView.now_application_guid )',
+        overlaps="now_application_identity,now_identity"
     )
 
     application_reason_codes = db.relationship(
@@ -110,6 +113,7 @@ class ApplicationsView(Base):
         secondary=
         'join(NOWPartyAppointment, Party, foreign(NOWPartyAppointment.party_guid)==remote(Party.party_guid))',
         secondaryjoin='foreign(NOWPartyAppointment.party_guid)==remote(Party.party_guid)',
+        overlaps='now_party_appt,party,contacts,now_application'
     )
 
     def __repr__(self):

--- a/services/core-api/app/api/now_applications/models/blasting_operation.py
+++ b/services/core-api/app/api/now_applications/models/blasting_operation.py
@@ -15,7 +15,7 @@ class BlastingOperation(Base):
 
     now_application_id = db.Column(
         db.Integer, db.ForeignKey('now_application.now_application_id'), primary_key=True)
-    now_application = db.relationship('NOWApplication')
+    now_application = db.relationship('NOWApplication', back_populates='blasting_operation')
 
     has_storage_explosive_on_site = db.Column(db.Boolean)
     explosive_permit_issued = db.Column(db.Boolean)

--- a/services/core-api/app/api/now_applications/models/equipment.py
+++ b/services/core-api/app/api/now_applications/models/equipment.py
@@ -16,8 +16,8 @@ class Equipment(AuditMixin, Base):
     description = db.Column(db.String)
     quantity = db.Column(db.Integer)
     capacity = db.Column(db.String)
-    _etl_equipment = db.relationship('ETLEquipment', load_on_pending=True)
-    activity_equipment_xref = db.relationship('ActivityEquipmentXref', load_on_pending=True)
+    _etl_equipment = db.relationship('ETLEquipment', load_on_pending=True, back_populates='equipment')
+    activity_equipment_xref = db.relationship('ActivityEquipmentXref', load_on_pending=True, overlaps='equipment')
 
     def __repr__(self):
         return '<Equipment %r>' % self.equipment_id

--- a/services/core-api/app/api/now_applications/models/etl_equipment.py
+++ b/services/core-api/app/api/now_applications/models/etl_equipment.py
@@ -14,4 +14,4 @@ class ETLEquipment(Base):
     equipment_id = db.Column(db.Integer, db.ForeignKey('equipment.equipment_id'), primary_key=True)
     equipmentid = db.Column(db.Integer)
 
-    equipment = db.relationship('Equipment', uselist=False, load_on_pending=True)
+    equipment = db.relationship('Equipment', uselist=False, load_on_pending=True, back_populates='_etl_equipment')

--- a/services/core-api/app/api/now_applications/models/now_application.py
+++ b/services/core-api/app/api/now_applications/models/now_application.py
@@ -108,7 +108,7 @@ class NOWApplication(Base, AuditMixin):
     proposed_annual_maximum_tonnage = db.Column(db.Numeric(14, 2))
     adjusted_annual_maximum_tonnage = db.Column(db.Numeric(14, 2))
 
-    now_application_identity = db.relationship('NOWApplicationIdentity', uselist=False)
+    now_application_identity = db.relationship('NOWApplicationIdentity', uselist=False, back_populates='now_application')
 
     first_aid_equipment_on_site = db.Column(db.String)
     first_aid_cert_level = db.Column(db.String)
@@ -130,8 +130,8 @@ class NOWApplication(Base, AuditMixin):
 
     reviews = db.relationship('NOWApplicationReview', lazy='select', backref='now_application')
 
-    blasting_operation = db.relationship('BlastingOperation', lazy='joined', uselist=False)
-    state_of_land = db.relationship('StateOfLand', lazy='joined', uselist=False)
+    blasting_operation = db.relationship('BlastingOperation', lazy='joined', uselist=False, back_populates='now_application')
+    state_of_land = db.relationship('StateOfLand', lazy='joined', uselist=False, back_populates='now_application')
 
     # Securities
     liability_adjustment = db.Column(db.Numeric(16, 2))
@@ -140,21 +140,21 @@ class NOWApplication(Base, AuditMixin):
     security_not_required_reason = db.Column(db.String)
 
     # Activities
-    camp = db.relationship('Camp', lazy='selectin', uselist=False)
+    camp = db.relationship('Camp', lazy='selectin', uselist=False, overlaps='now_application')
     cut_lines_polarization_survey = db.relationship(
-        'CutLinesPolarizationSurvey', lazy='selectin', uselist=False)
-    exploration_access = db.relationship('ExplorationAccess', lazy='selectin', uselist=False)
+        'CutLinesPolarizationSurvey', lazy='selectin', uselist=False, overlaps='now_application')
+    exploration_access = db.relationship('ExplorationAccess', lazy='selectin', uselist=False, overlaps='now_application')
     exploration_surface_drilling = db.relationship(
-        'ExplorationSurfaceDrilling', lazy='selectin', uselist=False)
-    mechanical_trenching = db.relationship('MechanicalTrenching', lazy='selectin', uselist=False)
-    placer_operation = db.relationship('PlacerOperation', lazy='selectin', uselist=False)
+        'ExplorationSurfaceDrilling', lazy='selectin', uselist=False, overlaps='now_application')
+    mechanical_trenching = db.relationship('MechanicalTrenching', lazy='selectin', uselist=False, overlaps='now_application')
+    placer_operation = db.relationship('PlacerOperation', lazy='selectin', uselist=False, overlaps='now_application')
     sand_gravel_quarry_operation = db.relationship(
-        'SandGravelQuarryOperation', lazy='selectin', uselist=False)
-    settling_pond = db.relationship('SettlingPond', lazy='selectin', uselist=False)
-    surface_bulk_sample = db.relationship('SurfaceBulkSample', lazy='selectin', uselist=False)
+        'SandGravelQuarryOperation', lazy='selectin', uselist=False, overlaps='now_application')
+    settling_pond = db.relationship('SettlingPond', lazy='selectin', uselist=False, overlaps='now_application')
+    surface_bulk_sample = db.relationship('SurfaceBulkSample', lazy='selectin', uselist=False, overlaps='now_application')
     underground_exploration = db.relationship(
-        'UndergroundExploration', lazy='selectin', uselist=False)
-    water_supply = db.relationship('WaterSupply', lazy='selectin', uselist=False)
+        'UndergroundExploration', lazy='selectin', uselist=False, overlaps='now_application')
+    water_supply = db.relationship('WaterSupply', lazy='selectin', uselist=False, overlaps='now_application')
 
     # Progress
     application_progress = db.relationship('NOWApplicationProgress', lazy='selectin', uselist=True)
@@ -165,7 +165,9 @@ class NOWApplication(Base, AuditMixin):
         lazy='selectin',
         primaryjoin=
         'and_(NOWApplicationDocumentXref.now_application_id==NOWApplication.now_application_id, NOWApplicationDocumentXref.now_application_review_id==None, NOWApplicationDocumentXref.deleted_ind==False)',
-        order_by='desc(NOWApplicationDocumentXref.create_timestamp)')
+        order_by='desc(NOWApplicationDocumentXref.create_timestamp)',
+        back_populates='now_application'
+    )
 
     application_reason_codes = db.relationship(
         'ApplicationReasonXref',
@@ -195,7 +197,8 @@ class NOWApplication(Base, AuditMixin):
         'NOWPartyAppointment',
         lazy='selectin',
         primaryjoin=
-        'and_(NOWPartyAppointment.now_application_id == NOWApplication.now_application_id, NOWPartyAppointment.deleted_ind==False)'
+        'and_(NOWPartyAppointment.now_application_id == NOWApplication.now_application_id, NOWPartyAppointment.deleted_ind==False)',
+        back_populates='now_application'
     )
 
     status = db.relationship(
@@ -206,7 +209,7 @@ class NOWApplication(Base, AuditMixin):
     )
 
     equipment = db.relationship(
-        'Equipment', secondary='activity_equipment_xref', load_on_pending=True)
+        'Equipment', secondary='activity_equipment_xref', load_on_pending=True, overlaps='equipment')
 
     def __repr__(self):
         return '<NOWApplication %r>' % self.now_application_guid

--- a/services/core-api/app/api/now_applications/models/now_application_delay.py
+++ b/services/core-api/app/api/now_applications/models/now_application_delay.py
@@ -33,7 +33,7 @@ class NOWApplicationDelay(Base, AuditMixin):
 
     now_application_guid = db.Column(
         db.Integer, db.ForeignKey('now_application_identity.now_application_guid'), nullable=False)
-    now_application = db.relationship('NOWApplicationIdentity')
+    now_application = db.relationship('NOWApplicationIdentity', back_populates='application_delays')
 
     #Reason for delay (behaves like type tables)
     delay_type_code = db.Column(

--- a/services/core-api/app/api/now_applications/models/now_application_document_xref.py
+++ b/services/core-api/app/api/now_applications/models/now_application_document_xref.py
@@ -40,7 +40,7 @@ class NOWApplicationDocumentXref(SoftDeleteMixin, AuditMixin, Base):
         db.Integer, db.ForeignKey('now_application_review.now_application_review_id'))
 
     now_application_document_type = db.relationship('NOWApplicationDocumentType', lazy='joined')
-    now_application = db.relationship('NOWApplication', lazy='select')
+    now_application = db.relationship('NOWApplication', lazy='select', back_populates='documents', overlaps="documents")
     now_application_document_sub_type_code = association_proxy(
         'now_application_document_type', 'now_application_document_sub_type_code')
 

--- a/services/core-api/app/api/now_applications/models/now_application_identity.py
+++ b/services/core-api/app/api/now_applications/models/now_application_identity.py
@@ -43,12 +43,14 @@ class NOWApplicationIdentity(Base, AuditMixin):
     application_delays = db.relationship('NOWApplicationDelay')
     is_document_import_requested = db.Column(db.Boolean, server_default=FetchedValue())
 
-    now_application = db.relationship('NOWApplication')
+    now_application = db.relationship('NOWApplication', back_populates='now_application_identity')
     application_delays = db.relationship(
         'NOWApplicationDelay',
         lazy='selectin',
         uselist=True,
-        order_by='desc(NOWApplicationDelay.start_date)')
+        order_by='desc(NOWApplicationDelay.start_date)',
+        back_populates='now_application'
+    )
 
     def __repr__(self):
         return f'{self.__class__.__name__} {self.now_application_guid}'

--- a/services/core-api/app/api/now_applications/models/now_party_appointment.py
+++ b/services/core-api/app/api/now_applications/models/now_party_appointment.py
@@ -23,10 +23,10 @@ class NOWPartyAppointment(SoftDeleteMixin, AuditMixin, Base):
     merged_from_party_guid = db.Column(UUID(as_uuid=True), db.ForeignKey('party.party_guid'))
 
     # Relationships
-    party = db.relationship('Party', lazy='joined', foreign_keys=party_guid)
+    party = db.relationship('Party', lazy='joined', foreign_keys=party_guid, back_populates='now_party_appt')
     merged_from_party = db.relationship('Party', foreign_keys=merged_from_party_guid)
     mine_party_appt_type = db.relationship('MinePartyAppointmentType', lazy='joined')
-    now_application = db.relationship('NOWApplication', lazy='selectin')
+    now_application = db.relationship('NOWApplication', lazy='selectin', back_populates='contacts')
 
     mine_party_appt_type_code_description = association_proxy('mine_party_appt_type', 'description')
     party_name = association_proxy('party', 'party_name')

--- a/services/core-api/app/api/now_applications/models/state_of_land.py
+++ b/services/core-api/app/api/now_applications/models/state_of_land.py
@@ -13,7 +13,7 @@ class StateOfLand(Base):
 
     now_application_id = db.Column(
         db.Integer, db.ForeignKey('now_application.now_application_id'), primary_key=True)
-    now_application = db.relationship('NOWApplication')
+    now_application = db.relationship('NOWApplication', back_populates='state_of_land')
 
     has_community_water_shed = db.Column(db.Boolean)
     has_archaeology_sites_affected = db.Column(db.Boolean)

--- a/services/core-api/app/api/parties/party/models/address.py
+++ b/services/core-api/app/api/parties/party/models/address.py
@@ -23,7 +23,7 @@ class Address(SoftDeleteMixin, AuditMixin, Base):
     address_type_code = db.Column(db.String, nullable=False, server_default=FetchedValue())
 
     party_guid = db.Column(UUID(as_uuid=True), db.ForeignKey('party.party_guid'), nullable=False)
-    party = db.relationship('Party', lazy='joined')
+    party = db.relationship('Party', lazy='joined', back_populates='address')
 
     def __repr__(self):
         return '<Address %r>' % self.address_id

--- a/services/core-api/app/api/parties/party/models/party.py
+++ b/services/core-api/app/api/parties/party/models/party.py
@@ -31,7 +31,7 @@ class Party(SoftDeleteMixin, AuditMixin, Base):
     email = db.Column(db.String)
     email_sec = db.Column(db.String)
     party_type_code = db.Column(db.String, db.ForeignKey('party_type_code.party_type_code'))
-    address = db.relationship('Address', lazy='joined')
+    address = db.relationship('Address', lazy='joined', back_populates='party')
     job_title = db.Column(db.String)
     job_title_code = db.Column(db.String, db.ForeignKey('mine_party_appt_type_code.mine_party_appt_type_code'))
     postnominal_letters = db.Column(db.String)
@@ -44,25 +44,28 @@ class Party(SoftDeleteMixin, AuditMixin, Base):
         'MinePartyAppointment',
         lazy='joined',
         primaryjoin=
-        'and_(MinePartyAppointment.party_guid == Party.party_guid, MinePartyAppointment.deleted_ind==False)'
+        'and_(MinePartyAppointment.party_guid == Party.party_guid, MinePartyAppointment.deleted_ind==False)',
+        back_populates='party'
     )
 
     now_party_appt = db.relationship(
         'NOWPartyAppointment',
         lazy='selectin',
         primaryjoin=
-        'and_(NOWPartyAppointment.party_guid == Party.party_guid, NOWPartyAppointment.deleted_ind==False)'
+        'and_(NOWPartyAppointment.party_guid == Party.party_guid, NOWPartyAppointment.deleted_ind==False)',
+        back_populates='party'
     )
 
     business_role_appts = db.relationship(
         'PartyBusinessRoleAppointment',
         lazy='selectin',
         primaryjoin=
-        'and_(PartyBusinessRoleAppointment.party_guid == Party.party_guid, PartyBusinessRoleAppointment.deleted_ind==False)'
+        'and_(PartyBusinessRoleAppointment.party_guid == Party.party_guid, PartyBusinessRoleAppointment.deleted_ind==False)',
+        back_populates='party'
     )
 
     party_orgbook_entity = db.relationship(
-        'PartyOrgBookEntity', backref='party_orgbook_entity', uselist=False, lazy='select')
+        'PartyOrgBookEntity', backref='party_orgbook_entity', uselist=False, lazy='select', overlaps='party')
 
     organization = db.relationship(
         'Party',
@@ -75,7 +78,8 @@ class Party(SoftDeleteMixin, AuditMixin, Base):
         'PartyVerifiableCredentialConnection',
         lazy='select',
         uselist=True,
-        order_by='desc(PartyVerifiableCredentialConnection.update_timestamp)',)
+        order_by='desc(PartyVerifiableCredentialConnection.update_timestamp)',
+        overlaps='active_digital_wallet_connection')
         
     active_digital_wallet_connection = db.relationship(
         'PartyVerifiableCredentialConnection',
@@ -83,7 +87,8 @@ class Party(SoftDeleteMixin, AuditMixin, Base):
         uselist=False,
         remote_side=[party_guid],
         primaryjoin=
-        'and_(PartyVerifiableCredentialConnection.party_guid == Party.party_guid, PartyVerifiableCredentialConnection.connection_state==\'active\')')
+        'and_(PartyVerifiableCredentialConnection.party_guid == Party.party_guid, PartyVerifiableCredentialConnection.connection_state==\'active\')',
+        overlaps='digital_wallet_invitations')
 
 
     @hybrid_property

--- a/services/core-api/app/api/parties/party/models/party_orgbook_entity.py
+++ b/services/core-api/app/api/parties/party/models/party_orgbook_entity.py
@@ -22,7 +22,7 @@ class PartyOrgBookEntity(AuditMixin, Base):
     association_user = db.Column(db.DateTime, nullable=False, default=User().get_user_username)
     association_timestamp = db.Column(db.DateTime, nullable=False, server_default=FetchedValue())
 
-    party = db.relationship('Party')
+    party = db.relationship('Party', overlaps='party')
 
     def __repr__(self):
         return f'{self.__class__.__name__} {self.party_orgbook_entity_id}'

--- a/services/core-api/app/api/parties/party_appt/models/mine_party_appt.py
+++ b/services/core-api/app/api/parties/party_appt/models/mine_party_appt.py
@@ -63,7 +63,7 @@ class MinePartyAppointment(SoftDeleteMixin, AuditMixin, Base):
     union_rep_company = db.Column(db.String)
 
     # Relationships
-    party = db.relationship('Party', lazy='joined', foreign_keys=party_guid)
+    party = db.relationship('Party', lazy='joined', foreign_keys=party_guid, back_populates='mine_party_appt')
     merged_from_party = db.relationship('Party', foreign_keys=merged_from_party_guid)
     mine_tailings_storage_facility = db.relationship('MineTailingsStorageFacility', lazy='joined')
     mine_party_appt_type = db.relationship(

--- a/services/core-api/app/api/parties/party_appt/models/party_business_role_appt.py
+++ b/services/core-api/app/api/parties/party_appt/models/party_business_role_appt.py
@@ -22,7 +22,7 @@ class PartyBusinessRoleAppointment(SoftDeleteMixin, AuditMixin, Base):
     end_date = db.Column(db.Date)
 
     # Relationships
-    party = db.relationship('Party', lazy='selectin', foreign_keys=party_guid)
+    party = db.relationship('Party', lazy='selectin', foreign_keys=party_guid, back_populates='business_role_appts')
     merged_from_party = db.relationship('Party', foreign_keys=merged_from_party_guid)
     party_business_role = db.relationship(
         'PartyBusinessRole', backref='party_business_role_appt', lazy='selectin')

--- a/services/core-api/app/api/projects/information_requirements_table/models/information_requirements_table.py
+++ b/services/core-api/app/api/projects/information_requirements_table/models/information_requirements_table.py
@@ -36,7 +36,8 @@ class InformationRequirementsTable(SoftDeleteMixin, AuditMixin, Base):
         lazy='select',
         secondary='information_requirements_table_document_xref',
         secondaryjoin=
-        'and_(foreign(InformationRequirementsTableDocumentXref.mine_document_guid) == remote(MineDocument.mine_document_guid), MineDocument.deleted_ind == False, MineDocument.is_archived == False)'
+        'and_(foreign(InformationRequirementsTableDocumentXref.mine_document_guid) == remote(MineDocument.mine_document_guid), MineDocument.deleted_ind == False, MineDocument.is_archived == False)',
+        overlaps="information_requirements_table_document_xref,mine_document,documents"
     )
 
     def __repr__(self):

--- a/services/core-api/app/api/projects/information_requirements_table/models/information_requirements_table_document_xref.py
+++ b/services/core-api/app/api/projects/information_requirements_table/models/information_requirements_table_document_xref.py
@@ -27,7 +27,7 @@ class InformationRequirementsTableDocumentXref(Base):
         ),
         nullable=False)
 
-    mine_document = db.relationship('MineDocument', lazy='select')
+    mine_document = db.relationship('MineDocument', lazy='select' , overlaps="mine_document,information_requirements_table_document_xref")
     mine_guid = association_proxy('mine_document', 'mine_guid')
     document_manager_guid = association_proxy('mine_document', 'document_manager_guid')
     document_name = association_proxy('mine_document', 'document_name')

--- a/services/core-api/app/api/projects/major_mine_application/models/major_mine_application.py
+++ b/services/core-api/app/api/projects/major_mine_application/models/major_mine_application.py
@@ -37,7 +37,8 @@ class MajorMineApplication(SoftDeleteMixin, AuditMixin, Base):
         'MineDocument',
         lazy='select',
         secondary='major_mine_application_document_xref',
-        secondaryjoin='and_(foreign(MajorMineApplicationDocumentXref.mine_document_guid) == remote(MineDocument.mine_document_guid), MineDocument.deleted_ind == False, MineDocument.is_archived == False)'
+        secondaryjoin='and_(foreign(MajorMineApplicationDocumentXref.mine_document_guid) == remote(MineDocument.mine_document_guid), MineDocument.deleted_ind == False, MineDocument.is_archived == False)',
+        overlaps='major_mine_application_document_xref,mine_document,documents'
     )
 
     def __repr__(self):

--- a/services/core-api/app/api/projects/major_mine_application/models/major_mine_application_document_xref.py
+++ b/services/core-api/app/api/projects/major_mine_application/models/major_mine_application_document_xref.py
@@ -27,7 +27,7 @@ class MajorMineApplicationDocumentXref(Base):
             'major_mine_application_document_type.major_mine_application_document_type_code'),
         nullable=False)
 
-    mine_document = db.relationship('MineDocument', lazy='select')
+    mine_document = db.relationship('MineDocument', lazy='select', overlaps='major_mine_application_document_xref')
     mine_guid = association_proxy('mine_document', 'mine_guid')
     document_manager_guid = association_proxy('mine_document', 'document_manager_guid')
     document_name = association_proxy('mine_document', 'document_name')

--- a/services/core-api/app/api/projects/project_decision_package/models/project_decision_package.py
+++ b/services/core-api/app/api/projects/project_decision_package/models/project_decision_package.py
@@ -34,7 +34,8 @@ class ProjectDecisionPackage(SoftDeleteMixin, AuditMixin, Base):
         'MineDocument',
         lazy='select',
         secondary='project_decision_package_document_xref',
-        secondaryjoin='and_(foreign(ProjectDecisionPackageDocumentXref.mine_document_guid) == remote(MineDocument.mine_document_guid), MineDocument.deleted_ind == False, MineDocument.is_archived == False)'
+        secondaryjoin='and_(foreign(ProjectDecisionPackageDocumentXref.mine_document_guid) == remote(MineDocument.mine_document_guid), MineDocument.deleted_ind == False, MineDocument.is_archived == False)',
+        overlaps="mine_document,project_decision_package_document_xref,documents"
     )
 
     def __repr__(self):

--- a/services/core-api/app/api/projects/project_decision_package/models/project_decision_package_document_xref.py
+++ b/services/core-api/app/api/projects/project_decision_package/models/project_decision_package_document_xref.py
@@ -27,7 +27,7 @@ class ProjectDecisionPackageDocumentXref(Base):
             'project_decision_package_document_type.project_decision_package_document_type_code'),
         nullable=False)
 
-    mine_document = db.relationship('MineDocument', lazy='select')
+    mine_document = db.relationship('MineDocument', lazy='select', overlaps="project_decision_package_document_xref")
     mine_guid = association_proxy('mine_document', 'mine_guid')
     document_manager_guid = association_proxy('mine_document', 'document_manager_guid')
     document_name = association_proxy('mine_document', 'document_name')

--- a/services/core-api/app/api/projects/project_summary/models/project_summary.py
+++ b/services/core-api/app/api/projects/project_summary/models/project_summary.py
@@ -57,7 +57,8 @@ class ProjectSummary(SoftDeleteMixin, AuditMixin, Base):
     project = db.relationship("Project", back_populates="project_summary")
     contacts = db.relationship(
         'ProjectContact',
-        primaryjoin="and_(ProjectSummary.project_guid==foreign(ProjectContact.project_guid), ProjectContact.deleted_ind == False)"
+        primaryjoin="and_(ProjectSummary.project_guid==foreign(ProjectContact.project_guid), ProjectContact.deleted_ind == False)",
+        overlaps="contacts"
     )
     agent = db.relationship(
         'Party', lazy='joined', foreign_keys=agent_party_guid
@@ -78,7 +79,8 @@ class ProjectSummary(SoftDeleteMixin, AuditMixin, Base):
         'MineDocument',
         lazy='select',
         secondary='project_summary_document_xref',
-        secondaryjoin='and_(and_(foreign(ProjectSummaryDocumentXref.mine_document_guid) == remote(MineDocument.mine_document_guid), MineDocument.deleted_ind == False), MineDocument.is_archived == False)'
+        secondaryjoin='and_(and_(foreign(ProjectSummaryDocumentXref.mine_document_guid) == remote(MineDocument.mine_document_guid), MineDocument.deleted_ind == False), MineDocument.is_archived == False)',
+        overlaps="mine_document,project_summary_document_xref,documents"
     )
 
     def __repr__(self):

--- a/services/core-api/app/api/projects/project_summary/models/project_summary_document_xref.py
+++ b/services/core-api/app/api/projects/project_summary/models/project_summary_document_xref.py
@@ -24,7 +24,7 @@ class ProjectSummaryDocumentXref(Base):
         db.ForeignKey('project_summary_document_type.project_summary_document_type_code'),
         nullable=False)
 
-    mine_document = db.relationship('MineDocument', lazy='select')
+    mine_document = db.relationship('MineDocument', lazy='select', overlaps="project_summary_document_xref")
     mine_guid = association_proxy('mine_document', 'mine_guid')
     document_manager_guid = association_proxy('mine_document', 'document_manager_guid')
     document_name = association_proxy('mine_document', 'document_name')

--- a/services/core-api/app/api/securities/models/bond.py
+++ b/services/core-api/app/api/securities/models/bond.py
@@ -41,8 +41,8 @@ class Bond(Base, AuditMixin):
     note = db.Column(db.String)
 
     payer = db.relationship('Party', lazy='joined')
-    permit = db.relationship('Permit', uselist=False, lazy='joined', secondary='bond_permit_xref')
-    documents = db.relationship('BondDocument', lazy='select')
+    permit = db.relationship('Permit', uselist=False, lazy='joined', secondary='bond_permit_xref', back_populates='bonds')
+    documents = db.relationship('BondDocument', lazy='select', back_populates='bond')
     closed_date = db.Column(db.DateTime)
     closed_note = db.Column(db.String)
 

--- a/services/core-api/app/api/securities/models/bond_document.py
+++ b/services/core-api/app/api/securities/models/bond_document.py
@@ -19,4 +19,4 @@ class BondDocument(MineDocument):
     bond_document_type_code = db.Column(
         db.String, db.ForeignKey('bond_document_type.bond_document_type_code'), nullable=False)
 
-    bond = db.relationship('Bond', lazy='joined')
+    bond = db.relationship('Bond', lazy='joined', back_populates='documents')

--- a/services/core-api/app/api/securities/models/reclamation_invoice_document.py
+++ b/services/core-api/app/api/securities/models/reclamation_invoice_document.py
@@ -11,4 +11,4 @@ class ReclamationInvoiceDocument(MineDocument):
 
     reclamation_invoice_id = db.Column(db.Integer, db.ForeignKey('reclamation_invoice.reclamation_invoice_id'))
 
-    reclamation_invoice = db.relationship('ReclamationInvoice', lazy='joined')
+    reclamation_invoice = db.relationship('ReclamationInvoice', lazy='joined', back_populates='documents')

--- a/services/core-api/app/api/variances/models/variance.py
+++ b/services/core-api/app/api/variances/models/variance.py
@@ -59,7 +59,8 @@ class Variance(SoftDeleteMixin, AuditMixin, Base):
         lazy='joined',
         secondary='variance_document_xref',
         secondaryjoin=
-        'and_(foreign(VarianceDocumentXref.mine_document_guid) == remote(MineDocument.mine_document_guid),MineDocument.deleted_ind == False)'
+        'and_(foreign(VarianceDocumentXref.mine_document_guid) == remote(MineDocument.mine_document_guid),MineDocument.deleted_ind == False)',
+        overlaps="mine_document,documents"
     )
     inspector = db.relationship('Party', lazy='joined', foreign_keys=[inspector_party_guid])
     mine = db.relationship('Mine', lazy='joined')


### PR DESCRIPTION
## Objective 

[MDS-5409](https://bcmines.atlassian.net/browse/MDS-5409)

The SQLAlchemy version upgrade performed in https://github.com/bcgov/mds/pull/2930 highlighted a couple of things with how we're mapping relationships between dependent models. In many cases we have conflicts between relationships so they will write data to the same columns, and we do not specify the intended behavior through `back_populates` or `viewonly` - the issue is explained in the [SQLAlchemy docs](https://docs.sqlalchemy.org/en/14/errors.html#error-qzyx).

This is not a breaking change in SQLAlchemy 1.4, just a new warning highlighting the issue.
This PR resolves the warning (where possible), or silences it where it doesn't cause any issues