### PR TITLE
[MDS-5860] Fix inconsistent toast error message from api calls

### DIFF
--- a/services/common/src/redux/actionCreators/activityActionCreator.ts
+++ b/services/common/src/redux/actionCreators/activityActionCreator.ts
@@ -3,7 +3,7 @@ import { success, error, request } from "../actions/genericActions";
 import CustomAxios from "../customAxios";
 import { storeActivities } from "../actions/activityActions";
 import { AxiosResponse } from "axios";
-import { IActivity } from "@mds/common";
+import { IActivity } from "@mds/common/interfaces";
 import {
   ACTIVITIES,
   ACTIVITIES_MARK_AS_READ,
@@ -37,9 +37,8 @@ export const fetchActivities = (
       dispatch(storeActivities(response.data));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(GET_ACTIVITIES));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading()));
 };
@@ -54,9 +53,8 @@ export const markActivitiesAsRead = (activity_guids: string[]): AppThunk => (dis
     .then(() => {
       dispatch(success(GET_ACTIVITIES));
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(GET_ACTIVITIES));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading()));
 };

--- a/services/common/src/redux/actionCreators/damActionCreator.ts
+++ b/services/common/src/redux/actionCreators/damActionCreator.ts
@@ -1,6 +1,6 @@
 import { hideLoading, showLoading } from "react-redux-loading-bar";
 import { notification } from "antd";
-import { ENVIRONMENT } from "@mds/common";
+import { ENVIRONMENT } from "@mds/common/constants";
 import { CREATE_DAM, GET_DAM, UPDATE_DAM } from "@mds/common/constants/reducerTypes";
 import { DAM, DAMS } from "@mds/common/constants/API";
 import { error, request, success } from "../actions/genericActions";
@@ -8,69 +8,67 @@ import { error, request, success } from "../actions/genericActions";
 import CustomAxios from "../customAxios";
 import { createRequestHeader } from "../utils/RequestHeaders";
 import { storeDam } from "../actions/damActions";
-import { ICreateDam, IDam } from "@mds/common";
+import { ICreateDam, IDam } from "@mds/common/interfaces";
 import { AppThunk } from "@mds/common/interfaces/appThunk.type";
 import { AxiosResponse } from "axios";
 
-export const createDam =
-  (payload: ICreateDam): AppThunk<Promise<AxiosResponse<IDam>>> =>
-  (dispatch): Promise<AxiosResponse<IDam>> => {
-    dispatch(request(CREATE_DAM));
-    dispatch(showLoading());
+export const createDam = (payload: ICreateDam): AppThunk<Promise<AxiosResponse<IDam>>> => (
+  dispatch
+): Promise<AxiosResponse<IDam>> => {
+  dispatch(request(CREATE_DAM));
+  dispatch(showLoading());
 
-    return CustomAxios()
-      .post(`${ENVIRONMENT.apiUrl}${DAMS()}`, payload, createRequestHeader())
-      .then((response: AxiosResponse<IDam>) => {
-        notification.success({
-          message: "Successfully created new Dam",
-          duration: 10,
-        });
-        dispatch(success(CREATE_DAM));
-        return response;
-      })
-      .catch(() => {
-        dispatch(error(CREATE_DAM));
-        throw new Error("Failed to create Dam");
-      })
-      .finally(() => dispatch(hideLoading()));
-  };
+  return CustomAxios()
+    .post(`${ENVIRONMENT.apiUrl}${DAMS()}`, payload, createRequestHeader())
+    .then((response: AxiosResponse<IDam>) => {
+      notification.success({
+        message: "Successfully created new Dam",
+        duration: 10,
+      });
+      dispatch(success(CREATE_DAM));
+      return response;
+    })
+    .catch(() => {
+      dispatch(error(CREATE_DAM));
+    })
+    .finally(() => dispatch(hideLoading()));
+};
 
-export const updateDam =
-  (damGuid: string, payload: Partial<IDam>): AppThunk<Promise<AxiosResponse<IDam>>> =>
-  (dispatch): Promise<AxiosResponse<IDam>> => {
-    dispatch(request(UPDATE_DAM));
-    dispatch(showLoading());
+export const updateDam = (
+  damGuid: string,
+  payload: Partial<IDam>
+): AppThunk<Promise<AxiosResponse<IDam>>> => (dispatch): Promise<AxiosResponse<IDam>> => {
+  dispatch(request(UPDATE_DAM));
+  dispatch(showLoading());
 
-    return CustomAxios()
-      .patch(`${ENVIRONMENT.apiUrl}${DAM(damGuid)}`, payload, createRequestHeader())
-      .then((response) => {
-        dispatch(success(UPDATE_DAM));
-        dispatch(storeDam(response.data));
-        return response;
-      })
-      .catch((err) => {
-        dispatch(error(UPDATE_DAM));
-        throw new Error(err);
-      })
-      .finally(() => dispatch(hideLoading()));
-  };
+  return CustomAxios()
+    .patch(`${ENVIRONMENT.apiUrl}${DAM(damGuid)}`, payload, createRequestHeader())
+    .then((response) => {
+      dispatch(success(UPDATE_DAM));
+      dispatch(storeDam(response.data));
+      return response;
+    })
+    .catch(() => {
+      dispatch(error(UPDATE_DAM));
+    })
+    .finally(() => dispatch(hideLoading()));
+};
 
-export const fetchDam =
-  (damGuid: string): AppThunk<Promise<AxiosResponse<IDam>>> =>
-  (dispatch): Promise<AxiosResponse<IDam>> => {
-    dispatch(request(GET_DAM));
-    dispatch(showLoading());
+export const fetchDam = (damGuid: string): AppThunk<Promise<AxiosResponse<IDam>>> => (
+  dispatch
+): Promise<AxiosResponse<IDam>> => {
+  dispatch(request(GET_DAM));
+  dispatch(showLoading());
 
-    return CustomAxios()
-      .get(`${ENVIRONMENT.apiUrl}${DAM(damGuid)}`, createRequestHeader())
-      .then((response: AxiosResponse<IDam>) => {
-        dispatch(success(GET_DAM));
-        dispatch(storeDam(response.data));
-        return response;
-      })
-      .catch((err) => {
-        dispatch(error(GET_DAM));
-        throw new Error(err);
-      })
-      .finally(() => dispatch(hideLoading()));
-  };
+  return CustomAxios()
+    .get(`${ENVIRONMENT.apiUrl}${DAM(damGuid)}`, createRequestHeader())
+    .then((response: AxiosResponse<IDam>) => {
+      dispatch(success(GET_DAM));
+      dispatch(storeDam(response.data));
+      return response;
+    })
+    .catch(() => {
+      dispatch(error(GET_DAM));
+    })
+    .finally(() => dispatch(hideLoading()));
+};

