### PR TITLE
[MDS-5990] IRT Submit Button Issue

### DIFF
--- a/services/minespace-web/src/components/pages/Project/InformationRequirementsTableStepForm.tsx
+++ b/services/minespace-web/src/components/pages/Project/InformationRequirementsTableStepForm.tsx
@@ -158,26 +158,24 @@ const StepForms = ({
                   project?.information_requirements_table?.irt_guid
                 )}
               >
-                <AuthorizationWrapper>
-                  <Popconfirm
-                    placement="topRight"
-                    title="Are you sure you want to submit your final IRT, no changes could be made after submitting?"
-                    onConfirm={() =>
-                      handleIRTUpdate(
-                        {
-                          status_code: "SUB",
-                        },
-                        "Successfully submitted final IRT."
-                      )
-                    }
-                    okText="Yes"
-                    cancelText="No"
-                  >
-                    <Button id="submit_irt" type="primary">
-                      Submit IRT
-                    </Button>
-                  </Popconfirm>
-                </AuthorizationWrapper>
+                <Popconfirm
+                  placement="topRight"
+                  title="Are you sure you want to submit your final IRT, no changes could be made after submitting?"
+                  onConfirm={() =>
+                    handleIRTUpdate(
+                      {
+                        status_code: "SUB",
+                      },
+                      "Successfully submitted final IRT."
+                    )
+                  }
+                  okText="Yes"
+                  cancelText="No"
+                >
+                  <Button id="submit_irt" type="primary">
+                    Submit IRT
+                  </Button>
+                </Popconfirm>
               </Link>
             </>
           ) : (


### PR DESCRIPTION
## Objective 

[MDS-5990](https://bcmines.atlassian.net/browse/MDS-5990)

_Why are you making this change? Provide a short explanation and/or screenshots_

1. Initially in [MDS-5964](https://github.com/bcgov/mds/pull/3107/files) removed the json data readings from the request. But when submitting the IRT at the last step, BE update the `current_status_code`. Hence reverted the change back and added a validation for request.json to address the 415 issue existed before.
I left the email notification part as it is.

2. FE removed the AuthorizationWrapper in order to address the submit button not visible issue for users in MS
