### PR TITLE
[MDS-5899] - now by now numbers

### DIFF
--- a/services/core-api/app/api/now_applications/namespace.py
+++ b/services/core-api/app/api/now_applications/namespace.py
@@ -1,6 +1,8 @@
 from flask_restx import Namespace
 
 from app.api.now_applications.resources.now_application_import_resource import NOWApplicationImportResource
+from app.api.now_applications.resources.now_application_now_numbers_list_resource import \
+    NOWApplicationNOWNumbersListResource
 from app.api.now_applications.resources.now_application_resource import NOWApplicationResource
 from app.api.now_applications.resources.now_application_list_resource import NOWApplicationListResource
 from app.api.now_applications.resources.now_activity_type_resource import NOWActivityTypeResource
@@ -24,6 +26,7 @@ from app.api.now_applications.resources.now_application_import_submission_docume
 api = Namespace('now-applications', description='Core Notice of Work operations')
 
 api.add_resource(NOWApplicationListResource, '')
+api.add_resource(NOWApplicationNOWNumbersListResource, '/now-numbers')
 api.add_resource(NOWApplicationImportResource, '/<string:application_guid>/import')
 api.add_resource(NOWApplicationImportSubmissionDocumentsJobResource,
                  '/<string:application_guid>/import-submission-documents-job')

--- a/services/core-api/app/api/now_applications/resources/now_application_base_list_resource.py
+++ b/services/core-api/app/api/now_applications/resources/now_application_base_list_resource.py
@@ -1,0 +1,124 @@
+from flask_restx import Resource
+from sqlalchemy import and_, func, or_
+from sqlalchemy_filters import apply_sort, apply_pagination
+
+from app.api.mines.mine.models.mine import Mine
+from app.api.now_applications.models import ApplicationsView
+from app.api.utils.custom_reqparser import CustomReqparser
+from app.api.utils.resources_mixins import UserMixin
+
+PAGE_DEFAULT = 1
+PER_PAGE_DEFAULT = 25
+SORT_FIELD_DEFAULT = 'received_date'
+SORT_DIR_DEFAULT = 'desc'
+
+class NowApplicationBaseListResource(Resource, UserMixin):
+    parser = CustomReqparser()
+
+    def _apply_filters_and_pagination(self,
+                                      page_number=PAGE_DEFAULT,
+                                      page_size=PER_PAGE_DEFAULT,
+                                      sort_field=None,
+                                      sort_dir=None,
+                                      mine_guid=None,
+                                      lead_inspector_name=None,
+                                      issuing_inspector_name=None,
+                                      notice_of_work_type_description=[],
+                                      mine_region=[],
+                                      mine_name=None,
+                                      now_number=None,
+                                      mine_search=None,
+                                      now_application_status_description=[],
+                                      originating_system=[],
+                                      submissions_only=None,
+                                      import_timestamp_since=None,
+                                      update_timestamp_since=None,
+                                      application_type=None,
+                                      permit_no=None,
+                                      party=None,
+                                      now_numbers=None):
+
+        filters = []
+        base_query = ApplicationsView.query
+        if now_numbers is not None:
+            filters.append(ApplicationsView.now_number.in_(now_numbers))
+
+        if application_type:
+            filters.append(ApplicationsView.application_type_code == application_type)
+
+        if submissions_only:
+            filters.append(
+                and_(ApplicationsView.originating_system != None,
+                     ApplicationsView.originating_system != 'MMS'))
+
+        if mine_guid:
+            filters.append(ApplicationsView.mine_guid == mine_guid)
+
+        if lead_inspector_name:
+            filters.append(
+                func.lower(ApplicationsView.lead_inspector_name).contains(
+                    func.lower(lead_inspector_name)))
+
+        if issuing_inspector_name:
+            filters.append(
+                func.lower(ApplicationsView.issuing_inspector_name).contains(
+                    func.lower(issuing_inspector_name)))
+
+        if notice_of_work_type_description:
+            filters.append(
+                ApplicationsView.notice_of_work_type_description.in_(
+                    notice_of_work_type_description))
+
+        if now_number:
+            filters.append(ApplicationsView.now_number == now_number)
+
+        if mine_region or mine_search or mine_name:
+            base_query = base_query.join(Mine)
+
+        if mine_region:
+            filters.append(Mine.mine_region.in_(mine_region))
+
+        if originating_system:
+            filters.append(ApplicationsView.originating_system.in_(originating_system))
+
+        if mine_name:
+            filters.append(func.lower(Mine.mine_name).contains(func.lower(mine_name)))
+
+        if mine_search:
+            filters.append(
+                or_(
+                    func.lower(ApplicationsView.mine_no).contains(func.lower(mine_search)),
+                    func.lower(Mine.mine_name).contains(func.lower(mine_search)),
+                    func.lower(Mine.mine_no).contains(func.lower(mine_search))))
+
+        if permit_no:
+            filters.append(func.lower(ApplicationsView.permit_no).contains(func.lower(str(permit_no))))
+
+        if party:
+            filters.append(func.lower(ApplicationsView.party).contains(func.lower(str(party))))
+
+        if now_application_status_description:
+            filters.append(
+                ApplicationsView.now_application_status_description.in_(
+                    now_application_status_description))
+
+        if import_timestamp_since:
+            filters.append(ApplicationsView.import_timestamp >= import_timestamp_since)
+
+        if update_timestamp_since:
+            filters.append(ApplicationsView.update_timestamp >= update_timestamp_since)
+        base_query = base_query.filter(*filters)
+
+        if sort_field and sort_dir:
+            sort_criteria = None
+            if sort_field in ['mine_region', 'mine_name']:
+                sort_criteria = [{'model': 'Mine', 'field': sort_field, 'direction': sort_dir}]
+            else:
+                sort_criteria = [{
+                    'model': 'ApplicationsView',
+                    'field': sort_field,
+                    'direction': sort_dir,
+                }]
+            base_query = apply_sort(base_query, sort_criteria)
+
+        return apply_pagination(base_query, page_number, page_size)

