### PR TITLE
[MDS-5866] CRR/PRR updates

### DIFF
--- a/migrations/sql/V2024.03.22.14.25__update_compliance_article_long_descriptions.sql
+++ b/migrations/sql/V2024.03.22.14.25__update_compliance_article_long_descriptions.sql
@@ -1,0 +1,78 @@
+ALTER TABLE mine_report_definition
+ADD COLUMN is_prr_only BOOLEAN DEFAULT FALSE;
+
+UPDATE mine_report_definition
+SET is_prr_only = FALSE
+WHERE is_prr_only IS NULL;
+
+ALTER TABLE mine_report_definition
+ALTER COLUMN is_prr_only SET NOT NULL;
+
+DO $$
+    DECLARE
+        annual_placer_report_id INTEGER;
+        annual_work_and_reclamation_report_id INTEGER;
+        multi_year_report_id INTEGER;
+
+    BEGIN
+
+        SELECT mine_report_definition_id INTO annual_placer_report_id
+        FROM mine_report_definition
+        WHERE report_name = 'Annual Summary of Placer Activities';
+
+        SELECT mine_report_definition_id INTO annual_work_and_reclamation_report_id
+        FROM mine_report_definition
+        WHERE report_name = 'Annual Summary of Work and Reclamation Report';
+
+        SELECT mine_report_definition_id INTO multi_year_report_id
+        FROM mine_report_definition
+        WHERE report_name = 'Multi-Year Area Based Permit Updates';
+
+        UPDATE mine_report_definition
+        SET is_prr_only = TRUE, is_common = FALSE
+        WHERE mine_report_definition_id = annual_placer_report_id
+           OR mine_report_definition_id = annual_work_and_reclamation_report_id
+           OR mine_report_definition_id = multi_year_report_id;
+
+    END
+$$;
+
+UPDATE compliance_article
+SET
+    sub_paragraph = '(g)',
+    long_description = 'This report is an annually completed PDF fillable form called "Annual Summary of Work and Reclamation" and required maps for Sand and Gravel/Quarry Operations where required by permit condition.'
+WHERE
+    section = '10'
+    AND sub_section = '4'
+    AND paragraph = '4'
+    AND sub_paragraph = 'g';
+
+DO
+$$
+    DECLARE
+        report_id INTEGER;
+        correct_compliance_article_id INTEGER;
+        incorrect_compliance_article_id INTEGER;
+    BEGIN
+
+        SELECT mine_report_definition_id INTO report_id
+        FROM mine_report_definition
+        WHERE report_name = 'Annual Summary of Work and Reclamation Report';
+
+        SELECT compliance_article_id INTO incorrect_compliance_article_id
+        FROM mine_report_definition_compliance_article_xref
+        WHERE mine_report_definition_id = report_id;
+
+        SELECT compliance_article_id INTO correct_compliance_article_id
+        FROM compliance_article
+        WHERE section = '10'
+          AND sub_section = '4'
+          AND paragraph = '4'
+          AND sub_paragraph = '(g)';
+
+        UPDATE mine_report_definition_compliance_article_xref
+            SET compliance_article_id = correct_compliance_article_id
+        WHERE mine_report_definition_id = report_id
+          AND compliance_article_id = incorrect_compliance_article_id;
+    END
+$$;

