### PR TITLE
[MDS-6004] Data handling on project summary form

### DIFF
--- a/services/common/src/components/projectSummary/AuthorizationsInvolved.tsx
+++ b/services/common/src/components/projectSummary/AuthorizationsInvolved.tsx
@@ -43,9 +43,9 @@ import { IProjectSummaryDocument } from "@mds/common/interfaces";
 import {
   renderTextColumn,
   renderDateColumn,
+  renderCategoryColumn,
 } from "@mds/common/components/common/CoreTableCommonColumns";
 import DocumentTable from "@mds/common/components/documents/DocumentTable";
-import { renderCategoryColumn } from "@mds/common/components/common/CoreTableCommonColumns";
 import { MineDocument } from "@mds/common/models/documents/document";
 import { Link } from "react-router-dom";
 

--- a/services/common/src/components/projectSummary/AuthorizationsInvolved.tsx
+++ b/services/common/src/components/projectSummary/AuthorizationsInvolved.tsx
@@ -565,6 +565,7 @@ export const AuthorizationsInvolved = (props) => {
     } else {
       const index = formValues.authorizationTypes.indexOf(code);
       dispatch(arrayRemove(FORM.ADD_EDIT_PROJECT_SUMMARY, `authorizationTypes`, index));
+      dispatch(change(FORM.ADD_EDIT_PROJECT_SUMMARY, `authorizations[${code}]`, null));
     }
   };
 

