### PR TITLE
[MDS-6006] Allow ability to edit and remove the orgbook associations

### DIFF
--- a/services/common/src/components/parties/OrgBookSearch.tsx
+++ b/services/common/src/components/parties/OrgBookSearch.tsx
@@ -60,11 +60,9 @@ const OrgBookSearch: FC<OrgBookSearchProps> = ({
     setIsSearching(false);
   };
 
-  const placeHolder = "Start typing to search OrgBook...";
-
   useEffect(() => {
     if (selectedParty !== current_party) {
-      setSelectedParty(placeHolder);
+      setSelectedParty(undefined);
     }
   }, [current_party]);
 
@@ -102,7 +100,7 @@ const OrgBookSearch: FC<OrgBookSearchProps> = ({
         showSearch
         showArrow
         labelInValue
-        placeholder={placeHolder}
+        placeholder="Start typing to search OrgBook..."
         notFoundContent={isSearching ? <Spin size="small" indicator={<LoadingOutlined />} /> : null}
         filterOption={false}
         onSearch={handleSearchDebounced}

--- a/services/common/src/components/parties/OrgBookSearch.tsx
+++ b/services/common/src/components/parties/OrgBookSearch.tsx
@@ -34,7 +34,6 @@ const OrgBookSearch: FC<OrgBookSearchProps> = ({
 
   const [options, setOptions] = useState([]);
   const [isSearching, setIsSearching] = useState(false);
-  const [isAssociated, setIsAssociated] = useState(current_party !== undefined);
   const [selectedParty, setSelectedParty] = useState(current_party);
 
   const handleChange = () => {
@@ -84,7 +83,6 @@ const OrgBookSearch: FC<OrgBookSearchProps> = ({
     const credentialId = value.key;
     await dispatch(fetchOrgBookCredential(credentialId));
     setSelectedParty(value.label);
-    setIsAssociated(true);
   };
 
   useEffect(() => {
@@ -110,7 +108,7 @@ const OrgBookSearch: FC<OrgBookSearchProps> = ({
         onChange={handleChange}
         onSelect={handleSelect}
         style={{ width: "100%" }}
-        disabled={isAssociated}
+        disabled={isDisabled}
         defaultValue={current_party}
         value={selectedParty}
       >

--- a/services/common/src/components/parties/OrgBookSearch.tsx
+++ b/services/common/src/components/parties/OrgBookSearch.tsx
@@ -12,7 +12,6 @@ import {
 } from "@mds/common/redux/actionCreators/orgbookActionCreator";
 import { LoadingOutlined } from "@ant-design/icons";
 import { IOrgbookCredential } from "@mds/common/interfaces";
-import { NONE } from "@mds/minespace-web/src/constants/strings";
 
 interface OrgBookSearchProps {
   isDisabled?: boolean;
@@ -61,9 +60,11 @@ const OrgBookSearch: FC<OrgBookSearchProps> = ({
     setIsSearching(false);
   };
 
+  const placeHolder = "Start typing to search OrgBook...";
+
   useEffect(() => {
     if (selectedParty !== current_party) {
-      setSelectedParty(NONE);
+      setSelectedParty(placeHolder);
     }
   }, [current_party]);
 
@@ -101,7 +102,7 @@ const OrgBookSearch: FC<OrgBookSearchProps> = ({
         showSearch
         showArrow
         labelInValue
-        placeholder="Start typing to search OrgBook..."
+        placeholder={placeHolder}
         notFoundContent={isSearching ? <Spin size="small" indicator={<LoadingOutlined />} /> : null}
         filterOption={false}
         onSearch={handleSearchDebounced}

--- a/services/common/src/components/parties/OrgBookSearch.tsx
+++ b/services/common/src/components/parties/OrgBookSearch.tsx
@@ -12,13 +12,19 @@ import {
 } from "@mds/common/redux/actionCreators/orgbookActionCreator";
 import { LoadingOutlined } from "@ant-design/icons";
 import { IOrgbookCredential } from "@mds/common/interfaces";
+import { NONE } from "@mds/minespace-web/src/constants/strings";
 
 interface OrgBookSearchProps {
   isDisabled?: boolean;
   setCredential: (credential: IOrgbookCredential) => void;
+  current_party: string;
 }
 
-const OrgBookSearch: FC<OrgBookSearchProps> = ({ isDisabled = false, setCredential }) => {
+const OrgBookSearch: FC<OrgBookSearchProps> = ({
+  isDisabled = false,
+  setCredential,
+  current_party,
+}) => {
   const dispatch = useDispatch();
 
   const searchOrgBookResults = useSelector(getSearchOrgBookResults);
@@ -28,6 +34,8 @@ const OrgBookSearch: FC<OrgBookSearchProps> = ({ isDisabled = false, setCredenti
 
   const [options, setOptions] = useState([]);
   const [isSearching, setIsSearching] = useState(false);
+  const [isAssociated, setIsAssociated] = useState(current_party !== undefined);
+  const [selectedParty, setSelectedParty] = useState(current_party);
 
   const handleChange = () => {
     setIsSearching(false);
@@ -55,6 +63,12 @@ const OrgBookSearch: FC<OrgBookSearchProps> = ({ isDisabled = false, setCredenti
   };
 
   useEffect(() => {
+    if (selectedParty !== current_party) {
+      setSelectedParty(NONE);
+    }
+  }, [current_party]);
+
+  useEffect(() => {
     if (searchOrgBookResults) {
       const selectOptions = searchOrgBookResults
         .filter((result) => result.names && result.names.length > 0)
@@ -69,6 +83,8 @@ const OrgBookSearch: FC<OrgBookSearchProps> = ({ isDisabled = false, setCredenti
   const handleSelect = async (value) => {
     const credentialId = value.key;
     await dispatch(fetchOrgBookCredential(credentialId));
+    setSelectedParty(value.label);
+    setIsAssociated(true);
   };
 
   useEffect(() => {
@@ -94,7 +110,9 @@ const OrgBookSearch: FC<OrgBookSearchProps> = ({ isDisabled = false, setCredenti
         onChange={handleChange}
         onSelect={handleSelect}
         style={{ width: "100%" }}
-        disabled={isDisabled}
+        disabled={isAssociated}
+        defaultValue={current_party}
+        value={selectedParty}
       >
         {options.map((option) => (
           <Select.Option key={option.value}>{option.text}</Select.Option>

--- a/services/common/src/redux/actionCreators/partiesActionCreator.ts
+++ b/services/common/src/redux/actionCreators/partiesActionCreator.ts
@@ -298,6 +298,28 @@ export const createPartyOrgBookEntity = (
     .finally(() => dispatch(hideLoading("modal")));
 };
 
+export const deletePartyOrgBookEntity = (
+  partyGuid: string
+): AppThunk<Promise<AxiosResponse<IPartyOrgBookEntity>>> => (dispatch) => {
+  dispatch(request(reducerTypes.PARTY_ORGBOOK_ENTITY));
+  dispatch(showLoading("modal"));
+  return CustomAxios()
+    .delete(ENVIRONMENT.apiUrl + API.PARTY_ORGBOOK_ENTITY(partyGuid), createRequestHeader())
+    .then((response) => {
+      dispatch(hideLoading("modal"));
+      notification.success({
+        message: "Successfully disassociated party with OrgBook entity",
+        duration: 10,
+      });
+      dispatch(success(reducerTypes.PARTY_ORGBOOK_ENTITY));
+      return response;
+    })
+    .catch(() => {
+      dispatch(error(reducerTypes.PARTY_ORGBOOK_ENTITY));
+    })
+    .finally(() => dispatch(hideLoading("modal")));
+};
+
 export const mergeParties = (payload: IMergeParties): AppThunk<Promise<AxiosResponse<IParty>>> => (
   dispatch
 ): Promise<AxiosResponse<IParty>> => {

--- a/services/core-api/app/api/parties/party/models/party_orgbook_entity.py
+++ b/services/core-api/app/api/parties/party/models/party_orgbook_entity.py
@@ -23,7 +23,6 @@ class PartyOrgBookEntity(AuditMixin, Base):
     association_user = db.Column(db.String, nullable=False, default=User().get_user_username)
     association_timestamp = db.Column(db.DateTime, nullable=False, server_default=FetchedValue())
 
-
     def __repr__(self):
         return f'{self.__class__.__name__} {self.party_orgbook_entity_id}'
 
@@ -49,3 +48,6 @@ class PartyOrgBookEntity(AuditMixin, Base):
             company_alias=company_alias)
         party_orgbook_entity.save()
         return party_orgbook_entity
+
+    def delete(self, commit=True):
+        super(PartyOrgBookEntity, self).delete(commit)

--- a/services/core-api/app/api/parties/party/resources/party_orgbook_entity_list_resource.py
+++ b/services/core-api/app/api/parties/party/resources/party_orgbook_entity_list_resource.py
@@ -60,10 +60,9 @@ class PartyOrgBookEntityListResource(Resource, UserMixin):
 
         return party_orgbook_entity, 201
 
-    @api.expect(parser)
     @api.doc(description='Delete a Party OrgBook Entity.')
     @requires_role_mine_admin
-    @api.marshal_with(PARTY_ORGBOOK_ENTITY, code=201)
+    @api.marshal_with(PARTY_ORGBOOK_ENTITY, code=204)
     def delete(self, party_guid):
         party_orgbook_entity = PartyOrgBookEntity.find_by_party_guid(party_guid)
         if party_orgbook_entity is None:

--- a/services/core-api/app/api/parties/party/resources/party_orgbook_entity_list_resource.py
+++ b/services/core-api/app/api/parties/party/resources/party_orgbook_entity_list_resource.py
@@ -4,7 +4,7 @@ from flask_restx import Resource
 from werkzeug.exceptions import BadRequest, InternalServerError, NotFound, BadGateway
 
 from app.extensions import api
-from app.api.utils.access_decorators import requires_role_edit_party
+from app.api.utils.access_decorators import requires_role_edit_party, requires_role_mine_admin
 from app.api.utils.resources_mixins import UserMixin
 from app.api.utils.custom_reqparser import CustomReqparser
 from app.api.parties.party.models.party_orgbook_entity import PartyOrgBookEntity
@@ -62,7 +62,7 @@ class PartyOrgBookEntityListResource(Resource, UserMixin):
 
     @api.expect(parser)
     @api.doc(description='Delete a Party OrgBook Entity.')
-    @requires_role_edit_party
+    @requires_role_mine_admin
     @api.marshal_with(PARTY_ORGBOOK_ENTITY, code=201)
     def delete(self, party_guid):
         party_orgbook_entity = PartyOrgBookEntity.find_by_party_guid(party_guid)

--- a/services/core-api/app/api/parties/party/resources/party_orgbook_entity_list_resource.py
+++ b/services/core-api/app/api/parties/party/resources/party_orgbook_entity_list_resource.py
@@ -59,3 +59,15 @@ class PartyOrgBookEntityListResource(Resource, UserMixin):
         party.save()
 
         return party_orgbook_entity, 201
+
+    @api.expect(parser)
+    @api.doc(description='Delete a Party OrgBook Entity.')
+    @requires_role_edit_party
+    @api.marshal_with(PARTY_ORGBOOK_ENTITY, code=201)
+    def delete(self, party_guid):
+        party_orgbook_entity = PartyOrgBookEntity.find_by_party_guid(party_guid)
+        if party_orgbook_entity is None:
+            raise NotFound('OrgBook entity not found.')
+
+        party_orgbook_entity.delete()
+        return None, 204

--- a/services/core-web/src/components/Forms/parties/PartyOrgBookForm.tsx
+++ b/services/core-web/src/components/Forms/parties/PartyOrgBookForm.tsx
@@ -43,6 +43,7 @@ export const PartyOrgBookForm: FC<PartyOrgBookFormProps> = ({ party }) => {
     setIsAssociating(true);
 
     await dispatch(deletePartyOrgBookEntity(party.party_guid));
+    await dispatch(fetchPartyById(party.party_guid));
     setIsAssociating(false);
     setCurrentParty("");
     setIsAssociated(false);


### PR DESCRIPTION
## Objective 

[MDS-6006](https://bcmines.atlassian.net/browse/MDS-6006)

- Users can change an orgbook party connection to a party through the party edit modal 
- User with core_admin can delete an existing orgbook party connection through the party edit modal
   - This is a hard delete from `party_orgbook_entity` table.

_Why are you making this change? Provide a short explanation and/or screenshots_
<img width="1152" alt="Screenshot 2024-06-05 at 5 21 43 PM" src="https://github.com/bcgov/mds/assets/118843449/bc12cffc-bfb6-4988-a767-8358401af0fe">
<img width="1160" alt="Screenshot 2024-06-05 at 5 22 03 PM" src="https://github.com/bcgov/mds/assets/118843449/159a0acb-50f9-4c3b-8390-bd76e98883d8">


