### PR TITLE
[MDS-5783] Fixed now document generation

### DIFF
--- a/services/core-api/app/api/document_generation/resources/now_document_resource.py
+++ b/services/core-api/app/api/document_generation/resources/now_document_resource.py
@@ -16,6 +16,7 @@ from app.api.now_applications.models.now_application_document_xref import NOWApp
 from app.api.services.document_generator_service import DocumentGeneratorService
 from app.api.services.document_manager_service import DocumentManagerService
 from app.api.now_applications.response_models import NOW_APPLICATION_DOCUMENT
+from app.api.utils.access_decorators import requires_role_edit_permit
 
 
 class NoticeOfWorkDocumentResource(Resource, UserMixin):
@@ -30,6 +31,7 @@ class NoticeOfWorkDocumentResource(Resource, UserMixin):
             'is_preview':
             'If true, returns the generated document without creating the document record.'
         })
+    @requires_role_edit_permit
     def get(self):
         token = request.args.get('token', '')
         return_record = request.args.get('return_record') == 'true'


### PR DESCRIPTION
## Objective 

[MDS-5783](https://bcmines.atlassian.net/browse/MDS-5783)

This PR fixes a 500 error when trying to generate a NOW Document. Updated the role of the now document generation resource. It does verify a token passed along already, but needs to do a permissions check as some of the queries tries to use data about the current user.

![image](https://github.com/bcgov/mds/assets/66635118/b6299afc-c6df-4aa8-a2be-59c989c318f8)
