### PR TITLE
[FIX] Fixed red underlines for cypress commands in VSCode

### DIFF
--- a/services/core-web/cypress/tsconfig.json
+++ b/services/core-web/cypress/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["es5", "dom"],
+    "types": ["cypress", "node"]
+  },
+  "include": ["**/*.ts"]
+}

--- a/services/minespace-web/cypress/tsconfig.json
+++ b/services/minespace-web/cypress/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["es5", "dom"],
+    "types": ["cypress", "node"]
+  },
+  "include": ["**/*.ts"]
+}


### PR DESCRIPTION
## Objective 

[MDS-0000](https://bcmines.atlassian.net/browse/MDS-0000)

**Before:**
![image](https://github.com/bcgov/mds/assets/66635118/0f0e6c06-b96b-479f-90b1-2fd6a9939415)

**After:**
![image](https://github.com/bcgov/mds/assets/66635118/d8a7e288-94d0-42b5-8a5a-52a171b19469)