--- a/services/common/src/redux/selectors/projectSelectors.ts
+++ b/services/common/src/redux/selectors/projectSelectors.ts
@@ -40,7 +40,7 @@ const formatProjectContact = (contacts): IProjectContact[] => {
   return formattedContacts;
 };
 const formatAuthorizations = (authorizations = [], amsAuthTypes, statusCode) => {
-  const authorizationTypes = uniq(authorizations.map((a) => a.project_summary_authorization_type));
+  const authorizationTypes = uniq(authorizations?.map((a) => a.project_summary_authorization_type));
   const formattedAuthorizations = {};
   let ams_terms_agreed = false;
 

--- a/services/common/src/redux/selectors/projectSelectors.ts
+++ b/services/common/src/redux/selectors/projectSelectors.ts
@@ -39,7 +39,7 @@ const formatProjectContact = (contacts): IProjectContact[] => {
 
   return formattedContacts;
 };
-const formatAuthorizations = (authorizations = [], amsAuthTypes, statusCode) => {
+const formatAuthorizations = (amsAuthTypes, statusCode, authorizations = []) => {
   const authorizationTypes = uniq(authorizations?.map((a) => a.project_summary_authorization_type));
   const formattedAuthorizations = {};
   let ams_terms_agreed = false;
@@ -89,7 +89,7 @@ export const getFormattedProjectSummary = createSelector(
       agent,
       facility_operator,
       confirmation_of_submission,
-      ...formatAuthorizations(summary.authorizations, amsAuthTypes, summary.status_code),
+      ...formatAuthorizations(amsAuthTypes, summary.status_code, summary.authorizations),
     };
 
     formattedSummary.project_lead_party_guid = project.project_lead_party_guid;

--- a/services/common/src/tests/mocks/dataMocks.tsx
+++ b/services/common/src/tests/mocks/dataMocks.tsx
@@ -7282,7 +7282,8 @@ export const PROJECT_SUMMARIES = {
 
 export const PROJECT_SUMMARY = {
   mine_guid: "60300a07-376c-46f1-a984-88a813f91438",
-  project_summary_guid: "81324623978135",
+  project_guid: "74120872-74f2-4e27-82e6-878ddb472e5a",
+  project_summary_guid: "70414192-ca71-4d03-93a5-630491e9c554",
   status_code: "OPN",
   project_summary_title: "Sample title",
   project_summary_description: "Sample description",

--- a/services/minespace-web/src/components/Forms/projects/projectSummary/ProjectSummaryForm.tsx
+++ b/services/minespace-web/src/components/Forms/projects/projectSummary/ProjectSummaryForm.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from "react";
 import { useSelector } from "react-redux";
-import { flattenObject, resetForm } from "@common/utils/helpers";
+import { flattenObject } from "@common/utils/helpers";
 import { formValueSelector, getFormSyncErrors, getFormValues } from "redux-form";
 import * as FORM from "@/constants/forms";
 import DocumentUpload from "@/components/Forms/projects/projectSummary/DocumentUpload";

--- a/services/minespace-web/src/components/Forms/projects/projectSummary/ProjectSummaryForm.tsx
+++ b/services/minespace-web/src/components/Forms/projects/projectSummary/ProjectSummaryForm.tsx
@@ -118,7 +118,7 @@ export const ProjectSummaryForm: FC<ProjectSummaryFormProps> = ({ ...props }) =>
       reduxFormConfig={{
         touchOnBlur: true,
         touchOnChange: false,
-        onSubmitSuccess: resetForm(FORM.ADD_EDIT_PROJECT_SUMMARY),
+        enableReinitialize: true,
       }}
     >
       <SteppedForm

--- a/services/minespace-web/src/components/pages/Project/ProjectSummaryPage.tsx
+++ b/services/minespace-web/src/components/pages/Project/ProjectSummaryPage.tsx
@@ -65,8 +65,13 @@ export const ProjectSummaryPage = () => {
   const dispatch = useDispatch();
   const { isFeatureEnabled } = useFeatureFlag();
   const amsFeatureEnabled = isFeatureEnabled(Feature.AMS_AGENT);
-  const [isLoaded, setIsLoaded] = useState(false);
-  const [isEditMode, setIsEditMode] = useState(false);
+  const isDefaultEditMode = Boolean(projectGuid && projectSummaryGuid);
+  const isDefaultLoaded = isDefaultEditMode
+    ? formattedProjectSummary?.project_summary_guid === projectSummaryGuid &&
+      formattedProjectSummary?.project_guid === projectGuid
+    : mine?.mine_guid === mineGuid;
+  const [isLoaded, setIsLoaded] = useState(isDefaultLoaded);
+  const [isEditMode, setIsEditMode] = useState(isDefaultEditMode);
   const history = useHistory();
   const location = useLocation();
   const projectFormTabs = getProjectFormTabs(amsFeatureEnabled);
@@ -76,9 +81,10 @@ export const ProjectSummaryPage = () => {
     if (projectGuid && projectSummaryGuid) {
       setIsEditMode(true);
       dispatch(fetchRegions(undefined));
-      return dispatch(fetchProjectById(projectGuid));
+      dispatch(fetchProjectById(projectGuid));
+    } else {
+      dispatch(fetchMineRecordById(mineGuid));
     }
-    return dispatch(fetchMineRecordById(mineGuid));
   };
 
   useEffect(() => {
@@ -181,10 +187,7 @@ export const ProjectSummaryPage = () => {
         );
       })
       .then(async () => {
-        return handleFetchData();
-      })
-      .then(() => {
-        setIsLoaded(true);
+        handleFetchData();
       });
   };
 

--- a/services/minespace-web/src/components/pages/Project/ProjectSummaryPage.tsx
+++ b/services/minespace-web/src/components/pages/Project/ProjectSummaryPage.tsx
@@ -5,7 +5,7 @@ import { Link, Prompt, useHistory, useLocation, useParams } from "react-router-d
 import { getFormSyncErrors, getFormValues, reset, submit, touch } from "redux-form";
 import { Col, Divider, Row, Typography } from "antd";
 import ArrowLeftOutlined from "@ant-design/icons/ArrowLeftOutlined";
-import { getMines } from "@mds/common/redux/selectors/mineSelectors";
+import { getMineById } from "@mds/common/redux/selectors/mineSelectors";
 import {
   getFormattedProjectSummary,
   getProject,
@@ -47,10 +47,11 @@ interface IParams {
 }
 
 export const ProjectSummaryPage = () => {
+  const { mineGuid, projectGuid, projectSummaryGuid, tab } = useParams<IParams>();
   const anyTouched = useSelector(
     (state) => state.form[FORM.ADD_EDIT_PROJECT_SUMMARY]?.anyTouched || false
   );
-  const mines = useSelector(getMines);
+  const mine = useSelector((state) => getMineById(state, mineGuid));
   const projectSummary = useSelector(getProjectSummary);
   const formattedProjectSummary = useSelector(getFormattedProjectSummary);
   const project = useSelector(getProject);
@@ -64,7 +65,6 @@ export const ProjectSummaryPage = () => {
   const dispatch = useDispatch();
   const { isFeatureEnabled } = useFeatureFlag();
   const amsFeatureEnabled = isFeatureEnabled(Feature.AMS_AGENT);
-  const { mineGuid, projectGuid, projectSummaryGuid, tab } = useParams<IParams>();
   const [isLoaded, setIsLoaded] = useState(false);
   const [isEditMode, setIsEditMode] = useState(false);
   const history = useHistory();
@@ -82,10 +82,10 @@ export const ProjectSummaryPage = () => {
   };
 
   useEffect(() => {
-    if (project) {
+    if ((formattedProjectSummary?.project_guid && isEditMode) || mine?.mine_guid) {
       setIsLoaded(true);
     }
-  }, [project]);
+  }, [formattedProjectSummary, mine]);
 
   useEffect(() => {
     if (!isLoaded) {
@@ -272,9 +272,7 @@ export const ProjectSummaryPage = () => {
     }
   };
 
-  const mineName = isEditMode
-    ? formattedProjectSummary?.mine_name || ""
-    : mines[mineGuid]?.mine_name || "";
+  const mineName = isEditMode ? formattedProjectSummary?.mine_name || "" : mine?.mine_name || "";
   const title = isEditMode
     ? `Edit project description - ${projectSummary?.project_summary_title}`
     : `New project description for ${mineName}`;

--- a/services/minespace-web/src/tests/components/project/projectSummaryPage/__snapshots__/ProjectSummaryPage.spec.tsx.snap
+++ b/services/minespace-web/src/tests/components/project/projectSummaryPage/__snapshots__/ProjectSummaryPage.spec.tsx.snap
@@ -22,7 +22,7 @@ exports[`ProjectSummaryPage renders properly 1`] = `
       class="ant-col ant-col-24"
     >
       <a
-        href="/projects/undefined/overview"
+        href="/projects/74120872-74f2-4e27-82e6-878ddb472e5a/overview"
       >
         <span
           aria-label="arrow-left"


### PR DESCRIPTION
## Objective 
There were a few issues:
- the conditions for testing if the page is loaded are different for new & existing records. For existing records, we want to wait for the formattedProjectSummary, for new, only the mine
- data was reverting when Saving a page and then clicking Back!
   - this is because the form wasn't picking up changes to formattedProjectSummary, so there was a whole series of state changes between clicking save & getting the new data back where it would use the old data to initialize the form (component was re-mounted but data hadn't been fetched yet). Setting enableReinitialize = true fixed that (see reduxForm docs for further details: https://redux-form.com/6.2.1/docs/api/reduxform.md/)
- and then I broke the test because I changed the loading conditions (making it return "Loading" component)
   - gave the isLoaded and isEditMode state values on mount that were appropriate.
   - updated mock data to match, because default values check that data matches requested guids
- When removing a category of authorizations, it wasn't changing it properly in the form values, so it wasn't getting deleted
- removed some returns that weren't being used and redundant setStates in troubleshooting process - this didn't fix anything but it didn't break anything either, and it's cleaner.

[MDS-6004](https://bcmines.atlassian.net/browse/MDS-6004)