### PR TITLE
[MDS-5895] Setting report email links with right env

### DIFF
--- a/services/core-api/app/api/incidents/models/mine_incident.py
+++ b/services/core-api/app/api/incidents/models/mine_incident.py
@@ -299,7 +299,7 @@ class MineIncident(SoftDeleteMixin, AuditMixin, Base):
                 "mine_name": self.mine_table.mine_name,
                 "mine_no": self.mine_table.mine_no,
             },
-            "incident_link": f'{Config.CORE_PRODUCTION_URL}/mines/{self.mine.mine_guid}/incidents/{self.mine_incident_guid}',
+            "incident_link": f'{Config.CORE_PROD_URL}/mines/{self.mine.mine_guid}/incidents/{self.mine_incident_guid}',
         }
 
         minespace_context = {
@@ -310,7 +310,7 @@ class MineIncident(SoftDeleteMixin, AuditMixin, Base):
                 "mine_name": self.mine_table.mine_name,
                 "mine_no": self.mine_table.mine_no,
             },
-            "minespace_incident_link": f'{Config.MINESPACE_PRODUCTION_URL}/mines/{self.mine.mine_guid}/incidents/{self.mine_incident_guid}',
+            "minespace_incident_link": f'{Config.MINESPACE_PROD_URL}/mines/{self.mine.mine_guid}/incidents/{self.mine_incident_guid}',
         }
         EmailService.send_template_email(subject, emli_recipients, emli_body, emli_context, cc=cc)
         EmailService.send_template_email(subject, minespace_recipients, minespace_body, minespace_context, cc=cc)
@@ -322,7 +322,7 @@ class MineIncident(SoftDeleteMixin, AuditMixin, Base):
         cc = None
 
         subject = f'{self.mine_name}: The status of a reportable incident {self.mine_incident_report_no} has been updated on {format_email_datetime_to_string(self.update_timestamp)}'
