### PR TITLE
[MDS-5409] Fixed format of core-api readiness query to work with new SQLAlchemy version

### DIFF
--- a/services/core-api/app/__init__.py
+++ b/services/core-api/app/__init__.py
@@ -277,7 +277,7 @@ def register_routes(app):
                 return {'ready': False}, 503
 
     def get_database_status():
-        return db.session.query("up").from_statement(text("SELECT 1 as up")).all()[0][0] == 1
+        return db.session.query(text("up")).from_statement(text("SELECT 1 as up")).all()[0][0] == 1
 
     def get_cache_status():
         now = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')


### PR DESCRIPTION
## Objective 

[MDS-5409](https://bcmines.atlassian.net/browse/MDS-5409)

This PR fixes an issue where the DB Readiness query fails with the following error caused by the recent upgrades. This prevents new core API pods from becoming ready to receive traffic.

![image](https://github.com/bcgov/mds/assets/66635118/ce6f94de-06e3-4eb4-b350-2d52bdb0e669)
