### PR TITLE
[MDS-5707] Added missing View all role to TSF endpoint

### DIFF
--- a/services/core-api/app/api/mines/tailings/resources/tailings.py
+++ b/services/core-api/app/api/mines/tailings/resources/tailings.py
@@ -12,7 +12,7 @@ from app.api.mines.mine.models.mine import Mine
 from app.api.mines.response_models import MINE_TSF_DETAIL_MODEL, MINE_TSF_MODEL
 from app.api.mines.tailings.models.tailings import MineTailingsStorageFacility, FacilityType
 from app.api.parties.party_appt.models.mine_party_appt import MinePartyAppointment
-from app.api.utils.access_decorators import requires_any_of, EDIT_TSF, MINESPACE_PROPONENT, is_minespace_user
+from app.api.utils.access_decorators import VIEW_ALL, requires_any_of, EDIT_TSF, MINESPACE_PROPONENT, is_minespace_user
 from app.api.utils.resources_mixins import UserMixin
 from app.extensions import api
 
@@ -88,7 +88,7 @@ class MineTailingsStorageFacilityResource(Resource, UserMixin):
         store_missing=False)
 
     @api.doc(description='Get a tailing storage facility for the given mine')
-    @requires_any_of([MINESPACE_PROPONENT, EDIT_TSF])
+    @requires_any_of([MINESPACE_PROPONENT, EDIT_TSF, VIEW_ALL])
     @api.marshal_with(MINE_TSF_DETAIL_MODEL)
     def get(self, mine_guid, mine_tailings_storage_facility_guid):
         mine = Mine.find_by_mine_guid(mine_guid)

--- a/services/core-api/tests/auth/test_expected_auth.py
+++ b/services/core-api/tests/auth/test_expected_auth.py
@@ -88,7 +88,7 @@ from app.api.mines.alerts.resources.mine_alert import GlobalMineAlertListResourc
      (MineTailingsStorageFacilityListResource, "get", [VIEW_ALL]),
      (MineTailingsStorageFacilityListResource, "post", [MINESPACE_PROPONENT, EDIT_TSF]),
      (MineTailingsStorageFacilityResource, "put", [EDIT_TSF, MINESPACE_PROPONENT]),
-     (MineTailingsStorageFacilityResource, "put", [EDIT_TSF, MINESPACE_PROPONENT, VIEW_ALL]),
+     (MineTailingsStorageFacilityResource, "get", [EDIT_TSF, MINESPACE_PROPONENT, VIEW_ALL]),
      (MineTenureTypeCodeResource, "get", [VIEW_ALL]), (MineTypeListResource, "post", [MINE_EDIT]),
      (MineTypeResource, "delete", [MINE_EDIT]),
      (MineVarianceDocumentUploadResource, "post", [EDIT_VARIANCE, MINESPACE_PROPONENT]),

--- a/services/core-api/tests/auth/test_expected_auth.py
+++ b/services/core-api/tests/auth/test_expected_auth.py
@@ -88,6 +88,7 @@ from app.api.mines.alerts.resources.mine_alert import GlobalMineAlertListResourc
      (MineTailingsStorageFacilityListResource, "get", [VIEW_ALL]),
      (MineTailingsStorageFacilityListResource, "post", [MINESPACE_PROPONENT, EDIT_TSF]),
      (MineTailingsStorageFacilityResource, "put", [EDIT_TSF, MINESPACE_PROPONENT]),
+     (MineTailingsStorageFacilityResource, "put", [EDIT_TSF, MINESPACE_PROPONENT, VIEW_ALL]),
      (MineTenureTypeCodeResource, "get", [VIEW_ALL]), (MineTypeListResource, "post", [MINE_EDIT]),
      (MineTypeResource, "delete", [MINE_EDIT]),
      (MineVarianceDocumentUploadResource, "post", [EDIT_VARIANCE, MINESPACE_PROPONENT]),


### PR DESCRIPTION
## Objective 

[MDS-5707](https://bcmines.atlassian.net/browse/MDS-5707)

Added missing `VIEW_ALL` role to the TSF retrieval endpoint.