-        link = f'{Config.MINESPACE_PRODUCTION_URL}/mines/{self.mine.mine_guid}/incidents/{self.mine_incident_guid}/review' if is_prop else f'{Config.CORE_PRODUCTION_URL}/mines/{self.mine.mine_guid}/incidents/{self.mine_incident_guid}'
+        link = f'{Config.MINESPACE_PROD_URL}/mines/{self.mine.mine_guid}/incidents/{self.mine_incident_guid}/review' if is_prop else f'{Config.CORE_PROD_URL}/mines/{self.mine.mine_guid}/incidents/{self.mine_incident_guid}'
         body = open("app/templates/email/incident/minespace_awaiting_incident_final_report_email.html", "r").read() if is_prop else open("app/templates/email/incident/emli_awaiting_incident_final_report_email.html", "r").read()
 
         context = {
@@ -343,7 +343,7 @@ class MineIncident(SoftDeleteMixin, AuditMixin, Base):
         recipients = [PROP_EMAIL if is_prop else OCI_EMAIL]
         cc = None
 
-        link = f'{Config.MINESPACE_PRODUCTION_URL}/mines/{self.mine.mine_guid}/incidents/{self.mine_incident_guid}/review' if is_prop else f'{Config.CORE_PRODUCTION_URL}/mines/{self.mine.mine_guid}/incidents/{self.mine_incident_guid}'
+        link = f'{Config.MINESPACE_PROD_URL}/mines/{self.mine.mine_guid}/incidents/{self.mine_incident_guid}/review' if is_prop else f'{Config.CORE_PROD_URL}/mines/{self.mine.mine_guid}/incidents/{self.mine_incident_guid}'
         body = open("app/templates/email/incident/minespace_final_report_received_incident_email.html", "r").read() if is_prop else open("app/templates/email/incident/emli_final_report_received_incident_email.html", "r").read()
         subject = f'{self.mine_name}: A final incident report on {self.mine_incident_report_no} has been submitted on {format_email_datetime_to_string(self.update_timestamp)}'
         context = {

--- a/services/core-api/app/api/mines/reports/models/mine_report.py
+++ b/services/core-api/app/api/mines/reports/models/mine_report.py
@@ -19,6 +19,7 @@ from app.api.constants import MAJOR_MINES_OFFICE_EMAIL, MDS_EMAIL, PERM_RECL_EMA
 from app.api.activity.utils import trigger_notification
 from app.api.activity.models.activity_notification import ActivityType, ActivityRecipients
 from app.api.mines.reports.models.mine_report_notification import MineReportNotification
+from app.api.utils.helpers import get_current_core_or_ms_env_url
 
 class MineReport(SoftDeleteMixin, AuditMixin, Base):
     __tablename__ = "mine_report"
@@ -139,18 +140,8 @@ class MineReport(SoftDeleteMixin, AuditMixin, Base):
 
         due_date = due_date = (self.due_date).strftime("%b %d %Y") if self.due_date else "N/A"
 
-        core_url = Config.CORE_PRODUCTION_URL
-        ms_url = Config.MINESPACE_PRODUCTION_URL
-
-        if Config.ENVIRONMENT_NAME == 'local':
-            core_url = Config.CORE_LOCAL_URL
-            ms_url = Config.MINESPACE_LOCAL_URL
-        elif Config.ENVIRONMENT_NAME == 'dev':
-            core_url = Config.CORE_DEV_URL
-            ms_url = Config.MINESPACE_DEV_URL
-        elif Config.ENVIRONMENT_NAME != 'prod':
-            core_url = Config.CORE_TEST_URL
-            ms_url = Config.MINESPACE_TEST_URL
+        core_url = get_current_core_or_ms_env_url("core")
+        ms_url = get_current_core_or_ms_env_url("ms")
 
         core_report_page_link =  f'{core_url}/dashboard/reporting/mine/{self.mine.mine_guid}/report/{self.mine_report_guid}'
         ms_report_page_link = f'{ms_url}/mines/{self.mine.mine_guid}/reports/{self.mine_report_guid}'
@@ -258,7 +249,7 @@ class MineReport(SoftDeleteMixin, AuditMixin, Base):
             body_verb = 'uploaded document(s) to' if is_edit else 'submitted'
             body = f'<p>{self.mine.mine_name} (Mine no: {self.mine.mine_no}) has {body_verb} a "{self.mine_report_definition_report_name}" report.</p>'
 
-            link = f'{Config.CORE_PRODUCTION_URL}/mine-dashboard/{self.mine.mine_guid}/reports/code-required-reports'
+            link = f'{Config.CORE_PROD_URL}/mine-dashboard/{self.mine.mine_guid}/reports/code-required-reports'
             body += f'<p>View updates in Core: <a href="{link}" target="_blank">{link}</a></p>'
             EmailService.send_email(subject, recipients, body)
 

--- a/services/core-api/app/api/mines/reports/models/mine_report.py
+++ b/services/core-api/app/api/mines/reports/models/mine_report.py
@@ -138,8 +138,22 @@ class MineReport(SoftDeleteMixin, AuditMixin, Base):
         core_recipients, ms_recipients = self.collectRecipients(is_proponent)
 
         due_date = due_date = (self.due_date).strftime("%b %d %Y") if self.due_date else "N/A"
-        core_report_page_link =  f'{Config.CORE_PRODUCTION_URL}/dashboard/reporting/mine/{self.mine.mine_guid}/report/{self.mine_report_guid}'
-        ms_report_page_link = f'{Config.MINESPACE_PRODUCTION_URL}/mines/{self.mine.mine_guid}/reports/{self.mine_report_guid}'
+
+        core_url = Config.CORE_PRODUCTION_URL
+        ms_url = Config.MINESPACE_PRODUCTION_URL
+
+        if Config.ENVIRONMENT_NAME == 'local':
+            core_url = Config.CORE_LOCAL_URL
+            ms_url = Config.MINESPACE_LOCAL_URL
+        elif Config.ENVIRONMENT_NAME == 'dev':
+            core_url = Config.CORE_DEV_URL
+            ms_url = Config.MINESPACE_DEV_URL
+        else:
+            core_url = Config.CORE_TEST_URL
+            ms_url = Config.MINESPACE_TEST_URL
+
+        core_report_page_link =  f'{core_url}/dashboard/reporting/mine/{self.mine.mine_guid}/report/{self.mine_report_guid}'
+        ms_report_page_link = f'{ms_url}/mines/{self.mine.mine_guid}/reports/{self.mine_report_guid}'
         report_name = ""
 
         if is_crr:
@@ -167,7 +181,7 @@ class MineReport(SoftDeleteMixin, AuditMixin, Base):
               "report_due_date": due_date,
               "report_recieved_date": (self.received_date).strftime("%b %d %Y at %I:%M %p"),
           },
-          "minespace_login_link": Config.MINESPACE_PRODUCTION_URL,
+          "minespace_login_link": ms_url,
           "core_report_page_link": core_report_page_link,
           "ms_report_page_link": ms_report_page_link
         }