--- a/services/common/src/redux/actionCreators/documentActionCreator.ts
+++ b/services/common/src/redux/actionCreators/documentActionCreator.ts
@@ -5,7 +5,8 @@ import * as reducerTypes from "@mds/common/constants/reducerTypes";
 import { hideLoading, showLoading } from "react-redux-loading-bar";
 
 import { notification } from "antd";
-import { ENVIRONMENT, IMineDocumentVersion } from "@mds/common";
+import { ENVIRONMENT } from "@mds/common/constants";
+import { IMineDocumentVersion } from "@mds/common/interfaces";
 import { error, request, success } from "@mds/common/redux/actions/genericActions";
 import CustomAxios from "@mds/common/redux/customAxios";
 import * as API from "@mds/common/constants/API";
@@ -43,9 +44,8 @@ export const postNewDocumentVersion = ({
       dispatch(success(reducerTypes.POST_NEW_DOCUMENT_VERSION));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.POST_NEW_DOCUMENT_VERSION));
-      throw new Error(err);
     })
     .finally(() => {
       dispatch(hideLoading());
@@ -69,9 +69,8 @@ export const pollDocumentUploadStatus = (
       dispatch(success(reducerTypes.POLL_DOCUMENT_UPLOAD_STATUS));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.POLL_DOCUMENT_UPLOAD_STATUS));
-      throw new Error(err);
     })
     .finally(() => {
       dispatch(hideLoading());
@@ -91,9 +90,8 @@ export const documentsCompression = (mineGuid, documentManagerGuids) => (dispatc
       dispatch(success(reducerTypes.DOCUMENTS_COMPRESSION));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.DOCUMENTS_COMPRESSION));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading()));
 };
@@ -111,9 +109,8 @@ export const pollDocumentsCompressionProgress = (taskId) => (dispatch) => {
       dispatch(documentActions.storeDocumentCompressionProgress(response.data));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.POLL_DOCUMENTS_COMPRESSION_PROGRESS));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading()));
 };

--- a/services/common/src/redux/actionCreators/explosivesPermitActionCreator.ts
+++ b/services/common/src/redux/actionCreators/explosivesPermitActionCreator.ts
@@ -1,6 +1,7 @@
 import { notification } from "antd";
 import { showLoading, hideLoading } from "react-redux-loading-bar";
-import { ENVIRONMENT, IExplosivesPermit } from "@mds/common";
+import { ENVIRONMENT } from "@mds/common/constants";
+import { IExplosivesPermit } from "@mds/common/interfaces";
 import { request, success, error } from "../actions/genericActions";
 import * as reducerTypes from "@mds/common/constants/reducerTypes";
 import * as explosivesPermitActions from "../actions/explosivesPermitActions";
@@ -29,9 +30,8 @@ export const createExplosivesPermit = (
       dispatch(success(reducerTypes.CREATE_EXPLOSIVES_PERMIT));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.CREATE_EXPLOSIVES_PERMIT));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading("modal")));
 };
@@ -50,9 +50,8 @@ export const fetchExplosivesPermits = (
       dispatch(explosivesPermitActions.storeExplosivesPermits(response.data));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.GET_EXPLOSIVES_PERMITS));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading()));
 };
@@ -80,9 +79,8 @@ export const updateExplosivesPermit = (
       dispatch(success(reducerTypes.UPDATE_EXPLOSIVES_PERMIT));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.UPDATE_EXPLOSIVES_PERMIT));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading("modal")));
 };
@@ -106,9 +104,8 @@ export const deleteExplosivesPermit = (
       dispatch(success(reducerTypes.DELETE_EXPLOSIVES_PERMIT));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.DELETE_EXPLOSIVES_PERMIT));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading()));
 };

--- a/services/common/src/redux/actionCreators/explosivesPermitAmendmentActionCreator.ts
+++ b/services/common/src/redux/actionCreators/explosivesPermitAmendmentActionCreator.ts
@@ -1,6 +1,7 @@
 import { notification } from "antd";
 import { hideLoading, showLoading } from "react-redux-loading-bar";
-import { ENVIRONMENT, IExplosivesPermitAmendment } from "@mds/common";
+import { ENVIRONMENT } from "@mds/common/constants";
+import { IExplosivesPermitAmendment } from "@mds/common/interfaces";
 import { error, request, success } from "../actions/genericActions";
 import * as reducerTypes from "@mds/common/constants/reducerTypes";
 import * as API from "@mds/common/constants/API";
@@ -31,9 +32,8 @@ export const createExplosivesPermitAmendment = (
       dispatch(success(reducerTypes.CREATE_EXPLOSIVES_PERMIT_AMENDMENT));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.CREATE_EXPLOSIVES_PERMIT_AMENDMENT));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading("modal")));
 };
@@ -63,9 +63,8 @@ export const updateExplosivesPermitAmendment = (
       dispatch(success(reducerTypes.UPDATE_EXPLOSIVES_PERMIT_AMENDMENT));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.UPDATE_EXPLOSIVES_PERMIT_AMENDMENT));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading("modal")));
 };

--- a/services/common/src/redux/actionCreators/externalAuthorizationActionCreator.js
+++ b/services/common/src/redux/actionCreators/externalAuthorizationActionCreator.js
@@ -1,5 +1,5 @@
 import { showLoading, hideLoading } from "react-redux-loading-bar";
-import { ENVIRONMENT } from "@mds/common";
+import { ENVIRONMENT } from "@mds/common/constants";
 import { request, success, error } from "../actions/genericActions";
 import * as reducerTypes from "@mds/common/constants/reducerTypes";
 import * as externalAuthActions from "../actions/externalAuthorizationActions";
@@ -18,9 +18,8 @@ export const fetchMineEpicInformation = (mineGuid) => (dispatch) => {
       dispatch(externalAuthActions.storeEpicInfo(response.data, mineGuid));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.GET_MINE_EPIC_INFO));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading()));
 };

--- a/services/common/src/redux/actionCreators/incidentActionCreator.ts
+++ b/services/common/src/redux/actionCreators/incidentActionCreator.ts
@@ -1,6 +1,6 @@
 import { showLoading, hideLoading } from "react-redux-loading-bar";
 import { notification } from "antd";
