### PR TITLE
[MDS-5935] UpdatedCore API dependencies and base python image (3.11.9-slim)

### DIFF
--- a/services/core-api/Dockerfile
+++ b/services/core-api/Dockerfile
@@ -1,9 +1,10 @@
-FROM python:3.11.7
+FROM python:3.11.9-slim
 
 WORKDIR /app
 
 # Update installation utility
 RUN apt-get update
+RUN apt-get install build-essential -y
 
 # Install the requirements
 COPY requirements.txt .

--- a/services/core-api/Dockerfile.ci
+++ b/services/core-api/Dockerfile.ci
@@ -1,6 +1,8 @@
-FROM python:3.11.7
+FROM python:3.11.9-slim
 
 WORKDIR /app
+
+RUN apt-get install build-essential -y
 
 # Update installation utility
 RUN apt-get update
@@ -8,6 +10,7 @@ RUN apt-get update
 # Install the requirements
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
+
 
 COPY . .
 

--- a/services/core-api/requirements.txt
+++ b/services/core-api/requirements.txt
@@ -14,7 +14,7 @@ names==0.3.0
 petl==1.6.8
 psycopg2-binary==2.9.6
 PyJWT==2.4.0
-cryptography==42.0.2
+cryptography==42.0.7
 pytest==8.0.0
 pytest-cov==4.1.0
 python-dateutil==2.8.2
@@ -38,7 +38,7 @@ cerberus==1.3.4
 celery[redis]==5.3.6
 celery-redbeat==2.2.0
 cachelib
-gunicorn==19.10.0
+gunicorn==22.0.0
 opentelemetry-distro==0.43b0
 opentelemetry-exporter-otlp==1.22.0
 opentelemetry-instrumentation==0.43b0
@@ -52,6 +52,6 @@ opentelemetry-instrumentation-redis==0.43b0
 opentelemetry-instrumentation-requests==0.43b0
 opentelemetry-instrumentation-sqlalchemy==0.43b0
 opentelemetry-instrumentation-urllib3==0.43b0
-Pillow==10.2.0
+Pillow==10.3.0
 setuptools==65.5.1
 urllib3==1.26.11


### PR DESCRIPTION
## Objective 

[MDS-5935](https://bcmines.atlassian.net/browse/MDS-5935)

This PR upgrades the base python image used by the Core API to Python 3.11.9, and changes it to use the `slim` version.
1. This makes the base image a whole lot smaller, and does not include a couple of packages with reported vulnerabilities. I've yet to find any dependencies requiring OS dependencies not included in the slim version.
2. Updates Gunicorn, Pillow, and cryptography to fix a couple of reported vulnerabilities