### PR TITLE
[MDS-5827] Removed docman and nris dev postgres dockerfiles

### DIFF
--- a/services/document-manager/postgres/Dockerfile.dev
+++ b/services/document-manager/postgres/Dockerfile.dev
@@ -1,7 +1,0 @@
-FROM postgres:9.6
-
-# Copy only migration scripts for creation
-RUN echo "CREATE USER postgres" >> /docker-entrypoint-initdb.d/01-create-user.sql
-
-# Set the working directory to container entrypoint
-WORKDIR /docker-entrypoint-initdb.d

--- a/services/nris-api/docker-compose.yaml
+++ b/services/nris-api/docker-compose.yaml
@@ -23,8 +23,7 @@ services:
     restart: always
     container_name: nris_postgres
     build:
-      context: postgres
-      dockerfile: Dockerfile.dev
+      context: ../postgres
     environment:
       - POSTGRES_USER=nris
       - POSTGRES_PASSWORD=VsPJAuMJHu3IVMEv

--- a/services/nris-api/postgres/Dockerfile.dev
+++ b/services/nris-api/postgres/Dockerfile.dev
@@ -1,7 +1,0 @@
-FROM postgres:9.6
-
-# Copy only migration scripts for creation
-RUN echo "CREATE USER postgres" >> /docker-entrypoint-initdb.d/01-create-user.sql
-
-# Set the working directory to container entrypoint
-WORKDIR /docker-entrypoint-initdb.d


### PR DESCRIPTION
## Objective 

[MDS-5827](https://bcmines.atlassian.net/browse/MDS-5827)

Removed docman and nris postgres Dockerfiles.
Updated the nris docker-compose to rely on the core build of postgres instead.

