### PR TITLE
[MDS-5491] fix icon align issue, update snapshot test.

### DIFF
--- a/services/minespace-web/src/components/dashboard/mine/MineDashboardRoutes.tsx
+++ b/services/minespace-web/src/components/dashboard/mine/MineDashboardRoutes.tsx
@@ -13,76 +13,76 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
   faHouse,
   faFiles,
-  faCircleCheck,
+  faFileCircleCheck,
   faClipboardList,
   faBrakeWarning,
   faHexagonExclamation,
   faDiamondTurnRight,
   faShieldKeyhole,
   faHouseWater,
+  faUserMagnifyingGlass,
 } from "@fortawesome/pro-light-svg-icons";
-import { faBuildingMagnifyingGlass } from "@fortawesome/pro-solid-svg-icons";
 
 export const getMineDashboardRoutes = (isMajorMine: boolean) =>
   [
     {
       key: "overview",
       label: "Overview",
-      icon: <FontAwesomeIcon icon={faHouse} />,
+      icon: <FontAwesomeIcon icon={faHouse} style={{ width: "24px" }} />,
       component: Overview,
     },
     isMajorMine && {
       key: "applications",
       label: "Applications",
-      icon: <FontAwesomeIcon icon={faFiles} />,
+      icon: <FontAwesomeIcon icon={faFiles} style={{ width: "24px" }} />,
       component: Projects,
     },
     {
       key: "permits",
       label: "Permits",
-      icon: <FontAwesomeIcon icon={faCircleCheck} />,
+      icon: <FontAwesomeIcon icon={faFileCircleCheck} style={{ width: "24px" }} />,
       component: PermitTabContainer,
     },
     {
       key: "inspections",
       label: "Inspections",
-      icon: <FontAwesomeIcon icon={faBuildingMagnifyingGlass as any} />,
+      icon: <FontAwesomeIcon icon={faUserMagnifyingGlass} style={{ width: "24px" }} />,
       component: Inspections,
     },
     {
       key: "reports",
       label: "Reports",
-      icon: <FontAwesomeIcon icon={faClipboardList} />,
+      icon: <FontAwesomeIcon icon={faClipboardList} style={{ width: "24px" }} />,
       component: Reports,
     },
     {
       key: "incidents",
       label: "Incidents",
-      icon: <FontAwesomeIcon icon={faBrakeWarning} />,
+      icon: <FontAwesomeIcon icon={faBrakeWarning} style={{ width: "24px" }} />,
       component: Incidents,
     },
     {
       key: "nods",
       label: "Notices of Departure",
-      icon: <FontAwesomeIcon icon={faHexagonExclamation} />,
+      icon: <FontAwesomeIcon icon={faHexagonExclamation} style={{ width: "24px" }} />,
       component: NoticesOfDeparture,
     },
     {
       key: "variances",
       label: "Variances",
-      icon: <FontAwesomeIcon icon={faDiamondTurnRight} />,
+      icon: <FontAwesomeIcon icon={faDiamondTurnRight} style={{ width: "24px" }} />,
       component: Variances,
     },
     {
       key: "bonds",
       label: "Bonds",
-      icon: <FontAwesomeIcon icon={faShieldKeyhole} />,
+      icon: <FontAwesomeIcon icon={faShieldKeyhole} style={{ width: "24px" }} />,
       component: Bonds,
     },
     {
       key: "tailings",
       label: "Tailings & Dams",
-      icon: <FontAwesomeIcon icon={faHouseWater} />,
+      icon: <FontAwesomeIcon icon={faHouseWater} style={{ width: "24px" }} />,
       component: Tailings,
     },
   ].filter(Boolean);

--- a/services/minespace-web/src/tests/components/dashboard/mine/__snapshots__/MineDashboard.spec.tsx.snap
+++ b/services/minespace-web/src/tests/components/dashboard/mine/__snapshots__/MineDashboard.spec.tsx.snap
@@ -47,6 +47,7 @@ exports[`MineDashboard renders properly 1`] = `
             data-prefix="fal"
             focusable="false"
             role="img"
+            style="width: 24px;"
             viewBox="0 0 576 512"
             xmlns="http://www.w3.org/2000/svg"
           >
@@ -70,16 +71,17 @@ exports[`MineDashboard renders properly 1`] = `
         >
           <svg
             aria-hidden="true"
