### PR TITLE
[MDS-6042] Added links to permit search results, UX tweaks on permit detail page

### DIFF
--- a/services/common/src/tests/mocks/dataMocks.tsx
+++ b/services/common/src/tests/mocks/dataMocks.tsx
@@ -7220,6 +7220,7 @@ export const PROJECT_SUMMARY: IProjectSummary = {
   expected_permit_application_date: "2020-11-12T22:18:19+00:00",
   expected_permit_receipt_date: "2020-11-20T22:18:19+00:00",
   expected_project_start_date: "2020-11-22T22:18:19+00:00",
+  is_historic: false,
   documents: [
     {
       project_summary_id: 1304,
@@ -7479,6 +7480,7 @@ export const PROJECT_SUMMARIES = {
       expected_permit_application_date: "2020-11-12T22:18:19+00:00",
       expected_permit_receipt_date: "2020-11-20T22:18:19+00:00",
       expected_project_start_date: "2020-11-22T22:18:19+00:00",
+      is_historic: false,
       documents: [],
       contacts: [],
     },

--- a/services/core-web/src/components/mine/Permit/ViewPermit.tsx
+++ b/services/core-web/src/components/mine/Permit/ViewPermit.tsx
@@ -11,6 +11,10 @@ import { fetchPermits } from "@mds/common/redux/actionCreators/permitActionCreat
 import { getMineById } from "@mds/common/redux/selectors/mineSelectors";
 import * as routes from "@/constants/routes";
 import { fetchMineRecordById } from "@mds/common/redux/actionCreators/mineActionCreator";
+import CoreTag from "@mds/common/components/common/CoreTag";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import CompanyIcon from "@mds/common/assets/icons/CompanyIcon";
+import { faLocationDot } from "@fortawesome/pro-light-svg-icons";
 
 const { Title, Text } = Typography;
 
@@ -39,11 +43,11 @@ const ViewPermit = () => {
       label: "Permit Overview",
       children: <ViewPermitOverview />,
     },
-    {
-      key: "2",
-      label: "Permit Conditions",
-      children: <ViewPermitConditions />,
-    },
+    // {
+    //   key: "2",
+    //   label: "Permit Conditions",
+    //   children: <ViewPermitConditions />,
+    // },
   ];
 
   return (
@@ -63,10 +67,10 @@ const ViewPermit = () => {
           </Title>
         </Col>
         <Col>
-          <Tag>{mine?.mine_name}</Tag>
+          <CoreTag icon={<FontAwesomeIcon icon={faLocationDot} />} text={mine?.mine_name} />
         </Col>
         <Col>
-          <Tag>{permit?.current_permittee}</Tag>
+          <CoreTag icon={<CompanyIcon />} text={permit?.current_permittee} />
         </Col>
       </Row>
       <Tabs items={tabItems} />

--- a/services/core-web/src/components/mine/Permit/ViewPermitOverview.tsx
+++ b/services/core-web/src/components/mine/Permit/ViewPermitOverview.tsx
@@ -67,9 +67,9 @@ const ViewPermitOverview = () => {
             Permit Overview
           </Title>
         </Col>
-        <Col>
+        {/* <Col>
           <Button type="primary">Edit Permit</Button>
-        </Col>
+        </Col> */}
       </Row>
       {permit && mine ? (
         <Row>

--- a/services/core-web/src/components/search/MineResultsTable.js
+++ b/services/core-web/src/components/search/MineResultsTable.js
@@ -11,6 +11,8 @@ import {
   renderTextColumn,
 } from "@mds/common/components/common/CoreTableCommonColumns";
 import CoreTable from "@mds/common/components/common/CoreTable";
+import { Feature } from "@mds/common";
+import { useFeatureFlag } from "@mds/common/providers/featureFlags/useFeatureFlag";
 
 /**
  * @class  MineResultsTable - displays a table of mine search results
@@ -27,6 +29,9 @@ const propTypes = {
 const defaultProps = {};
 
 export const MineResultsTable = (props) => {
+  const { isFeatureEnabled } = useFeatureFlag();
+  const digitizedPermitsEnabled = isFeatureEnabled(Feature.DIGITIZED_PERMITS);
+
   const columns = [
     {
       title: "Mine Name",
@@ -44,10 +49,24 @@ export const MineResultsTable = (props) => {
     {
       title: "Permit No.",
       key: "permit_no",
-      render: (record) =>
-        record.mine_permit.map((permit) => (
-          <p key={"mine-permits" + permit.permit_no}>{permit.permit_no}</p>
-        )),
+      render: (record) => {
+        return record.mine_permit.map((permit) => {
+          if (digitizedPermitsEnabled) {
+            return (
+              <p>
+                <Link
+                  key={"mine-permits" + permit.permit_no}
+                  to={router.VIEW_MINE_PERMIT.dynamicRoute(record.mine_guid, permit.permit_guid)}
+                >
+                  {permit.permit_no}
+                </Link>
+              </p>
+            );
+          } else {
+            return <p key={"mine-permits" + permit.permit_no}>{permit.permit_no}</p>;
+          }
+        });
+      },
     },
     renderTextColumn("mine_region", "Region"),
     {

--- a/services/core-web/src/components/search/PermitResultsTable.js
+++ b/services/core-web/src/components/search/PermitResultsTable.js
@@ -9,6 +9,8 @@ import {
   renderHighlightedTextColumn,
   renderTextColumn,
 } from "@mds/common/components/common/CoreTableCommonColumns";
+import { useFeatureFlag } from "@mds/common/providers/featureFlags/useFeatureFlag";
+import { Feature } from "@mds/common";
 
 /**
  * @class  PermitResultsTable - displays a table of mine search results
@@ -23,8 +25,29 @@ const propTypes = {
 const defaultProps = {};
 
 export const PermitResultsTable = (props) => {
+  const { isFeatureEnabled } = useFeatureFlag();
+
   const columns = [
-    renderHighlightedTextColumn("permit_no", "Permit No.", props.highlightRegex),
+    {
+      title: "Permit No.",
+      key: "permit_no",
+      render: (record) => {
+        if (isFeatureEnabled(Feature.DIGITIZED_PERMITS)) {
+          return (
+            <Link
+              to={router.VIEW_MINE_PERMIT.dynamicRoute(
+                record.mine[0].mine_guid,
+                record.permit_guid
+              )}
+            >
+              <Highlight search={props.highlightRegex}>{record.permit_no}</Highlight>
+            </Link>
+          );
+        } else {
+          return <Highlight search={props.highlightRegex}>{record.permit_no}</Highlight>;
+        }
+      },
+    },
     renderHighlightedTextColumn("current_permittee", "Permittee", props.highlightRegex),
     renderTextColumn("current_permittee", "Permittee"),
     {

--- a/services/core-web/src/tests/components/mine/Permit/__snapshots__/ViewPermit.spec.tsx.snap
+++ b/services/core-web/src/tests/components/mine/Permit/__snapshots__/ViewPermit.spec.tsx.snap
@@ -43,19 +43,173 @@ exports[`ViewPermit renders properly 1`] = `
       class="ant-col"
       style="padding-left: 8px; padding-right: 8px;"
     >
-      <span
-        class="ant-tag"
+      <div
+        class="ant-row ant-row-space-between ant-row-middle tag"
       >
-        mine3
-      </span>
+        <svg
+          aria-hidden="true"
+          class="svg-inline--fa fa-location-dot "
+          data-icon="location-dot"
+          data-prefix="fal"
+          focusable="false"
+          role="img"
+          viewBox="0 0 384 512"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M352 192c0-88.4-71.6-160-160-160S32 103.6 32 192c0 15.6 5.4 37 16.6 63.4c10.9 25.9 26.2 54 43.6 82.1c34.1 55.3 74.4 108.2 99.9 140c25.4-31.8 65.8-84.7 99.9-140c17.3-28.1 32.7-56.3 43.6-82.1C346.6 229 352 207.6 352 192zm32 0c0 87.4-117 243-168.3 307.2c-12.3 15.3-35.1 15.3-47.4 0C117 435 0 279.4 0 192C0 86 86 0 192 0S384 86 384 192zm-240 0a48 48 0 1 0 96 0 48 48 0 1 0 -96 0zm48 80a80 80 0 1 1 0-160 80 80 0 1 1 0 160z"
+            fill="currentColor"
+          />
+        </svg>
+        <span
+          class="ant-typography margin-medium--left"
+        >
+          mine3
+        </span>
+      </div>
     </div>
     <div
       class="ant-col"
       style="padding-left: 8px; padding-right: 8px;"
     >
-      <span
-        class="ant-tag"
-      />
+      <div
+        class="ant-row ant-row-space-between ant-row-middle tag"
+      >
+        <span
+          class="anticon"
+          role="img"
+        >
+          <svg
+            fill="none"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M7 3H17C18.1046 3 19 3.89543 19 5V21H5V5C5 3.89543 5.89543 3 7 3Z"
+              fill="transparent"
+              stroke="#3C3636"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="1"
+            />
+            <mask
+              fill="white"
+              id="path-2-inside-1"
+            >
+              <rect
+                height="3"
+                rx="0.5"
+                width="4"
+                x="7"
+                y="5"
+              />
+            </mask>
+            <rect
+              height="3"
+              mask="url(#path-2-inside-1)"
+              rx="0.5"
+              stroke="#3C3636"
+              stroke-width="2"
+              width="4"
+              x="7"
+              y="5"
+            />
+            <mask
+              fill="white"
+              id="path-3-inside-2"
+            >
+              <rect
+                height="3"
+                rx="0.5"
+                width="4"
+                x="13"
+                y="5"
+              />
+            </mask>
+            <rect
+              height="3"
+              mask="url(#path-3-inside-2)"
+              rx="0.5"
+              stroke="#3C3636"
+              stroke-width="2"
+              width="4"
+              x="13"
+              y="5"
+            />
+            <mask
+              fill="white"
+              id="path-4-inside-3"
+            >
+              <rect
+                height="3"
+                rx="0.5"
+                width="4"
+                x="7"
+                y="10"
+              />
+            </mask>
+            <rect
+              height="3"
+              mask="url(#path-4-inside-3)"
+              rx="0.5"
+              stroke="#3C3636"
+              stroke-width="2"
+              width="4"
+              x="7"
+              y="10"
+            />
+            <mask
+              fill="white"
+              id="path-5-inside-4"
+            >
+              <rect
+                height="3"
+                rx="0.5"
+                width="4"
+                x="13"
+                y="10"
+              />
+            </mask>
+            <rect
+              height="3"
+              mask="url(#path-5-inside-4)"
+              rx="0.5"
+              stroke="#3C3636"
+              stroke-width="2"
+              width="4"
+              x="13"
+              y="10"
+            />
+            <mask
+              fill="white"
+              id="path-6-inside-5"
+            >
+              <rect
+                height="6"
+                rx="0.5"
+                width="4"
+                x="13"
+                y="15"
+              />
+            </mask>
+            <rect
+              height="6"
+              mask="url(#path-6-inside-5)"
+              rx="0.5"
+              stroke="#3C3636"
+              stroke-width="2"
+              width="4"
+              x="13"
+              y="15"
+            />
+          </svg>
+        </span>
+        <span
+          class="ant-typography margin-medium--left"
+        />
+      </div>
     </div>
   </div>
   <div
@@ -85,21 +239,6 @@ exports[`ViewPermit renders properly 1`] = `
               tabindex="0"
             >
               Permit Overview
-            </div>
-          </div>
-          <div
-            class="ant-tabs-tab"
-            data-node-key="2"
-          >
-            <div
-              aria-controls="rc-tabs-test-panel-2"
-              aria-selected="false"
-              class="ant-tabs-tab-btn"
-              id="rc-tabs-test-tab-2"
-              role="tab"
-              tabindex="0"
-            >
-              Permit Conditions
             </div>
           </div>
           <div
@@ -171,18 +310,6 @@ exports[`ViewPermit renders properly 1`] = `
                 >
                   Permit Overview
                 </h2>
-              </div>
-              <div
-                class="ant-col"
-              >
-                <button
-                  class="ant-btn ant-btn-primary"
-                  type="button"
-                >
-                  <span>
-                    Edit Permit
-                  </span>
-                </button>
               </div>
             </div>
             <div

--- a/services/core-web/src/tests/components/mine/Permit/__snapshots__/ViewPermitOverview.spec.tsx.snap
+++ b/services/core-web/src/tests/components/mine/Permit/__snapshots__/ViewPermitOverview.spec.tsx.snap
@@ -16,18 +16,6 @@ exports[`MinePermitInfo renders properly 1`] = `
         Permit Overview
       </h2>
     </div>
-    <div
-      class="ant-col"
-    >
-      <button
-        class="ant-btn ant-btn-primary"
-        type="button"
-      >
-        <span>
-          Edit Permit
-        </span>
-      </button>
-    </div>
   </div>
   <div
     class="ant-row"

--- a/services/core-web/src/tests/components/search/__snapshots__/PermitResultsTable.spec.js.snap
+++ b/services/core-web/src/tests/components/search/__snapshots__/PermitResultsTable.spec.js.snap
@@ -12,10 +12,8 @@ exports[`PermitResultsTable renders properly 1`] = `
     columns={
       Array [
         Object {
-          "dataIndex": "permit_no",
           "key": "permit_no",
           "render": [Function],
-          "sorter": [Function],
           "title": "Permit No.",
         },
         Object {


### PR DESCRIPTION
## Objective 

[MDS-6042](https://bcmines.atlassian.net/browse/MDS-6042)

- Link "Permit No." columns on search result page to the new permit detail page (behind a feature flag)
- Hide Permit Conditions tab and "Edit Permit" button as they currently do nothing (in case we want to release permit detail page).
- Reinstated the new header tag
![image](https://github.com/user-attachments/assets/f1efafc4-6996-4e3e-868d-00c5140ceb79)
![image](https://github.com/user-attachments/assets/9bff596e-dbdd-4a63-82cd-619bdadf57ce)

![image](https://github.com/user-attachments/assets/d3353786-2331-472f-934d-f3e62f743ad4)
