### PR TITLE
[MDS-5818] CRR Cleanup

### DIFF
--- a/services/common/src/components/reports/ReportDetailsForm-edit.spec.tsx
+++ b/services/common/src/components/reports/ReportDetailsForm-edit.spec.tsx
@@ -5,7 +5,7 @@ import ReportDetailsForm from "./ReportDetailsForm";
 import { Button } from "antd";
 import * as MOCK from "@mds/common/tests/mocks/dataMocks";
 import { AUTHENTICATION } from "@mds/common/constants/reducerTypes";
-import { SystemFlagEnum, USER_ROLES } from "@mds/common";
+import { SystemFlagEnum, USER_ROLES } from "@mds/common/constants";
 
 const mineReportSubmission = MOCK.MINE_REPORT_SUBMISSIONS[0];
 
@@ -19,6 +19,17 @@ const initialState = {
     userAccessData: [USER_ROLES.role_edit_reports],
   },
 };
+
+function mockFunction() {
+  const original = jest.requireActual("react-router-dom");
+  return {
+    ...original,
+    useParams: jest.fn().mockReturnValue({
+      reportGuid: "1234",
+    }),
+  };
+}
+jest.mock("react-router-dom", () => mockFunction());
 
 describe("ReportDetailsForm", () => {
   it("renders edit mode properly", () => {

--- a/services/common/src/components/reports/ReportDetailsForm-view.spec.tsx
+++ b/services/common/src/components/reports/ReportDetailsForm-view.spec.tsx
@@ -6,7 +6,7 @@ import { Button } from "antd";
 import { AUTHENTICATION, STATIC_CONTENT } from "@mds/common/constants/reducerTypes";
 import * as MOCK from "@mds/common/tests/mocks/dataMocks";
 import { IMineReportSubmission } from "../..";
-import { SystemFlagEnum, USER_ROLES } from "@mds/common";
+import { SystemFlagEnum, USER_ROLES } from "@mds/common/constants";
 
 const mineReportSubmission = MOCK.MINE_REPORT_SUBMISSIONS[0];
 const initialState = {
@@ -24,6 +24,17 @@ const initialState = {
     userAccessData: [USER_ROLES.role_edit_reports],
   },
 };
+
+function mockFunction() {
+  const original = jest.requireActual("react-router-dom");
+  return {
+    ...original,
+    useParams: jest.fn().mockReturnValue({
+      reportGuid: "1234",
+    }),
+  };
+}
+jest.mock("react-router-dom", () => mockFunction());
 
 describe("ReportDetailsForm", () => {
   it("renders view mode properly", () => {

--- a/services/common/src/components/reports/ReportDetailsForm.tsx
+++ b/services/common/src/components/reports/ReportDetailsForm.tsx
@@ -60,6 +60,7 @@ import {
 } from "@mds/common/redux/actionCreators/reportCommentActionCreator";
 import AuthorizationWrapper from "@mds/common/wrappers/AuthorizationWrapper";
 import { USER_ROLES } from "@mds/common/constants/environment";
+import { useParams } from "react-router-dom";
 
 const RenderContacts: FC<any> = ({ fields, isEditMode, mineSpaceEdit }) => {
   const canEdit = isEditMode && !mineSpaceEdit;
@@ -125,6 +126,8 @@ const ReportDetailsForm: FC<ReportDetailsFormProps> = ({
   handleSubmit,
   currentReportDefinition,
 }) => {
+  const { reportGuid } = useParams<{ reportGuid?: string }>();
+
   const coreEditReportPermission = USER_ROLES.role_edit_reports;
   const coreViewAllPermission = USER_ROLES.role_view;
   const dispatch = useDispatch();
@@ -333,6 +336,7 @@ const ReportDetailsForm: FC<ReportDetailsFormProps> = ({
         name={FORM.VIEW_EDIT_REPORT}
         onSubmit={handleSubmit}
         isEditMode={isEditMode}
+        reduxFormConfig={{ enableReinitialize: !!reportGuid }}
         initialValues={initialValues}
       >
         {system === SystemFlagEnum.core && formButtons}

--- a/services/common/src/components/reports/reportSubmissionSlice.ts
+++ b/services/common/src/components/reports/reportSubmissionSlice.ts
@@ -53,9 +53,13 @@ const submissionSlice = createAppSlice({
       async (payload: IMineReportSubmission, thunkApi) => {
         const headers = createRequestHeader();
         thunkApi.dispatch(showLoading());
+        const successMessage = payload.mine_report_guid
+          ? "Report successfully resubmitted"
+          : "Successfully created new report submission";
+
         const messages = {
           errorToastMessage: "default",
-          successToastMessage: "Successfully created new report submission",
+          successToastMessage: successMessage,
         };
         const received_date = payload.received_date ?? moment().format("YYYY-MM-DD");
         const resp = await CustomAxios(messages).post(

--- a/services/core-api/app/api/mines/reports/models/mine_report.py
+++ b/services/core-api/app/api/mines/reports/models/mine_report.py
@@ -195,7 +195,7 @@ class MineReport(SoftDeleteMixin, AuditMixin, Base):
                 cls.due_date.asc())
             if reports_type == MINE_REPORT_TYPE['PERMIT REQUIRED REPORTS']:
                 reports = reports.filter(MineReport.permit_condition_category_code.isnot(None))
-            else:
+            elif reports_type == MINE_REPORT_TYPE['CODE REQUIRED REPORTS']:
                 reports = reports.filter(MineReport.permit_condition_category_code.is_(None))
             return reports.all()
         except ValueError:

--- a/services/core-api/tests/reports/resource/test_mine_report_submissions_resource.py
+++ b/services/core-api/tests/reports/resource/test_mine_report_submissions_resource.py
@@ -142,5 +142,5 @@ def test_post_additional_mine_report_submission(test_client, db_session, auth_he
     
     # fields that should not change
     assert previous_submission['received_date'] == latest_submission['received_date']    
-    assert previous_submission['create_timestamp'] == latest_submission['create_timestamp']
+    assert previous_submission['create_timestamp'] + '+00:00' == latest_submission['create_timestamp']
     

--- a/services/core-api/tests/reports/resource/test_mine_report_submissions_resource.py
+++ b/services/core-api/tests/reports/resource/test_mine_report_submissions_resource.py
@@ -142,5 +142,5 @@ def test_post_additional_mine_report_submission(test_client, db_session, auth_he
     
     # fields that should not change
     assert previous_submission['received_date'] == latest_submission['received_date']    
-    assert previous_submission['create_timestamp'] + '+00:00' == latest_submission['create_timestamp']
+    assert previous_submission['create_timestamp'] == latest_submission['create_timestamp']
     

--- a/services/core-api/tests/search/resource/test_search_resource.py
+++ b/services/core-api/tests/search/resource/test_search_resource.py
@@ -28,7 +28,7 @@ def test_search_party(test_client, db_session, auth_headers):
     assert len([
         key for key, value in get_data['search_results'].items()
         if key is not 'party' and len(value) is 0
-    ]) == 4
+    ]) == 5
     assert get_resp.status_code == 200
 
 

--- a/services/minespace-web/package.json
+++ b/services/minespace-web/package.json
@@ -66,6 +66,7 @@
     "react-redux-loading-bar": "5.0.0",
     "react-responsive": "7.0.0",
     "react-router-dom": "5.3.3",
+    "react-scroll": "1.7.12",
     "redux": "5.0.0",
     "redux-form": "8.2.6",
     "redux-form-input-masks": "2.0.1",

--- a/services/minespace-web/src/components/dashboard/mine/reports/Reports.tsx
+++ b/services/minespace-web/src/components/dashboard/mine/reports/Reports.tsx
@@ -17,6 +17,7 @@ import { IMine, IMineReport, Feature } from "@mds/common";
 import { Link, useHistory } from "react-router-dom";
 import * as routes from "@/constants/routes";
 import { useFeatureFlag } from "@mds/common/providers/featureFlags/useFeatureFlag";
+import { Link as ScrollLink, Element } from "react-scroll";
 
 interface ReportsProps {
   mine: IMine;
@@ -31,13 +32,23 @@ export const Reports: FC<ReportsProps> = ({ mine, ...props }) => {
 
   const [isLoaded, setIsLoaded] = useState(false);
   const [report, setReport] = useState(null);
+  const [permitRequiredReports, setPermitRequiredReports] = useState<IMineReport[]>([]);
+  const [codeRequiredReports, setCodeRequiredReports] = useState<IMineReport[]>([]);
+
+  useEffect(() => {
+    const pRRs = mineReports.filter((report) => !!report.permit_guid);
+    const cRRs = mineReports.filter((report) => !report.permit_guid);
+
+    setPermitRequiredReports(pRRs);
+    setCodeRequiredReports(cRRs);
+  }, [mineReports]);
 
   useEffect(() => {
     let isMounted = true;
 
     setIsLoaded(false);
 
-    dispatch(fetchMineReports(mine.mine_guid)).then(() => {
+    dispatch(fetchMineReports(mine.mine_guid, null)).then(() => {
       if (isMounted) {
         setIsLoaded(true);
       }
@@ -56,7 +67,7 @@ export const Reports: FC<ReportsProps> = ({ mine, ...props }) => {
 
     await dispatch(createMineReport(mine.mine_guid, formValues));
     await dispatch(closeModal());
-    return dispatch(fetchMineReports(mine.mine_guid));
+    return dispatch(fetchMineReports(mine.mine_guid, null));
   };
 
   const handleEditReport = async (values) => {
@@ -84,7 +95,7 @@ export const Reports: FC<ReportsProps> = ({ mine, ...props }) => {
     }
     await dispatch(updateMineReport(mine.mine_guid, report.mine_report_guid, payload));
     await dispatch(closeModal());
-    return dispatch(fetchMineReports(mine.mine_guid));
+    return dispatch(fetchMineReports(mine.mine_guid, null));
   };
 
   const openReport = (reportRecord: IMineReport) => {
@@ -156,6 +167,20 @@ export const Reports: FC<ReportsProps> = ({ mine, ...props }) => {
               Reports
             </Typography.Title>
             <Typography.Paragraph>
+              View all{" "}
+              <ScrollLink to="codeRequiredReports" smooth={true}>
+                Code Required Reports
+              </ScrollLink>{" "}
+              and{" "}
+              <ScrollLink to="permitRequiredReports" smooth={true}>
+                Permit Required Reports
+              </ScrollLink>{" "}
+              for this mine.
+            </Typography.Paragraph>
+            <Element name="codeRequiredReports">
+              <Typography.Title level={4}>Code Required Reports</Typography.Title>
+            </Element>
+            <Typography.Paragraph>
               This table shows reports from the Health, Safety and Reclamation code that your mine
               has submitted to the Ministry. It also shows reports the Ministry has requested from
               your mine. If you do not see an HSRC report that your mine must submit, click Submit
@@ -172,7 +197,23 @@ export const Reports: FC<ReportsProps> = ({ mine, ...props }) => {
             <ReportsTable
               openReport={openReport}
               openEditReportModal={openEditReportModal}
-              mineReports={mineReports}
+              mineReports={codeRequiredReports}
+              isLoaded={isLoaded}
+            />
+            <Element name="permitRequiredReports">
+              <Typography.Title level={4}>Permit Required Reports</Typography.Title>
+            </Element>
+            <Typography.Paragraph>
+              This table shows documents submitted pursuant to regulatory requirements established
+              by conditions in site-specific Mines Act permits. It also shows reports the Ministry
+              has requested from your mine. If you do not see a permit required report that your
+              mine must submit, click Submit Report, choose the report you need to send and then
+              attach the file or files.
+            </Typography.Paragraph>
+            <ReportsTable
+              openReport={openReport}
+              openEditReportModal={openEditReportModal}
+              mineReports={permitRequiredReports}
               isLoaded={isLoaded}
             />
           </Col>

--- a/services/minespace-web/src/components/dashboard/mine/reports/ReportsTable.tsx
+++ b/services/minespace-web/src/components/dashboard/mine/reports/ReportsTable.tsx
@@ -141,6 +141,16 @@ export const ReportsTable: FC<ReportsTableProps> = (props) => {
     columns = [...columns, ...newColumns];
   }
 
+  if (props.mineReports.some((report) => report.permit_guid)) {
+    columns = columns.map((col) => {
+      if (col.key === "code_section") {
+        return renderTextColumn("permit_number", "Permit #", true, null, 5);
+      } else {
+        return col;
+      }
+    });
+  }
+
   const transformRowData = (reports: IMineReport[]): IMineReport[] =>
     reports.map((report) => {
       const { mine_report_submissions } = report;

--- a/services/minespace-web/src/tests/components/dashboard/mine/reports/__snapshots__/Reports.spec.tsx.snap
+++ b/services/minespace-web/src/tests/components/dashboard/mine/reports/__snapshots__/Reports.spec.tsx.snap
@@ -26,6 +26,32 @@ exports[`Reports renders properly 1`] = `
         <div
           class="ant-typography"
         >
+          View all
+           
+          <a>
+            Code Required Reports
+          </a>
+           
+          and
+           
+          <a>
+            Permit Required Reports
+          </a>
+           
+          for this mine.
+        </div>
+        <div
+          name="codeRequiredReports"
+        >
+          <h4
+            class="ant-typography"
+          >
+            Code Required Reports
+          </h4>
+        </div>
+        <div
+          class="ant-typography"
+        >
           This table shows reports from the Health, Safety and Reclamation code that your mine has submitted to the Ministry. It also shows reports the Ministry has requested from your mine. If you do not see an HSRC report that your mine must submit, click Submit Report, choose the report you need to send and then attach the file or files.
         </div>
         <div
@@ -43,6 +69,481 @@ exports[`Reports renders properly 1`] = `
         class="ant-col ant-col-24"
         style="padding: 16px 8px 16px 8px;"
       >
+        <div
+          class="ant-table-wrapper  core-table"
+        >
+          <div
+            class="ant-spin-nested-loading"
+          >
+            <div>
+              <div
+                aria-busy="true"
+                aria-live="polite"
+                class="ant-spin ant-spin-spinning"
+              >
+                <span
+                  aria-label="loading"
+                  class="anticon anticon-loading ant-spin-dot"
+                  role="img"
+                  style="font-size: 40px;"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="anticon-spin"
+                    data-icon="loading"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="0 0 1024 1024"
+                    width="1em"
+                  >
+                    <path
+                      d="M988 548c-19.9 0-36-16.1-36-36 0-59.4-11.6-117-34.6-171.3a440.45 440.45 0 00-94.3-139.9 437.71 437.71 0 00-139.9-94.3C629 83.6 571.4 72 512 72c-19.9 0-36-16.1-36-36s16.1-36 36-36c69.1 0 136.2 13.5 199.3 40.3C772.3 66 827 103 874 150c47 47 83.9 101.8 109.7 162.7 26.7 63.1 40.2 130.2 40.2 199.3.1 19.9-16 36-35.9 36z"
+                    />
+                  </svg>
+                </span>
+              </div>
+            </div>
+            <div
+              class="ant-spin-container ant-spin-blur"
+            >
+              <div
+                class="ant-table ant-table-small ant-table-empty"
+              >
+                <div
+                  class="ant-table-container"
+                >
+                  <div
+                    class="ant-table-content"
+                  >
+                    <table
+                      style="table-layout: auto;"
+                    >
+                      <colgroup>
+                        <col />
+                        <col />
+                        <col
+                          style="width: 5px;"
+                        />
+                        <col
+                          style="width: 5px;"
+                        />
+                      </colgroup>
+                      <thead
+                        class="ant-table-thead"
+                      >
+                        <tr>
+                          <th
+                            aria-label="Report Name"
+                            class="ant-table-cell ant-table-column-has-sorters"
+                            tabindex="0"
+                          >
+                            <div
+                              class="ant-table-column-sorters"
+                            >
+                              <span
+                                class="ant-table-column-title"
+                              >
+                                Report Name
+                              </span>
+                              <span
+                                class="ant-table-column-sorter ant-table-column-sorter-full"
+                              >
+                                <span
+                                  class="ant-table-column-sorter-inner"
+                                >
+                                  <span
+                                    aria-label="caret-up"
+                                    class="anticon anticon-caret-up ant-table-column-sorter-up"
+                                    role="presentation"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      data-icon="caret-up"
+                                      fill="currentColor"
+                                      focusable="false"
+                                      height="1em"
+                                      viewBox="0 0 1024 1024"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M858.9 689L530.5 308.2c-9.4-10.9-27.5-10.9-37 0L165.1 689c-12.2 14.2-1.2 35 18.5 35h656.8c19.7 0 30.7-20.8 18.5-35z"
+                                      />
+                                    </svg>
+                                  </span>
+                                  <span
+                                    aria-label="caret-down"
+                                    class="anticon anticon-caret-down ant-table-column-sorter-down"
+                                    role="presentation"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      data-icon="caret-down"
+                                      fill="currentColor"
+                                      focusable="false"
+                                      height="1em"
+                                      viewBox="0 0 1024 1024"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
+                                      />
+                                    </svg>
+                                  </span>
+                                </span>
+                              </span>
+                            </div>
+                          </th>
+                          <th
+                            class="ant-table-cell"
+                          >
+                            Code Section
+                          </th>
+                          <th
+                            aria-label="Compliance Year"
+                            class="ant-table-cell ant-table-column-has-sorters"
+                            tabindex="0"
+                          >
+                            <div
+                              class="ant-table-column-sorters"
+                            >
+                              <span
+                                class="ant-table-column-title"
+                              >
+                                Compliance Year
+                              </span>
+                              <span
+                                class="ant-table-column-sorter ant-table-column-sorter-full"
+                              >
+                                <span
+                                  class="ant-table-column-sorter-inner"
+                                >
+                                  <span
+                                    aria-label="caret-up"
+                                    class="anticon anticon-caret-up ant-table-column-sorter-up"
+                                    role="presentation"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      data-icon="caret-up"
+                                      fill="currentColor"
+                                      focusable="false"
+                                      height="1em"
+                                      viewBox="0 0 1024 1024"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M858.9 689L530.5 308.2c-9.4-10.9-27.5-10.9-37 0L165.1 689c-12.2 14.2-1.2 35 18.5 35h656.8c19.7 0 30.7-20.8 18.5-35z"
+                                      />
+                                    </svg>
+                                  </span>
+                                  <span
+                                    aria-label="caret-down"
+                                    class="anticon anticon-caret-down ant-table-column-sorter-down"
+                                    role="presentation"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      data-icon="caret-down"
+                                      fill="currentColor"
+                                      focusable="false"
+                                      height="1em"
+                                      viewBox="0 0 1024 1024"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
+                                      />
+                                    </svg>
+                                  </span>
+                                </span>
+                              </span>
+                            </div>
+                          </th>
+                          <th
+                            aria-label="Due"
+                            class="ant-table-cell ant-table-column-has-sorters"
+                            tabindex="0"
+                          >
+                            <div
+                              class="ant-table-column-sorters"
+                            >
+                              <span
+                                class="ant-table-column-title"
+                              >
+                                Due
+                              </span>
+                              <span
+                                class="ant-table-column-sorter ant-table-column-sorter-full"
+                              >
+                                <span
+                                  class="ant-table-column-sorter-inner"
+                                >
+                                  <span
+                                    aria-label="caret-up"
+                                    class="anticon anticon-caret-up ant-table-column-sorter-up"
+                                    role="presentation"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      data-icon="caret-up"
+                                      fill="currentColor"
+                                      focusable="false"
+                                      height="1em"
+                                      viewBox="0 0 1024 1024"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M858.9 689L530.5 308.2c-9.4-10.9-27.5-10.9-37 0L165.1 689c-12.2 14.2-1.2 35 18.5 35h656.8c19.7 0 30.7-20.8 18.5-35z"
+                                      />
+                                    </svg>
+                                  </span>
+                                  <span
+                                    aria-label="caret-down"
+                                    class="anticon anticon-caret-down ant-table-column-sorter-down"
+                                    role="presentation"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      data-icon="caret-down"
+                                      fill="currentColor"
+                                      focusable="false"
+                                      height="1em"
+                                      viewBox="0 0 1024 1024"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
+                                      />
+                                    </svg>
+                                  </span>
+                                </span>
+                              </span>
+                            </div>
+                          </th>
+                          <th
+                            aria-label="Submitted On"
+                            class="ant-table-cell ant-table-column-has-sorters"
+                            tabindex="0"
+                          >
+                            <div
+                              class="ant-table-column-sorters"
+                            >
+                              <span
+                                class="ant-table-column-title"
+                              >
+                                Submitted On
+                              </span>
+                              <span
+                                class="ant-table-column-sorter ant-table-column-sorter-full"
+                              >
+                                <span
+                                  class="ant-table-column-sorter-inner"
+                                >
+                                  <span
+                                    aria-label="caret-up"
+                                    class="anticon anticon-caret-up ant-table-column-sorter-up"
+                                    role="presentation"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      data-icon="caret-up"
+                                      fill="currentColor"
+                                      focusable="false"
+                                      height="1em"
+                                      viewBox="0 0 1024 1024"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M858.9 689L530.5 308.2c-9.4-10.9-27.5-10.9-37 0L165.1 689c-12.2 14.2-1.2 35 18.5 35h656.8c19.7 0 30.7-20.8 18.5-35z"
+                                      />
+                                    </svg>
+                                  </span>
+                                  <span
+                                    aria-label="caret-down"
+                                    class="anticon anticon-caret-down ant-table-column-sorter-down"
+                                    role="presentation"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      data-icon="caret-down"
+                                      fill="currentColor"
+                                      focusable="false"
+                                      height="1em"
+                                      viewBox="0 0 1024 1024"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
+                                      />
+                                    </svg>
+                                  </span>
+                                </span>
+                              </span>
+                            </div>
+                          </th>
+                          <th
+                            aria-label="Requested By"
+                            class="ant-table-cell ant-table-column-has-sorters"
+                            tabindex="0"
+                          >
+                            <div
+                              class="ant-table-column-sorters"
+                            >
+                              <span
+                                class="ant-table-column-title"
+                              >
+                                Requested By
+                              </span>
+                              <span
+                                class="ant-table-column-sorter ant-table-column-sorter-full"
+                              >
+                                <span
+                                  class="ant-table-column-sorter-inner"
+                                >
+                                  <span
+                                    aria-label="caret-up"
+                                    class="anticon anticon-caret-up ant-table-column-sorter-up"
+                                    role="presentation"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      data-icon="caret-up"
+                                      fill="currentColor"
+                                      focusable="false"
+                                      height="1em"
+                                      viewBox="0 0 1024 1024"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M858.9 689L530.5 308.2c-9.4-10.9-27.5-10.9-37 0L165.1 689c-12.2 14.2-1.2 35 18.5 35h656.8c19.7 0 30.7-20.8 18.5-35z"
+                                      />
+                                    </svg>
+                                  </span>
+                                  <span
+                                    aria-label="caret-down"
+                                    class="anticon anticon-caret-down ant-table-column-sorter-down"
+                                    role="presentation"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      data-icon="caret-down"
+                                      fill="currentColor"
+                                      focusable="false"
+                                      height="1em"
+                                      viewBox="0 0 1024 1024"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
+                                      />
+                                    </svg>
+                                  </span>
+                                </span>
+                              </span>
+                            </div>
+                          </th>
+                          <th
+                            aria-label="Status"
+                            class="ant-table-cell ant-table-column-has-sorters"
+                            tabindex="0"
+                          >
+                            <div
+                              class="ant-table-column-sorters"
+                            >
+                              <span
+                                class="ant-table-column-title"
+                              >
+                                Status
+                              </span>
+                              <span
+                                class="ant-table-column-sorter ant-table-column-sorter-full"
+                              >
+                                <span
+                                  class="ant-table-column-sorter-inner"
+                                >
+                                  <span
+                                    aria-label="caret-up"
+                                    class="anticon anticon-caret-up ant-table-column-sorter-up"
+                                    role="presentation"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      data-icon="caret-up"
+                                      fill="currentColor"
+                                      focusable="false"
+                                      height="1em"
+                                      viewBox="0 0 1024 1024"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M858.9 689L530.5 308.2c-9.4-10.9-27.5-10.9-37 0L165.1 689c-12.2 14.2-1.2 35 18.5 35h656.8c19.7 0 30.7-20.8 18.5-35z"
+                                      />
+                                    </svg>
+                                  </span>
+                                  <span
+                                    aria-label="caret-down"
+                                    class="anticon anticon-caret-down ant-table-column-sorter-down"
+                                    role="presentation"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      data-icon="caret-down"
+                                      fill="currentColor"
+                                      focusable="false"
+                                      height="1em"
+                                      viewBox="0 0 1024 1024"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
+                                      />
+                                    </svg>
+                                  </span>
+                                </span>
+                              </span>
+                            </div>
+                          </th>
+                          <th
+                            class="ant-table-cell actions-column"
+                          />
+                        </tr>
+                      </thead>
+                      <tbody
+                        class="ant-table-tbody"
+                      >
+                        <tr
+                          class="ant-table-placeholder"
+                        >
+                          <td
+                            class="ant-table-cell"
+                            colspan="8"
+                          >
+                            This mine has no report data.
+                          </td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          name="permitRequiredReports"
+        >
+          <h4
+            class="ant-typography"
+          >
+            Permit Required Reports
+          </h4>
+        </div>
+        <div
+          class="ant-typography"
+        >
+          This table shows documents submitted pursuant to regulatory requirements established by conditions in site-specific Mines Act permits. It also shows reports the Ministry has requested from your mine. If you do not see a permit required report that your mine must submit, click Submit Report, choose the report you need to send and then attach the file or files.
+        </div>
         <div
           class="ant-table-wrapper  core-table"
         >

--- a/yarn.lock
+++ b/yarn.lock
@@ -2767,6 +2767,7 @@ __metadata:
     react-redux-loading-bar: 5.0.0
     react-responsive: 7.0.0
     react-router-dom: 5.3.3
+    react-scroll: 1.7.12
     redux: 5.0.0
     redux-form: 8.2.6
     redux-form-input-masks: 2.0.1


### PR DESCRIPTION
## Objective 

[MDS-5818](https://bcmines.atlassian.net/browse/MDS-5818)

- Updated the wording of the toast message when a user updates a report vs a newly created one
- Added PRR reports to a second table on Minespace (below CRRs on the same page)
- Fixed a bug where the view screen for a report would have blank values if the user had just backed out of creating a new report

<img width="1728" alt="image" src="https://github.com/bcgov/mds/assets/83598933/a8e36d0e-55f0-49fb-9c33-4b0b89c61b62">