-            class="svg-inline--fa fa-circle-check ant-menu-item-icon"
-            data-icon="circle-check"
+            class="svg-inline--fa fa-file-circle-check ant-menu-item-icon"
+            data-icon="file-circle-check"
             data-prefix="fal"
             focusable="false"
             role="img"
-            viewBox="0 0 512 512"
+            style="width: 24px;"
+            viewBox="0 0 576 512"
             xmlns="http://www.w3.org/2000/svg"
           >
             <path
-              d="M256 32a224 224 0 1 1 0 448 224 224 0 1 1 0-448zm0 480A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM363.3 203.3c6.2-6.2 6.2-16.4 0-22.6s-16.4-6.2-22.6 0L224 297.4l-52.7-52.7c-6.2-6.2-16.4-6.2-22.6 0s-6.2 16.4 0 22.6l64 64c6.2 6.2 16.4 6.2 22.6 0l128-128z"
+              d="M64 480H296.2c9.8 11.8 21 22.3 33.5 31.3c-3.2 .5-6.4 .7-9.7 .7H64c-35.3 0-64-28.7-64-64V64C0 28.7 28.7 0 64 0H220.1c12.7 0 24.9 5.1 33.9 14.1L369.9 129.9c9 9 14.1 21.2 14.1 33.9v34.7c-11.2 3.2-21.9 7.4-32 12.6V192H240c-26.5 0-48-21.5-48-48V32H64C46.3 32 32 46.3 32 64V448c0 17.7 14.3 32 32 32zM351.5 160c-.7-2.8-2.1-5.4-4.2-7.4L231.4 36.7c-2.1-2.1-4.6-3.5-7.4-4.2V144c0 8.8 7.2 16 16 16H351.5zM432 480a112 112 0 1 0 0-224 112 112 0 1 0 0 224zm0-256a144 144 0 1 1 0 288 144 144 0 1 1 0-288zm67.3 100.7c6.2 6.2 6.2 16.4 0 22.6l-72 72c-6.2 6.2-16.4 6.2-22.6 0l-40-40c-6.2-6.2-6.2-16.4 0-22.6s16.4-6.2 22.6 0L416 385.4l60.7-60.7c6.2-6.2 16.4-6.2 22.6 0z"
               fill="currentColor"
             />
           </svg>
