### PR TITLE
[MDS-5833] backend allow reissuance

### DIFF
--- a/migrations/sql/V2024.03.19.15.05__add_vc_locked_column.sql
+++ b/migrations/sql/V2024.03.19.15.05__add_vc_locked_column.sql
@@ -1,0 +1,1 @@
+ALTER TABLE permit ADD COLUMN IF NOT EXISTS mines_act_permit_vc_locked BOOLEAN;

--- a/services/core-api/app/api/mines/permits/permit/models/permit.py
+++ b/services/core-api/app/api/mines/permits/permit/models/permit.py
@@ -32,6 +32,9 @@ class Permit(SoftDeleteMixin, AuditMixin, Base):
     status_changed_timestamp = db.Column(db.DateTime)
     project_id = db.Column(db.String)
 
+    #if true, this permit is locked from any vc'ed issued for it. 
+    mines_act_permit_vc_locked = db.Column(db.Boolean, default=False) 
+
     _all_permit_amendments = db.relationship(
         'PermitAmendment',
         backref='permit',

--- a/services/core-api/app/api/mines/permits/permit/resources/permit.py
+++ b/services/core-api/app/api/mines/permits/permit/resources/permit.py
@@ -322,6 +322,12 @@ class PermitResource(Resource, UserMixin):
         location='json',
         store_missing=False,
         help='{ mine_commodity_code, mine_disturbance_code}.')
+    
+    parser.add_argument(
+        'mines_act_permit_vc_locked',
+        type=json.dumps,
+        location='json',
+        store_missing=False)
 
     @api.doc(params={'permit_guid': 'Permit guid.'})
     @requires_role_view_all

--- a/services/core-api/app/api/mines/permits/permit_amendment/models/permit_amendment.py
+++ b/services/core-api/app/api/mines/permits/permit_amendment/models/permit_amendment.py
@@ -96,7 +96,7 @@ class PermitAmendment(SoftDeleteMixin, AuditMixin, Base):
         'PartyVerifiableCredentialMinesActPermit',
         lazy='selectin',
         order_by='desc(PartyVerifiableCredentialMinesActPermit.update_timestamp)')
-    
+    mines_act_permit_vc_locked = db.association_proxy("Permit", 'mines_act_permit_vc_locked')
 
     @hybrid_property
     def issuing_inspector_name(self):

--- a/services/core-api/app/api/mines/permits/permit_amendment/models/permit_amendment.py
+++ b/services/core-api/app/api/mines/permits/permit_amendment/models/permit_amendment.py
@@ -96,7 +96,7 @@ class PermitAmendment(SoftDeleteMixin, AuditMixin, Base):
         'PartyVerifiableCredentialMinesActPermit',
         lazy='selectin',
         order_by='desc(PartyVerifiableCredentialMinesActPermit.update_timestamp)')
-    mines_act_permit_vc_locked = db.association_proxy("Permit", 'mines_act_permit_vc_locked')
+    mines_act_permit_vc_locked = association_proxy("Permit", 'mines_act_permit_vc_locked')
 
     @hybrid_property
     def issuing_inspector_name(self):

--- a/services/core-api/app/api/mines/response_models.py
+++ b/services/core-api/app/api/mines/response_models.py
@@ -209,6 +209,7 @@ PERMIT_AMENDMENT_SHORT_MODEL = api.model(
         'permit_conditions_last_updated_date': fields.DateTime,
         'has_permit_conditions': fields.Boolean,
         'vc_credential_exch_state': fields.String,
+        'mines_act_permit_vc_locked': fields.Boolean,
         'is_generated_in_core': fields.Boolean,
     })
 

