### PR TITLE
[MDS-5867] Update "Back to Reports" link in Core

### DIFF
--- a/services/common/src/constants/enums.ts
+++ b/services/common/src/constants/enums.ts
@@ -206,3 +206,9 @@ export enum MineReportType {
   "permit-required-reports" = "PRR",
   "tailings-reports" = "TAR",
 }
+
+export enum MineReportTypeUrlParam {
+  "CRR" = "code-required-reports",
+  "PRR" = "permit-required-reports",
+  "TAR" = "tailings-reports",
+}

--- a/services/core-web/src/components/mine/Reports/ReportPage.tsx
+++ b/services/core-web/src/components/mine/Reports/ReportPage.tsx
@@ -13,6 +13,7 @@ import {
   IMineReportSubmission,
   MINE_REPORT_STATUS_HASH,
   MINE_REPORT_SUBMISSION_CODES,
+  MineReportTypeUrlParam,
 } from "@mds/common";
 import { getMineById } from "@mds/common/redux/selectors/mineSelectors";
 import { fetchMineRecordById } from "@mds/common/redux/actionCreators/mineActionCreator";
@@ -37,7 +38,9 @@ const ReportPage: FC = () => {
   const { mineGuid, reportGuid } = useParams<{ mineGuid: string; reportGuid: string }>();
   const mine = useSelector((state) => getMineById(state, mineGuid));
   const mineReportStatusOptions = useSelector(getDropdownMineReportStatusOptions);
-  const latestSubmission = useSelector((state) => getLatestReportSubmission(state, reportGuid));
+  const latestSubmission: IMineReportSubmission = useSelector((state) =>
+    getLatestReportSubmission(state, reportGuid)
+  );
 
   const [selectedStatus, setSelectedStatus] = useState<MINE_REPORT_SUBMISSION_CODES>(
     latestSubmission?.mine_report_submission_status_code
@@ -181,7 +184,13 @@ const ReportPage: FC = () => {
           </Row>
         </Typography.Title>
       </Row>
-      <Link to={routes.REPORTS_DASHBOARD.route}>
+      <Link
+        to={routes.MINE_REPORTS.dynamicRoute(
+          mineGuid,
+          MineReportTypeUrlParam[latestSubmission?.report_type],
+          {}
+        )}
+      >
         <ArrowLeftOutlined />
         Back to: Reports
       </Link>

--- a/services/core-web/src/tests/components/Forms/reports/__snapshots__/ReportPage-prr.spec.tsx.snap
+++ b/services/core-web/src/tests/components/Forms/reports/__snapshots__/ReportPage-prr.spec.tsx.snap
@@ -51,7 +51,7 @@ exports[`ReportPage renders view mode properly 1`] = `
         </h1>
       </div>
       <a
-        href="/dashboard/reporting/reports"
+        href="/mine-dashboard/8e9ca839-a28e-427e-997e-9ef23d9d97cd/required-reports/permit-required-reports"
       >
         <span
           aria-label="arrow-left"

--- a/services/core-web/src/tests/components/Forms/reports/__snapshots__/ReportPage.spec.tsx.snap
+++ b/services/core-web/src/tests/components/Forms/reports/__snapshots__/ReportPage.spec.tsx.snap
@@ -53,7 +53,7 @@ exports[`ReportPage renders view mode properly 1`] = `
         </h1>
       </div>
       <a
-        href="/dashboard/reporting/reports"
+        href="/mine-dashboard/18133c75-49ad-4101-85f3-a43e35ae989a/required-reports/code-required-reports"
       >
         <span
           aria-label="arrow-left"


### PR DESCRIPTION
The "Back to Reports" link when viewing a report in Core was directing the user to the global reports list rather than back to the reports for that particular mine.  Updated the link.

## Objective 

[MDS-5867](https://bcmines.atlassian.net/browse/MDS-5867)