-import { ENVIRONMENT } from "@mds/common";
+import { ENVIRONMENT } from "@mds/common/constants";
 import { request, success, error } from "../actions/genericActions";
 import * as reducerTypes from "@mds/common/constants/reducerTypes";
 import * as Strings from "@mds/common/constants/strings";
@@ -28,9 +28,8 @@ export const createMineIncident = (
       dispatch(success(reducerTypes.CREATE_MINE_INCIDENT));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.CREATE_MINE_INCIDENT));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading("modal")));
 };
@@ -90,9 +89,8 @@ export const updateMineIncident = (
       dispatch(success(reducerTypes.UPDATE_MINE_INCIDENT));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.UPDATE_MINE_INCIDENT));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading("modal")));
 };
@@ -115,9 +113,8 @@ export const removeDocumentFromMineIncident = (mineGuid, mineIncidentGuid, mineD
       dispatch(success(reducerTypes.REMOVE_DOCUMENT_FROM_MINE_INCIDENT));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.REMOVE_DOCUMENT_FROM_MINE_INCIDENT));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading()));
 };
@@ -151,9 +148,8 @@ export const deleteMineIncident = (mineGuid, mineIncidentGuid) => (dispatch) => 
       dispatch(success(reducerTypes.DELETE_MINE_INCIDENT));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.DELETE_MINE_INCIDENT));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading()));
 };
@@ -187,9 +183,8 @@ export const createMineIncidentNote = (mineIncidentGuid, payload) => (dispatch) 
       dispatch(success(reducerTypes.CREATE_MINE_INCIDENT_NOTE));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.CREATE_MINE_INCIDENT_NOTE));
-      throw new Error(err);
     });
 };
 
@@ -208,8 +203,7 @@ export const deleteMineIncidentNote = (mineIncidentGuid, mineIncidentNoteGuid) =
       dispatch(success(reducerTypes.DELETE_MINE_INCIDENT_NOTE));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.DELETE_MINE_INCIDENT_NOTE));
-      throw new Error(err);
     });
 };

--- a/services/common/src/redux/actionCreators/mineActionCreator.ts
+++ b/services/common/src/redux/actionCreators/mineActionCreator.ts
@@ -1,6 +1,6 @@
 import { notification } from "antd";
 import { showLoading, hideLoading } from "react-redux-loading-bar";
-import { ENVIRONMENT } from "@mds/common";
+import { ENVIRONMENT } from "@mds/common/constants";
 import { request, success, error } from "../actions/genericActions";
 import * as reducerTypes from "@mds/common/constants/reducerTypes";
 import * as mineActions from "../actions/mineActions";
@@ -9,7 +9,7 @@ import * as String from "@mds/common/constants/strings";
 import * as API from "@mds/common/constants/API";
 import { createRequestHeader } from "../utils/RequestHeaders";
 import CustomAxios from "../customAxios";
-import { ITailingsStorageFacility, ICreateTailingsStorageFacility } from "@mds/common";
+import { ITailingsStorageFacility, ICreateTailingsStorageFacility } from "@mds/common/interfaces";
 import { AppThunk } from "@mds/common/interfaces/appThunk.type";
 import { AxiosResponse } from "axios";
 
@@ -35,9 +35,8 @@ export const createMineRecord = (payload) => (dispatch) => {
       dispatch(success(reducerTypes.CREATE_MINE_RECORD));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.CREATE_MINE_RECORD));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading("modal")));
 };
@@ -55,9 +54,8 @@ export const updateMineRecord = (id, payload, mineName) => (dispatch) => {
       dispatch(success(reducerTypes.UPDATE_MINE_RECORD));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.UPDATE_MINE_RECORD));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading("modal")));
 };
@@ -88,9 +86,8 @@ export const removeMineType = (mineGuid, mineTypeGuid, tenure) => (dispatch) => 
       });
       dispatch(success(reducerTypes.REMOVE_MINE_TYPE));
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.REMOVE_MINE_TYPE));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading("modal")));
 };
@@ -114,9 +111,8 @@ export const createTailingsStorageFacility = (
       dispatch(tsfActions.storeTsf(response.data));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.CREATE_TSF));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading()));
 };
@@ -141,9 +137,8 @@ export const updateTailingsStorageFacility = (
       dispatch(tsfActions.storeTsf(response.data));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.UPDATE_TSF));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading()));
 };
@@ -293,9 +288,8 @@ export const setMineVerifiedStatus = (mine_guid, payload) => (dispatch) => {
       dispatch(success(reducerTypes.SET_MINE_VERIFIED_STATUS));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.SET_MINE_VERIFIED_STATUS));
-      throw new Error(err);
     });
 };
 
@@ -371,9 +365,8 @@ export const createMineComment = (mineGuid, payload) => (dispatch) => {
       dispatch(success(reducerTypes.CREATE_MINE_COMMENTS));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.CREATE_MINE_COMMENTS));
-      throw new Error(err);
     });
 };
 
@@ -392,8 +385,7 @@ export const deleteMineComment = (mineGuid, commentGuid) => (dispatch) => {
       dispatch(success(reducerTypes.DELETE_MINE_COMMENT));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.DELETE_MINE_COMMENT));
-      throw new Error(err);
     });
 };

--- a/services/common/src/redux/actionCreators/noticeOfDepartureActionCreator.ts
+++ b/services/common/src/redux/actionCreators/noticeOfDepartureActionCreator.ts
@@ -1,6 +1,7 @@
 import { notification } from "antd";
 import { hideLoading, showLoading } from "react-redux-loading-bar";
-import { ENVIRONMENT, INoticeOfDeparture, ICreateNoD, INodDocumentPayload } from "@mds/common";
+import { INoticeOfDeparture, ICreateNoD, INodDocumentPayload } from "@mds/common/interfaces";
+import { ENVIRONMENT } from "@mds/common/constants";
 import { IDispatchError, error, request, success } from "../actions/genericActions";
 import {
   ADD_DOCUMENT_TO_NOTICE_OF_DEPARTURE,
@@ -42,11 +43,12 @@ export const createNoticeOfDeparture = (
       dispatch(success(CREATE_NOTICE_OF_DEPARTURE));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(CREATE_NOTICE_OF_DEPARTURE));
-      throw new Error(err);
     })
-    .finally(() => dispatch(hideLoading("modal")));
+    .finally(() => {
+      dispatch(hideLoading("modal"));
+    });
 };
 
 export const fetchNoticesOfDeparture = (
@@ -89,9 +91,8 @@ export const updateNoticeOfDeparture = (
       dispatch(success(UPDATE_NOTICE_OF_DEPARTURE));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(UPDATE_NOTICE_OF_DEPARTURE));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading("modal")));
 };