--- a/services/core-api/app/api/mines/response_models.py
+++ b/services/core-api/app/api/mines/response_models.py
@@ -298,6 +298,7 @@ PERMIT_MODEL = api.model(
         'current_permittee': fields.String,
         'current_permittee_guid': fields.String,
         'current_permittee_digital_wallet_connection_state': fields.String,
+        'mines_act_permit_vc_locked': fields.Boolean,
         'project_id': fields.String,
         'permit_amendments': fields.List(fields.Nested(PERMIT_AMENDMENT_MODEL)),
         'remaining_static_liability': fields.Float,

--- a/services/core-api/app/api/verifiable_credentials/models/credentials.py
+++ b/services/core-api/app/api/verifiable_credentials/models/credentials.py
@@ -16,6 +16,9 @@ class PartyVerifiableCredentialMinesActPermit(AuditMixin, Base):
     rev_reg_id = db.Column(db.String, nullable=True)
     cred_rev_id = db.Column(db.String, nullable=True)
 
+
+    permit_amendment = db.relationship('PermitAmendment', lazy='select', back_populates='mines_act_permit_vc')
+    
     def __repr__(self):
         return '<PartyVerifiableCredentialMinesActPermit cred_exch_id=%r, party_guid=%r, permit_amendment_id=%r>' % self.cred_exch_id, self.party_guid, self.permit_amendment_id
         

--- a/services/core-api/app/api/verifiable_credentials/models/credentials.py
+++ b/services/core-api/app/api/verifiable_credentials/models/credentials.py
@@ -23,8 +23,9 @@ class PartyVerifiableCredentialMinesActPermit(AuditMixin, Base):
         return '<PartyVerifiableCredentialMinesActPermit cred_exch_id=%r, party_guid=%r, permit_amendment_id=%r>' % self.cred_exch_id, self.party_guid, self.permit_amendment_id
         
     @classmethod
-    def find_by_cred_exch_id(cls, cred_exch_id) -> "PartyVerifiableCredentialMinesActPermit":
-        return cls.query.filter_by(cred_exch_id=cred_exch_id).one_or_none()
+    def find_by_cred_exch_id(cls, cred_exch_id, unsafe:bool =False) -> "PartyVerifiableCredentialMinesActPermit":
+        query = cls.query.unbound_unsafe() if unsafe else cls.query
+        return query.filter_by(cred_exch_id=cred_exch_id).one_or_none()
 
     @classmethod
     def find_by_party_guid(cls, party_guid) -> "PartyVerifiableCredentialMinesActPermit":

--- a/services/core-api/app/api/verifiable_credentials/models/credentials.py
+++ b/services/core-api/app/api/verifiable_credentials/models/credentials.py
@@ -17,7 +17,7 @@ class PartyVerifiableCredentialMinesActPermit(AuditMixin, Base):
     cred_rev_id = db.Column(db.String, nullable=True)
 
 
-    permit_amendment = db.relationship('PermitAmendment', lazy='select', back_populates='mines_act_permit_vc')
+    permit_amendment = db.relationship('PermitAmendment', lazy='select')
     
     def __repr__(self):
         return '<PartyVerifiableCredentialMinesActPermit cred_exch_id=%r, party_guid=%r, permit_amendment_id=%r>' % self.cred_exch_id, self.party_guid, self.permit_amendment_id

--- a/services/core-api/app/api/verifiable_credentials/resources/verifiable_credential_map.py
+++ b/services/core-api/app/api/verifiable_credentials/resources/verifiable_credential_map.py
@@ -59,7 +59,9 @@ class VerifiableCredentialMinesActPermitResource(Resource, UserMixin):
         if pending_creds:
             raise BadRequest(f"There is a pending credential offer, accept or delete that offer first, cred_exch_id={existing_cred_exch.cred_exch_id}, cred_exch_state={existing_cred_exch.cred_exch_state}")
 
-
+        if permit_amendment.permit.mines_act_permit_vc_locked:
+            raise BadRequest(f"This permit cannot be offered as a credential")
+         
         # collect information for schema
         # https://github.com/bcgov/bc-vcpedia/blob/main/credentials/bc-mines-act-permit/1.1.1/governance.md#261-schema-definition
         credential_attrs={}

--- a/services/core-api/app/api/verifiable_credentials/resources/verifiable_credential_webhook.py
+++ b/services/core-api/app/api/verifiable_credentials/resources/verifiable_credential_webhook.py
@@ -20,6 +20,7 @@ CONNECTIONS = "connections"
 CREDENTIAL_OFFER = "issue_credential"
 OUT_OF_BAND = "out_of_band"
 PING = "ping"
+ISSUER_CREDENTIAL_REVOKED = "issuer_cred_rev"
 
 class VerifiableCredentialWebhookResource(Resource, UserMixin):
     @api.doc(description='Endpoint to recieve webhooks from Traction.', params={})
@@ -67,7 +68,12 @@ class VerifiableCredentialWebhookResource(Resource, UserMixin):
 
                 cred_exch_record.save()
                 current_app.logger.info(f"Updated cred_exch_record cred_exch_id={cred_exch_id} with state={new_state}")
+        elif topic == ISSUER_CREDENTIAL_REVOKED:
+            current_app.logger.info(f"CREDENTIAL SUCCESSFULLY REVOKED received={request.get_json()}")
+            cred_exch = PartyVerifiableCredentialMinesActPermit.find_by_cred_exch_id(webhook_body["cred_ex_id"])
+            cred_exch.permit_amendment.permit.mines_act_permit_vc_locked = True
+            cred_exch.save()
         elif topic == PING:
-                current_app.logger.info(f"TrustPing received={request.get_json()}")
+            current_app.logger.info(f"TrustPing received={request.get_json()}")
         else:
             current_app.logger.info(f"unknown topic '{topic}', webhook_body={webhook_body}")

--- a/services/core-api/app/api/verifiable_credentials/resources/verifiable_credential_webhook.py
+++ b/services/core-api/app/api/verifiable_credentials/resources/verifiable_credential_webhook.py
@@ -70,7 +70,7 @@ class VerifiableCredentialWebhookResource(Resource, UserMixin):
                 current_app.logger.info(f"Updated cred_exch_record cred_exch_id={cred_exch_id} with state={new_state}")
         elif topic == ISSUER_CREDENTIAL_REVOKED:
             current_app.logger.info(f"CREDENTIAL SUCCESSFULLY REVOKED received={request.get_json()}")
-            cred_exch = PartyVerifiableCredentialMinesActPermit.find_by_cred_exch_id(webhook_body["cred_ex_id"])
+            cred_exch = PartyVerifiableCredentialMinesActPermit.find_by_cred_exch_id(webhook_body["cred_ex_id"], unsafe=True)
             cred_exch.permit_amendment.permit.mines_act_permit_vc_locked = True
             cred_exch.save()
         elif topic == PING:


### PR DESCRIPTION
## Objective 

[MDS-5833](https://bcmines.atlassian.net/browse/MDS-5833)

_Why are you making this change? Provide a short explanation and/or screenshots_

Backend functionality to secure the revoked permit so it cannot be immediately re-issued through minespace. 

Minespace UI needs to check for this new bool on the permit_record, and the Core UI needs controls to reenable to the permit (through the PUT /permit/ endpoint)