### PR TITLE
[FIX] Fixed capitalization of permit association proxy

### DIFF
--- a/services/core-api/app/api/mines/permits/permit_amendment/models/permit_amendment.py
+++ b/services/core-api/app/api/mines/permits/permit_amendment/models/permit_amendment.py
@@ -96,7 +96,7 @@ class PermitAmendment(SoftDeleteMixin, AuditMixin, Base):
         'PartyVerifiableCredentialMinesActPermit',
         lazy='selectin',
         order_by='desc(PartyVerifiableCredentialMinesActPermit.update_timestamp)')
-    mines_act_permit_vc_locked = association_proxy("Permit", 'mines_act_permit_vc_locked')
+    mines_act_permit_vc_locked = association_proxy("permit", 'mines_act_permit_vc_locked')
 
     @hybrid_property
     def issuing_inspector_name(self):


### PR DESCRIPTION
## Objective 

Fixes the capitalization for the `vc_locked association_proxy` as it causes an error when looking up a NoW.

<img width="501" alt="image" src="https://github.com/bcgov/mds/assets/66635118/e6799cea-4f16-41e8-805f-89139a621947">

<img width="1399" alt="image" src="https://github.com/bcgov/mds/assets/66635118/741713c1-7520-4266-b2a0-7ab538a126c7">
