### PR TITLE
[MDS-5831] removed exception on no municipality

### DIFF
--- a/services/core-api/app/api/projects/project_summary/models/project_summary.py
+++ b/services/core-api/app/api/projects/project_summary/models/project_summary.py
@@ -380,9 +380,6 @@ class ProjectSummary(SoftDeleteMixin, AuditMixin, Base):
             fop_party.save()
             self.facility_operator_guid = fop_party.party_guid
 
-        municipality = Municipality.find_by_guid(nearest_municipality)
-        if not municipality:
-            raise Exception('Municipality ID provided does not exist in the municipalities table')
         self.nearest_municipality_guid = nearest_municipality
 
         # Create or update existing documents.


### PR DESCRIPTION
## Objective 

Since municipality can be null, removed the exception being thrown if it is.

[MDS-5831](https://bcmines.atlassian.net/browse/MDS-5831)

_Why are you making this change? Provide a short explanation and/or screenshots_
