### PR TITLE
[CHORE] Set up seed data for Cypress tests in Minespace

### DIFF
--- a/services/minespace-web/cypress/e2e/homepage.cy.ts
+++ b/services/minespace-web/cypress/e2e/homepage.cy.ts
@@ -10,5 +10,11 @@ describe("Mines Page", () => {
     cy.url({ timeout: 15000 }).should("include", "/mines");
     cy.get("h1.ant-typography").should("have.text", "My Mines");
     cy.get("h4.ant-typography").should("have.text", "Welcome, cypress@bceid.");
+    cy.contains("Evergreen Cypress Mine").should("exist");
+    cy.contains("Evergreen Cypress Mine").click();
+    cy.get("h1.ant-typography").should("have.text", "Evergreen Cypress Mine");
+    cy.contains(
+      "This tab contains general information about your mine and important contacts at EMLI."
+    ).should("exist");
   });
 });


### PR DESCRIPTION
## Objective 

In the Cypress work previously this sprint, I noticed that currently there's no mine access set up for the minespace user used in Cypress tests, so we can't really test anything. This PR sets up the basics for it by modifying the `seeddb` script to 

1. Create a Major Mine that can be used for testing
2. Create a Minespace user that correspond to the keycloak user used by the cypress tests
3. Subscribe the user to the mine.

Note: `make seeddb` will have to be run once if you want to use Cypress locally

<img width="929" alt="image" src="https://github.com/bcgov/mds/assets/66635118/03d094c5-f561-4bec-8a89-afb8d5e939c3">
<img width="936" alt="image" src="https://github.com/bcgov/mds/assets/66635118/95b8e912-e8db-441b-a35f-e3a1e1bc1173">

