### PR TITLE
[MDS-5730] Made staging area and building detail polymorphic identity unique

### DIFF
--- a/services/core-api/app/api/now_applications/models/activity_detail/building_detail.py
+++ b/services/core-api/app/api/now_applications/models/activity_detail/building_detail.py
@@ -10,7 +10,7 @@ from app.api.now_applications.models.activity_detail.activity_detail_base import
 
 class BuildingDetail(ActivityDetailBase):
     __tablename__ = 'building_detail'
-    __mapper_args__ = {'polymorphic_identity': 'camp'}
+    __mapper_args__ = {'polymorphic_identity': 'building'}
 
     activity_detail_id = db.Column(
         db.Integer, db.ForeignKey('activity_detail.activity_detail_id'), primary_key=True)

--- a/services/core-api/app/api/now_applications/models/activity_detail/staging_area_detail.py
+++ b/services/core-api/app/api/now_applications/models/activity_detail/staging_area_detail.py
@@ -2,7 +2,6 @@ from app.api.now_applications.models.activity_detail.activity_detail_base import
 
 
 class StagingAreaDetail(ActivityDetailBase):
-    __mapper_args__ = {'polymorphic_identity': 'camp'}
-
+    __mapper_args__ = {'polymorphic_identity': 'staging_area'}
     def __repr__(self):
         return f'<{self.__class__.__name__} {self.activity_detail_id}>'


### PR DESCRIPTION
## Objective 

[MDS-5730](https://bcmines.atlassian.net/browse/MDS-5730)

🐉 🐉 🐉 🐉 

With the upgrade to SQLAlchemy 1.4, the Polymorphic identity warning with NoW building, camps, and Staging areas, described in https://bcmines.atlassian.net/browse/MDS-5494 has been upgraded to cause an error instead of just a warning, causing a 400 error when viewing a NoW with any of the entities associated 
![image](https://github.com/bcgov/mds/assets/66635118/2c7721f1-11e8-46c5-8533-07f2f6fea895)

The issue comes down to Staging Areas, Buildings and Camps all sharing the polymorphic identity "camp", as they have the same activity type.

This PR fixes the error by assigning a unique polymorphic identity to each of them, while still keeping the activity type the same. Whether Staging Areas, Buildings, and Camps all should have the same activity type is a question and rabbit hole for another day.

![image](https://github.com/bcgov/mds/assets/66635118/9ff23aa0-d925-4025-ae43-9f86016dd3bc)