--- a/services/core-api/app/api/mines/reports/models/mine_report.py
+++ b/services/core-api/app/api/mines/reports/models/mine_report.py
@@ -138,8 +138,8 @@ class MineReport(SoftDeleteMixin, AuditMixin, Base):
         core_recipients, ms_recipients = self.collectRecipients(is_proponent)
 
         due_date = due_date = (self.due_date).strftime("%b %d %Y") if self.due_date else "N/A"
-        core_report_page_link =  f'{Config.CORE_PRODUCTION_URL}/mine-dashboard/{self.mine.mine_guid}/required-reports/{report_code.lower()}-required-reports'
-        ms_report_page_link = f'{Config.MINESPACE_PRODUCTION_URL}/mines/{self.mine.mine_guid}/reports'
+        core_report_page_link =  f'{Config.CORE_PRODUCTION_URL}/dashboard/reporting/mine/{self.mine.mine_guid}/report/{self.mine_report_guid}'
+        ms_report_page_link = f'{Config.MINESPACE_PRODUCTION_URL}/mines/{self.mine.mine_guid}/reports/{self.mine_report_guid}'
         report_name = ""
 
         if is_crr:

--- a/services/core-api/app/api/mines/reports/models/mine_report.py
+++ b/services/core-api/app/api/mines/reports/models/mine_report.py
@@ -148,7 +148,7 @@ class MineReport(SoftDeleteMixin, AuditMixin, Base):
         elif Config.ENVIRONMENT_NAME == 'dev':
             core_url = Config.CORE_DEV_URL
             ms_url = Config.MINESPACE_DEV_URL
-        else:
+        elif Config.ENVIRONMENT_NAME != 'prod':
             core_url = Config.CORE_TEST_URL
             ms_url = Config.MINESPACE_TEST_URL
 

--- a/services/core-api/app/api/mines/tailings/models/tailings.py
+++ b/services/core-api/app/api/mines/tailings/models/tailings.py
@@ -168,6 +168,6 @@ class MineTailingsStorageFacility(AuditMixin, Base):
         recipients = MINESPACE_TSF_UPDATE_EMAIL
         subject = f'TSF Information Update for {self.mine.mine_name}'
         body = f'<p>{self.mine.mine_name} (Mine No.: {self.mine.mine_no}) has requested to update their TSF information.</p>'
-        link = f'{Config.CORE_PRODUCTION_URL}/mine-dashboard/{self.mine.mine_guid}/permits-and-approvals/tailings'
+        link = f'{Config.CORE_PROD_URL}/mine-dashboard/{self.mine.mine_guid}/permits-and-approvals/tailings'
         body += f'<p>View updates in Core: <a href="{link}" target="_blank">{link}</a></p>'
         EmailService.send_email(subject, recipients, body)

--- a/services/core-api/app/api/mines/work_information/models/mine_work_information.py
+++ b/services/core-api/app/api/mines/work_information/models/mine_work_information.py
@@ -104,7 +104,7 @@ class MineWorkInformation(SoftDeleteMixin, AuditMixin, Base):
         body += f'<p><b>Work Status: </b>{self.work_status}</p>'
         body += f'<p><b>Comments: </b>{self.work_comments}</p>'
         body += f'<p><b>Updated By: </b>{self.updated_by}</p>'
-        link = f'{Config.CORE_PRODUCTION_URL}/mine-dashboard/{self.mine.mine_guid}/mine-information/general'
+        link = f'{Config.CORE_PROD_URL}/mine-dashboard/{self.mine.mine_guid}/mine-information/general'
         body += f'<p>View updates in Core: <a href="{link}" target="_blank">{link}</a></p>'
         EmailService.send_email(subject, recipients, body)
 

