### PR TITLE
[FIX] Add in spatial bundle feature flag to FE

### DIFF
--- a/services/common/src/utils/featureFlag.ts
+++ b/services/common/src/utils/featureFlag.ts
@@ -18,6 +18,7 @@ export enum Feature {
   AMS_AGENT = "ams_agent",
   HSRC_CODE_EDIT = "hsrc_code_edit",
   MULTIPART_UPLOAD = "s3_multipart_upload",
+  SPATIAL_BUNDLE = "spatial_bundle",
 }
 
 export const initializeFlagsmith = async (flagsmithUrl, flagsmithKey) => {


### PR DESCRIPTION
## Objective 
- put spatial bundle behind feature flag
- The way I did it _will_ result in a minor UI difference from pre-feature flag
  - before adding the spatial features, there was a single document table with a "category" column to indicate spatial/supporting
  - I figured it wouldn't be a problem to keep the tables separate like they will be when the flag is turned on 
