### PR TITLE
[MDS-6005] Notify MMO on report submission for 10.4.4(g)

### DIFF
--- a/migrations/sql/V2024.05.30.13.24__update_mine_report_definition_10-4-4-g.sql
+++ b/migrations/sql/V2024.05.30.13.24__update_mine_report_definition_10-4-4-g.sql
@@ -5,7 +5,7 @@ INSERT INTO mine_report_notification
         (SELECT compliance_article_id FROM compliance_article WHERE section = '10' AND sub_section = '4' AND paragraph = '4' AND sub_paragraph = '(g)'),
         (SELECT contact_guid FROM emli_contact WHERE emli_contact_type_code = 'MMO'),
         true, 
-        true
+        false
     );
 
 UPDATE mine_report_definition

--- a/migrations/sql/V2024.05.30.13.24__update_mine_report_definition_10-4-4-g.sql
+++ b/migrations/sql/V2024.05.30.13.24__update_mine_report_definition_10-4-4-g.sql
@@ -1,0 +1,13 @@
+INSERT INTO mine_report_notification 
+    (compliance_article_id, contact_guid, is_major_mine, is_regional_mine)
+    VALUES
+    (
+        (SELECT compliance_article_id FROM compliance_article WHERE section = '10' AND sub_section = '4' AND paragraph = '4' AND sub_paragraph = '(g)'),
+        (SELECT contact_guid FROM emli_contact WHERE emli_contact_type_code = 'MMO'),
+        true, 
+        true
+    );
+
+UPDATE mine_report_definition
+    SET is_prr_only = FALSE
+    WHERE report_name = 'Annual Summary of Work and Reclamation Report';


### PR DESCRIPTION
## Objective 
[MDS-6005](https://bcmines.atlassian.net/browse/MDS-6005)
- Just to note something I thought was strange: perm recl does _not_ get an email sent without the entry in mine_report_notification which is added by the migration (and this is the only record that references that contact) but with it, it sends _twice_
- once to `PermRecl@gov.bc.ca` and again to `permrecl@gov.bc.ca`
- I decided that this was probably a can of worms though- I tested emailing _myself_ with different upper/lower and only got it once so I concluded that this is fine. Couple things that might be causing this that I didn't want to change the logic for:
   - we have two defined constants for this same email, MAJOR_MINES_OFFICE_EMAIL, and PERM_RECL_EMAIL (and it's also in emli_contacts table)
   - mine_report.py-->getReportSpecificEmailsByReportType: looks like it adds PERM_RECL for major mines but only if there are contacts associated with the compliance article
   - and also there is no lower-casing in the comparison to see if an email is already in the list

_Why are you making this change? Provide a short explanation and/or screenshots_