--- a/services/core-api/app/api/now_applications/resources/now_application_now_numbers_list_resource.py
+++ b/services/core-api/app/api/now_applications/resources/now_application_now_numbers_list_resource.py
@@ -1,0 +1,88 @@
+from flask import request
+from flask_restx import Resource, inputs
+
+from app.api.now_applications.resources.now_application_base_list_resource import NowApplicationBaseListResource
+from app.api.now_applications.response_models import NOW_VIEW_LIST
+from app.api.utils.access_decorators import requires_any_of, VIEW_ALL, GIS
+from app.api.utils.custom_reqparser import CustomReqparser
+from app.api.utils.resources_mixins import UserMixin
+from app.extensions import api
+
+PAGE_DEFAULT = 1
+PER_PAGE_DEFAULT = 25
+SORT_FIELD_DEFAULT = 'received_date'
+SORT_DIR_DEFAULT = 'desc'
+
+
+class NOWApplicationNOWNumbersListResource(NowApplicationBaseListResource):
+    parser = CustomReqparser()
+    parser.add_argument('now_numbers', type=list, location='json', required=False)
+
+    @api.doc(description='Fetch NoW applications by list of now_numbers.', params={
+            'page': f'The page number of paginated records to return. Default: {PAGE_DEFAULT}',
+            'per_page': f'The number of records to return per page. Default: {PER_PAGE_DEFAULT}',
+            'sort_field': f'The field to sort on. Default: {SORT_FIELD_DEFAULT}',
+            'sort_dir': f'The direction to sort on, accepts asc|desc. Default: {SORT_DIR_DEFAULT}',
+            'now_application_status_description':
+            'Comma-separated list of statuses to include in results. Default: All statuses.',
+            'notice_of_work_type_description': 'Substring to match with a NoW\'s type',
+            'now_number': 'Number of the NoW',
+            'mine_region': 'Mine region code to match with a NoW. Default: All regions.',
+            'mine_name': 'Substring to match against a mine name',
+            'mine_guid': 'filter by a given mine guid',
+            'permit_no': 'filter by a given permit number',
+            'party': 'filter by a given party name',
+            'permit_guid': 'filter by a given permit guid',
+            'mine_search': 'Substring to match against a NoW mine number or mine name',
+            'submissions_only': 'Boolean to filter based on NROS/VFCBC/Core submissions only',
+            'lead_inspector_name': 'Substring to match against a lead inspector\'s name',
+            'issuing_inspector_name': 'Substring to match against an issuing inspector\'s name',
+            'import_timestamp_since': 'Filter by applications created since this date.',
+            'update_timestamp_since': 'Filter by applications updated since this date.',
+            'application_type': 'Application type NOW or ADA.',
+            'originating_system': 'System that the application was submitted through (ex: Core, MMS, VFCBC). Default: All systems',
+        })
+    @requires_any_of([VIEW_ALL, GIS])
+    @api.marshal_with(NOW_VIEW_LIST, code=200)
+    def post(self):
+        now_numbers = self.parser.parse_args()['now_numbers']
+
+        records, pagination_details = self._apply_filters_and_pagination(
+            page_number=request.args.get('page', PAGE_DEFAULT, type=int),
+            page_size=request.args.get('per_page', PER_PAGE_DEFAULT, type=int),
+            sort_field=request.args.get('sort_field', SORT_FIELD_DEFAULT, type=str),
+            sort_dir=request.args.get('sort_dir', SORT_DIR_DEFAULT, type=str),
+            originating_system=request.args.getlist('originating_system', type=str),
+            mine_guid=request.args.get('mine_guid', type=str),
+            now_application_status_description=request.args.getlist(
+                'now_application_status_description', type=str),
+            notice_of_work_type_description=request.args.getlist(
+                'notice_of_work_type_description', type=str),
+            mine_region=request.args.getlist('mine_region', type=str),
+            mine_name=request.args.get('mine_name', type=str),
+            now_number=request.args.get('now_number', type=str),
+            mine_search=request.args.get('mine_search', type=str),
+            lead_inspector_name=request.args.get('lead_inspector_name', type=str),
+            issuing_inspector_name=request.args.get('issuing_inspector_name', type=str),
+            submissions_only=request.args.get('submissions_only', type=str) in ['true', 'True'],
+            import_timestamp_since=request.args.get(
+                'import_timestamp_since',
+                type=lambda x: inputs.datetime_from_iso8601(x) if x else None),
+            update_timestamp_since=request.args.get(
+                'update_timestamp_since',
+                type=lambda x: inputs.datetime_from_iso8601(x) if x else None),
+            application_type=request.args.get('application_type', type=str),
+            permit_no=request.args.get('permit_no', type=str),
+            party=request.args.get('party', type=str),
+            now_numbers=now_numbers,
+        )
+
+        data = records.all()
+
+        return {
+            'records': data,
+            'current_page': pagination_details.page_number,
+            'total_pages': pagination_details.num_pages,
+            'items_per_page': pagination_details.page_size,
+            'total': pagination_details.total_results,
+        }