@@ -138,7 +139,7 @@ export const addDocumentToNoticeOfDeparture = (
     })
     .catch((err) => {
       dispatch(error(ADD_DOCUMENT_TO_NOTICE_OF_DEPARTURE));
-      throw new Error(err);
+      return Promise.reject(err);
     })
     .finally(() => dispatch(hideLoading("modal")));
 };
@@ -167,6 +168,6 @@ export const removeFileFromDocumentManager = ({
       return response;
     })
     .catch((err) => {
-      throw new Error(err);
+      return Promise.reject(err);
     });
 };

--- a/services/common/src/redux/actionCreators/noticeOfWorkActionCreator.js
+++ b/services/common/src/redux/actionCreators/noticeOfWorkActionCreator.js
@@ -1,6 +1,6 @@
 import { notification } from "antd";
 import { showLoading, hideLoading } from "react-redux-loading-bar";
-import { ENVIRONMENT } from "@mds/common";
+import { ENVIRONMENT } from "@mds/common/constants";
 import { error, request, success } from "../actions/genericActions";
 import * as API from "@mds/common/constants/API";
 import { createRequestHeader } from "../utils/RequestHeaders";
@@ -96,9 +96,8 @@ export const createNoticeOfWorkApplication = (payload) => (dispatch) => {
       });
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.CREATE_NOTICE_OF_WORK_APPLICATION));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading()));
 };
@@ -124,11 +123,10 @@ export const createNoticeOfWorkApplicationImportSubmissionDocumentsJob = (applic
       });
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(
         error(reducerTypes.CREATE_NOTICE_OF_WORK_APPLICATION_IMPORT_SUBMISSION_DOCUMENTS_JOB)
       );
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading()));
 };
@@ -154,9 +152,8 @@ export const importNoticeOfWorkApplication = (
       dispatch(success(reducerTypes.IMPORT_NOTICE_OF_WORK_APPLICATION));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.IMPORT_NOTICE_OF_WORK_APPLICATION));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading()));
 };
@@ -216,9 +213,8 @@ export const updateNoticeOfWorkApplication = (
       dispatch(success(reducerTypes.UPDATE_NOTICE_OF_WORK_APPLICATION));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.UPDATE_NOTICE_OF_WORK_APPLICATION));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading()));
 };
@@ -245,9 +241,8 @@ export const createNoticeOfWorkApplicationProgress = (applicationGuid, progressC
       dispatch(success(reducerTypes.CREATE_NOTICE_OF_WORK_APPLICATION_PROGRESS));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.CREATE_NOTICE_OF_WORK_APPLICATION_PROGRESS));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading()));
 };
@@ -277,9 +272,8 @@ export const updateNoticeOfWorkApplicationProgress = (
       dispatch(success(reducerTypes.UPDATE_NOTICE_OF_WORK_APPLICATION_PROGRESS));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.UPDATE_NOTICE_OF_WORK_APPLICATION_PROGRESS));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading()));
 };
@@ -318,9 +312,8 @@ export const createNoticeOfWorkApplicationReview = (applicationGuid, payload) =>
       dispatch(success(reducerTypes.CREATE_NOTICE_OF_WORK_APPLICATION_REVIEW));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.CREATE_NOTICE_OF_WORK_APPLICATION_REVIEW));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading()));
 };
@@ -348,9 +341,8 @@ export const updateNoticeOfWorkApplicationReview = (
       dispatch(success(reducerTypes.UPDATE_NOTICE_OF_WORK_APPLICATION_REVIEW));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.UPDATE_NOTICE_OF_WORK_APPLICATION_REVIEW));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading()));
 };
@@ -428,9 +420,8 @@ export const updateNoticeOfWorkStatus = (now_application_guid, payload) => (disp
       dispatch(success(reducerTypes.UPDATE_NOTICE_OF_WORK_STATUS));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.UPDATE_NOTICE_OF_WORK_STATUS));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading("modal")));
 };
@@ -456,9 +447,8 @@ export const createApplicationDelay = (applicationGuid, payload) => (dispatch) =
       dispatch(success(reducerTypes.CREATE_NOTICE_OF_WORK_APPLICATION_DELAY));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.CREATE_NOTICE_OF_WORK_APPLICATION_DELAY));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading()));
 };
@@ -480,9 +470,8 @@ export const updateApplicationDelay = (applicationGuid, delayGuid, payload) => (
       dispatch(success(reducerTypes.UPDATE_NOTICE_OF_WORK_APPLICATION_DELAY));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.UPDATE_NOTICE_OF_WORK_APPLICATION_DELAY));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading()));
 };
@@ -500,9 +489,8 @@ export const fetchApplicationDelay = (applicationGuid) => (dispatch) => {
       dispatch(noticeOfWorkActions.storeNoticeOfWorkApplicationDelay(response.data));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.FETCH_NOTICE_OF_WORK_APPLICATION_DELAY));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading()));
 };
@@ -546,9 +534,8 @@ export const createAdminAmendmentApplication = (payload) => (dispatch) => {
       });
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.CREATE_ADMIN_AMENDMENT_APPLICATION));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading("modal")));
 };

--- a/services/common/src/redux/actionCreators/partiesActionCreator.ts
+++ b/services/common/src/redux/actionCreators/partiesActionCreator.ts
@@ -1,7 +1,7 @@
 import { notification } from "antd";
 import { showLoading, hideLoading } from "react-redux-loading-bar";
 import queryString from "query-string";
-import { ENVIRONMENT, IUpdatePartyAppointment, removeNullValues } from "@mds/common";
+import { ENVIRONMENT, removeNullValues } from "@mds/common/constants";
 import { request, success, error } from "../actions/genericActions";
 import * as reducerTypes from "@mds/common/constants/reducerTypes";
 import * as partyActions from "../actions/partyActions";
@@ -21,7 +21,8 @@ import {
   ICreateOrgBookEntity,
   IPartyOrgBookEntity,
   IMergeParties,
-} from "@mds/common";
+  IUpdatePartyAppointment,
+} from "@mds/common/interfaces";
 import { AppThunk } from "@mds/common/interfaces/appThunk.type";
 import { AxiosResponse } from "axios";
 
@@ -42,9 +43,8 @@ export const createParty = (payload: ICreateParty): AppThunk<Promise<AxiosRespon
       dispatch(partyActions.storeLastCreatedParty(response.data));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.CREATE_PARTY));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading("modal")));
 };
