### PR TITLE
[MDS-5788] Fixed error when loading original NOW application + regenerating map

### DIFF
--- a/services/core-api/app/api/mines/mine/resources/mine_map.py
+++ b/services/core-api/app/api/mines/mine/resources/mine_map.py
@@ -30,7 +30,7 @@ class MineMapResource(Resource, UserMixin):
         # TODO: Use some custom representation of this data vs JSON. The
         # json string is massive (with 50,000 points: 16mb uncompressed, 2.5mb compressed).
         # A quick test using delimented data brings this down to ~1mb compressed.
-        map_result = None #cache.get(MINE_MAP_CACHE)
+        map_result = cache.get(MINE_MAP_CACHE)
         last_modified = cache.get(MINE_MAP_CACHE + '_LAST_MODIFIED')
         if not map_result:
             map_result = MineMapResource.rebuild_and_return_map_cache()

--- a/services/core-api/app/api/now_applications/models/now_application.py
+++ b/services/core-api/app/api/now_applications/models/now_application.py
@@ -108,7 +108,7 @@ class NOWApplication(Base, AuditMixin):
     proposed_annual_maximum_tonnage = db.Column(db.Numeric(14, 2))
     adjusted_annual_maximum_tonnage = db.Column(db.Numeric(14, 2))
 
-    now_application_identity = db.relationship('NOWApplicationIdentity', uselist=False, back_populates='now_application')
+    now_application_identity = db.relationship('NOWApplicationIdentity', uselist=False)
 
     first_aid_equipment_on_site = db.Column(db.String)
     first_aid_cert_level = db.Column(db.String)
@@ -130,8 +130,8 @@ class NOWApplication(Base, AuditMixin):
 
     reviews = db.relationship('NOWApplicationReview', lazy='select', backref='now_application')
 
-    blasting_operation = db.relationship('BlastingOperation', lazy='joined', uselist=False, back_populates='now_application')
-    state_of_land = db.relationship('StateOfLand', lazy='joined', uselist=False, back_populates='now_application')
+    blasting_operation = db.relationship('BlastingOperation', lazy='joined', uselist=False)
+    state_of_land = db.relationship('StateOfLand', lazy='joined', uselist=False)
 
     # Securities
     liability_adjustment = db.Column(db.Numeric(16, 2))
@@ -166,7 +166,7 @@ class NOWApplication(Base, AuditMixin):
         primaryjoin=
         'and_(NOWApplicationDocumentXref.now_application_id==NOWApplication.now_application_id, NOWApplicationDocumentXref.now_application_review_id==None, NOWApplicationDocumentXref.deleted_ind==False)',
         order_by='desc(NOWApplicationDocumentXref.create_timestamp)',
-        back_populates='now_application'
+
     )
 
     application_reason_codes = db.relationship(
@@ -198,7 +198,7 @@ class NOWApplication(Base, AuditMixin):
         lazy='selectin',
         primaryjoin=
         'and_(NOWPartyAppointment.now_application_id == NOWApplication.now_application_id, NOWPartyAppointment.deleted_ind==False)',
-        back_populates='now_application'
+
     )
 
     status = db.relationship(


### PR DESCRIPTION
## Objective 

[MDS-5788](https://bcmines.atlassian.net/browse/MDS-5788)

Removed a couple of backref attributes that were added to the `now` model as part of the python upgrades. These caused an integrity error when using the `transmogrify_now` function.
Also fixed an error I noticed when regenerating the map cache asynchronously
![image](https://github.com/bcgov/mds/assets/66635118/7761ee70-ee90-473c-88fa-5bafc5860cbb)