--- a/services/core-api/tests/now_applications/resources/test_now_application_now_numbers_list_resource.py
+++ b/services/core-api/tests/now_applications/resources/test_now_application_now_numbers_list_resource.py
@@ -1,0 +1,43 @@
+import json
+
+from tests.now_application_factories import NOWApplicationIdentityFactory
+
+
+class TestApplicationNowNumbersResource:
+    """POST /now-applications/now-numbers"""
+
+    def test_get_now_application_no_now_number_success(self, test_client, db_session, auth_headers):
+        num_created = 3
+        NOWApplicationIdentityFactory.create_batch(size=num_created)
+
+        post_resp = test_client.post(f'/now-applications/now-numbers', headers=auth_headers['full_auth_header'])
+        assert post_resp.status_code == 200, post_resp.response
+        get_data = json.loads(post_resp.data.decode())
+        assert len(get_data['records']) == num_created
+
+    def test_get_now_application_by_now_number_success_filter_by_guid(self, test_client, db_session,
+                                                                      auth_headers):
+        num_created = 3
+        NOWApplicationlist = NOWApplicationIdentityFactory.create_batch(size=num_created)
+
+        post_resp = test_client.post(
+            f'/now-applications/now-numbers?mine_guid={NOWApplicationlist[0].mine_guid}',
+            headers=auth_headers['full_auth_header'])
+        assert post_resp.status_code == 200, post_resp.response
+        get_data = json.loads(post_resp.data.decode())
+        assert len(get_data['records']) == 1
+
+    def test_get_now_application_by_now_number_success(self, test_client, db_session, auth_headers):
+        num_created = 3
+        NOWApplicationList = NOWApplicationIdentityFactory.create_batch(size=num_created)
+
+        payload = {
+            'now_numbers': [str(NOWApplicationList[0].now_number), str(NOWApplicationList[1].now_number)]
+        }
+
+        post_resp = test_client.post(
+            f'/now-applications/now-numbers', json=payload, headers=auth_headers['full_auth_header'])
+
+        assert post_resp.status_code == 200, post_resp.response
+        response_data = json.loads(post_resp.get_data(as_text=True))
+        assert len(response_data['records']) == 2


### PR DESCRIPTION
## Objective 

- Created a new post endpoint for fetching a list of NoW.
- A `post` endpoint is being utilized due to the expected high number of passed numbers (200+)
- Refactored current now_application list resource to have a base class that could be shared with the new resource (since the filtering logic is quite complex and is used in the new resource as well)

POST `{{baseUrl}}/now-applications/now-numbers`

Payload:

{
    "now_numbers": ["1","2","3"]
}

[MDS-5899](https://bcmines.atlassian.net/browse/MDS-5899)


