### PR TITLE
[MDS-5740] Filtering only EOR for EoR display in General page.

### DIFF
--- a/services/core-web/src/components/mine/Tailings/MineTSFCard.tsx
+++ b/services/core-web/src/components/mine/Tailings/MineTSFCard.tsx
@@ -8,7 +8,9 @@ interface TSFCardProps {
 
 export const TSFCard: FC<TSFCardProps> = (props) => {
   const tsf_eor = props.PartyRelationships.filter(
-    (pr) => pr.related_guid === props.tailingsStorageFacility.mine_tailings_storage_facility_guid
+    (pr) =>
+      pr.related_guid === props.tailingsStorageFacility.mine_tailings_storage_facility_guid &&
+      pr.mine_party_appt_type_code === "EOR"
   ).sort((a, b) => Date.parse(a.start_date) - Date.parse(b.start_date))[0];
   return (
     <div>


### PR DESCRIPTION
## Objective 

[MDS-5740](https://bcmines.atlassian.net/browse/MDS-5740)

_Why are you making this change? Provide a short explanation and/or screenshots_

The issue was in `MineTSFCard.tsx` it doesn't filter the EOR parties to show in General page. As a result when there's a TSF party available that party appears under EOR in General page. 

So fixed this by applying a filter to filter only EOR type.