### PR TITLE
[MDS-5790] - Made getting started page for CRR/PRR reinitialize default values

### DIFF
--- a/services/common/src/components/reports/ReportGetStarted.tsx
+++ b/services/common/src/components/reports/ReportGetStarted.tsx
@@ -157,7 +157,7 @@ const ReportGetStarted: FC<ReportGetStartedProps> = ({
     <FormWrapper
       name={FORM.VIEW_EDIT_REPORT}
       onSubmit={handleSubmit}
-      reduxFormConfig={{ destroyOnUnmount: false }}
+      reduxFormConfig={{ destroyOnUnmount: false, enableReinitialize: true }}
       initialValues={{
         report_type: reportType ? MineReportType[reportType] : REPORT_TYPE_CODES.CRR,
       }}


### PR DESCRIPTION
## Objective 

[MDS-5790](https://bcmines.atlassian.net/browse/MDS-5790)

The getting started page for CRRs/PRRs was holding onto the default value from the first way it was accessed and not updating if you navigated away and returned from the other flow.  Set enableReinitialize to true for the form, so this won't happen.

