### PR TITLE
[MDS-5802] Major Projects Summary validation errors

### DIFF
--- a/services/core-api/app/api/projects/project/models/project.py
+++ b/services/core-api/app/api/projects/project/models/project.py
@@ -258,10 +258,6 @@ class Project(AuditMixin, Base):
         for contact in contacts:
             updated_contact_guid = contact.get('project_contact_guid')
             new_address_data = contact.get('address', None)
-            if new_address_data:
-                validate_phone_no(contact.get('phone_number'), new_address_data.get('address_type_code', "CAN"))
-            else:
-                validate_phone_no(contact.get('phone_number'))
 
             if updated_contact_guid:
                 updated_contact = ProjectContact.find_project_contact_by_guid(updated_contact_guid)

--- a/services/core-api/app/api/projects/project_summary/models/project_summary.py
+++ b/services/core-api/app/api/projects/project_summary/models/project_summary.py
@@ -30,7 +30,6 @@ from cerberus import Validator
 import json
 
 from app.api.utils.common_validation_schemas import primary_address_schema, base_address_schema, address_na_schema, address_int_schema, party_base_schema, project_summary_base_schema
-from app.api.utils.helpers import validate_phone_no
 
 class ProjectSummary(SoftDeleteMixin, AuditMixin, Base):
     __tablename__ = 'project_summary'
@@ -225,12 +224,6 @@ class ProjectSummary(SoftDeleteMixin, AuditMixin, Base):
         if isinstance(party_data.get('party_name'), dict):
             # Update party_name with the label if it exists
             party_data['party_name'] = party_data['party_name'].get('label')
-
-        if isinstance(address_data, list):
-            # Validate only the phone number used for the mailing address
-            validate_phone_no(party_data.get('phone_no'), address_data[0].get('address_type_code'))
-        elif address_data is not None:
-            validate_phone_no(party_data.get('phone_no'), address_data.get('address_type_code'))
 
         if party_guid is not None and existing_party is not None:
             existing_party.deep_update_from_dict(party_data)
@@ -522,7 +515,6 @@ class ProjectSummary(SoftDeleteMixin, AuditMixin, Base):
                 'ams_terms_agreed': {
                     'required': True,
                     'type': 'boolean',
-                    'allowed': [True],
                 }
             }
 

--- a/services/core-api/tests/projects/project_summaries/resources/test_project_summary_resource.py
+++ b/services/core-api/tests/projects/project_summaries/resources/test_project_summary_resource.py
@@ -204,7 +204,7 @@ def test_update_project_summary_bad_request_with_validation_errors(test_client, 
     'agent': ['{"address": ["no definitions validate", {"anyof definition 0": ["must be of list type"], "anyof definition 1": [{"address_line_1": ["null value not allowed"]}]}]}'], 
     'facility': [], 
     'legal_land': ['{"is_crown_land_federal_or_provincial": ["null value not allowed"]}'], 
-    'declaration': ['{"ams_terms_agreed": ["unallowed value False"], "confirmation_of_submission": ["null value not allowed"]}']}"""
+    'declaration': ['{"confirmation_of_submission": ["null value not allowed"]}']}"""
     
     assert put_resp.status_code == 400
     assert put_data['message'] == re.compile(r"\s+").sub(" ", error_message).strip()

--- a/services/minespace-web/src/components/pages/Project/ProjectSummaryPage.tsx
+++ b/services/minespace-web/src/components/pages/Project/ProjectSummaryPage.tsx
@@ -70,6 +70,7 @@ interface ProjectSummaryPageProps {
   anyTouched: boolean;
   formattedProjectSummary: any;
   location: Record<any, string>;
+  change: any;
 }
 
 interface IParams {
@@ -99,6 +100,7 @@ export const ProjectSummaryPage: FC<ProjectSummaryPageProps> = (props) => {
     createProjectSummary,
     updateProjectSummary,
     updateProject,
+    change,
   } = props;
 
   const { isFeatureEnabled } = useFeatureFlag();
@@ -275,7 +277,7 @@ export const ProjectSummaryPage: FC<ProjectSummaryPageProps> = (props) => {
     const filtered = file_to_upload.filter((doc) => !doc.mine_document_guid);
     values.authorizations.AIR_EMISSIONS_DISCHARGE_PERMIT.AMENDMENT[0].amendment_documents = filtered;
 
-    props.change(
+    change(
       FORM.ADD_EDIT_PROJECT_SUMMARY,
       values.authorizations.AIR_EMISSIONS_DISCHARGE_PERMIT.AMENDMENT[0].amendment_documents,
       filtered


### PR DESCRIPTION
## Objective 

[MDS-5802](https://bcmines.atlassian.net/browse/MDS-5802)

- Removed validate_phone_no helper function call for project contacts and project party. The cereberus schema validation will do this now.

- Adjusted `ams_terms_agreed` to not only accept True. This was causing a validation error when a user tries to update the Authorization Involved section by selecting something like `Air emissions discharge permit` input. By selecting `Air emissions discharge permit` it requires the user to agree to the ams terms and condition in the declaration section and because this application was submitted and now has `"SUB"` as it's `status_code`, a full validation is done on all sections and we will get the validation error for `ams_terms_agreed` not being true.
