### PR TITLE
[MDS-5731] Reverted Discord notification lambda to python 3.9

### DIFF
--- a/terraform/modules/build/notify.py
+++ b/terraform/modules/build/notify.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.11
+#!/usr/bin/python3.9
 import json
 import logging
 import urllib3

--- a/terraform/modules/discord_sysdig_webhook.tf
+++ b/terraform/modules/discord_sysdig_webhook.tf
@@ -47,7 +47,7 @@ resource "aws_lambda_function" "discord_notify" {
   s3_bucket = aws_s3_bucket.lambda_bucket.id
   s3_key = aws_s3_object.lambda_notification.key
 
-  runtime = "python3.11"
+  runtime = "python3.9"
   handler = "notify.lambda_handler"
 
   layers        = ["arn:aws:lambda:ca-central-1:017000801446:layer:AWSLambdaPowertoolsPython:36"]


### PR DESCRIPTION
## Objective 

[MDS-5731](https://bcmines.atlassian.net/browse/MDS-5731)

The discord terraform provider depends on a version of the AWS terraform module that doesn't have support for python 3.11 lambdas which causes an error when deploying, so reverting to 3.9.

![image](https://github.com/bcgov/mds/assets/66635118/e6025df3-2917-406c-8191-c3d32f5fcde9)
