### PR TITLE
[MDS-5920] Feature/fix anoncred commodity and disturbance codes

### DIFF
--- a/services/core-api/app/api/verifiable_credentials/manager.py
+++ b/services/core-api/app/api/verifiable_credentials/manager.py
@@ -15,6 +15,7 @@ from app.api.mines.mine.models.mine import Mine
 from app.api.parties.party.models.party import Party
 from app.api.mines.permits.permit.models.permit import Permit
 from app.api.mines.permits.permit_amendment.models.permit_amendment import PermitAmendment
+from app.api.mines.mine.models.mine_type import MineType
 from app.api.verifiable_credentials.models.credentials import PartyVerifiableCredentialMinesActPermit
 from app.api.verifiable_credentials.models.connection import PartyVerifiableCredentialConnection
 from app.api.services.traction_service import TractionService
@@ -98,16 +99,24 @@ class VerifiableCredentialManager():
         # https://github.com/bcgov/bc-vcpedia/blob/main/credentials/bc-mines-act-permit/1.1.1/governance.md#261-schema-definition
         credential_attrs = {}
 
+        #mine_types should related to the permits
+        #all mine_types for all permits are used in mine.mine_type
+        #but we only want the mine_type for this specific permit/permit_amendment.
+
+        #not really a 'mine_type' if it's managed at the permit level.
+        mine_type = MineType.find_by_permit_guid(permit_amendment.permit_guid,
+                                                 permit_amendment.mine_guid)
+
         mine_disturbance_list = [
-            mtd.mine_disturbance_literal
-            for mtd in permit_amendment.mine.mine_type[0].mine_type_detail
+            mtd.mine_disturbance_literal for mtd in mine_type.mine_type_detail
             if mtd.mine_disturbance_code
         ]
+
         mine_commodity_list = [
-            mtd.mine_commodity_literal
-            for mtd in permit_amendment.mine.mine_type[0].mine_type_detail
+            mtd.mine_commodity_literal for mtd in mine_type.mine_type_detail
             if mtd.mine_commodity_code
         ]
+
         mine_status_xref = permit_amendment.mine.mine_status[0].mine_status_xref
 
         credential_attrs["permit_no"] = permit_amendment.permit_no

--- a/services/core-api/app/api/verifiable_credentials/manager.py
+++ b/services/core-api/app/api/verifiable_credentials/manager.py
@@ -109,6 +109,9 @@ class VerifiableCredentialManager():
             if mt.mine_guid == permit_amendment.permit.mine_guid
         ][0] if permit_amendment.permit.site_properties else None
 
+        mine_disturbance_list = []
+        mine_commodity_list = []
+
         if mine_type:
             mine_disturbance_list = [
                 mtd.mine_disturbance_literal for mtd in mine_type.mine_type_detail

--- a/services/core-api/app/api/verifiable_credentials/manager.py
+++ b/services/core-api/app/api/verifiable_credentials/manager.py
@@ -107,17 +107,18 @@ class VerifiableCredentialManager():
         mine_type = [
             mt for mt in permit_amendment.permit.site_properties
             if mt.mine_guid == permit_amendment.permit.mine_guid
-        ][0] if permit_amendment.permit.site_properties else []
+        ][0] if permit_amendment.permit.site_properties else None
 
-        mine_disturbance_list = [
-            mtd.mine_disturbance_literal for mtd in mine_type.mine_type_detail
-            if mtd.mine_disturbance_code
-        ]
+        if mine_type:
+            mine_disturbance_list = [
+                mtd.mine_disturbance_literal for mtd in mine_type.mine_type_detail
+                if mtd.mine_disturbance_code
+            ]
 
-        mine_commodity_list = [
-            mtd.mine_commodity_literal for mtd in mine_type.mine_type_detail
-            if mtd.mine_commodity_code
-        ]
+            mine_commodity_list = [
+                mtd.mine_commodity_literal for mtd in mine_type.mine_type_detail
+                if mtd.mine_commodity_code
+            ]
 
         mine_status_xref = permit_amendment.mine.mine_status[0].mine_status_xref
 

--- a/services/core-api/app/api/verifiable_credentials/manager.py
+++ b/services/core-api/app/api/verifiable_credentials/manager.py
@@ -104,8 +104,10 @@ class VerifiableCredentialManager():
         #but we only want the mine_type for this specific permit/permit_amendment.
 
         #not really a 'mine_type' if it's managed at the permit level.
