### PR TITLE
[MDS-6052] Fixed permission issue when running permit condition extraction in dev/test

### DIFF
--- a/services/permits/app/compare_extraction_results.py
+++ b/services/permits/app/compare_extraction_results.py
@@ -7,10 +7,10 @@ import argparse
 import os
 
 import pandas as pd
+from app.permit_conditions.validator.permit_condition_model import PermitCondition
 from diff_match_patch import diff_match_patch
 from fuzzywuzzy import fuzz
 from jinja2 import Environment, FileSystemLoader
-from permit_conditions.validator.permit_condition_model import PermitCondition
 
 
 # Function to create Content instances from a DataFrame

--- a/services/permits/app/extract_and_validate_pdf.py
+++ b/services/permits/app/extract_and_validate_pdf.py
@@ -57,7 +57,7 @@ def extract_and_validate_conditions(pdf_csv_pairs):
     oauth_session = authenticate_with_oauth()
 
     pairs = []
-    for pdf_path, expected_csv_path in args.pdf_csv_pairs:
+    for pdf_path, expected_csv_path in pdf_csv_pairs:
         print(f"Processing {pdf_path}...")
 
         # 1. Extract conditions from PDF

--- a/services/permits/app/permit_conditions/validator/permit_condition_validator.py
+++ b/services/permits/app/permit_conditions/validator/permit_condition_validator.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import operator
+import os
 from functools import reduce
 from typing import List, Optional
 
@@ -16,6 +17,8 @@ from haystack.dataclasses import ChatMessage
 from pydantic import BaseModel, Field
 
 logger = logging.getLogger(__name__)
+
+DEBUG_MODE = os.environ.get("DEBUG_MODE", "false").lower() == "true"
 
 
 class ExtractionIteration(BaseModel):
@@ -71,13 +74,14 @@ class PermitConditionValidator:
                     {condition.condition_text}
                 """
 
-        with open(f"page_{self.start_page}.json", "w") as f:
-            f.write(
-                json.dumps(
-                    PermitConditions(conditions=conditions).model_dump(mode="json"),
-                    indent=4,
+        if DEBUG_MODE:
+            with open(f"page_{self.start_page}.json", "w") as f:
+                f.write(
+                    json.dumps(
+                        PermitConditions(conditions=conditions).model_dump(mode="json"),
+                        indent=4,
+                    )
                 )
-            )
 
         # If there are more pages to process, return the next iteration
         if self.start_page + self.max_pages < len(data.documents):


### PR DESCRIPTION
## Objective 

[MDS-6052](https://bcmines.atlassian.net/browse/MDS-6052)

Fixed a permission issue when running permit condition extraction in dev/test caused by a missing `DEBUG_MODE` flag