--- a/services/core-api/app/api/notice_of_departure/models/notice_of_departure.py
+++ b/services/core-api/app/api/notice_of_departure/models/notice_of_departure.py
@@ -236,6 +236,6 @@ class NoticeOfDeparture(SoftDeleteMixin, AuditMixin, Base):
 
         subject = f'Notice of Departure Submitted for {self.mine.mine_name}'
         body = f'<p>{self.mine.mine_name} (Mine no: {self.mine.mine_no}) has submitted a "Notice of Departure from Approval" report.</p>'
-        link = f'{Config.CORE_PRODUCTION_URL}/mine-dashboard/{self.mine.mine_guid}/permits-and-approvals/notices-of-departure'
+        link = f'{Config.CORE_PROD_URL}/mine-dashboard/{self.mine.mine_guid}/permits-and-approvals/notices-of-departure'
         body += f'<p>View updates in Core: <a href="{link}" target="_blank">{link}</a></p>'
         EmailService.send_email(subject, recipients, body, cc=cc)

--- a/services/core-api/app/api/parties/party_appt/models/mine_party_appt.py
+++ b/services/core-api/app/api/parties/party_appt/models/mine_party_appt.py
@@ -358,7 +358,7 @@ class MinePartyAppointment(SoftDeleteMixin, AuditMixin, Base):
             if recipients:
                 cache.set(EDIT_TSF_EMAILS, recipients, timeout=TIMEOUT_24_HOURS)
 
-        button_link = f'{Config.CORE_PRODUCTION_URL}/mine-dashboard/{self.mine.mine_guid}/permits-and-approvals/tailings/{self.mine_tailings_storage_facility.mine_tailings_storage_facility_guid}/{party_page}'
+        button_link = f'{Config.CORE_PROD_URL}/mine-dashboard/{self.mine.mine_guid}/permits-and-approvals/tailings/{self.mine_tailings_storage_facility.mine_tailings_storage_facility_guid}/{party_page}'
         # change from UTC to PST
         submitted_at = format_email_datetime_to_string(datetime.utcnow())
         start_date = self.start_date.strftime('%b %d %Y') if self.start_date else 'No date provided',

--- a/services/core-api/app/api/projects/information_requirements_table/models/information_requirements_table.py
+++ b/services/core-api/app/api/projects/information_requirements_table/models/information_requirements_table.py
@@ -88,13 +88,13 @@ class InformationRequirementsTable(SoftDeleteMixin, AuditMixin, Base):
         subject = f'IRT Submitted for {self.project.mine_name}'
         body = f'<p>{self.project.mine_name} (Mine no: {self.project.mine_no}) has updated {self.project.project_title} by submitting an IRT.</p>'
 
-        link = f'{Config.CORE_PRODUCTION_URL}/pre-applications/{self.project.project_guid}/information-requirements-table/{self.irt_guid}/intro-project-overview'
+        link = f'{Config.CORE_PROD_URL}/pre-applications/{self.project.project_guid}/information-requirements-table/{self.irt_guid}/intro-project-overview'
         body += f'<p>View IRT in Core: <a href="{link}" target="_blank">{link}</a></p>'
         EmailService.send_email(subject, recipients, body)
 
     def send_irt_approval_email(self):
         recipients = [contact.email for contact in self.project.contacts]
-        link = f'{Config.MINESPACE_PRODUCTION_URL}/projects/{self.project.project_guid}/information-requirements-table/{self.irt_guid}/review/intro-project-overview'
+        link = f'{Config.MINESPACE_PROD_URL}/projects/{self.project.project_guid}/information-requirements-table/{self.irt_guid}/review/intro-project-overview'
 
         subject = f'IRT Notification for {self.project.mine_name}:{self.project.project_title}'
         body = f'<p>An IRT has been approved for {self.project.mine_name}:(Mine no: {self.project.mine_no})-{self.project.project_title}.</p>'

