### PR TITLE
[MDS-5870] Create new project bug: Previously viewed project info displayed

### DIFF
--- a/services/core-web/src/components/Forms/projectSummaries/ProjectSummaryForm.tsx
+++ b/services/core-web/src/components/Forms/projectSummaries/ProjectSummaryForm.tsx
@@ -195,7 +195,7 @@ const renderNestedFields = (
   { change, isNewProject },
   isEditMode,
   dropdownProjectSummaryPermitTypes,
-  formattedProjectSummary
+  formValues
 ) => {
   return (
     <div>
@@ -207,7 +207,7 @@ const renderNestedFields = (
             fieldName={`${code}.project_summary_permit_type`}
             options={dropdownProjectSummaryPermitTypes}
             formName={FORM.ADD_EDIT_PROJECT_SUMMARY}
-            formValues={formattedProjectSummary}
+            formValues={formValues}
             change={change}
             component={renderConfig.GROUP_CHECK_BOX}
             label={
@@ -215,7 +215,7 @@ const renderNestedFields = (
                 <p>What type of permit is involved in your application?</p>
               </>
             }
-            setInitialValues={() => setInitialValues(code, formattedProjectSummary)}
+            setInitialValues={() => setInitialValues(code, formValues)}
             disabled={!isNewProject && !isEditMode}
           />
         </>
@@ -268,7 +268,9 @@ const ProjectSummaryForm: FC<InjectedFormProps<IProjectSummary> & ProjectSummary
 
   const projectLeadData = [unassignedProjectLeadEntry, ...projectLeads[0]?.opt];
   const [checked, setChecked] = useState(
-    formattedProjectSummary ? formattedProjectSummary.authorizationOptions : []
+    !props.isNewProject && formattedProjectSummary
+      ? formattedProjectSummary.authorizationOptions
+      : []
   );
   const { mineGuid } = useParams<{ mineGuid: string }>();
   const history = useHistory();
@@ -448,7 +450,7 @@ const ProjectSummaryForm: FC<InjectedFormProps<IProjectSummary> & ProjectSummary
                           props,
                           isEditMode,
                           dropdownProjectSummaryPermitTypes,
-                          formattedProjectSummary
+                          props.isNewProject ? props.initialValues : formattedProjectSummary
                         )}
                     </FormSection>
                   );

--- a/services/core-web/src/components/mine/Projects/ProjectSummary.tsx
+++ b/services/core-web/src/components/mine/Projects/ProjectSummary.tsx
@@ -110,10 +110,10 @@ export const ProjectSummary: FC = () => {
     }
     return dispatch(fetchMineRecordById(projectMineGuid)).then(() => {
       const mine = mines[projectMineGuid];
+      setIsNewProject(true);
       setIsLoaded(true);
       setActiveTab(tab);
       setMineName(mine.mine_name);
-      setIsNewProject(true);
     });
   };
 
@@ -332,7 +332,9 @@ export const ProjectSummary: FC = () => {
           className={fixedTop ? "padding-lg view--header fixed-scroll" : " padding-lg view--header"}
         >
           <h1>
-            {formattedProjectSummary.project_summary_title ?? "New Project Description"}
+            {!isNewProject
+              ? formattedProjectSummary.project_summary_title
+              : "New Project Description"}
             <span className="padding-sm--left">
               <Tag title={`Mine: ${mineName}`}>
                 <Link
@@ -348,7 +350,7 @@ export const ProjectSummary: FC = () => {
           <Link
             data-cy="back-to-project-link"
             to={
-              formattedProjectSummary.project_guid
+              formattedProjectSummary.project_guid && !isNewProject
                 ? routes.PROJECTS.dynamicRoute(formattedProjectSummary.project_guid)
                 : routes.MINE_PRE_APPLICATIONS.dynamicRoute(mineGuid)
             }

--- a/services/core-web/src/components/mine/Projects/ProjectSummary.tsx
+++ b/services/core-web/src/components/mine/Projects/ProjectSummary.tsx
@@ -170,7 +170,7 @@ export const ProjectSummary: FC = () => {
     return dispatch(
       updateProjectSummary(
         { projectGuid: project_guid, projectSummaryGuid },
-        handleTransformPayload({ ...formValues }),
+        handleTransformPayload({ ...formValues, applicant: null }),
         message
       )
     )


### PR DESCRIPTION
## Objective 

[MDS-5870](https://bcmines.atlassian.net/browse/MDS-5870)

-Issue was when a user creates a new project in Core, sometimes the previously viewed project's information is being display on the page.

-Made use of existing isNewProject prop to help set the behaviour and inputs of Project Summary page when creating a new project.
