### PR TITLE
[FIX] BE condition to check AMS terms agreed

### DIFF
--- a/services/core-api/app/api/projects/project_summary/models/project_summary.py
+++ b/services/core-api/app/api/projects/project_summary/models/project_summary.py
@@ -350,8 +350,10 @@ class ProjectSummary(SoftDeleteMixin, AuditMixin, Base):
     def validate_new_submission(self, new_data):
         ams_terms_agreed = new_data.get('ams_terms_agreed')
         confirmation_of_submission = new_data.get('confirmation_of_submission')
-        ams_authorizations = new_data.get('ams_authorizations')
-        ams_condition = ams_terms_agreed or ams_authorizations == None
+        ams_authorizations = new_data.get('ams_authorizations', {})
+        ams_new = ams_authorizations.get('new', [])
+        ams_amendments = ams_authorizations.get('amendments', [])
+        ams_condition = ams_terms_agreed or (len(ams_new) == 0 and len(ams_amendments) == 0)
         terms_agreed = ams_condition and confirmation_of_submission
 
         if not terms_agreed:

--- a/services/core-api/tests/projects/project_summaries/resources/test_project_summary_resource.py
+++ b/services/core-api/tests/projects/project_summaries/resources/test_project_summary_resource.py
@@ -139,6 +139,33 @@ def test_update_project_summary_bad_request_without_terms_ams_auths(test_client,
     assert put_resp.status_code == 400
     assert put_data['message'] == "400 Bad Request: Please agree to the terms and conditions of submission"
 
+def test_submit_project_summary_without_ams_auths(test_client, db_session, auth_headers):
+    '''Project summary submitted without AMS authorizations submitted successfully'''
+    project = ProjectFactory(project_summary=0)
+    project_summary = ProjectSummaryFactory(project=project)
+    party = PartyFactory(person=True)
+
+    data = {}
+    data['documents'] = []
+    data['mine_guid'] = project_summary.project.mine_guid
+    data['project_summary_title'] = project_summary.project_summary_title
+    data['status_code'] = 'SUB'
+    data['confirmation_of_submission'] = True
+    data['ams_authorizations'] = {
+        'amendments': [],
+        'new': []
+    }
+    data['project_lead_party_guid'] = party.party_guid
+
+    put_resp = test_client.put(
+        f'/projects/{project.project_guid}/project-summaries/{project_summary.project_summary_guid}',
+        headers=auth_headers['full_auth_header'],
+        json=data)
+    put_data = json.loads(put_resp.data.decode())
+
+    # should not be bad request
+    assert put_resp.status_code == 200
+
 def test_update_project_summary_with_ams_auths(test_client, db_session, auth_headers):
     '''AMS authorizations are posted successfully'''
     project = ProjectFactory(project_summary=0)


### PR DESCRIPTION
## Objective 
- condition was incorrect on whether to check if "ams_terms_agreed" box was checked- was looking for `None` when it should have been looking for data shaped like `{amendments: [], new: []}`
- BE test to match

[MDS-5844](https://bcmines.atlassian.net/browse/MDS-5844)

_Why are you making this change? Provide a short explanation and/or screenshots_
