### PR TITLE
[MDS-5834] Core-VC - update text when no credential issued

### DIFF
--- a/services/core-web/src/components/mine/DigitalPermitCredential/ViewDigitalPermitCredential.tsx
+++ b/services/core-web/src/components/mine/DigitalPermitCredential/ViewDigitalPermitCredential.tsx
@@ -3,7 +3,7 @@ import {
   VC_ACTIVE_CONNECTION_STATES,
   VC_CONNECTION_STATES,
   VC_CRED_ISSUE_STATES,
-} from "@mds/common";
+} from "@mds/common/constants";
 import {
   IMine,
   IMineCommodityOption,
@@ -290,7 +290,8 @@ export const ViewDigitalPermitCredential: FC = () => {
             <Row align="middle" justify="space-between">
               <Col span={8}>
                 <Paragraph className="margin-none">
-                  {VC_CRED_ISSUE_STATES[connectionDetails[0]?.cred_exch_state]}
+                  {VC_CRED_ISSUE_STATES[connectionDetails[0]?.cred_exch_state] ??
+                    "No Credential Issued"}
                 </Paragraph>
               </Col>
               <Col span={16}>

--- a/services/core-web/src/tests/components/mine/DigitalPermitCredential/__snapshots__/ViewDigitalPermitCredential.spec.tsx.snap
+++ b/services/core-web/src/tests/components/mine/DigitalPermitCredential/__snapshots__/ViewDigitalPermitCredential.spec.tsx.snap
@@ -287,7 +287,9 @@ exports[`ViewDigitalPermitCredential renders properly 1`] = `
         >
           <div
             class="ant-typography margin-none"
-          />
+          >
+            No Credential Issued
+          </div>
         </div>
         <div
           class="ant-col ant-col-16"


### PR DESCRIPTION
## Objective 

Added some default text if a credential has not yet been issued

[MDS-5834](https://bcmines.atlassian.net/browse/MDS-5834)

<img width="1228" alt="image" src="https://github.com/bcgov/mds/assets/83598933/fa00db91-13da-4dd0-bfb5-5a293aec28c2">
