### PR TITLE
[FIX] Wait for data to be fetched before loading page on Project Summary Form

### DIFF
--- a/services/core-web/src/components/mine/Projects/ProjectSummary.tsx
+++ b/services/core-web/src/components/mine/Projects/ProjectSummary.tsx
@@ -7,7 +7,6 @@ import { Button, Col, Row, Tag } from "antd";
 import EnvironmentOutlined from "@ant-design/icons/EnvironmentOutlined";
 import ArrowLeftOutlined from "@ant-design/icons/ArrowLeftOutlined";
 
-import NullScreen from "@/components/common/NullScreen";
 import {
   getFormattedProjectSummary,
   getProject,
@@ -82,21 +81,12 @@ export const ProjectSummary: FC = () => {
 
   useEffect(() => {
     if (!isLoaded) {
-      handleFetchData();
+      handleFetchData().then(() => setIsLoaded(true));
     }
     return () => {
       dispatch(clearProjectSummary());
     };
   }, []);
-
-  useEffect(() => {
-    if (
-      (formattedProjectSummary?.project_guid && !isNewProject) ||
-      (isNewProject && mine?.mine_guid)
-    ) {
-      setIsLoaded(true);
-    }
-  }, [formattedProjectSummary, mine]);
 
   const removeUploadedDocument = (payload, docs) => {
     if (Array.isArray(payload.documents)) {
@@ -191,6 +181,7 @@ export const ProjectSummary: FC = () => {
       if (projectGuid && projectSummaryGuid) {
         await handleUpdateProjectSummary(values, message);
         handleTabChange(newActiveTab);
+        setIsLoaded(true);
       }
     } catch (err) {
       console.log(err);

--- a/services/core-web/src/components/mine/Projects/ProjectSummary.tsx
+++ b/services/core-web/src/components/mine/Projects/ProjectSummary.tsx
@@ -69,14 +69,14 @@ export const ProjectSummary: FC = () => {
   const activeTab = tab ?? projectFormTabs[0];
   const mineName = mine?.mine_name ?? formattedProjectSummary?.mine_name ?? "";
 
-  const handleFetchData = () => {
+  const handleFetchData = async () => {
     setIsLoaded(false);
     if (projectGuid && projectSummaryGuid) {
       setIsNewProject(false);
-      dispatch(fetchRegions(undefined));
-      dispatch(fetchProjectById(projectGuid));
+      await dispatch(fetchRegions(undefined));
+      await dispatch(fetchProjectById(projectGuid));
     } else {
-      dispatch(fetchMineRecordById(mineGuid));
+      await dispatch(fetchMineRecordById(mineGuid));
     }
   };
 
@@ -90,7 +90,10 @@ export const ProjectSummary: FC = () => {
   }, []);
 
   useEffect(() => {
-    if ((formattedProjectSummary?.project_guid && !isNewProject) || mine?.mine_guid) {
+    if (
+      (formattedProjectSummary?.project_guid && !isNewProject) ||
+      (isNewProject && mine?.mine_guid)
+    ) {
       setIsLoaded(true);
     }
   }, [formattedProjectSummary, mine]);
@@ -149,7 +152,7 @@ export const ProjectSummary: FC = () => {
         );
       })
       .then(async () => {
-        handleFetchData();
+        await handleFetchData();
       });
   };
 

--- a/services/minespace-web/src/components/pages/Project/ProjectSummaryPage.tsx
+++ b/services/minespace-web/src/components/pages/Project/ProjectSummaryPage.tsx
@@ -67,18 +67,18 @@ export const ProjectSummaryPage = () => {
   const projectFormTabs = getProjectFormTabs(amsFeatureEnabled);
   const activeTab = tab ?? projectFormTabs[0];
 
-  const handleFetchData = () => {
+  const handleFetchData = async () => {
     if (projectGuid && projectSummaryGuid) {
       setIsEditMode(true);
-      dispatch(fetchRegions(undefined));
-      dispatch(fetchProjectById(projectGuid));
+      await dispatch(fetchRegions(undefined));
+      await dispatch(fetchProjectById(projectGuid));
     } else {
-      dispatch(fetchMineRecordById(mineGuid));
+      await dispatch(fetchMineRecordById(mineGuid));
     }
   };
 
   useEffect(() => {
-    if ((formattedProjectSummary?.project_guid && isEditMode) || mine?.mine_guid) {
+    if ((formattedProjectSummary?.project_guid && isEditMode) || (!isEditMode && mine?.mine_guid)) {
       setIsLoaded(true);
     }
   }, [formattedProjectSummary, mine]);
@@ -118,7 +118,7 @@ export const ProjectSummaryPage = () => {
         );
       })
       .then(async () => {
-        handleFetchData();
+        await handleFetchData();
       });
   };
 

--- a/services/minespace-web/src/components/pages/Project/ProjectSummaryPage.tsx
+++ b/services/minespace-web/src/components/pages/Project/ProjectSummaryPage.tsx
@@ -78,14 +78,8 @@ export const ProjectSummaryPage = () => {
   };
 
   useEffect(() => {
-    if ((formattedProjectSummary?.project_guid && isEditMode) || (!isEditMode && mine?.mine_guid)) {
-      setIsLoaded(true);
-    }
-  }, [formattedProjectSummary, mine]);
-
-  useEffect(() => {
     if (!isLoaded) {
-      handleFetchData();
+      handleFetchData().then(() => setIsLoaded(true));
     }
     return () => {
       dispatch(clearProjectSummary());
@@ -138,7 +132,7 @@ export const ProjectSummaryPage = () => {
     });
   };
 
-  const handleTabChange = (newTab) => {
+  const handleTabChange = async (newTab) => {
     if (!newTab) {
       return;
     }
@@ -169,6 +163,7 @@ export const ProjectSummaryPage = () => {
       if (projectGuid && projectSummaryGuid) {
         await handleUpdateProjectSummary(values, message);
         handleTabChange(newActiveTab);
+        setIsLoaded(true);
       }
     } catch (err) {
       console.log(err);


### PR DESCRIPTION
## Objective 
- sorting out timing issue on project summary that was causing issues on Project Contacts and making the page "flash"

Something like the following was happening:
1. Form is submitted
2. Page is set as not loaded
3. Request sent to update the project summary
4. Tab is changed
5. Page is set as loaded
6. The project contacts page sets a default project contact
7. Request comes back with updated project summary
8. The form is re-initialized with no project contacts

Made it more like:
1. Form is submitted
2. Page is set as not loaded
3. Request sent to update the project summary
4. Request comes back with updated project summary
5. Tab is changed
6. Page is set as loaded
7. The project contacts page sets a default project contact

[MDS-0000](https://bcmines.atlassian.net/browse/MDS-0000)