@@ -69,9 +69,8 @@ export const updateParty = (
       dispatch(success(reducerTypes.UPDATE_PARTY));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.UPDATE_PARTY));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading("modal")));
 };
@@ -98,9 +97,8 @@ export const fetchPartyById = (id: string): AppThunk => (dispatch) => {
       dispatch(success(reducerTypes.GET_PARTY));
       dispatch(partyActions.storeParty(response.data, id));
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.GET_PARTY));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading()));
 };
@@ -123,9 +121,8 @@ export const addPartyRelationship = (
       dispatch(success(reducerTypes.ADD_PARTY_RELATIONSHIP));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.ADD_PARTY_RELATIONSHIP));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading("modal")));
 };
@@ -154,9 +151,8 @@ export const updatePartyRelationship = (
       dispatch(success(reducerTypes.UPDATE_PARTY_RELATIONSHIP));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.UPDATE_PARTY_RELATIONSHIP));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading("modal")));
 };
@@ -221,9 +217,8 @@ export const removePartyRelationship = (
       dispatch(success(reducerTypes.REMOVE_PARTY_RELATIONSHIP));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.REMOVE_PARTY_RELATIONSHIP));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading()));
 };
@@ -243,9 +238,8 @@ export const deleteParty = (party_guid: string): AppThunk<Promise<AxiosResponse<
       dispatch(success(reducerTypes.DELETE_PARTY));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.DELETE_PARTY));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading()));
 };
@@ -275,9 +269,8 @@ export const addDocumentToRelationship = (
       dispatch(success(reducerTypes.ADD_DOCUMENT_TO_RELATIONSHIP));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.ADD_DOCUMENT_TO_RELATIONSHIP));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading("modal")));
 };
@@ -299,9 +292,8 @@ export const createPartyOrgBookEntity = (
       dispatch(success(reducerTypes.PARTY_ORGBOOK_ENTITY));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.PARTY_ORGBOOK_ENTITY));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading("modal")));
 };
@@ -323,9 +315,8 @@ export const mergeParties = (payload: IMergeParties): AppThunk<Promise<AxiosResp
       dispatch(partyActions.storeLastCreatedParty(response.data));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.MERGE_PARTIES));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading()));
 };

--- a/services/common/src/redux/actionCreators/permitActionCreator.ts
+++ b/services/common/src/redux/actionCreators/permitActionCreator.ts
@@ -1,7 +1,7 @@
 import { notification } from "antd";
 import { showLoading, hideLoading } from "react-redux-loading-bar";
+import { ENVIRONMENT } from "@mds/common/constants";
 import {
-  ENVIRONMENT,
   ICreatePermitPayload,
   IPermit,
   IPermitAmendment,
@@ -11,7 +11,7 @@ import {
   IPatchPermitNumber,
   IPatchPermitVCLocked,
   IStandardPermitCondition,
-} from "@mds/common";
+} from "@mds/common/interfaces";
 import { request, success, error, IDispatchError } from "../actions/genericActions";
 import * as reducerTypes from "@mds/common/constants/reducerTypes";
 import * as permitActions from "../actions/permitActions";
@@ -38,9 +38,8 @@ export const createPermit = (
       dispatch(success(reducerTypes.CREATE_PERMIT));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.CREATE_PERMIT));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading("modal")));
 };
@@ -76,9 +75,8 @@ export const fetchDraftPermitByNOW = (
       dispatch(permitActions.storeDraftPermits(response.data));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.GET_PERMITS));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading()));
 };
@@ -104,9 +102,8 @@ export const updatePermit = (
       dispatch(success(reducerTypes.UPDATE_PERMIT));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.UPDATE_PERMIT));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading()));
 };
@@ -134,9 +131,8 @@ export const createPermitAmendment = (
       dispatch(success(reducerTypes.CREATE_PERMIT_AMENDMENT));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.CREATE_PERMIT_AMENDMENT));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading("modal")));
 };
@@ -162,9 +158,8 @@ export const createPermitAmendmentVC = (
       dispatch(success(reducerTypes.PERMIT_AMENDMENT_VC));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.PERMIT_AMENDMENT_VC));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading()));
 };
@@ -197,9 +192,8 @@ export const updatePermitAmendment = (
       dispatch(success(reducerTypes.UPDATE_PERMIT_AMENDMENT));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.UPDATE_PERMIT_AMENDMENT));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading()));
 };
@@ -219,9 +213,8 @@ export const getPermitAmendment = (
       dispatch(success(reducerTypes.GET_PERMIT_AMENDMENT));
       return response.data;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.GET_PERMIT_AMENDMENT));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading()));
 };
@@ -252,9 +245,8 @@ export const removePermitAmendmentDocument = (
       dispatch(success(reducerTypes.UPDATE_PERMIT_AMENDMENT_DOCUMENT));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.UPDATE_PERMIT_AMENDMENT_DOCUMENT));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading()));
 };
@@ -278,9 +270,8 @@ export const deletePermit = (
       dispatch(success(reducerTypes.DELETE_PERMIT));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.DELETE_PERMIT));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading()));
 };
@@ -305,9 +296,8 @@ export const deletePermitAmendment = (
       dispatch(success(reducerTypes.DELETE_PERMIT_AMENDMENT));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.DELETE_PERMIT_AMENDMENT));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading()));
 };

--- a/services/common/src/redux/actionCreators/projectActionCreator.ts
+++ b/services/common/src/redux/actionCreators/projectActionCreator.ts
@@ -7,8 +7,8 @@ import * as projectActions from "../actions/projectActions";
 import * as API from "@mds/common/constants/API";
 import { createRequestHeader } from "../utils/RequestHeaders";
 import CustomAxios from "../customAxios";
+import { ENVIRONMENT } from "@mds/common/constants";
 import {
-  ENVIRONMENT,
   ICreateProjectSummary,
   IProjectSummary,
   IProject,
@@ -19,7 +19,7 @@ import {
   IMajorMinesApplication,
   IProjectDecisionPackage,
   IProjectPageData,
-} from "@mds/common";
+} from "@mds/common/interfaces";
 import { AppThunk } from "@mds/common/interfaces/appThunk.type";
 import { AxiosResponse } from "axios";
 
@@ -78,9 +78,8 @@ export const updateProjectSummary = (
       dispatch(projectActions.storeProjectSummary(payload));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.UPDATE_MINE_PROJECT_SUMMARY));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading()));
 };
@@ -105,9 +104,8 @@ export const updateProject = (
       dispatch(projectActions.storeProject(payload));
       return response.data;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.UPDATE_PROJECT));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading()));
 };