--- a/services/core-api/app/api/projects/major_mine_application/models/major_mine_application.py
+++ b/services/core-api/app/api/projects/major_mine_application/models/major_mine_application.py
@@ -93,8 +93,8 @@ class MajorMineApplication(SoftDeleteMixin, AuditMixin, Base):
         def generate_list_element(element):
             return f'<li>{element}</li>'
 
-        # TODO: Update this link with Config.MINESPACE_PRODUCTION_URL}/projects/{self.project_guid}/major-mine-application/{self.major_mine_application_guid}/review?step=3 and update frontend to support that
-        link = f'{Config.MINESPACE_PRODUCTION_URL}/projects/{self.project_guid}/major-mine-application/entry'
+        # TODO: Update this link with Config.MINESPACE_PROD_URL}/projects/{self.project_guid}/major-mine-application/{self.major_mine_application_guid}/review?step=3 and update frontend to support that
+        link = f'{Config.MINESPACE_PROD_URL}/projects/{self.project_guid}/major-mine-application/entry'
 
         subject = f'Major Mine Application Submitted for {self.project.project_title}'
         body = '<p>The following documents have been submitted with this Major Mine Application:</p>'

--- a/services/core-api/app/api/projects/project_summary/models/project_summary.py
+++ b/services/core-api/app/api/projects/project_summary/models/project_summary.py
@@ -553,7 +553,7 @@ class ProjectSummary(SoftDeleteMixin, AuditMixin, Base):
                 "mine_name": mine.mine_name,
                 "mine_no": mine.mine_no,
             },
-            "core_project_summary_link": f'{Config.CORE_PRODUCTION_URL}/pre-applications/{self.project.project_guid}/overview'
+            "core_project_summary_link": f'{Config.CORE_PROD_URL}/pre-applications/{self.project.project_guid}/overview'
         }
 
         minespace_context = {
@@ -561,7 +561,7 @@ class ProjectSummary(SoftDeleteMixin, AuditMixin, Base):
                 "mine_name": mine.mine_name,
                 "mine_no": mine.mine_no,
             },
-            "minespace_project_summary_link": f'{Config.MINESPACE_PRODUCTION_URL}/projects/{self.project.project_guid}/overview',
+            "minespace_project_summary_link": f'{Config.MINESPACE_PROD_URL}/projects/{self.project.project_guid}/overview',
             "ema_auth_link": f'{Config.EMA_AUTH_LINK}',
         }
 

--- a/services/core-api/app/api/utils/helpers.py
+++ b/services/core-api/app/api/utils/helpers.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from pytz import timezone, utc
 from PIL import Image
 from flask import current_app
+from app.config import Config
 
 
 def clean_HTML_string(raw_html):
@@ -81,9 +82,6 @@ def create_image_with_aspect_ratio(source, width=None, height=None):
     return {'source': source, 'width': width, 'height': height}
 
 def validate_phone_no(phone_no, address_type_code='CAN'):
-    current_app.logger.info("inside validate_phone_no")
-    current_app.logger.info(phone_no)
-    current_app.logger.info(address_type_code)
     if not phone_no:
         raise AssertionError('Phone number is not provided.')
     # TODO: this is an arbitrary limit for phone number characters, actual number depends on formatting decisions
@@ -92,3 +90,11 @@ def validate_phone_no(phone_no, address_type_code='CAN'):
     if address_type_code in ['CAN', 'USA'] and not re.match(r'[0-9]{3}-[0-9]{3}-[0-9]{4}', phone_no):
         raise AssertionError('Invalid phone number format, must be of XXX-XXX-XXXX.')
     return phone_no
+
+def get_current_core_or_ms_env_url(app):
+    if app == 'core':
+        core_config_property = f'CORE_{(Config.ENVIRONMENT_NAME).upper()}_URL'
+        return getattr(Config, core_config_property)
+    elif app == 'ms':
+        ms_config_property = f'MINESPACE_{(Config.ENVIRONMENT_NAME).upper()}_URL'
+        return getattr(Config, ms_config_property)

--- a/services/core-api/app/api/variances/models/variance.py
+++ b/services/core-api/app/api/variances/models/variance.py
@@ -186,6 +186,6 @@ class Variance(SoftDeleteMixin, AuditMixin, Base):
         body += f'<p><b>Description: </b>{self.note}</p>'
         body += f'<p><b>Applied for By: </b>{self.created_by}</p>'
 
