### PR TITLE
[MDS-5760] ESUP table "Explosives" link opens "Detonators" modal

### DIFF
--- a/services/core-web/src/components/mine/ExplosivesPermit/MineExplosivesPermitTable.tsx
+++ b/services/core-web/src/components/mine/ExplosivesPermit/MineExplosivesPermitTable.tsx
@@ -480,7 +480,7 @@ const MineExplosivesPermitTable: FC<RouteComponentProps & MineExplosivesPermitTa
         render: (text, record) => (
           <div
             className="underline"
-            onClick={(event) => handleOpenViewMagazineModal(event, record, "DET")}
+            onClick={(event) => handleOpenViewMagazineModal(event, record, "EXP")}
           >
             {text || "0"} kg
           </div>


### PR DESCRIPTION
## Objective 
- told it to open the explosives modal instead

[MDS-5760](https://bcmines.atlassian.net/browse/MDS-5760)
