### PR TITLE
[MDS-6030] Perform sonarcloud scan after merging into develop

### DIFF
--- a/.github/workflows/common-package.unit.yaml
+++ b/.github/workflows/common-package.unit.yaml
@@ -5,7 +5,11 @@ on:
     paths:
       - services/common/**
   workflow_dispatch:
-
+  push:
+    branches:
+      - develop
+    paths:
+      - services/common/**
 jobs:
   test-common-package:
     name: test-common-package

--- a/.github/workflows/core-web.unit.yaml
+++ b/.github/workflows/core-web.unit.yaml
@@ -6,6 +6,12 @@ on:
     paths:
       - services/common/**
       - services/core-web/**
+  push:
+    branches:
+      - develop
+    paths:
+      - services/common/**
+      - services/core-web/**
 
 jobs:
   tests-unit-frontend:

--- a/.github/workflows/minespace.unit.yaml
+++ b/.github/workflows/minespace.unit.yaml
@@ -5,6 +5,12 @@ on:
     paths:
       - services/common/**
       - services/minespace-web/**
+  push:
+    branches:
+      - develop
+    paths:
+      - services/common/**
+      - services/minespace-web/**
 
 jobs:
   tests-unit-minespace:

--- a/.github/workflows/tests.integration.yaml
+++ b/.github/workflows/tests.integration.yaml
@@ -8,6 +8,11 @@ on:
       - services/postgres/**
       - docker-compose
       - docker-compose.ci.yaml
+  push:
+    branches:
+      - develop
+    paths:
+      - services/core-api/**
 
 jobs:
   tests-verify-migrations:


### PR DESCRIPTION
## Objective 

[MDS-6030](https://bcmines.atlassian.net/browse/MDS-6030)

Re-run tests and sonarcloud scan after merging into develop.
Why? If you check out test reporting in SonarCloud, coverage of the develop branch is still listed as 0%. Why? As currently set up, we only scan the branches you create a PR for.

![image](https://github.com/bcgov/mds/assets/66635118/f9a811da-cd59-4ebf-abde-e42b2a4fb0e3)
