### PR TITLE
[FIX] Pull keycloak from quay.io instead of dockerhub

### DIFF
--- a/cypress/.docker/keycloak/Dockerfile.test
+++ b/cypress/.docker/keycloak/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM jboss/keycloak
+FROM quay.io/keycloak/keycloak:16.1.1
 
 USER 0
 USER 1000


### PR DESCRIPTION
## Objective 

Keycloak was removed from Dockerhub, so pull it from quay.io instead.

Fixes the following error when starting Keycloak locally:
![image](https://github.com/bcgov/mds/assets/66635118/3744592f-d3ba-4cfb-a25e-7d8f5bc5ba8c)