-        mine_type = MineType.find_by_permit_guid(permit_amendment.permit_guid,
-                                                 permit_amendment.mine_guid)
+        mine_type = [
+            mt for mt in permit_amendment.permit.site_properties
+            if mt.mine_guid == permit_amendment.permit.mine_guid
+        ][0] if permit_amendment.permit.site_properties else []
 
         mine_disturbance_list = [
             mtd.mine_disturbance_literal for mtd in mine_type.mine_type_detail

--- a/services/core-api/tests/verifiable_credentials/test_manager.py
+++ b/services/core-api/tests/verifiable_credentials/test_manager.py
@@ -1,19 +1,31 @@
-
 from app.api.verifiable_credentials.manager import VerifiableCredentialManager
-
+from app.api.mines.mine.models.mine_type import MineType
 from tests.factories import create_mine_and_permit, PartyFactory, MinePartyAppointmentFactory
 
 
 class TestVerifiableCredentialManager:
     """test MinesActPermit 1.1.1 attributes"""
-    def test_collect_attributes_for_mines_act_permit_111(self, test_client, db_session, auth_headers):
+
+    def test_collect_attributes_for_mines_act_permit_111(self, test_client, db_session,
+                                                         auth_headers):
         mine, permit = create_mine_and_permit()
         permittee_appt = MinePartyAppointmentFactory(permittee=True)
 
         pa = permit.permit_amendments[0]
         permit.bonds[0].bond_status_code = "ACT"
-        mine_disturbance_list = [mtd.mine_disturbance_literal for mtd in pa.mine.mine_type[0].mine_type_detail if mtd.mine_disturbance_code]
-        mine_commodity_list = [mtd.mine_commodity_literal for mtd in pa.mine.mine_type[0].mine_type_detail if mtd.mine_commodity_code]  
+
+        mine_type = [mt for mt in pa.permit.site_properties if mt.mine_guid == pa.permit.mine_guid
+                     ][0] if pa.permit.site_properties else []
+
+        mine_disturbance_list = [
+            mtd.mine_disturbance_literal for mtd in mine_type.mine_type_detail
+            if mtd.mine_disturbance_code
+        ]
+
+        mine_commodity_list = [
+            mtd.mine_commodity_literal for mtd in mine_type.mine_type_detail
+            if mtd.mine_commodity_code
+        ]
         mine_status_xref = pa.mine.mine_status[0].mine_status_xref
 
         assert pa.permit_no
@@ -32,11 +44,14 @@ class TestVerifiableCredentialManager:
         assert attributes["permit_no"] == pa.permit_no
         assert attributes["permit_status"] == permit.permit_status_code_description
         # assert attributes["permittee_name"] == permit.current_permittee
-        assert attributes["mine_operation_status"] == mine_status_xref.mine_operation_status.description
+        assert attributes[
+            "mine_operation_status"] == mine_status_xref.mine_operation_status.description
         if mine_status_xref.mine_operation_status_reason:
-            assert attributes["mine_operation_status_reason"] == mine_status_xref.mine_operation_status_reason.description 
+            assert attributes[
+                "mine_operation_status_reason"] == mine_status_xref.mine_operation_status_reason.description
         if mine_status_xref.mine_operation_status_sub_reason:
-            assert attributes["mine_operation_status_sub_reason"] == mine_status_xref.mine_operation_status_sub_reason.description
+            assert attributes[
+                "mine_operation_status_sub_reason"] == mine_status_xref.mine_operation_status_sub_reason.description
         if mine_disturbance_list:
             assert attributes["mine_disturbance"]
         if mine_commodity_list:

--- a/services/core-api/tests/verifiable_credentials/test_manager.py
+++ b/services/core-api/tests/verifiable_credentials/test_manager.py
@@ -16,6 +16,9 @@ class TestVerifiableCredentialManager:
 
         mine_type = [mt for mt in pa.permit.site_properties if mt.mine_guid == pa.permit.mine_guid
                      ][0] if pa.permit.site_properties else None
+        mine_disturbance_list = []
+        mine_commodity_list = []
+
         if mine_type:
             mine_disturbance_list = [
                 mtd.mine_disturbance_literal for mtd in mine_type.mine_type_detail

--- a/services/core-api/tests/verifiable_credentials/test_manager.py
+++ b/services/core-api/tests/verifiable_credentials/test_manager.py
@@ -15,17 +15,18 @@ class TestVerifiableCredentialManager:
         permit.bonds[0].bond_status_code = "ACT"
 
         mine_type = [mt for mt in pa.permit.site_properties if mt.mine_guid == pa.permit.mine_guid
-                     ][0] if pa.permit.site_properties else []
+                     ][0] if pa.permit.site_properties else None
+        if mine_type:
+            mine_disturbance_list = [
+                mtd.mine_disturbance_literal for mtd in mine_type.mine_type_detail
+                if mtd.mine_disturbance_code
+            ]
 
-        mine_disturbance_list = [
-            mtd.mine_disturbance_literal for mtd in mine_type.mine_type_detail
-            if mtd.mine_disturbance_code
-        ]
+            mine_commodity_list = [
+                mtd.mine_commodity_literal for mtd in mine_type.mine_type_detail
+                if mtd.mine_commodity_code
+            ]
 
-        mine_commodity_list = [
-            mtd.mine_commodity_literal for mtd in mine_type.mine_type_detail
-            if mtd.mine_commodity_code
-        ]
         mine_status_xref = pa.mine.mine_status[0].mine_status_xref
 
         assert pa.permit_no


### PR DESCRIPTION
## Objective 

[MDS-5920](https://bcmines.atlassian.net/browse/MDS-5920)

Was getting disturbance and commodity codes from the more recent mine_types (regardless of the permit) 
Now I'm looking up mine_type by permit which can be managed and fixed in the UI!!