@@ -98,16 +100,17 @@ exports[`MineDashboard renders properly 1`] = `
         >
           <svg
             aria-hidden="true"
-            class="svg-inline--fa fa-building-magnifying-glass ant-menu-item-icon"
-            data-icon="building-magnifying-glass"
-            data-prefix="fas"
+            class="svg-inline--fa fa-user-magnifying-glass ant-menu-item-icon"
+            data-icon="user-magnifying-glass"
+            data-prefix="fal"
             focusable="false"
             role="img"
-            viewBox="0 0 603 512"
+            style="width: 24px;"
+            viewBox="0 0 640 512"
             xmlns="http://www.w3.org/2000/svg"
           >
             <path
-              d="M45.5 0C20.5 0 .3 20.2 .3 45.2V436.7c0 24.9 20.2 45.2 45.2 45.2h90.4V406.6c0-24.9 20.2-45.2 45.2-45.2s45.2 20.2 45.2 45.2v75.3h90.4c24.1 0 43.8-18.9 45.1-42.7c-53.1-23.3-90.3-76.3-90.3-138c0-10.3 1-20.4 3-30.1H256.3c-8.3 0-15.1-6.7-15.1-15.1V225.9c0-8.3 6.7-15.1 15.1-15.1h30.1c4.5 0 8.6 2 11.3 5.2c15.9-23.1 38-41.5 64-52.9V45.2c0-25-20.2-45.2-45.2-45.2H45.5zM60.6 225.9c0-8.3 6.7-15.1 15.1-15.1h30.1c8.3 0 15.1 6.7 15.1 15.1V256c0 8.3-6.7 15.1-15.1 15.1H75.6c-8.3 0-15.1-6.7-15.1-15.1V225.9zM166 210.8h30.1c8.3 0 15.1 6.7 15.1 15.1V256c0 8.3-6.7 15.1-15.1 15.1H166c-8.3 0-15.1-6.7-15.1-15.1V225.9c0-8.3 6.7-15.1 15.1-15.1zM75.6 90.4h30.1c8.3 0 15.1 6.7 15.1 15.1v30.1c0 8.3-6.7 15.1-15.1 15.1H75.6c-8.3 0-15.1-6.7-15.1-15.1V105.4c0-8.3 6.7-15.1 15.1-15.1zm75.3 15.1c0-8.3 6.7-15.1 15.1-15.1h30.1c8.3 0 15.1 6.7 15.1 15.1v30.1c0 8.3-6.7 15.1-15.1 15.1H166c-8.3 0-15.1-6.7-15.1-15.1V105.4zM256.3 90.4h30.1c8.3 0 15.1 6.7 15.1 15.1v30.1c0 8.3-6.7 15.1-15.1 15.1H256.3c-8.3 0-15.1-6.7-15.1-15.1V105.4c0-8.3 6.7-15.1 15.1-15.1zM422 226a75.3 75.3 0 1 1 0 150.6A75.3 75.3 0 1 1 422 226zm0 195.8c25.1 0 48.4-7.7 67.7-20.8l74.4 74.4c8.8 8.8 23.1 8.8 31.9 0s8.8-23.1 0-31.9L521.6 369c13.1-19.3 20.8-42.6 20.8-67.7c0-66.5-53.9-120.5-120.5-120.5s-120.5 53.9-120.5 120.5s53.9 120.5 120.5 120.5z"
+              d="M128 128a96 96 0 1 1 192 0 96 96 0 1 1 -192 0zM32 480c1.2-79.7 66.2-144 146.3-144h91.4c6.5 0 12.9 .4 19.2 1.2c-.6-5.7-.9-11.4-.9-17.2c0-5.1 .2-10.1 .7-15c-6.2-.7-12.6-1-19-1H178.3C79.8 304 0 383.8 0 482.3C0 498.7 13.3 512 29.7 512H418.3c16.4 0 29.7-13.3 29.7-29.7c0-.8 0-1.5 0-2.3H416 192 32zM224 256A128 128 0 1 0 224 0a128 128 0 1 0 0 256zm224-31.9a96 96 0 1 1 0 192 96 96 0 1 1 0-192zm0 224c29.6 0 56.8-10 78.5-26.9l86.2 86.2c6.2 6.2 16.4 6.2 22.6 0s6.2-16.4 0-22.6l-86.2-86.2C566 377 576 349.7 576 320.2c0-70.7-57.3-128-128-128s-128 57.3-128 128s57.3 128 128 128z"
               fill="currentColor"
             />
           </svg>
@@ -131,6 +134,7 @@ exports[`MineDashboard renders properly 1`] = `
             data-prefix="fal"
             focusable="false"
             role="img"
+            style="width: 24px;"
             viewBox="0 0 384 512"
             xmlns="http://www.w3.org/2000/svg"
           >
@@ -159,6 +163,7 @@ exports[`MineDashboard renders properly 1`] = `
             data-prefix="fal"
             focusable="false"
             role="img"
+            style="width: 24px;"
             viewBox="0 0 640 512"
             xmlns="http://www.w3.org/2000/svg"
           >
@@ -187,6 +192,7 @@ exports[`MineDashboard renders properly 1`] = `
             data-prefix="fal"
             focusable="false"
             role="img"
+            style="width: 24px;"
             viewBox="0 0 512 512"
             xmlns="http://www.w3.org/2000/svg"
           >
@@ -215,6 +221,7 @@ exports[`MineDashboard renders properly 1`] = `
             data-prefix="fal"
             focusable="false"
             role="img"
+            style="width: 24px;"
             viewBox="0 0 512 512"
             xmlns="http://www.w3.org/2000/svg"
           >
@@ -243,6 +250,7 @@ exports[`MineDashboard renders properly 1`] = `
             data-prefix="fal"
             focusable="false"
             role="img"
+            style="width: 24px;"
             viewBox="0 0 512 512"
             xmlns="http://www.w3.org/2000/svg"
           >
@@ -271,6 +279,7 @@ exports[`MineDashboard renders properly 1`] = `
             data-prefix="fal"
             focusable="false"
             role="img"
+            style="width: 24px;"
             viewBox="0 0 576 512"
             xmlns="http://www.w3.org/2000/svg"
           >


### PR DESCRIPTION
## Objective 

[MDS-5491](https://bcmines.atlassian.net/browse/MDS-5491)

_Why are you making this change? Provide a short explanation and/or screenshots_

- Update permits and inspections icons.
- Align labels and icons on the menu side bar.

![image](https://github.com/bcgov/mds/assets/72251620/8262a92a-7842-476f-8099-a056ebd26dab)