-        link = f'{Config.CORE_PRODUCTION_URL}/mine-dashboard/{self.mine.mine_guid}/permits-and-approvals/variances/'
+        link = f'{Config.CORE_PROD_URL}/mine-dashboard/{self.mine.mine_guid}/permits-and-approvals/variances/'
         body += f'<p>View updates in Core: <a href="{link}" target="_blank">{link}</a></p>'
         EmailService.send_email(subject, recipients, body)

--- a/services/core-api/app/config.py
+++ b/services/core-api/app/config.py
@@ -119,8 +119,22 @@ class Config(object):
     ENVIRONMENT_NAME = os.environ.get('ENVIRONMENT_NAME', 'dev')
     CORE_PRODUCTION_URL = os.environ.get('CORE_PRODUCTION_URL',
                                          'https://minesdigitalservices.gov.bc.ca')
+    CORE_TEST_URL = os.environ.get('CORE_TEST_URL',
+                                         'https://mds-test.apps.silver.devops.gov.bc.ca')
+    CORE_DEV_URL = os.environ.get('CORE_DEV_URL',
+                                         'https://mds-dev.apps.silver.devops.gov.bc.ca')
+    CORE_LOCAL_URL = os.environ.get('CORE_LOCAL_URL',
+                                         'http://localhost:3000')
+    
     MINESPACE_PRODUCTION_URL = os.environ.get('MINESPACE_PRODUCTION_URL',
                                               'https://minespace.gov.bc.ca')
+    MINESPACE_TEST_URL = os.environ.get('MINESPACE_TEST_URL',
+                                              'https://minespace-test.apps.silver.devops.gov.bc.ca')
+    MINESPACE_DEV_URL = os.environ.get('MINESPACE_DEV_URL',
+                                              'https://minespace-dev.apps.silver.devops.gov.bc.ca')
+    MINESPACE_LOCAL_URL = os.environ.get('MINESPACE_LOCAL_URL',
+                                              'http://localhost:3020')
+    
     MDS_NO_REPLY_EMAIL = os.environ.get('MDS_NO_REPLY_EMAIL', 'noreply-mds@gov.bc.ca')
     MDS_EMAIL = os.environ.get('MDS_EMAIL', 'mds@gov.bc.ca')
     MAJOR_MINES_OFFICE_EMAIL = os.environ.get('MAJOR_MINES_OFFICE_EMAIL', 'PermRecl@gov.bc.ca')

--- a/services/core-api/app/config.py
+++ b/services/core-api/app/config.py
@@ -117,7 +117,7 @@ class Config(object):
     NRIS_USER_NAME = os.environ.get('NRIS_USER_NAME', None)
     NRIS_PASS = os.environ.get('NRIS_PASS', None)
     ENVIRONMENT_NAME = os.environ.get('ENVIRONMENT_NAME', 'dev')
-    CORE_PRODUCTION_URL = os.environ.get('CORE_PRODUCTION_URL',
+    CORE_PROD_URL = os.environ.get('CORE_PRODUCTION_URL',
                                          'https://minesdigitalservices.gov.bc.ca')
     CORE_TEST_URL = os.environ.get('CORE_TEST_URL',
                                          'https://mds-test.apps.silver.devops.gov.bc.ca')
@@ -126,7 +126,7 @@ class Config(object):
     CORE_LOCAL_URL = os.environ.get('CORE_LOCAL_URL',
                                          'http://localhost:3000')
     
-    MINESPACE_PRODUCTION_URL = os.environ.get('MINESPACE_PRODUCTION_URL',
+    MINESPACE_PROD_URL = os.environ.get('MINESPACE_PRODUCTION_URL',
                                               'https://minespace.gov.bc.ca')
     MINESPACE_TEST_URL = os.environ.get('MINESPACE_TEST_URL',
                                               'https://minespace-test.apps.silver.devops.gov.bc.ca')


### PR DESCRIPTION
## Objective 

[MDS-5895](https://bcmines.atlassian.net/browse/MDS-5895)

-Report email links were always pointing to production regardless of environment, just adding adjustment
to point to the url depending on environment.
