### PR TITLE
[MDS-5569] After receiving a problem report allow the user the re-offer the credential

### DIFF
--- a/services/common/src/constants/enums.ts
+++ b/services/common/src/constants/enums.ts
@@ -138,7 +138,7 @@ export enum VC_CRED_ISSUE_STATES {
   credential_issued = "Pending",
   credential_acked = "Active",
   deleted = "Active",
-  abandoned = "Offer Rejected"
+  abandoned = "Error"
 }
 
 export enum PROJECT_SUMMARY_STATUS_CODES {

--- a/services/common/src/constants/enums.ts
+++ b/services/common/src/constants/enums.ts
@@ -138,6 +138,7 @@ export enum VC_CRED_ISSUE_STATES {
   credential_issued = "Pending",
   credential_acked = "Active",
   deleted = "Active",
+  abandoned = "Offer Rejected"
 }
 
 export enum PROJECT_SUMMARY_STATUS_CODES {

--- a/services/core-api/app/api/mines/permits/permit_amendment/models/permit_amendment.py
+++ b/services/core-api/app/api/mines/permits/permit_amendment/models/permit_amendment.py
@@ -94,8 +94,7 @@ class PermitAmendment(SoftDeleteMixin, AuditMixin, Base):
 
     vc_credential_exch = db.relationship(
         'PartyVerifiableCredentialMinesActPermit',
-        lazy='selectin',
-        uselist=False)
+        lazy='selectin')
     
 
     @hybrid_property
@@ -144,8 +143,10 @@ class PermitAmendment(SoftDeleteMixin, AuditMixin, Base):
     
     @hybrid_property
     def vc_credential_exch_state(self):
+        # TODO this assumes only one active credential for each mines act permit 
+        # this will need to be revisited to support additional issuances (wallet recovery) or multple schemas issued
         if self.vc_credential_exch:
-            return self.vc_credential_exch.cred_exch_state
+            return self.vc_credential_exch[0].cred_exch_state
         else:
             return None
 

--- a/services/core-api/app/api/services/traction_service.py
+++ b/services/core-api/app/api/services/traction_service.py
@@ -4,6 +4,7 @@ from flask import current_app
 from uuid import UUID
 from app.config import Config
 from app.api.parties.party.models.party import Party
+from app.api.verifiable_credentials.utils.aries_constants import DIDExchangeRequesterState
 from app.api.verifiable_credentials.models.connection import PartyVerifiableCredentialConnection
 
 
@@ -35,7 +36,7 @@ class TractionService():
         https://github.com/hyperledger/aries-rfcs/blob/main/features/0023-did-exchange/README.md"""
 
         vc_invitations = PartyVerifiableCredentialConnection.find_by_party_guid(party.party_guid)
-        active_invitation = [inv for inv in vc_invitations if inv.connection_state == "completed"]
+        active_invitation = [inv for inv in vc_invitations if inv.connection_state == DIDExchangeRequesterState.COMPLETED]
         if active_invitation: 
             current_app.logger.error(f"party_guid={party.party_guid} already has wallet connection, do not create another one")
             raise VerificableCredentialWorkflowError("cannot make invitation if mine already has active connection")

--- a/services/core-api/app/api/services/traction_service.py
+++ b/services/core-api/app/api/services/traction_service.py
@@ -4,7 +4,7 @@ from flask import current_app
 from uuid import UUID
 from app.config import Config
 from app.api.parties.party.models.party import Party
-from app.api.verifiable_credentials.utils.aries_constants import DIDExchangeRequesterState
+from app.api.verifiable_credentials.aries_constants import DIDExchangeRequesterState
 from app.api.verifiable_credentials.models.connection import PartyVerifiableCredentialConnection
 
 

--- a/services/core-api/app/api/verifiable_credentials/aries_constants.py
+++ b/services/core-api/app/api/verifiable_credentials/aries_constants.py
@@ -1,0 +1,26 @@
+
+
+class IssueCredentialIssuerState():
+    #https://github.com/hyperledger/aries-rfcs/blob/main/features/0036-issue-credential/README.md#states-for-issuer
+
+    PROPOSAL_RECEIVED = "proposal-received"
+    OFFER_SENT = "offer-sent"
+    REQUEST_RECEIVED = "request-received"
+    CREDENTIAL_ISSUED = "credential-issued"
+    DONE = "done"
+
+    #if problem report is received
+    ABANDONED = "abandoned"
+
+
+    pending_credential_states = [PROPOSAL_RECEIVED, OFFER_SENT, REQUEST_RECEIVED]
+    active_credential_states = [CREDENTIAL_ISSUED, DONE]
+
+class DIDExchangeRequesterState():
+    #https://github.com/hyperledger/aries-rfcs/tree/main/features/0023-did-exchange#requester
+    START = "start" 
+    INVITATION_RECEIVED = "invitation-received"
+    REQUEST_SENT = "request-sent"
+    RESPONSE_RECEIVED = "response-received"
+    ABANDONED = "abandoned"
+    COMPLETED = "completed"

--- a/services/core-api/app/api/verifiable_credentials/aries_constants.py
+++ b/services/core-api/app/api/verifiable_credentials/aries_constants.py
@@ -12,9 +12,12 @@ class IssueCredentialIssuerState():
     #if problem report is received
     ABANDONED = "abandoned"
 
+    #acapy sends these... not sure why they don't match
+    CREDENTIAL_ACKED = "credential_acked"
 
     pending_credential_states = [PROPOSAL_RECEIVED, OFFER_SENT, REQUEST_RECEIVED]
     active_credential_states = [CREDENTIAL_ISSUED, DONE]
+
 
 class DIDExchangeRequesterState():
     #https://github.com/hyperledger/aries-rfcs/tree/main/features/0023-did-exchange#requester

--- a/services/core-api/app/api/verifiable_credentials/aries_constants.py
+++ b/services/core-api/app/api/verifiable_credentials/aries_constants.py
@@ -12,11 +12,11 @@ class IssueCredentialIssuerState():
     #if problem report is received
     ABANDONED = "abandoned"
 
-    #acapy sends these... not sure why they don't match
+    #acapy sends these... not sure why they don't match the spec
     CREDENTIAL_ACKED = "credential_acked"
 
     pending_credential_states = [PROPOSAL_RECEIVED, OFFER_SENT, REQUEST_RECEIVED]
-    active_credential_states = [CREDENTIAL_ISSUED, DONE]
+    active_credential_states = [CREDENTIAL_ACKED, CREDENTIAL_ISSUED, DONE]
 
 
 class DIDExchangeRequesterState():

--- a/services/core-api/app/api/verifiable_credentials/models/credentials.py
+++ b/services/core-api/app/api/verifiable_credentials/models/credentials.py
@@ -2,7 +2,7 @@
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.schema import FetchedValue
 from app.extensions import db
-
+from typing import List
 from app.api.utils.models_mixins import AuditMixin, Base
 
 
@@ -28,5 +28,11 @@ class PartyVerifiableCredentialMinesActPermit(AuditMixin, Base):
         return cls.query.filter_by(party_guid=party_guid).all()
     
     @classmethod
-    def find_by_permit_amendment_guid(cls, permit_amendment_guid) -> "PartyVerifiableCredentialMinesActPermit":
-        return cls.query.filter_by(permit_amendment_guid=permit_amendment_guid).one_or_none()
+    def find_by_permit_amendment_guid(cls, permit_amendment_guid) -> List["PartyVerifiableCredentialMinesActPermit"]:
+        return cls.query.filter_by(permit_amendment_guid=permit_amendment_guid).all()
+
+    @classmethod
+    def find_issued_by_permit_amendment_guid(cls, permit_amendment_guid) -> List["PartyVerifiableCredentialMinesActPermit"]:
+        #https://github.com/hyperledger/aries-rfcs/blob/main/features/0036-issue-credential/README.md#states-for-issuer
+        return cls.query.filter_by(permit_amendment_guid=permit_amendment_guid).filter(PartyVerifiableCredentialMinesActPermit.cred_exch_state.in_(["credential_issued","done"])).all()
+    

--- a/services/core-api/app/api/verifiable_credentials/resources/verifiable_credential_map.py
+++ b/services/core-api/app/api/verifiable_credentials/resources/verifiable_credential_map.py
@@ -48,8 +48,8 @@ class VerifiableCredentialMinesActPermitResource(Resource, UserMixin):
             raise BadRequest(f"permit_amendment not found")
         
         existing_cred_exch = PartyVerifiableCredentialMinesActPermit.find_by_permit_amendment_guid(permit_amendment_guid=permit_amendment_guid)
-        if existing_cred_exch:
-            raise BadRequest(f"This permit_amendment has already been offered, cred_exch_id={existing_cred_exch.cred_exch_id}, cred_exch_state={existing_cred_exch.cred_exch_state}")
+        if existing_cred_exch and existing_cred_exch.cred_exch_state == "offer_sent":
+            raise BadRequest(f"There is a pending credential offer, resolve or delete that offer first, cred_exch_id={existing_cred_exch.cred_exch_id}, cred_exch_state={existing_cred_exch.cred_exch_state}")
 
 
         # collect information for schema

--- a/services/core-api/app/api/verifiable_credentials/resources/verifiable_credential_map.py
+++ b/services/core-api/app/api/verifiable_credentials/resources/verifiable_credential_map.py
@@ -8,6 +8,7 @@ from app.api.parties.party.models.party import Party
 from app.api.mines.permits.permit_amendment.models.permit_amendment import PermitAmendment
 from app.api.verifiable_credentials.models.connection import PartyVerifiableCredentialConnection
 from app.api.verifiable_credentials.models.credentials import PartyVerifiableCredentialMinesActPermit
+from app.api.verifiable_credentials.aries_constants import IssueCredentialIssuerState
 
 from app.api.services.traction_service import TractionService
 from app.api.utils.resources_mixins import UserMixin
@@ -50,7 +51,7 @@ class VerifiableCredentialMinesActPermitResource(Resource, UserMixin):
         existing_cred_exch = PartyVerifiableCredentialMinesActPermit.find_by_permit_amendment_guid(permit_amendment_guid=permit_amendment_guid) or []
         
         # If a user has deleted the credential from their wallet, they will need another copy so only limit on pending for UX reasons
-        pending_creds = [e for e in existing_cred_exch if e.cred_exch_state in ["offer_sent", "request_receieved"]]
+        pending_creds = [e for e in existing_cred_exch if e.cred_exch_state in IssueCredentialIssuerState.pending_credential_states]
 
         #https://github.com/hyperledger/aries-rfcs/tree/main/features/0036-issue-credential#states-for-issuer
         if pending_creds:

--- a/services/core-api/app/api/verifiable_credentials/resources/verifiable_credential_map.py
+++ b/services/core-api/app/api/verifiable_credentials/resources/verifiable_credential_map.py
@@ -48,8 +48,10 @@ class VerifiableCredentialMinesActPermitResource(Resource, UserMixin):
             raise BadRequest(f"permit_amendment not found")
         
         existing_cred_exch = PartyVerifiableCredentialMinesActPermit.find_by_permit_amendment_guid(permit_amendment_guid=permit_amendment_guid)
-        if existing_cred_exch and existing_cred_exch.cred_exch_state == "offer_sent":
-            raise BadRequest(f"There is a pending credential offer, resolve or delete that offer first, cred_exch_id={existing_cred_exch.cred_exch_id}, cred_exch_state={existing_cred_exch.cred_exch_state}")
+        
+        #https://github.com/hyperledger/aries-rfcs/tree/main/features/0036-issue-credential#states-for-issuer
+        if existing_cred_exch and existing_cred_exch.cred_exch_state in ["offer_sent", "request_receieved"]:
+            raise BadRequest(f"There is a pending credential offer, accept or delete that offer first, cred_exch_id={existing_cred_exch.cred_exch_id}, cred_exch_state={existing_cred_exch.cred_exch_state}")
 
 
         # collect information for schema

--- a/services/core-api/app/api/verifiable_credentials/resources/verifiable_credential_map.py
+++ b/services/core-api/app/api/verifiable_credentials/resources/verifiable_credential_map.py
@@ -47,10 +47,13 @@ class VerifiableCredentialMinesActPermitResource(Resource, UserMixin):
         if not (permit_amendment):
             raise BadRequest(f"permit_amendment not found")
         
-        existing_cred_exch = PartyVerifiableCredentialMinesActPermit.find_by_permit_amendment_guid(permit_amendment_guid=permit_amendment_guid)
+        existing_cred_exch = PartyVerifiableCredentialMinesActPermit.find_by_permit_amendment_guid(permit_amendment_guid=permit_amendment_guid) or []
         
+        # If a user has deleted the credential from their wallet, they will need another copy so only limit on pending for UX reasons
+        pending_creds = [e for e in existing_cred_exch if e.cred_exch_state in ["offer_sent", "request_receieved"]]
+
         #https://github.com/hyperledger/aries-rfcs/tree/main/features/0036-issue-credential#states-for-issuer
-        if existing_cred_exch and existing_cred_exch.cred_exch_state in ["offer_sent", "request_receieved"]:
+        if pending_creds:
             raise BadRequest(f"There is a pending credential offer, accept or delete that offer first, cred_exch_id={existing_cred_exch.cred_exch_id}, cred_exch_state={existing_cred_exch.cred_exch_state}")
 
 

--- a/services/core-api/app/api/verifiable_credentials/resources/verifiable_credential_webhook.py
+++ b/services/core-api/app/api/verifiable_credentials/resources/verifiable_credential_webhook.py
@@ -11,7 +11,7 @@ from app.api.services.traction_service import TractionService
 
 from app.api.verifiable_credentials.models.connection import PartyVerifiableCredentialConnection
 from app.api.verifiable_credentials.models.credentials import PartyVerifiableCredentialMinesActPermit
-from app.api.verifiable_credentials.utils.aries_constants import DIDExchangeRequesterState, IssueCredentialIssuerState
+from app.api.verifiable_credentials.aries_constants import DIDExchangeRequesterState, IssueCredentialIssuerState
 
 from app.api.utils.feature_flag import Feature, is_feature_enabled
 

--- a/services/core-api/app/api/verifiable_credentials/resources/verifiable_credential_webhook.py
+++ b/services/core-api/app/api/verifiable_credentials/resources/verifiable_credential_webhook.py
@@ -11,6 +11,7 @@ from app.api.services.traction_service import TractionService
 
 from app.api.verifiable_credentials.models.connection import PartyVerifiableCredentialConnection
 from app.api.verifiable_credentials.models.credentials import PartyVerifiableCredentialMinesActPermit
+from app.api.verifiable_credentials.utils.aries_constants import DIDExchangeRequesterState, IssueCredentialIssuerState
 
 from app.api.utils.feature_flag import Feature, is_feature_enabled
 
@@ -38,7 +39,7 @@ class VerifiableCredentialWebhookResource(Resource, UserMixin):
             assert vc_conn, f"connection.invitation_msg_id={invitation_id} not found. webhook_body={webhook_body}"
             vc_conn.connection_id = webhook_body["connection_id"]
             new_state = webhook_body["state"]
-            if new_state != vc_conn.connection_state and vc_conn.connection_state != 'completed':
+            if new_state != vc_conn.connection_state and vc_conn.connection_state != DIDExchangeRequesterState.COMPLETED:
                 # 'completed' is the final succesful state.
                 vc_conn.connection_state=new_state
                 vc_conn.save()
@@ -60,7 +61,7 @@ class VerifiableCredentialWebhookResource(Resource, UserMixin):
                 # 'deleted' or 'credential_acked' should both be considered successful
                 # 'deleted' is the final state, do not update 
                 cred_exch_record.cred_exch_state=new_state
-                if new_state == "credential_acked":
+                if new_state == IssueCredentialIssuerState.CREDENTIAL_ACKED:
                     cred_exch_record.rev_reg_id = webhook_body["revoc_reg_id"]
                     cred_exch_record.cred_rev_id = webhook_body["revocation_id"]
 

--- a/services/core-web/cypress/e2e/majorprojects.cy.ts
+++ b/services/core-web/cypress/e2e/majorprojects.cy.ts
@@ -1,4 +1,4 @@
-describe.skip("Major Projects", () => {
+describe("Major Projects", () => {
   beforeEach(() => {
     cy.login();
 

--- a/services/core-web/cypress/e2e/majorprojects.cy.ts
+++ b/services/core-web/cypress/e2e/majorprojects.cy.ts
@@ -1,4 +1,4 @@
-describe("Major Projects", () => {
+describe.skip("Major Projects", () => {
   beforeEach(() => {
     cy.login();
 

--- a/services/minespace-web/src/components/dashboard/mine/permits/PermitsTable.tsx
+++ b/services/minespace-web/src/components/dashboard/mine/permits/PermitsTable.tsx
@@ -86,10 +86,10 @@ export const PermitsTable: FC<PermitsTableProps> = (props) => {
 
   if (showVCColumn || isFeatureEnabled(Feature.MINESPACE_ESUPS)) {
     const colourMap = {
-      VC_CRED_ISSUE_STATES.null: "#D8292F",
-      VC_CRED_ISSUE_STATES.offer_sent: "#F1C21B",
-      VC_CRED_ISSUE_STATES.credential_acked: "#45A776",
-      VC_CRED_ISSUE_STATES.abandoned: "#D8292F",
+      [VC_CRED_ISSUE_STATES.null]: "#D8292F",
+      [VC_CRED_ISSUE_STATES.offer_sent]: "#F1C21B",
+      [VC_CRED_ISSUE_STATES.credential_acked]: "#45A776",
+      [VC_CRED_ISSUE_STATES.abandoned]: "#D8292F",
     };
     const issuanceStateColumn = {
       title: "Issuance State",

--- a/services/minespace-web/src/components/dashboard/mine/permits/PermitsTable.tsx
+++ b/services/minespace-web/src/components/dashboard/mine/permits/PermitsTable.tsx
@@ -86,9 +86,9 @@ export const PermitsTable: FC<PermitsTableProps> = (props) => {
 
   if (showVCColumn || isFeatureEnabled(Feature.MINESPACE_ESUPS)) {
     const colourMap = {
-      "Not Active": "#D8292F",
-      Pending: "#F1C21B",
-      Active: "#45A776",
+      VC_CRED_ISSUE_STATES.null: "#D8292F",
+      VC_CRED_ISSUE_STATES.offer_sent: "#F1C21B",
+      VC_CRED_ISSUE_STATES.credential_acked: "#45A776",
       VC_CRED_ISSUE_STATES.abandoned: "#D8292F",
     };
     const issuanceStateColumn = {

--- a/services/minespace-web/src/components/dashboard/mine/permits/PermitsTable.tsx
+++ b/services/minespace-web/src/components/dashboard/mine/permits/PermitsTable.tsx
@@ -89,7 +89,7 @@ export const PermitsTable: FC<PermitsTableProps> = (props) => {
       "Not Active": "#D8292F",
       Pending: "#F1C21B",
       Active: "#45A776",
-      "Offer Rejected": "#D8292F",
+      VC_CRED_ISSUE_STATES.abandoned: "#D8292F",
     };
     const issuanceStateColumn = {
       title: "Issuance State",

--- a/services/minespace-web/src/components/dashboard/mine/permits/PermitsTable.tsx
+++ b/services/minespace-web/src/components/dashboard/mine/permits/PermitsTable.tsx
@@ -89,6 +89,7 @@ export const PermitsTable: FC<PermitsTableProps> = (props) => {
       "Not Active": "#D8292F",
       Pending: "#F1C21B",
       Active: "#45A776",
+      "Offer Rejected": "#D8292F",
     };
     const issuanceStateColumn = {
       title: "Issuance State",


### PR DESCRIPTION
## Objective 

[MDS-5569](https://bcmines.atlassian.net/browse/MDS-5569)

NOTE: Traction Tenant UI does not send the problem report when 'deleting' a cred offer https://github.com/bcgov/traction/issues/999

Tested by manually calling the problem report endpoint in traction. 

We need some additional consideration for multiple credential exchanges per permit_amendment record. 
- Failed/rejected offers
- multiple active permits of different schema. 