### PR TITLE
[MDS-5707] Added missing generate_history_table_migration make command, ignore guids in history table

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,6 +141,12 @@ clean: stop |
 	@docker rmi -f mds_postgres mds_backend mds_frontend mds_flyway
 	@docker volume rm mds_postgres_data -f
 
+# Generates a migration file to support versioning of the specified table
+# Usage: make generate_history_table_migration TABLE=<table_name>
+generate_history_table_migration:
+	@echo "+\n++ Generating history table migration ...\n+"
+	@docker compose $(DC_FILE) exec backend bash -c "flask generate_history_table_migration $(TABLE)"
+
 # initial project setup for local/codespaces development
 init:
 	@./bin/setup_codespaces.sh

--- a/services/common/src/components/history/DiffColumn.tsx
+++ b/services/common/src/components/history/DiffColumn.tsx
@@ -16,17 +16,19 @@ const DiffColumn: React.FC<DiffColumnProps> = ({ differences, valueMapper }) => 
    * If a valueMapper is not provided or a the given field does not have a corresponding mapping,
    * the field_name will be formatted to sentence case for easier readability.
    */
-  const mappedDifferences = differences.map((change) => {
-    const mapper = valueMapper ? valueMapper[change.field_name] : null;
-    const fromMapped = mapper?.data?.find((data) => data.value === change.from);
-    const toMapped = mapper?.data?.find((data) => data.value === change.to);
+  const mappedDifferences = differences
+    .filter((change) => !change.field_name?.endsWith("_guid")) // Ignore any fields we can reasonably assume the user doesn't care about
+    .map((change) => {
+      const mapper = valueMapper ? valueMapper[change.field_name] : null;
+      const fromMapped = mapper?.data?.find((data) => data.value === change.from);
+      const toMapped = mapper?.data?.find((data) => data.value === change.to);
 
-    return {
-      field_name: mapper?.title ?? formatSnakeCaseToSentenceCase(change.field_name, "_"),
-      from: fromMapped?.label || change.from,
-      to: toMapped?.label || change.to,
-    };
-  });
+      return {
+        field_name: mapper?.title ?? formatSnakeCaseToSentenceCase(change.field_name, "_"),
+        from: fromMapped?.label || change.from,
+        to: toMapped?.label || change.to,
+      };
+    });
 
   return (
     <div className="padding-md--top">


### PR DESCRIPTION
## Objective 

[MDS-5707](https://bcmines.atlassian.net/browse/MDS-5707)

Had the `make generate_history_table_migration` command in my stashed changes, so included that one.

Made the DiffColumn component ignore any columns ending with `_guid`
