### PR TITLE
[MDS-5915] Fix company alias bug.

### DIFF
--- a/services/minespace-web/src/components/Forms/projects/projectSummary/Applicant.tsx
+++ b/services/minespace-web/src/components/Forms/projects/projectSummary/Applicant.tsx
@@ -96,6 +96,10 @@ const Applicant = () => {
         };
         setVerifiedCredential(payload);
       });
+
+      if (credential_id !== credential.id)
+        dispatch(change(FORM.ADD_EDIT_PROJECT_SUMMARY, "company_alias", null));
+
       dispatch(change(FORM.ADD_EDIT_PROJECT_SUMMARY, "applicant.credential_id", credential.id));
       const orgBookEntity = {
         registration_id: credential.topic.source_id,
@@ -109,7 +113,6 @@ const Applicant = () => {
       dispatch(
         change(FORM.ADD_EDIT_PROJECT_SUMMARY, "applicant.party_orgbook_entity", orgBookEntity)
       );
-      dispatch(change(FORM.ADD_EDIT_PROJECT_SUMMARY, "company_alias", null));
     }
   }, [credential]);
 


### PR DESCRIPTION
## Objective 

[MDS-5915](https://bcmines.atlassian.net/browse/MDS-5915)

_Why are you making this change? Provide a short explanation and/or screenshots_

In the previous version of the code, there was a bug that resulted in the company alias data being set to null. This bug has been addressed in the updated code, which ensures that the company alias data is only set to null when the new company orgbook is selected. This fix resolves the issue and ensures that the company alias data is properly handled.