### PR TITLE
[FIX] Match "is_historic" flag to current feature flag status

### DIFF
--- a/services/core-api/app/api/projects/project_summary/models/project_summary.py
+++ b/services/core-api/app/api/projects/project_summary/models/project_summary.py
@@ -906,8 +906,9 @@ class ProjectSummary(SoftDeleteMixin, AuditMixin, Base):
                authorizations=[],
                ams_authorizations=None,
                submission_date=None,
-               add_to_session=True,
-               is_historic=False):
+               add_to_session=True):
+
+        is_historic = not is_feature_enabled(Feature.AMS_AGENT)
 
         project_summary = cls(
             project_summary_description=project_summary_description,


### PR DESCRIPTION
## Objective 
- make sure that records created after the migration is pushed to prod, but before the flag is turned on, are validated consistently by setting is_historic based on the flag.
