### PR TITLE
[MDS-5913]addressing dynamic route bug in authorization

### DIFF
--- a/services/common/src/components/projectSummary/AuthorizationsInvolved.tsx
+++ b/services/common/src/components/projectSummary/AuthorizationsInvolved.tsx
@@ -49,6 +49,8 @@ import DocumentTable from "@mds/common/components/documents/DocumentTable";
 import { MineDocument } from "@mds/common/models/documents/document";
 import { Link } from "react-router-dom";
 import { PROJECT_SUMMARY_DOCUMENT_TYPE_CODE_STATE } from "../..";
+import { SystemFlagEnum } from "@mds/common/constants/enums";
+import { getSystemFlag } from "@mds/common/redux/selectors/authenticationSelectors";
 
 const RenderEMAPermitCommonSections = ({ code, isAmendment, index }) => {
   const dispatch = useDispatch();
@@ -519,6 +521,9 @@ export const AuthorizationsInvolved = () => {
   const amsAuthTypes = useSelector(getAmsAuthorizationTypes);
   const formValues = useSelector(getFormValues(FORM.ADD_EDIT_PROJECT_SUMMARY));
 
+  const systemFlag = useSelector(getSystemFlag);
+  const isCore = systemFlag === SystemFlagEnum.core;
+
   const handleChange = (e, code) => {
     if (e.target.checked) {
       let formVal;
@@ -586,14 +591,18 @@ export const AuthorizationsInvolved = () => {
                                           For intent to depart from a Mines Act authorized mine plan
                                           and reclamation program, as per HSRC code 10.1.18, submit
                                           a{" "}
-                                          <Link
-                                            to={GLOBAL_ROUTES?.MINE_DASHBOARD.dynamicRoute(
-                                              formValues?.mine_guid,
-                                              "nods"
-                                            )}
-                                          >
-                                            Notice of Departure
-                                          </Link>{" "}
+                                          {isCore ? (
+                                            "Notice of Departure"
+                                          ) : (
+                                            <Link
+                                              to={GLOBAL_ROUTES?.MINE_DASHBOARD.dynamicRoute(
+                                                formValues?.mine_guid,
+                                                "nods"
+                                              )}
+                                            >
+                                              Notice of Departure
+                                            </Link>
+                                          )}{" "}
                                           through MineSpace
                                         </li>
                                         <li>


### PR DESCRIPTION
## Objective 

[MDS-5913](https://bcmines.atlassian.net/browse/MDS-5913)

-Adjusted core to just display "Notice of Departure" as text whereas in minespace "Notice of Departure" is a link

![Screenshot (354)](https://github.com/bcgov/mds/assets/127789479/5e568738-ee09-4d75-98fc-91df4cc4e89a)

![Screenshot (355)](https://github.com/bcgov/mds/assets/127789479/b23b07bd-20f2-4680-9c51-9a0dfead6c6f)

