### PR TITLE
[MDS-5707] Updated tsf history text and format date column to match designs 

### DIFF
--- a/services/common/src/components/tailings/BasicInformation.tsx
+++ b/services/common/src/components/tailings/BasicInformation.tsx
@@ -32,12 +32,15 @@ export interface BasicInformationProps {
   showUpdateTimestamp: boolean;
   renderConfig: any;
   tsf: ITailingsStorageFacility;
+  mineName: string;
   canEditTSF?: boolean;
   isEditMode: boolean;
 }
 
 // Provide a mapping of the field names to the title and data for the field
 // This is used to display the field names and values in a more user-friendly way in the history modal
+// Defaults to Title Case for field names and keeping values as is for any fields where
+// a field mapping is not provided
 const historyDiffValueMapper = {
   facility_type: {
     title: "Facility Type",
@@ -78,7 +81,7 @@ const historyDiffValueMapper = {
 };
 
 export const BasicInformation: FC<BasicInformationProps> = (props) => {
-  const { permits, renderConfig, canEditTSF = false, tsf, isEditMode } = props;
+  const { permits, renderConfig, canEditTSF = false, tsf, isEditMode, mineName } = props;
   const [permitOptions, setPermitOptions] = useState([]);
   const [diffModalOpen, setDiffModalOpen] = useState(false);
 
@@ -224,7 +227,8 @@ export const BasicInformation: FC<BasicInformationProps> = (props) => {
         open={diffModalOpen}
         onCancel={() => setDiffModalOpen(false)}
         valueMapper={historyDiffValueMapper}
-        tsf={tsf}
+        mineName={mineName}
+        tsfName={tsf.mine_tailings_storage_facility_name}
         history={tsf.history}
       />
     </>

--- a/services/common/src/components/tailings/TailingsDiffModal.tsx
+++ b/services/common/src/components/tailings/TailingsDiffModal.tsx
@@ -1,11 +1,12 @@
 import { Button, Modal, Table, Typography } from "antd";
 import React, { FC } from "react";
 import DiffColumn from "../history/DiffColumn";
-import { ITailingsStorageFacility } from "@mds/common/interfaces/tailingsStorageFacility";
 import { DiffColumnValueMapper, IDiffColumn, IDiffEntry } from "../history/DiffColumn.interface";
+import { formatDate } from "@mds/common/redux/utils/helpers";
 
 interface ITailingsDiffModal {
-  tsf: ITailingsStorageFacility;
+  mineName: string;
+  tsfName: string;
   history: IDiffEntry[];
   open: boolean;
   valueMapper: DiffColumnValueMapper;
@@ -13,7 +14,8 @@ interface ITailingsDiffModal {
 }
 
 const TailingsDiffModal: FC<ITailingsDiffModal> = ({
-  tsf,
+  mineName,
+  tsfName,
   history,
   open = false,
   onCancel,
@@ -34,6 +36,7 @@ const TailingsDiffModal: FC<ITailingsDiffModal> = ({
       title: "Date",
       key: "updated_at",
       dataIndex: "updated_at",
+      render: (date: string) => formatDate(date),
     },
     {
       title: "Changes",
@@ -59,7 +62,7 @@ const TailingsDiffModal: FC<ITailingsDiffModal> = ({
     >
       <Typography.Title level={3}>View History</Typography.Title>
       <Typography.Paragraph>
-        You are viewing the past history of tailings storage facility for this mine.
+        You are viewing the past history of {tsfName} for this mine <b>({mineName})</b>
       </Typography.Paragraph>
       <Table
         className="diff-table"

--- a/services/core-web/common/components/tailings/TailingsSummaryPage.tsx
+++ b/services/core-web/common/components/tailings/TailingsSummaryPage.tsx
@@ -287,6 +287,7 @@ export const TailingsSummaryPage: FC<InjectedFormProps<ITailingsStorageFacility>
         >
           <Step key="basic-information">
             <BasicInformation
+              mineName={mineName}
               renderConfig={renderConfig}
               canEditTSF={canEditTSF}
               isEditMode={isUserActionEdit}

--- a/services/minespace-web/common/components/tailings/TailingsSummaryPage.tsx
+++ b/services/minespace-web/common/components/tailings/TailingsSummaryPage.tsx
@@ -287,6 +287,7 @@ export const TailingsSummaryPage: FC<InjectedFormProps<ITailingsStorageFacility>
         >
           <Step key="basic-information">
             <BasicInformation
+              mineName={mineName}
               renderConfig={renderConfig}
               canEditTSF={canEditTSF}
               isEditMode={isUserActionEdit}


### PR DESCRIPTION
## Objective 

[MDS-5707](https://bcmines.atlassian.net/browse/MDS-5707)

Updated tsf history text and format date column to match designs 
<img width="1234" alt="image" src="https://github.com/bcgov/mds/assets/66635118/feab5537-dccb-4429-8421-7b289d295b27">