@@ -143,9 +141,8 @@ export const fetchProjectSummaryById = (
       dispatch(success(reducerTypes.GET_PROJECT_SUMMARY));
       dispatch(projectActions.storeProjectSummary(response.data));
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.GET_PROJECT_SUMMARY));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading()));
 };
@@ -171,9 +168,8 @@ export const removeDocumentFromProjectSummary = (
       dispatch(success(reducerTypes.REMOVE_DOCUMENT_FROM_PROJECT_SUMMARY));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.REMOVE_DOCUMENT_FROM_PROJECT_SUMMARY));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading()));
 };
@@ -226,9 +222,8 @@ export const fetchProjectById = (projectGuid: string): AppThunk<Promise<IProject
       dispatch(projectActions.storeMajorMinesApplication(response.data.major_mine_application));
       return response.data;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.GET_PROJECT));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading()));
 };
@@ -266,9 +261,8 @@ export const deleteProjectSummary = (
       dispatch(success(reducerTypes.DELETE_PROJECT_SUMMARY));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.DELETE_PROJECT_SUMMARY));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading()));
 };
@@ -361,9 +355,8 @@ export const updateInformationRequirementsTable = (
       dispatch(success(reducerTypes.UPDATE_INFORMATION_REQUIREMENTS_TABLE));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.UPDATE_INFORMATION_REQUIREMENTS_TABLE));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading()));
 };
@@ -377,9 +370,8 @@ export const fetchRequirements = (): AppThunk => (dispatch) => {
       dispatch(success(reducerTypes.GET_REQUIREMENTS));
       dispatch(projectActions.storeRequirements(response.data));
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.GET_REQUIREMENTS));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading()));
 };
@@ -405,9 +397,8 @@ export const removeDocumentFromInformationRequirementsTable = (
       dispatch(success(reducerTypes.REMOVE_DOCUMENT_FROM_INFORMATION_REQUIREMENTS_TABLE));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.REMOVE_DOCUMENT_FROM_INFORMATION_REQUIREMENTS_TABLE));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading()));
 };
@@ -437,9 +428,8 @@ export const createMajorMineApplication = (
       dispatch(success(reducerTypes.CREATE_MAJOR_MINES_APPLICATION));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.CREATE_MAJOR_MINES_APPLICATION));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading()));
 };
@@ -469,9 +459,8 @@ export const updateMajorMineApplication = (
       dispatch(success(reducerTypes.UPDATE_MAJOR_MINES_APPLICATION));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.UPDATE_MAJOR_MINES_APPLICATION));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading()));
 };
@@ -501,9 +490,8 @@ export const removeDocumentFromMajorMineApplication = (
       dispatch(success(reducerTypes.REMOVE_DOCUMENT_FROM_MAJOR_MINE_APPLICATION));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.REMOVE_DOCUMENT_FROM_MAJOR_MINE_APPLICATION));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading()));
 };
@@ -528,9 +516,8 @@ export const createProjectDecisionPackage = (
       dispatch(success(reducerTypes.CREATE_PROJECT_DECISION_PACKAGE));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.CREATE_PROJECT_DECISION_PACKAGE));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading()));
 };
@@ -555,9 +542,8 @@ export const updateProjectDecisionPackage = (
       dispatch(success(reducerTypes.UPDATE_PROJECT_DECISION_PACKAGE));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.UPDATE_PROJECT_DECISION_PACKAGE));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading()));
 };
@@ -587,9 +573,8 @@ export const removeDocumentFromProjectDecisionPackage = (
       dispatch(success(reducerTypes.REMOVE_DOCUMENT_FROM_PROJECT_DECISION_PACKAGE));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.REMOVE_DOCUMENT_FROM_PROJECT_DECISION_PACKAGE));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading()));
 };
@@ -618,9 +603,8 @@ export const createProjectLinks = (
         return data;
       }
     )
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.CREATE_PROJECT_LINKS));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading()));
 };
@@ -645,9 +629,8 @@ export const deleteProjectLink = (
       dispatch(projectActions.removeProjectLink(projectLinkGuid));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.DELETE_PROJECT_LINK));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading()));
 };

--- a/services/common/src/redux/actionCreators/reportActionCreator.ts
+++ b/services/common/src/redux/actionCreators/reportActionCreator.ts
@@ -25,9 +25,8 @@ export const deleteMineReport = (mineGuid, mineReportGuid) => (dispatch) => {
       dispatch(success(reducerTypes.DELETE_MINE_REPORT));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.DELETE_MINE_REPORT));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading()));
 };
@@ -45,9 +44,8 @@ export const createMineReport = (mineGuid, payload) => (dispatch) => {
       dispatch(success(reducerTypes.CREATE_MINE_REPORT));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.CREATE_MINE_REPORT));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading("modal")));
 };
@@ -100,9 +98,8 @@ export const updateMineReport = (mineGuid, mineReportGuid, payload) => (dispatch
       dispatch(success(reducerTypes.UPDATE_MINE_REPORT));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.UPDATE_MINE_REPORT));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading("modal")));
 };
@@ -117,9 +114,8 @@ export const fetchMineReport = (mineGuid, mineReportGuid) => (dispatch) => {
       dispatch(mineReportActions.storeMineReport(response.data));
       return response.data;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.GET_MINE_REPORT));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading()));
 };

--- a/services/common/src/redux/actionCreators/searchActionCreator.js
+++ b/services/common/src/redux/actionCreators/searchActionCreator.js
@@ -1,5 +1,5 @@
 import { showLoading, hideLoading } from "react-redux-loading-bar";
-import { ENVIRONMENT } from "@mds/common";
+import { ENVIRONMENT } from "@mds/common/constants";
 import { request, success, error, clear } from "../actions/genericActions";
 import * as reducerTypes from "@mds/common/constants/reducerTypes";
 import * as searchActions from "../actions/searchActions";
@@ -21,9 +21,8 @@ export const fetchSearchResults = (searchTerm, searchTypes) => (dispatch) => {
       dispatch(hideLoading());
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.GET_SEARCH_RESULTS));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading()));
 };

--- a/services/common/src/redux/actionCreators/securitiesActionCreator.js
+++ b/services/common/src/redux/actionCreators/securitiesActionCreator.js
@@ -1,6 +1,6 @@
 import { showLoading, hideLoading } from "react-redux-loading-bar";
 import { notification } from "antd";
