### PR TITLE
[MDS-5779] Fixed NoW permit issuing

### DIFF
--- a/services/core-api/app/api/utils/access_decorators.py
+++ b/services/core-api/app/api/utils/access_decorators.py
@@ -31,6 +31,8 @@ EDIT_INCIDENTS = "core_edit_incidents"
 EDIT_TSF = "core_edit_tsf"
 EDIT_PROJECT_DECISION_PACKAGES = "core_edit_project_decision_packages"
 
+def require_auth():
+    return getJwtManager()._require_auth_validation()
 
 def is_minespace_user():
     return getJwtManager().validate_roles([MINESPACE_PROPONENT])

--- a/services/core-api/app/api/utils/include/user_info.py
+++ b/services/core-api/app/api/utils/include/user_info.py
@@ -1,4 +1,5 @@
 from flask import g, has_request_context, request
+from app.api.utils.access_decorators import require_auth
 
 VALID_REALM = ['idir']
 
@@ -22,8 +23,10 @@ class User:
         
         if hasattr(g, 'jwt_oidc_token_info'):
             return g.jwt_oidc_token_info
-        else:
-            raise Exception('No user info found. Make sure to authenticate the user first.')
+        elif has_request_context() and "authorization" in request.headers:
+            require_auth()
+
+            return g.jwt_oidc_token_info
 
     def get_user_email(self):
         raw_info = self.get_user_raw_info()

--- a/services/core-api/app/api/utils/include/user_info.py
+++ b/services/core-api/app/api/utils/include/user_info.py
@@ -22,8 +22,12 @@ class User:
             return DUMMY_AUTH_CLAIMS
         
         if hasattr(g, 'jwt_oidc_token_info'):
+            # The users token claims are set if role / auth checks have already been performed.
+            # This is the case for most API requests.
             return g.jwt_oidc_token_info
         elif has_request_context() and "authorization" in request.headers:
+            # In some cases (such as NoW document generation) the role / auth checks have not been performed yet,
+            # so we need to manually verify the users token before we can access the claims.
             require_auth()
 
             return g.jwt_oidc_token_info


### PR DESCRIPTION
## Objective 

[MDS-5779](https://bcmines.atlassian.net/browse/MDS-5779)

The `No user info found` exception was added together with the Python upgrades last sprint as a fail-safe to make sure we remember to authenticate all requests that require it. This caused some issues for cases that have "public" endpoints (NoW document generation, which handles auth "manually" with short lived tokens). Removed the failsafe, and added fallback parsing of the auth token when necessary. 

Will put adding that fail-safe into a separate ticket.
![image](https://github.com/bcgov/mds/assets/66635118/300ea6a5-fd52-45dc-b2ce-145ee23cc6dd)