### PR TITLE
[MDS-5730] Enable manual trigger of NRIS build

### DIFF
--- a/.github/workflows/nris.build.deploy.dev.yaml
+++ b/.github/workflows/nris.build.deploy.dev.yaml
@@ -1,6 +1,7 @@
 name: NRIS - Build & Deploy To DEV
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - develop


### PR DESCRIPTION
## Objective 

[MDS-5730](https://bcmines.atlassian.net/browse/MDS-5730)

Enabling manual build trigger of NRIS API. Testing it fully locally is proving a pain (hello Oracle), so just want to deploy my branch to dev and test it there...