-import { ENVIRONMENT } from "@mds/common";
+import { ENVIRONMENT } from "@mds/common/constants";
 import { request, success, error } from "../actions/genericActions";
 import * as securitiesActions from "../actions/securitiesActions";
 import * as reducerTypes from "@mds/common/constants/reducerTypes";
@@ -33,9 +33,8 @@ export const createBond = (payload) => (dispatch) => {
       dispatch(success(reducerTypes.CREATE_BOND));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.CREATE_BOND));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading("modal")));
 };
@@ -53,9 +52,8 @@ export const updateBond = (payload, bondGuid) => (dispatch) => {
       dispatch(success(reducerTypes.UPDATE_BOND));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.UPDATE_BOND));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading("modal")));
 };
@@ -73,9 +71,8 @@ export const transferBond = (payload, bondGuid) => (dispatch) => {
       dispatch(success(reducerTypes.TRANSFER_BOND));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.TRANSFER_BOND));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading("modal")));
 };
@@ -105,9 +102,8 @@ export const createReclamationInvoice = (payload) => (dispatch) => {
       dispatch(success(reducerTypes.CREATE_RECLAMATION_INVOICE));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.CREATE_RECLAMATION_INVOICE));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading("modal")));
 };
@@ -125,9 +121,8 @@ export const updateReclamationInvoice = (payload, invoiceGuid) => (dispatch) => 
       dispatch(success(reducerTypes.UPDATE_RECLAMATION_INVOICE));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.UPDATE_RECLAMATION_INVOICE));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading("modal")));
 };

--- a/services/common/src/redux/actionCreators/varianceActionCreator.ts
+++ b/services/common/src/redux/actionCreators/varianceActionCreator.ts
@@ -1,6 +1,6 @@
 import { notification } from "antd";
 import { showLoading, hideLoading } from "react-redux-loading-bar";
-import { ENVIRONMENT } from "@mds/common";
+import { ENVIRONMENT } from "@mds/common/constants";
 import { request, success, error, IDispatchError } from "../actions/genericActions";
 import * as reducerTypes from "@mds/common/constants/reducerTypes";
 import * as Strings from "@mds/common/constants/strings";
@@ -15,7 +15,7 @@ import {
   IVariance,
   IAddDocumentToVariancePayload,
   IFetchVariancesPayload,
-} from "@mds/common";
+} from "@mds/common/interfaces";
 
 export const createVariance = (
   { mineGuid },
@@ -34,9 +34,8 @@ export const createVariance = (
       dispatch(success(reducerTypes.CREATE_MINE_VARIANCE));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.CREATE_MINE_VARIANCE));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading("modal")));
 };
@@ -57,9 +56,8 @@ export const updateVariance = (
       dispatch(success(reducerTypes.UPDATE_MINE_VARIANCE));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.UPDATE_MINE_VARIANCE));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading("modal")));
 };
@@ -111,9 +109,8 @@ export const addDocumentToVariance = (
       dispatch(success(reducerTypes.ADD_DOCUMENT_TO_VARIANCE));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.ADD_DOCUMENT_TO_VARIANCE));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading("modal")));
 };
@@ -134,9 +131,8 @@ export const removeDocumentFromVariance = (
       dispatch(success(reducerTypes.REMOVE_DOCUMENT_FROM_VARIANCE));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.REMOVE_DOCUMENT_FROM_VARIANCE));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading("modal")));
 };
@@ -172,9 +168,8 @@ export const deleteVariance = (
       dispatch(success(reducerTypes.DELETE_VARIANCE));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.DELETE_VARIANCE));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading()));
 };

--- a/services/common/src/redux/actionCreators/verifiableCredentialActionCreator.ts
+++ b/services/common/src/redux/actionCreators/verifiableCredentialActionCreator.ts
@@ -1,4 +1,4 @@
-import { ENVIRONMENT } from "@mds/common";
+import { ENVIRONMENT } from "@mds/common/constants";
 import { request, success, error } from "../actions/genericActions";
 import * as reducerTypes from "@mds/common/constants/reducerTypes";
 import * as verfiableCredentialActions from "../actions/verfiableCredentialActions";
@@ -6,7 +6,7 @@ import { createRequestHeader } from "../utils/RequestHeaders";
 import { showLoading, hideLoading } from "react-redux-loading-bar";
 import CustomAxios from "../customAxios";
 import { AppThunk } from "@mds/common/interfaces/appThunk.type";
-import { IVCInvitation } from "@mds/common";
+import { IVCInvitation } from "@mds/common/interfaces";
 import { AxiosResponse } from "axios";
 import { notification } from "antd";
 
@@ -38,10 +38,9 @@ export const issueVCDigitalCredForPermit = (
       dispatch(hideLoading("modal"));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.ISSUE_VC));
       dispatch(hideLoading("modal"));
-      throw new Error(err);
     });
 };
 
@@ -89,9 +88,8 @@ export const fetchVCWalletInvitations = (
       dispatch(hideLoading("modal"));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.FETCH_VC_WALLET_CONNECTION_INVITATIONS));
       dispatch(hideLoading("modal"));
-      throw new Error(err);
     });
 };

--- a/services/common/src/redux/actionCreators/workInformationActionCreator.ts
+++ b/services/common/src/redux/actionCreators/workInformationActionCreator.ts
@@ -1,6 +1,6 @@
 import { showLoading, hideLoading } from "react-redux-loading-bar";
 import { notification } from "antd";
-import { ENVIRONMENT } from "@mds/common";
+import { ENVIRONMENT } from "@mds/common/constants";
 import { request, success, error } from "../actions/genericActions";
 import * as reducerTypes from "@mds/common/constants/reducerTypes";
 import * as workInformationActions from "../actions/workInformationActions";
@@ -9,7 +9,7 @@ import { createRequestHeader } from "../utils/RequestHeaders";
 import CustomAxios from "../customAxios";
 import { AxiosResponse } from "axios";
 import { AppThunk } from "@mds/common/interfaces/appThunk.type";
-import { IMineWorkInformation } from "@mds/common";
+import { IMineWorkInformation } from "@mds/common/interfaces";
 
 export const createMineWorkInformation = (
   mineGuid: string,
@@ -33,9 +33,8 @@ export const createMineWorkInformation = (
       dispatch(success(reducerTypes.CREATE_MINE_WORK_INFORMATION));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.CREATE_MINE_WORK_INFORMATION));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading("modal")));
 };
@@ -54,9 +53,8 @@ export const fetchMineWorkInformations = (
       dispatch(workInformationActions.storeMineWorkInformations(response.data));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.GET_MINE_WORK_INFORMATIONS));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading()));
 };
