### PR TITLE
[MDS-5935] Fixed core api build error

### DIFF
--- a/services/core-api/Dockerfile.ci
+++ b/services/core-api/Dockerfile.ci
@@ -2,10 +2,10 @@ FROM python:3.11.9-slim
 
 WORKDIR /app
 
-RUN apt-get install build-essential -y
 
 # Update installation utility
 RUN apt-get update
+RUN apt-get install build-essential -y
 
 # Install the requirements
 COPY requirements.txt .


### PR DESCRIPTION
## Objective 

[MDS-5935](https://bcmines.atlassian.net/browse/MDS-5935)

The previous PR introduced a deploy build error when trying to install the `build-essential` package. Updated the installation to happen after package lists have been updated

<img width="1110" alt="image" src="https://github.com/bcgov/mds/assets/66635118/4f7969dd-8fc9-4db6-9095-d650f9611cca">
