### PR TITLE
[MDS-5986] Do not allow multiple connections acceptance

### DIFF
--- a/services/core-api/app/api/services/traction_service.py
+++ b/services/core-api/app/api/services/traction_service.py
@@ -24,6 +24,10 @@ def traction_issue_credential_problem_report(cred_ex_id: str):
     return Config.TRACTION_HOST + f"/issue-credential/records/{cred_ex_id}/problem-report"
 
 
+def traction_reject_invitation(connection_id: str):
+    return Config.TRACTION_HOST + f"/didexchange/{connection_id}/reject"
+
+
 class VerificableCredentialWorkflowError(Exception):
     pass
 
@@ -90,6 +94,12 @@ class TractionService():
         revoke_resp = requests.delete(
             traction_connections + "/" + str(connection_id), headers=self.get_headers())
         assert revoke_resp.status_code == 200, f"revoke_resp={revoke_resp.json()}"
+        return True
+
+    def reject_invitation(self, connection_id) -> bool:
+        reject_resp = requests.delete(
+            traction_reject_invitation(connection_id), headers=self.get_headers())
+        assert reject_resp.status_code == 200, f"reject_resp={reject_resp.json()}"
         return True
 
     def offer_mines_act_permit_111(self, connection_id, attributes):

--- a/services/core-api/app/api/verifiable_credentials/resources/traction_webhook.py
+++ b/services/core-api/app/api/verifiable_credentials/resources/traction_webhook.py
@@ -63,7 +63,7 @@ class TractionWebhookResource(Resource, UserMixin):
                     if not traction_svc.reject_invitation(webhook_body["connection_id"]):
                         current_app.logger.error(
                             f"error occured while attempting to reject the connection")
-
+                    return
                 vc_conn.connection_id = webhook_body["connection_id"]
 
             if vc_conn.last_webhook_timestamp and vc_conn.last_webhook_timestamp >= webhook_timestamp:


### PR DESCRIPTION
## Objective 

[MDS-5986 ](https://bcmines.atlassian.net/browse/MDS-5986 )

_Why are you making this change? Provide a short explanation and/or screenshots_

When a second invitation is accepted, the webhook will not process it normally, and will delete the connection and invitiation record in traction so it cannot be processed again. 

This will need to be tested in Dev with a real-time integration. local testing is not representative of using webhook.site