--- a/services/common/src/components/reports/ReportGetStarted.tsx
+++ b/services/common/src/components/reports/ReportGetStarted.tsx
@@ -35,6 +35,7 @@ interface ReportGetStartedProps {
   mine: IMine;
   handleSubmit: (values: Partial<IMineReportSubmission>) => void;
   formButtons: ReactNode;
+  setDisableNextButton?: (value: boolean) => void;
 }
 
 export const ReportInfoBox: FC<{ mineReportDefinition: IMineReportDefinition; verb: string }> = ({
@@ -45,6 +46,14 @@ export const ReportInfoBox: FC<{ mineReportDefinition: IMineReportDefinition; ve
     <div className="report-info-box">
       {mineReportDefinition && (
         <div>
+          {mineReportDefinition.is_prr_only && (
+            <Alert
+              showIcon
+              description="Please submit this report as a permit required report."
+              type="warning"
+              className="margin-large--bottom"
+            />
+          )}
           <Typography.Title level={4} className="primary-colour">
             You are {verb}
           </Typography.Title>
@@ -152,7 +161,12 @@ export const RenderPRRFields: FC<{ mineGuid: string; fullWidth?: boolean }> = ({
   );
 };
 
-const ReportGetStarted: FC<ReportGetStartedProps> = ({ mine, handleSubmit, formButtons }) => {
+const ReportGetStarted: FC<ReportGetStartedProps> = ({
+  mine,
+  handleSubmit,
+  formButtons,
+  setDisableNextButton,
+}) => {
   const dispatch = useDispatch();
   const { reportType } = useParams<{ reportType?: string }>();
   const system = useSelector(getSystemFlag);
@@ -162,6 +176,14 @@ const ReportGetStarted: FC<ReportGetStartedProps> = ({ mine, handleSubmit, formB
   const selectedReportDefinition: IMineReportDefinition = useSelector(
     getMineReportDefinitionByGuid(formValues?.mine_report_definition_guid)
   );
+
+  useEffect(() => {
+    if (selectedReportDefinition && selectedReportDefinition.is_prr_only) {
+      setDisableNextButton(true);
+    } else {
+      setDisableNextButton(false);
+    }
+  }, [selectedReportDefinition, setDisableNextButton]);
 
   useEffect(() => {
     // Filter out common reports and sort alphabetically

--- a/services/common/src/components/reports/ReportSteps.tsx
+++ b/services/common/src/components/reports/ReportSteps.tsx
@@ -22,6 +22,7 @@ const ReportSteps = () => {
   const { mineGuid, reportType } = useParams<{ mineGuid: string; reportType: string }>();
   const [currentStep, setCurrentStep] = useState(0);
   const [initialValues, setInitialValues] = useState<Partial<IMineReportSubmission>>({});
+  const [disableNextButton, setDisableNextButton] = useState(false);
 
   const mine: IMine = useSelector((state) => getMineById(state, mineGuid));
 
@@ -49,11 +50,11 @@ const ReportSteps = () => {
         )}
         <Col>
           {nextButtonFunction ? (
-            <Button type="primary" onClick={nextButtonFunction}>
+            <Button disabled={disableNextButton} type="primary" onClick={nextButtonFunction}>
               {nextButtonTitle ?? "Next"}
             </Button>
           ) : (
-            <Button type="primary" htmlType="submit">
+            <Button disabled={disableNextButton} type="primary" htmlType="submit">
               {nextButtonTitle ?? "Next"}
             </Button>
           )}
@@ -73,6 +74,7 @@ const ReportSteps = () => {
                 setInitialValues(values);
                 setCurrentStep(currentStep + 1);
               }}
+              setDisableNextButton={setDisableNextButton}
               formButtons={renderStepButtons({
                 nextButtonTitle: "Add Report Details",
                 previousButtonTitle: "Cancel",

--- a/services/common/src/interfaces/reports/mineReportDefinition.interface.ts
+++ b/services/common/src/interfaces/reports/mineReportDefinition.interface.ts
@@ -14,6 +14,7 @@ export interface IMineReportDefinition {
   description: string;
   due_date_period_months?: number;
   is_common: boolean;
+  is_prr_only: boolean;
   mine_report_definition_guid: string;
   mine_report_due_date_type: string;
   report_name: string;

--- a/services/core-api/app/api/mines/reports/models/mine_report_definition.py
+++ b/services/core-api/app/api/mines/reports/models/mine_report_definition.py
@@ -3,7 +3,6 @@ from dateutil.relativedelta import relativedelta
 
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.schema import FetchedValue
-from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.ext.hybrid import hybrid_property
 
 from app.api.utils.models_mixins import Base, AuditMixin
@@ -24,6 +23,8 @@ class MineReportDefinition(Base, AuditMixin):
         nullable=False)
     active_ind = db.Column(db.Boolean, server_default=FetchedValue(), nullable=False)
     is_common = db.Column(db.Boolean, server_default=FetchedValue(), nullable=False)
+    is_prr_only = db.Column(db.Boolean, server_default=FetchedValue(), nullable=False)
+
     required = db.Column(db.Boolean)
 
     categories = db.relationship(

--- a/services/core-api/app/api/mines/response_models.py
+++ b/services/core-api/app/api/mines/response_models.py
@@ -756,6 +756,7 @@ MINE_REPORT_DEFINITION_MODEL = api.model(
         'categories': fields.List(fields.Nested(MINE_REPORT_DEFINITION_CATEGORIES)),
         'compliance_articles': fields.List(fields.Nested(COMPLIANCE_ARTICLE_MODEL)),
         'is_common': fields.Boolean,
+        'is_prr_only': fields.Boolean,
     })
 
 PAGINATED_LIST = api.model(


### PR DESCRIPTION
## Objective 

- Added migration to add `is_prr_only` column to the mine_report_definition table.
  - This is used to restrict the submission of certain reports as CRR and direct the user to submit a PRR (without removing them from the reports list)
- Added alert messaging to the description to direct the user 

[MDS-5866](https://bcmines.atlassian.net/browse/MDS-5866)

<img width="1728" alt="image" src="https://github.com/bcgov/mds/assets/83598933/c4de6037-f824-46d0-9447-2be78394a038">
