### PR TITLE
[MDS-6009] Altering unique constraint of permit_permit_no_unique in permit table

### DIFF
--- a/migrations/sql/V2024.07.04.13.26__alter_permit_permit_no_unique.sql
+++ b/migrations/sql/V2024.07.04.13.26__alter_permit_permit_no_unique.sql
@@ -1,0 +1,3 @@
+ALTER TABLE public.permit DROP CONSTRAINT permit_permit_no_unique;
+
+CREATE UNIQUE INDEX permit_permit_no_unique ON public.permit (permit_no) WHERE deleted_ind = FALSE;


### PR DESCRIPTION
## Objective 

[MDS-6009](https://bcmines.atlassian.net/browse/MDS-6009)

- Adjusting the unique constraint of permit_no column in the permit table so that a soft deleted permit_no will not prevent us from creating a new permit with the same permit_no. (kudos to Mat for the idea)
