### PR TITLE
[MDS-5771] Adding display of prr or crr report type

### DIFF
--- a/services/common/src/components/forms/RenderRadioButtons.tsx
+++ b/services/common/src/components/forms/RenderRadioButtons.tsx
@@ -11,6 +11,7 @@ interface RenderRadioButtonsProps extends BaseInputProps {
   label: string;
   customOptions?: IOption[];
   optionType?: "default" | "button";
+  isVertical?: boolean;
 }
 
 const RenderRadioButtons: FC<RenderRadioButtonsProps> = ({
@@ -22,6 +23,7 @@ const RenderRadioButtons: FC<RenderRadioButtonsProps> = ({
   customOptions,
   required = false,
   optionType = "default",
+  isVertical = false,
 }) => {
   const options = customOptions ?? [
     { label: "Yes", value: true },
@@ -52,6 +54,7 @@ const RenderRadioButtons: FC<RenderRadioButtonsProps> = ({
         options={options}
         optionType={optionType}
         buttonStyle="solid"
+        {...(isVertical && { className: "vertical-radio-group" })}
       />
     </Form.Item>
   );

--- a/services/common/src/components/reports/ReportDetailsForm.tsx
+++ b/services/common/src/components/reports/ReportDetailsForm.tsx
@@ -1,4 +1,4 @@
-import { Alert, Button, Col, Row, Typography, Radio } from "antd";
+import { Alert, Button, Col, Row, Typography } from "antd";
 import React, { FC, ReactNode, useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { arrayPush, change, Field, FieldArray, getFormValues } from "redux-form";
@@ -9,13 +9,20 @@ import { getMineReportDefinitionOptions } from "@mds/common/redux/selectors/stat
 import ReportFileUpload from "@mds/common/components/reports/ReportFileUpload";
 
 import { FORM } from "@mds/common/constants/forms";
-import { email, maxLength, required, yearNotInFuture } from "@mds/common/redux/utils/Validate";
+import {
+  email,
+  maxLength,
+  required,
+  yearNotInFuture,
+  requiredRadioButton,
+} from "@mds/common/redux/utils/Validate";
 import ReportFilesTable from "./ReportFilesTable";
 import { formatComplianceCodeReportName } from "@mds/common/redux/utils/helpers";
 import RenderDate from "../forms/RenderDate";
 import RenderSelect from "../forms/RenderSelect";
 import FormWrapper from "../forms/FormWrapper";
 import RenderField from "../forms/RenderField";
+import RenderRadioButtons from "../forms/RenderRadioButtons";
 import {
   IMineDocument,
   IMineReportDefinition,
@@ -118,7 +125,6 @@ const ReportDetailsForm: FC<ReportDetailsFormProps> = ({
   const mineReportDefinitionOptions = useSelector(getMineReportDefinitionOptions);
 
   const system = useSelector(getSystemFlag);
-  const isPermitRequiredReport = formValues?.permit_condition_category_code ? 2 : 1;
 
   // minespace users are only allowed to add documents
   const mineSpaceEdit =
@@ -130,6 +136,11 @@ const ReportDetailsForm: FC<ReportDetailsFormProps> = ({
       dispatch(fetchPartyRelationships({ mine_guid: mineGuid }));
     }
   }, []);
+
+  useEffect(() => {
+    const reportType = initialValues?.permit_condition_category_code ? "PRR" : "CRR";
+    dispatch(change(FORM.VIEW_EDIT_REPORT, "report_type", reportType));
+  }, [!formValues?.report_type]);
 
   useEffect(() => {
     if (currentReportDefinition) {
@@ -231,15 +242,22 @@ const ReportDetailsForm: FC<ReportDetailsFormProps> = ({
         <Row gutter={[16, 8]}>
           {system === SystemFlagEnum.core && (
             <Col span={24}>
-              <Typography.Paragraph>What is the type of the report?</Typography.Paragraph>
-              <Radio.Group
+              <Field
+                name="report_type"
+                id="report_type"
+                required
                 disabled={true}
-                className="vertical-radio-group"
-                value={isPermitRequiredReport}
-              >
-                <Radio value={1}>Code Required Report</Radio>
-                <Radio value={2}>Permit Required Report</Radio>
-              </Radio.Group>
+                props={{
+                  isVertical: true,
+                }}
+                label="What is the type of the report?"
+                component={RenderRadioButtons}
+                validate={[requiredRadioButton]}
+                customOptions={[
+                  { label: "Code Required Report", value: "CRR" },
+                  { label: "Permit Required Report", value: "PRR" },
+                ]}
+              />
             </Col>
           )}
           <Col span={12}>

--- a/services/common/src/components/reports/ReportDetailsForm.tsx
+++ b/services/common/src/components/reports/ReportDetailsForm.tsx
@@ -1,4 +1,4 @@
-import { Alert, Button, Col, Row, Typography } from "antd";
+import { Alert, Button, Col, Row, Typography, Radio } from "antd";
 import React, { FC, ReactNode, useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { arrayPush, change, Field, FieldArray, getFormValues } from "redux-form";
@@ -118,6 +118,7 @@ const ReportDetailsForm: FC<ReportDetailsFormProps> = ({
   const mineReportDefinitionOptions = useSelector(getMineReportDefinitionOptions);
 
   const system = useSelector(getSystemFlag);
+  const isPermitRequiredReport = formValues?.permit_condition_category_code ? 2 : 1;
 
   // minespace users are only allowed to add documents
   const mineSpaceEdit =
@@ -228,6 +229,19 @@ const ReportDetailsForm: FC<ReportDetailsFormProps> = ({
         initialValues={initialValues}
       >
         <Row gutter={[16, 8]}>
+          {system === SystemFlagEnum.core && (
+            <Col span={24}>
+              <Typography.Paragraph>What is the type of the report?</Typography.Paragraph>
+              <Radio.Group
+                disabled={true}
+                className="vertical-radio-group"
+                value={isPermitRequiredReport}
+              >
+                <Radio value={1}>Code Required Report</Radio>
+                <Radio value={2}>Permit Required Report</Radio>
+              </Radio.Group>
+            </Col>
+          )}
           <Col span={12}>
             <Field
               component={RenderSelect}

--- a/services/common/src/interfaces/reports/mineReportSubmission.interface.ts
+++ b/services/common/src/interfaces/reports/mineReportSubmission.interface.ts
@@ -23,6 +23,7 @@ export interface IMineReportSubmission {
   permit_number?: any;
   received_date: string;
   report_name?: string;
+  report_type?: string;
   submission_date: string;
   submission_year: number;
   submitter_email: string;

--- a/services/core-web/src/tests/components/Forms/reports/__snapshots__/ReportPage.spec.tsx.snap
+++ b/services/core-web/src/tests/components/Forms/reports/__snapshots__/ReportPage.spec.tsx.snap
@@ -298,6 +298,61 @@ exports[`ReportPage renders view mode properly 1`] = `
           style="margin: -4px -8px -4px -8px;"
         >
           <div
+            class="ant-col ant-col-24"
+            style="padding: 4px 8px 4px 8px;"
+          >
+            <div
+              class="ant-typography"
+            >
+              What is the type of the report?
+            </div>
+            <div
+              class="ant-radio-group ant-radio-group-outline vertical-radio-group"
+            >
+              <label
+                class="ant-radio-wrapper ant-radio-wrapper-checked ant-radio-wrapper-disabled"
+              >
+                <span
+                  class="ant-radio ant-radio-checked ant-radio-disabled"
+                >
+                  <input
+                    checked=""
+                    class="ant-radio-input"
+                    disabled=""
+                    type="radio"
+                    value="1"
+                  />
+                  <span
+                    class="ant-radio-inner"
+                  />
+                </span>
+                <span>
+                  Code Required Report
+                </span>
+              </label>
+              <label
+                class="ant-radio-wrapper ant-radio-wrapper-disabled"
+              >
+                <span
+                  class="ant-radio ant-radio-disabled"
+                >
+                  <input
+                    class="ant-radio-input"
+                    disabled=""
+                    type="radio"
+                    value="2"
+                  />
+                  <span
+                    class="ant-radio-inner"
+                  />
+                </span>
+                <span>
+                  Permit Required Report
+                </span>
+              </label>
+            </div>
+          </div>
+          <div
             class="ant-col ant-col-12"
             style="padding: 4px 8px 4px 8px;"
           >

--- a/services/core-web/src/tests/components/Forms/reports/__snapshots__/ReportPage.spec.tsx.snap
+++ b/services/core-web/src/tests/components/Forms/reports/__snapshots__/ReportPage.spec.tsx.snap
@@ -302,54 +302,96 @@ exports[`ReportPage renders view mode properly 1`] = `
             style="padding: 4px 8px 4px 8px;"
           >
             <div
-              class="ant-typography"
+              class="ant-form-item ant-form-item-with-help"
             >
-              What is the type of the report?
-            </div>
-            <div
-              class="ant-radio-group ant-radio-group-outline vertical-radio-group"
-            >
-              <label
-                class="ant-radio-wrapper ant-radio-wrapper-checked ant-radio-wrapper-disabled"
+              <div
+                class="ant-row ant-form-item-row"
               >
-                <span
-                  class="ant-radio ant-radio-checked ant-radio-disabled"
+                <div
+                  class="ant-col ant-form-item-label"
                 >
-                  <input
-                    checked=""
-                    class="ant-radio-input"
-                    disabled=""
-                    type="radio"
-                    value="1"
-                  />
-                  <span
-                    class="ant-radio-inner"
-                  />
-                </span>
-                <span>
-                  Code Required Report
-                </span>
-              </label>
-              <label
-                class="ant-radio-wrapper ant-radio-wrapper-disabled"
-              >
-                <span
-                  class="ant-radio ant-radio-disabled"
+                  <label
+                    class="ant-form-item-required"
+                    for="VIEW_EDIT_REPORT_report_type"
+                    title="What is the type of the report?"
+                  >
+                    What is the type of the report?
+                  </label>
+                </div>
+                <div
+                  class="ant-col ant-form-item-control"
                 >
-                  <input
-                    class="ant-radio-input"
-                    disabled=""
-                    type="radio"
-                    value="2"
-                  />
-                  <span
-                    class="ant-radio-inner"
-                  />
-                </span>
-                <span>
-                  Permit Required Report
-                </span>
-              </label>
+                  <div
+                    class="ant-form-item-control-input"
+                  >
+                    <div
+                      class="ant-form-item-control-input-content"
+                    >
+                      <div
+                        aria-required="true"
+                        class="ant-radio-group ant-radio-group-solid vertical-radio-group"
+                        id="VIEW_EDIT_REPORT_report_type"
+                      >
+                        <label
+                          class="ant-radio-wrapper ant-radio-wrapper-checked ant-radio-wrapper-disabled ant-radio-wrapper-in-form-item"
+                        >
+                          <span
+                            class="ant-radio ant-radio-checked ant-radio-disabled"
+                          >
+                            <input
+                              class="ant-radio-input"
+                              disabled=""
+                              name="report_type"
+                              type="radio"
+                              value="CRR"
+                            />
+                            <span
+                              class="ant-radio-inner"
+                            />
+                          </span>
+                          <span>
+                            Code Required Report
+                          </span>
+                        </label>
+                        <label
+                          class="ant-radio-wrapper ant-radio-wrapper-disabled ant-radio-wrapper-in-form-item"
+                        >
+                          <span
+                            class="ant-radio ant-radio-disabled"
+                          >
+                            <input
+                              class="ant-radio-input"
+                              disabled=""
+                              name="report_type"
+                              type="radio"
+                              value="PRR"
+                            />
+                            <span
+                              class="ant-radio-inner"
+                            />
+                          </span>
+                          <span>
+                            Permit Required Report
+                          </span>
+                        </label>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    style="display: flex; flex-wrap: nowrap;"
+                  >
+                    <div
+                      class="ant-form-item-explain ant-form-item-explain-connected"
+                      id="VIEW_EDIT_REPORT_report_type_help"
+                      role="alert"
+                    >
+                      <div
+                        class=""
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
             </div>
           </div>
           <div


### PR DESCRIPTION
## Objective 

[MDS-5771](https://bcmines.atlassian.net/browse/MDS-5771)

-Adding display of prr or crr report type in report page
-Currently should only have Code Required Report selected because the user selection in MDS-5781 hasn't been worked on yet.

![Screenshot (263)](https://github.com/bcgov/mds/assets/127789479/1a8f27ae-a351-44c3-a367-feeaed920d33)