@@ -84,9 +82,8 @@ export const updateMineWorkInformation = (
       dispatch(success(reducerTypes.UPDATE_MINE_WORK_INFORMATION));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.UPDATE_MINE_WORK_INFORMATION));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading("modal")));
 };
@@ -110,9 +107,8 @@ export const deleteMineWorkInformation = (
       dispatch(success(reducerTypes.DELETE_MINE_WORK_INFORMATION));
       return response;
     })
-    .catch((err) => {
+    .catch(() => {
       dispatch(error(reducerTypes.DELETE_MINE_WORK_INFORMATION));
-      throw new Error(err);
     })
     .finally(() => dispatch(hideLoading()));
 };

--- a/services/common/src/redux/customAxios.js
+++ b/services/common/src/redux/customAxios.js
@@ -46,9 +46,9 @@ const notifymAdmin = (error) => {
 };
 
 CustomAxios = ({
-  errorToastMessage = null,
+  errorToastMessage = "default",
   suppressErrorNotification = false,
-  successToastMessage = null,
+  successToastMessage = undefined,
 } = {}) => {
   const instance = axios.create();
 

--- a/services/core-api/app/api/notice_of_departure/resources/notice_of_departure_list.py
+++ b/services/core-api/app/api/notice_of_departure/resources/notice_of_departure_list.py
@@ -1,6 +1,6 @@
 from app.api.activity.models.activity_notification import ActivityType
 from flask_restx import Resource, reqparse, inputs
-from werkzeug.exceptions import NotFound
+from werkzeug.exceptions import NotFound, BadRequest
 from app.extensions import api
 from app.api.utils.resources_mixins import UserMixin
 from app.api.utils.access_decorators import (requires_any_of, VIEW_ALL, MINESPACE_PROPONENT,
@@ -69,6 +69,7 @@ class NoticeOfDepartureListResource(Resource, UserMixin):
     @api.expect(CREATE_NOD_MODEL)
     @api.marshal_with(NOD_MODEL, code=201)
     def post(self):
+        raise BadRequest('TEST this has been a bad request')
         parser = reqparse.RequestParser()
         parser.add_argument(
             'nod_title',

--- a/services/core-api/app/api/notice_of_departure/resources/notice_of_departure_list.py
+++ b/services/core-api/app/api/notice_of_departure/resources/notice_of_departure_list.py
@@ -69,7 +69,6 @@ class NoticeOfDepartureListResource(Resource, UserMixin):
     @api.expect(CREATE_NOD_MODEL)
     @api.marshal_with(NOD_MODEL, code=201)
     def post(self):
-        raise BadRequest('TEST this has been a bad request')
         parser = reqparse.RequestParser()
         parser.add_argument(
             'nod_title',

--- a/services/core-api/app/api/parties/party/resources/party_resource.py
+++ b/services/core-api/app/api/parties/party/resources/party_resource.py
@@ -212,6 +212,9 @@ class PartyResource(Resource, UserMixin):
     def put(self, party_guid):
         if is_minespace_user():
             user = bceid_username()
+            current_app.logger.debug('**********************')
+            current_app.logger.debug(user)
+            current_app.logger.debug('**********************')
             minespace_user = MinespaceUser.find_by_email(user + "@bceid")
             if not minespace_user:
                 raise BadRequest('User not found.')

--- a/services/core-web/src/tests/actionCreators/activityActionCreator.spec.js
+++ b/services/core-web/src/tests/actionCreators/activityActionCreator.spec.js
@@ -36,7 +36,6 @@ describe("`fetchActivities` action creator", () => {
 
   it("Request failure, dispatches `error` with correct response", () => {
     mockAxios.onGet(url, MOCK.createMockHeader()).reply(418, MOCK.ERROR);
-    expect.assertions(3);
     return fetchActivities(user)(dispatch).catch(() => {
       expect(requestSpy).toHaveBeenCalledTimes(1);
       expect(errorSpy).toHaveBeenCalledTimes(1);

--- a/services/minespace-web/src/components/Forms/contacts/AddContactFormDetails.js
+++ b/services/minespace-web/src/components/Forms/contacts/AddContactFormDetails.js
@@ -268,7 +268,7 @@ const mapDispatchToProps = (dispatch) =>
       createParty,
       updateParty,
       fetchParties: (...args) => debounce(() => dispatch(fetchParties(...args)), 1000),
-      initialize: (data) => initialize(FORM.ADD_CONTACT, data ?? {}),
+      initialize: (data) => initialize(FORM.ADD_CONTACT, data),
       reset,
       change,
     },

--- a/services/minespace-web/src/components/Forms/contacts/AddContactFormDetails.js
+++ b/services/minespace-web/src/components/Forms/contacts/AddContactFormDetails.js
@@ -66,7 +66,11 @@ export const AddContactFormDetails = (props) => {
         await props.onSubmit(party);
       } else if (props.isDirty) {
         // Selected party has been updated, update it
-        const { data: party } = await props.updateParty(payload, values.party_guid);
+        const response = await props.updateParty(payload, values.party_guid);
+
+        if (!response) return;
+
+        const { data: party } = response;
 
         await props.onSubmit(party);
       } else {
@@ -264,7 +268,7 @@ const mapDispatchToProps = (dispatch) =>
       createParty,
       updateParty,
       fetchParties: (...args) => debounce(() => dispatch(fetchParties(...args)), 1000),
-      initialize: (data) => initialize(FORM.ADD_CONTACT, data),
+      initialize: (data) => initialize(FORM.ADD_CONTACT, data ?? {}),
       reset,
       change,
     },

--- a/services/minespace-web/src/components/pages/Project/ProjectSummaryPage.tsx
+++ b/services/minespace-web/src/components/pages/Project/ProjectSummaryPage.tsx
@@ -267,9 +267,6 @@ export const ProjectSummaryPage: FC<ProjectSummaryPageProps> = (props) => {
           false
         );
       })
-      .catch((err) => {
-        throw new Error(err);
-      })
       .then(async () => {
         return handleFetchData();
       })


### PR DESCRIPTION
## Objective 

Errors that were being thrown by the frontend were being overridden when an action creator contained `throw new Error()`, but it's invocation didn't contain a `catch` block.

Did a search throughout the frontends and only found a very limited number of catch blocks, so removed the throw new Error from all actionCreators where this didn't exist.  

[MDS-5860](https://bcmines.atlassian.net/browse/MDS-5860)

<img width="1325" alt="image" src="https://github.com/bcgov/mds/assets/83598933/2870d063-3224-4064-8e88-b121f1c2f636">