### PR TITLE
[MDS-5409] Fixed startup command of Core Celery

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -120,6 +120,7 @@ services:
       - jaeger
       - otelcollector
       - keycloak
+      - core_api_celery
     healthcheck:
       test: [ "CMD", "curl", "localhost:5000/health" ]
       interval: 5s

--- a/services/core-api/celery.sh
+++ b/services/core-api/celery.sh
@@ -13,4 +13,4 @@
 
 cd /app || exit
 
-celery worker -n core_tasks@%h -A app.tasks.celery_entrypoint -Q core_tasks --loglevel=debug --concurrency=1 -B --scheduler redbeat.RedBeatScheduler -E --pidfile /tmp/celerybeat.pid -s /tmp/celerybeat-schedule
+celery -A app.tasks.celery_entrypoint worker -n core_tasks@%h -Q core_tasks --loglevel=debug --concurrency=1 -B --scheduler redbeat.RedBeatScheduler -E --pidfile /tmp/celerybeat.pid -s /tmp/celerybeat-schedule

--- a/services/core-api/requirements.txt
+++ b/services/core-api/requirements.txt
@@ -33,7 +33,7 @@ marshmallow_sqlalchemy==0.23.1
 python-docx==1.1.0
 sheet2dict==0.1.1
 cerberus==1.3.4
-celery[redis]==5.3.1
+celery[redis]==5.3.6
 celery-redbeat==2.2.0
 cachelib
 gunicorn==19.10.0


### PR DESCRIPTION
## Objective 

[MDS-5409](https://bcmines.atlassian.net/browse/MDS-5409)

The Celery startup command structure was changed slightly in the newest celery version which prevented the worker to start (the `-A` option was moved to a global param)