### PR TITLE
[FIX] Styling issues on All Documents page for Proejcts

### DIFF
--- a/services/common/src/components/common/CoreTableCommonColumns.tsx
+++ b/services/common/src/components/common/CoreTableCommonColumns.tsx
@@ -152,7 +152,7 @@ export const renderTaggedColumn = (
           <div className={`tag-text-${containerClass}`}>{text}</div>
           {tagText && (
             <div className="file-history-container">
-              <Tag className="table-tag-primary" icon={icon}>
+              <Tag className="table-tag table-tag--primary" icon={icon}>
                 {tagText}
               </Tag>
             </div>

--- a/services/common/src/components/documents/DocumentColumns.tsx
+++ b/services/common/src/components/documents/DocumentColumns.tsx
@@ -39,14 +39,14 @@ const documentWithTag = (
               <Tag
                 icon={<ClockCircleOutlined />}
                 style={{ border: "none" }}
-                className="file-version-amount table-tag-primary"
+                className="table-tag table-tag--primary"
               >
                 {record.number_prev_versions}
               </Tag>
             </Tooltip>
           </span>
         ) : null}
-        {record.is_archived ? <Tag>{"Archived"}</Tag> : null}
+        {record.is_archived ? <Tag className="table-tag table-tag--grey">{"Archived"}</Tag> : null}
       </span>
     </div>
   );

--- a/services/common/src/components/documents/spatial/SpatialDocumentTable.tsx
+++ b/services/common/src/components/documents/spatial/SpatialDocumentTable.tsx
@@ -1,6 +1,6 @@
 import React, { FC, useState } from "react";
 import { useDispatch } from "react-redux";
-import DocumentTableProps from "@mds/common/interfaces/document/documentTableProps.interface";
+import { GenericDocTableProps } from "@mds/common/interfaces/document/documentTableProps.interface";
 import CoreTable from "../../common/CoreTable";
 import { uploadDateColumn, uploadedByColumn } from "../DocumentColumns";
 import {
@@ -14,8 +14,15 @@ import DocumentCompression from "../DocumentCompression";
 import { MineDocument } from "@mds/common/models/documents/document";
 import { spatialBundlesFromFiles } from "@mds/common/redux/slices/spatialDataSlice";
 import { downloadFileFromDocumentManager } from "@mds/common/redux/utils/actionlessNetworkCalls";
+import { ISpatialBundle } from "@mds/common/interfaces/document/spatialBundle.interface";
+import { IMineDocument } from "@mds/common/interfaces";
 
-const SpatialDocumentTable: FC<DocumentTableProps> = ({ documents }) => {
+interface SpatialDocumentTableProps extends GenericDocTableProps<ISpatialBundle> {
+  documents: IMineDocument[];
+  categoryText?: string; // if set, will display a category column with this text
+}
+
+const SpatialDocumentTable: FC<SpatialDocumentTableProps> = ({ documents, categoryText }) => {
   const dispatch = useDispatch();
   const [isCompressionModalVisible, setIsCompressionModalVisible] = useState(false);
 
@@ -56,8 +63,19 @@ const SpatialDocumentTable: FC<DocumentTableProps> = ({ documents }) => {
     { key: "view-detail", label: "View Details", clickFunction: viewSpatialBundle },
   ];
 
+  const categoryColumn = categoryText
+    ? [
+        {
+          key: "category",
+          title: "Category",
+          render: () => <div title="Category">{categoryText}</div>,
+        },
+      ]
+    : [];
+
   const columns = [
     renderTaggedColumn("document_name", "bundleSize", "File Name"),
+    ...categoryColumn,
     uploadDateColumn("upload_date", "Last Modified"),
     uploadedByColumn("create_user", "Created By"),
     renderActionsColumn({ actions, recordActionsFilter }),

--- a/services/common/src/components/documents/spatial/__snapshots__/SpatialDocumentTable.spec.tsx.snap
+++ b/services/common/src/components/documents/spatial/__snapshots__/SpatialDocumentTable.spec.tsx.snap
@@ -272,7 +272,7 @@ exports[`SpatialDocumentTable renders properly 1`] = `
                           class="file-history-container"
                         >
                           <span
-                            class="ant-tag table-tag-primary"
+                            class="ant-tag table-tag table-tag--primary"
                           >
                             <svg
                               aria-hidden="true"

--- a/services/common/src/components/projects/ArchivedDocumentsSection.tsx
+++ b/services/common/src/components/projects/ArchivedDocumentsSection.tsx
@@ -12,12 +12,14 @@ interface ArchivedDocumentsSectionProps {
   documents: MineDocument[];
   titleLevel?: 1 | 2 | 3 | 4 | 5;
   href?: string;
+  showCategory?: boolean;
 }
 
 const ArchivedDocumentsSection: FC<ArchivedDocumentsSectionProps> = ({
   titleLevel = 4,
   href = "archived-documents",
   documents,
+  showCategory = true,
 }) => {
   const { isFeatureEnabled } = useFeatureFlag();
 
@@ -25,7 +27,9 @@ const ArchivedDocumentsSection: FC<ArchivedDocumentsSectionProps> = ({
     return <></>;
   }
 
-  const additionalColumns = [renderCategoryColumn("category_code", "Category", CATEGORY_CODE)];
+  const additionalColumns = showCategory
+    ? [renderCategoryColumn("category_code", "Category", CATEGORY_CODE)]
+    : [];
 
   return (
     <div id={href}>

--- a/services/common/src/components/projects/ProjectDocumentsTab.tsx
+++ b/services/common/src/components/projects/ProjectDocumentsTab.tsx
@@ -3,7 +3,13 @@ import { useDispatch, useSelector } from "react-redux";
 import ScrollSidePageWrapper from "../common/ScrollSidePageWrapper";
 import { ScrollSideMenuProps } from "../common/ScrollSideMenu";
 import { fetchProjectById } from "@mds/common/redux/actionCreators/projectActionCreator";
-import { Feature, IProject, IProjectSummaryAuthorization, SystemFlagEnum } from "../..";
+import {
+  CATEGORY_CODE,
+  Feature,
+  IProject,
+  IProjectSummaryAuthorization,
+  SystemFlagEnum,
+} from "../..";
 import { Alert, Col, Row, Typography } from "antd";
 import ProjectDocumentsTabSection from "./ProjectDocumentsTabSection";
 import { useFeatureFlag } from "@mds/common/providers/featureFlags/useFeatureFlag";
@@ -15,6 +21,7 @@ import SpatialDocumentTable from "../documents/spatial/SpatialDocumentTable";
 import { fetchMineDocuments } from "@mds/common/redux/actionCreators/mineActionCreator";
 import { MineDocument } from "@mds/common/models/documents/document";
 import Loading from "../common/Loading";
+import { getProjectSummaryDocumentTypesHash } from "@mds/common/redux/selectors/staticContentSelectors";
 
 interface ProjectDocumentsTabProps {
   project: IProject;
@@ -22,6 +29,8 @@ interface ProjectDocumentsTabProps {
 const ProjectDocumentsTab: FC<ProjectDocumentsTabProps> = ({ project }) => {
   const dispatch = useDispatch();
   const mineDocuments = useSelector(getMineDocuments);
+  const projectSummaryDocumentTypesHash = useSelector(getProjectSummaryDocumentTypesHash);
+
   const { isFeatureEnabled } = useFeatureFlag();
   const systemFlag = useSelector(getSystemFlag);
   const isCore = systemFlag === SystemFlagEnum.core;
@@ -72,28 +81,54 @@ const ProjectDocumentsTab: FC<ProjectDocumentsTabProps> = ({ project }) => {
       .toLowerCase();
   };
 
-  const projectSummaryDocs = project?.project_summary?.documents ?? [];
+  const projectSummaryDocs =
+    project?.project_summary?.documents.map(
+      (d) =>
+        new MineDocument({
+          ...d,
+          category: projectSummaryDocumentTypesHash[d.project_summary_document_type_code],
+        })
+    ) ?? [];
 
   const pdSpatialDocuments = projectSummaryDocs.filter(
-    (doc) => doc.project_summary_document_type_code === "SPT"
+    (doc) => doc.category === projectSummaryDocumentTypesHash.SPT
   );
   const pdSupportingDocuments = projectSummaryDocs.filter(
-    (doc) => doc.project_summary_document_type_code === "SPR"
+    (doc) => doc.category === projectSummaryDocumentTypesHash.SPR
   );
 
-  const majorMineAppDocs = project?.major_mine_application?.documents ?? [];
+  const majorMineAppDocs =
+    project?.major_mine_application?.documents.map(
+      (d) =>
+        new MineDocument({
+          ...d,
+          category: CATEGORY_CODE[d.major_mine_application_document_type_code],
+        })
+    ) ?? [];
 
-  const primaryDocuments = majorMineAppDocs.filter(
-    (doc) => doc.major_mine_application_document_type_code === "PRM"
-  );
-  const mmaSpatialDocuments = majorMineAppDocs.filter(
-    (doc) => doc.major_mine_application_document_type_code === "SPT"
-  );
+  const primaryDocuments = majorMineAppDocs.filter((doc) => doc.category === CATEGORY_CODE.PRM);
+  const mmaSpatialDocuments = majorMineAppDocs.filter((doc) => doc.category === CATEGORY_CODE.SPT);
   const mmaSupportingDocuments = majorMineAppDocs.filter(
-    (doc) => doc.major_mine_application_document_type_code === "SPR"
+    (doc) => doc.category === CATEGORY_CODE.SPR
   );
-  const ministryDecisionDocuments = project?.project_decision_package?.documents ?? [];
+  const ministryDecisionDocuments =
+    project?.project_decision_package?.documents?.map(
+      (d) =>
+        new MineDocument({
+          ...d,
+          category: CATEGORY_CODE[d.project_decision_package_document_type_code],
+        })
+    ) ?? [];
+  const irtDocuments =
+    project?.information_requirements_table?.documents?.map(
+      (d) =>
+        new MineDocument({
+          ...d,
+          category: CATEGORY_CODE[d.information_requirements_table_document_type_code],
+        })
+    ) ?? [];
 
+  const spatialCategoryText = "Spatial Files";
   const sections: any[] = [
     {
       href: "project-description",
@@ -123,7 +158,13 @@ const ProjectDocumentsTab: FC<ProjectDocumentsTabProps> = ({ project }) => {
             key={auth.project_summary_authorization_guid}
             canArchive={false}
             onArchivedDocuments={refreshData}
-            documents={auth.amendment_documents}
+            documents={auth.amendment_documents.map(
+              (d) =>
+                new MineDocument({
+                  ...d,
+                  category: projectSummaryDocumentTypesHash[d.project_summary_document_type_code],
+                })
+            )}
           />
         ),
       };
@@ -134,7 +175,7 @@ const ProjectDocumentsTab: FC<ProjectDocumentsTabProps> = ({ project }) => {
       content: (
         <>
           <Typography.Title level={4}>Spatial Components</Typography.Title>
-          <SpatialDocumentTable documents={pdSpatialDocuments.map((d) => new MineDocument(d))} />
+          <SpatialDocumentTable documents={pdSpatialDocuments} categoryText={spatialCategoryText} />
         </>
       ),
     },
@@ -145,7 +186,7 @@ const ProjectDocumentsTab: FC<ProjectDocumentsTabProps> = ({ project }) => {
         <ProjectDocumentsTabSection
           id="pd-supporting-documents"
           title="Supporting Documents"
-          documents={pdSupportingDocuments.map((d) => new MineDocument(d))}
+          documents={pdSupportingDocuments}
           onArchivedDocuments={refreshData}
         />
       ),
@@ -157,7 +198,7 @@ const ProjectDocumentsTab: FC<ProjectDocumentsTabProps> = ({ project }) => {
           id="information-requirements-table"
           key="information-requirements-table"
           onArchivedDocuments={refreshData}
-          documents={project.information_requirements_table.documents}
+          documents={irtDocuments}
         />
       ),
     },
@@ -180,7 +221,10 @@ const ProjectDocumentsTab: FC<ProjectDocumentsTabProps> = ({ project }) => {
       content: (
         <>
           <Typography.Title level={4}>Spatial Components</Typography.Title>
-          <SpatialDocumentTable documents={mmaSpatialDocuments.map((d) => new MineDocument(d))} />
+          <SpatialDocumentTable
+            documents={mmaSpatialDocuments}
+            categoryText={spatialCategoryText}
+          />
         </>
       ),
     },
@@ -203,13 +247,13 @@ const ProjectDocumentsTab: FC<ProjectDocumentsTabProps> = ({ project }) => {
           id="ministry-decision-documentation"
           key="ministry-decision-documentation"
           onArchivedDocuments={refreshData}
-          documents={ministryDecisionDocuments.map((doc) => new MineDocument(doc))}
+          documents={ministryDecisionDocuments}
         />
       ),
     },
     isFeatureEnabled(Feature.MAJOR_PROJECT_ARCHIVE_FILE) && {
       href: "archived-documents",
-      content: <ArchivedDocumentsSection documents={mineDocuments} />,
+      content: <ArchivedDocumentsSection documents={mineDocuments} showCategory={false} />,
     },
   ].filter(Boolean);
 

--- a/services/common/src/components/projects/ProjectDocumentsTabSection.tsx
+++ b/services/common/src/components/projects/ProjectDocumentsTabSection.tsx
@@ -1,14 +1,14 @@
 import React, { FC } from "react";
 import { Row, Col, Typography } from "antd";
 import DocumentTable from "../documents/DocumentTable";
-import { IMineDocument } from "../..";
 import { MineDocument } from "@mds/common/models/documents/document";
 import { formatUrlToUpperCaseString } from "@mds/common/redux/utils/helpers";
+import { renderTextColumn } from "../common/CoreTableCommonColumns";
 
 interface ProjectDocumentsTabSectionProps {
   id: string;
   title?: string;
-  documents: IMineDocument[];
+  documents: MineDocument[];
   onArchivedDocuments: () => Promise<void>;
   canArchive?: boolean;
 }
@@ -28,8 +28,9 @@ const ProjectDocumentsTabSection: FC<ProjectDocumentsTabSectionProps> = ({
       </Col>
       <Col span={24}>
         <DocumentTable
-          documents={documents?.map((d) => new MineDocument(d)) ?? []}
+          documents={documents ?? []}
           documentParent={title}
+          additionalColumns={[renderTextColumn("category", "Category")]}
           canArchiveDocuments={canArchive}
           onArchivedDocuments={onArchivedDocuments}
           showVersionHistory={true}

--- a/services/common/src/components/projects/__snapshots__/ProjectDocumentsTab.spec.tsx.snap
+++ b/services/common/src/components/projects/__snapshots__/ProjectDocumentsTab.spec.tsx.snap
@@ -339,6 +339,11 @@ exports[`ProjectDocumentsTab renders properly 1`] = `
                               </div>
                             </th>
                             <th
+                              class="ant-table-cell"
+                            >
+                              Category
+                            </th>
+                            <th
                               aria-label="Last Modified"
                               class="ant-table-cell ant-table-column-has-sorters"
                               tabindex="0"
@@ -520,7 +525,7 @@ exports[`ProjectDocumentsTab renders properly 1`] = `
                                   class="file-history-container"
                                 >
                                   <span
-                                    class="ant-tag table-tag-primary"
+                                    class="ant-tag table-tag table-tag--primary"
                                   >
                                     <svg
                                       aria-hidden="true"
@@ -538,10 +543,19 @@ exports[`ProjectDocumentsTab renders properly 1`] = `
                                       />
                                     </svg>
                                     <span>
-                                      4
+                                      5
                                     </span>
                                   </span>
                                 </div>
+                              </div>
+                            </td>
+                            <td
+                              class="ant-table-cell"
+                            >
+                              <div
+                                title="Category"
+                              >
+                                Spatial Files
                               </div>
                             </td>
                             <td
@@ -621,6 +635,15 @@ exports[`ProjectDocumentsTab renders properly 1`] = `
                                 >
                                   pdf1.kmz
                                 </div>
+                              </div>
+                            </td>
+                            <td
+                              class="ant-table-cell"
+                            >
+                              <div
+                                title="Category"
+                              >
+                                Spatial Files
                               </div>
                             </td>
                             <td
@@ -865,6 +888,11 @@ exports[`ProjectDocumentsTab renders properly 1`] = `
                                     </div>
                                   </th>
                                   <th
+                                    class="ant-table-cell"
+                                  >
+                                    Category
+                                  </th>
+                                  <th
                                     aria-label="File Type"
                                     class="ant-table-cell ant-table-column-has-sorters"
                                     tabindex="0"
@@ -1058,6 +1086,486 @@ exports[`ProjectDocumentsTab renders properly 1`] = `
                               >
                                 <tr
                                   class="ant-table-row ant-table-row-level-0 table-row-align-middle no-sub-table-expandable-rows fade-in"
+                                  data-row-key="811bea71-f93a-45a1-a8a0-09f918f1cb78"
+                                >
+                                  <td
+                                    class="ant-table-cell ant-table-selection-column"
+                                  >
+                                    <label
+                                      class="ant-checkbox-wrapper"
+                                    >
+                                      <span
+                                        class="ant-checkbox"
+                                      >
+                                        <input
+                                          class="ant-checkbox-input"
+                                          type="checkbox"
+                                        />
+                                        <span
+                                          class="ant-checkbox-inner"
+                                        />
+                                      </span>
+                                    </label>
+                                  </td>
+                                  <td
+                                    class="ant-table-cell ant-table-cell-with-append"
+                                  >
+                                    <span
+                                      class="ant-table-row-indent indent-level-0"
+                                      style="padding-left: 0px;"
+                                    />
+                                    <div
+                                      class="inline-flex flex-between file-name-container"
+                                      style="margin-left: 38px;"
+                                      title="File Name"
+                                    >
+                                      <a>
+                                        pdf1.kmz
+                                      </a>
+                                      <span
+                                        class="file-history-container"
+                                      />
+                                    </div>
+                                  </td>
+                                  <td
+                                    class="ant-table-cell"
+                                  >
+                                    <div
+                                      class="category-column"
+                                      title="Category"
+                                    >
+                                      N/A
+                                    </div>
+                                  </td>
+                                  <td
+                                    class="ant-table-cell"
+                                  >
+                                    <div
+                                      class="file_type-column"
+                                      title="File Type"
+                                    >
+                                      .kmz
+                                    </div>
+                                  </td>
+                                  <td
+                                    class="ant-table-cell ant-table-column-sort"
+                                  >
+                                    <div
+                                      title="Last Modified"
+                                    >
+                                      N/A
+                                    </div>
+                                  </td>
+                                  <td
+                                    class="ant-table-cell"
+                                  >
+                                    <div
+                                      class="create_user-column"
+                                      title="Created By"
+                                    >
+                                      idir\\username
+                                    </div>
+                                  </td>
+                                  <td
+                                    class="ant-table-cell actions-column ant-table-cell-fix-right ant-table-cell-fix-right-first"
+                                    style="position: sticky; right: 0px;"
+                                  >
+                                    <div>
+                                      <button
+                                        class="ant-btn ant-btn-default ant-dropdown-trigger actions-dropdown-button "
+                                        data-cy="menu-actions-button"
+                                        type="button"
+                                      >
+                                        <span>
+                                          Actions
+                                        </span>
+                                        <span
+                                          alt="Menu"
+                                          aria-label="caret-down"
+                                          class="anticon anticon-caret-down"
+                                          role="img"
+                                        >
+                                          <svg
+                                            aria-hidden="true"
+                                            class=""
+                                            data-icon="caret-down"
+                                            fill="currentColor"
+                                            focusable="false"
+                                            height="1em"
+                                            viewBox="0 0 1024 1024"
+                                            width="1em"
+                                          >
+                                            <path
+                                              d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
+                                            />
+                                          </svg>
+                                        </span>
+                                      </button>
+                                    </div>
+                                  </td>
+                                </tr>
+                                <tr
+                                  class="ant-table-row ant-table-row-level-0 table-row-align-middle no-sub-table-expandable-rows fade-in"
+                                  data-row-key="ffbf5b37-3520-4bf2-9050-2bc857ca6df9"
+                                >
+                                  <td
+                                    class="ant-table-cell ant-table-selection-column"
+                                  >
+                                    <label
+                                      class="ant-checkbox-wrapper"
+                                    >
+                                      <span
+                                        class="ant-checkbox"
+                                      >
+                                        <input
+                                          class="ant-checkbox-input"
+                                          type="checkbox"
+                                        />
+                                        <span
+                                          class="ant-checkbox-inner"
+                                        />
+                                      </span>
+                                    </label>
+                                  </td>
+                                  <td
+                                    class="ant-table-cell ant-table-cell-with-append"
+                                  >
+                                    <span
+                                      class="ant-table-row-indent indent-level-0"
+                                      style="padding-left: 0px;"
+                                    />
+                                    <div
+                                      class="inline-flex flex-between file-name-container"
+                                      style="margin-left: 38px;"
+                                      title="File Name"
+                                    >
+                                      <a>
+                                        shape.dbf
+                                      </a>
+                                      <span
+                                        class="file-history-container"
+                                      />
+                                    </div>
+                                  </td>
+                                  <td
+                                    class="ant-table-cell"
+                                  >
+                                    <div
+                                      class="category-column"
+                                      title="Category"
+                                    >
+                                      N/A
+                                    </div>
+                                  </td>
+                                  <td
+                                    class="ant-table-cell"
+                                  >
+                                    <div
+                                      class="file_type-column"
+                                      title="File Type"
+                                    >
+                                      .dbf
+                                    </div>
+                                  </td>
+                                  <td
+                                    class="ant-table-cell ant-table-column-sort"
+                                  >
+                                    <div
+                                      title="Last Modified"
+                                    >
+                                      N/A
+                                    </div>
+                                  </td>
+                                  <td
+                                    class="ant-table-cell"
+                                  >
+                                    <div
+                                      class="create_user-column"
+                                      title="Created By"
+                                    >
+                                      idir\\username
+                                    </div>
+                                  </td>
+                                  <td
+                                    class="ant-table-cell actions-column ant-table-cell-fix-right ant-table-cell-fix-right-first"
+                                    style="position: sticky; right: 0px;"
+                                  >
+                                    <div>
+                                      <button
+                                        class="ant-btn ant-btn-default ant-dropdown-trigger actions-dropdown-button "
+                                        data-cy="menu-actions-button"
+                                        type="button"
+                                      >
+                                        <span>
+                                          Actions
+                                        </span>
+                                        <span
+                                          alt="Menu"
+                                          aria-label="caret-down"
+                                          class="anticon anticon-caret-down"
+                                          role="img"
+                                        >
+                                          <svg
+                                            aria-hidden="true"
+                                            class=""
+                                            data-icon="caret-down"
+                                            fill="currentColor"
+                                            focusable="false"
+                                            height="1em"
+                                            viewBox="0 0 1024 1024"
+                                            width="1em"
+                                          >
+                                            <path
+                                              d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
+                                            />
+                                          </svg>
+                                        </span>
+                                      </button>
+                                    </div>
+                                  </td>
+                                </tr>
+                                <tr
+                                  class="ant-table-row ant-table-row-level-0 table-row-align-middle no-sub-table-expandable-rows fade-in"
+                                  data-row-key="64dff8f0-7f94-4eef-9ac1-7b70fd90e053"
+                                >
+                                  <td
+                                    class="ant-table-cell ant-table-selection-column"
+                                  >
+                                    <label
+                                      class="ant-checkbox-wrapper"
+                                    >
+                                      <span
+                                        class="ant-checkbox"
+                                      >
+                                        <input
+                                          class="ant-checkbox-input"
+                                          type="checkbox"
+                                        />
+                                        <span
+                                          class="ant-checkbox-inner"
+                                        />
+                                      </span>
+                                    </label>
+                                  </td>
+                                  <td
+                                    class="ant-table-cell ant-table-cell-with-append"
+                                  >
+                                    <span
+                                      class="ant-table-row-indent indent-level-0"
+                                      style="padding-left: 0px;"
+                                    />
+                                    <div
+                                      class="inline-flex flex-between file-name-container"
+                                      style="margin-left: 38px;"
+                                      title="File Name"
+                                    >
+                                      <a>
+                                        shape.prj
+                                      </a>
+                                      <span
+                                        class="file-history-container"
+                                      />
+                                    </div>
+                                  </td>
+                                  <td
+                                    class="ant-table-cell"
+                                  >
+                                    <div
+                                      class="category-column"
+                                      title="Category"
+                                    >
+                                      N/A
+                                    </div>
+                                  </td>
+                                  <td
+                                    class="ant-table-cell"
+                                  >
+                                    <div
+                                      class="file_type-column"
+                                      title="File Type"
+                                    >
+                                      .prj
+                                    </div>
+                                  </td>
+                                  <td
+                                    class="ant-table-cell ant-table-column-sort"
+                                  >
+                                    <div
+                                      title="Last Modified"
+                                    >
+                                      N/A
+                                    </div>
+                                  </td>
+                                  <td
+                                    class="ant-table-cell"
+                                  >
+                                    <div
+                                      class="create_user-column"
+                                      title="Created By"
+                                    >
+                                      idir\\username
+                                    </div>
+                                  </td>
+                                  <td
+                                    class="ant-table-cell actions-column ant-table-cell-fix-right ant-table-cell-fix-right-first"
+                                    style="position: sticky; right: 0px;"
+                                  >
+                                    <div>
+                                      <button
+                                        class="ant-btn ant-btn-default ant-dropdown-trigger actions-dropdown-button "
+                                        data-cy="menu-actions-button"
+                                        type="button"
+                                      >
+                                        <span>
+                                          Actions
+                                        </span>
+                                        <span
+                                          alt="Menu"
+                                          aria-label="caret-down"
+                                          class="anticon anticon-caret-down"
+                                          role="img"
+                                        >
+                                          <svg
+                                            aria-hidden="true"
+                                            class=""
+                                            data-icon="caret-down"
+                                            fill="currentColor"
+                                            focusable="false"
+                                            height="1em"
+                                            viewBox="0 0 1024 1024"
+                                            width="1em"
+                                          >
+                                            <path
+                                              d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
+                                            />
+                                          </svg>
+                                        </span>
+                                      </button>
+                                    </div>
+                                  </td>
+                                </tr>
+                                <tr
+                                  class="ant-table-row ant-table-row-level-0 table-row-align-middle no-sub-table-expandable-rows fade-in"
+                                  data-row-key="11fe5376-cd0e-4929-bcc2-85540fd121ed"
+                                >
+                                  <td
+                                    class="ant-table-cell ant-table-selection-column"
+                                  >
+                                    <label
+                                      class="ant-checkbox-wrapper"
+                                    >
+                                      <span
+                                        class="ant-checkbox"
+                                      >
+                                        <input
+                                          class="ant-checkbox-input"
+                                          type="checkbox"
+                                        />
+                                        <span
+                                          class="ant-checkbox-inner"
+                                        />
+                                      </span>
+                                    </label>
+                                  </td>
+                                  <td
+                                    class="ant-table-cell ant-table-cell-with-append"
+                                  >
+                                    <span
+                                      class="ant-table-row-indent indent-level-0"
+                                      style="padding-left: 0px;"
+                                    />
+                                    <div
+                                      class="inline-flex flex-between file-name-container"
+                                      style="margin-left: 38px;"
+                                      title="File Name"
+                                    >
+                                      <a>
+                                        shape.shp
+                                      </a>
+                                      <span
+                                        class="file-history-container"
+                                      />
+                                    </div>
+                                  </td>
+                                  <td
+                                    class="ant-table-cell"
+                                  >
+                                    <div
+                                      class="category-column"
+                                      title="Category"
+                                    >
+                                      N/A
+                                    </div>
+                                  </td>
+                                  <td
+                                    class="ant-table-cell"
+                                  >
+                                    <div
+                                      class="file_type-column"
+                                      title="File Type"
+                                    >
+                                      .shp
+                                    </div>
+                                  </td>
+                                  <td
+                                    class="ant-table-cell ant-table-column-sort"
+                                  >
+                                    <div
+                                      title="Last Modified"
+                                    >
+                                      N/A
+                                    </div>
+                                  </td>
+                                  <td
+                                    class="ant-table-cell"
+                                  >
+                                    <div
+                                      class="create_user-column"
+                                      title="Created By"
+                                    >
+                                      idir\\username
+                                    </div>
+                                  </td>
+                                  <td
+                                    class="ant-table-cell actions-column ant-table-cell-fix-right ant-table-cell-fix-right-first"
+                                    style="position: sticky; right: 0px;"
+                                  >
+                                    <div>
+                                      <button
+                                        class="ant-btn ant-btn-default ant-dropdown-trigger actions-dropdown-button "
+                                        data-cy="menu-actions-button"
+                                        type="button"
+                                      >
+                                        <span>
+                                          Actions
+                                        </span>
+                                        <span
+                                          alt="Menu"
+                                          aria-label="caret-down"
+                                          class="anticon anticon-caret-down"
+                                          role="img"
+                                        >
+                                          <svg
+                                            aria-hidden="true"
+                                            class=""
+                                            data-icon="caret-down"
+                                            fill="currentColor"
+                                            focusable="false"
+                                            height="1em"
+                                            viewBox="0 0 1024 1024"
+                                            width="1em"
+                                          >
+                                            <path
+                                              d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
+                                            />
+                                          </svg>
+                                        </span>
+                                      </button>
+                                    </div>
+                                  </td>
+                                </tr>
+                                <tr
+                                  class="ant-table-row ant-table-row-level-0 table-row-align-middle no-sub-table-expandable-rows fade-in"
                                   data-row-key="b869134f-bcf8-47d9-ac61-c90835e20601"
                                 >
                                   <td
@@ -1097,6 +1605,136 @@ exports[`ProjectDocumentsTab renders properly 1`] = `
                                       <span
                                         class="file-history-container"
                                       />
+                                    </div>
+                                  </td>
+                                  <td
+                                    class="ant-table-cell"
+                                  >
+                                    <div
+                                      class="category-column"
+                                      title="Category"
+                                    >
+                                      N/A
+                                    </div>
+                                  </td>
+                                  <td
+                                    class="ant-table-cell"
+                                  >
+                                    <div
+                                      class="file_type-column"
+                                      title="File Type"
+                                    >
+                                      .shx
+                                    </div>
+                                  </td>
+                                  <td
+                                    class="ant-table-cell ant-table-column-sort"
+                                  >
+                                    <div
+                                      title="Last Modified"
+                                    >
+                                      N/A
+                                    </div>
+                                  </td>
+                                  <td
+                                    class="ant-table-cell"
+                                  >
+                                    <div
+                                      class="create_user-column"
+                                      title="Created By"
+                                    >
+                                      idir\\username
+                                    </div>
+                                  </td>
+                                  <td
+                                    class="ant-table-cell actions-column ant-table-cell-fix-right ant-table-cell-fix-right-first"
+                                    style="position: sticky; right: 0px;"
+                                  >
+                                    <div>
+                                      <button
+                                        class="ant-btn ant-btn-default ant-dropdown-trigger actions-dropdown-button "
+                                        data-cy="menu-actions-button"
+                                        type="button"
+                                      >
+                                        <span>
+                                          Actions
+                                        </span>
+                                        <span
+                                          alt="Menu"
+                                          aria-label="caret-down"
+                                          class="anticon anticon-caret-down"
+                                          role="img"
+                                        >
+                                          <svg
+                                            aria-hidden="true"
+                                            class=""
+                                            data-icon="caret-down"
+                                            fill="currentColor"
+                                            focusable="false"
+                                            height="1em"
+                                            viewBox="0 0 1024 1024"
+                                            width="1em"
+                                          >
+                                            <path
+                                              d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
+                                            />
+                                          </svg>
+                                        </span>
+                                      </button>
+                                    </div>
+                                  </td>
+                                </tr>
+                                <tr
+                                  class="ant-table-row ant-table-row-level-0 table-row-align-middle no-sub-table-expandable-rows fade-in"
+                                  data-row-key="b869134f-bcf8-47d9-ac61-c90835e20601"
+                                >
+                                  <td
+                                    class="ant-table-cell ant-table-selection-column"
+                                  >
+                                    <label
+                                      class="ant-checkbox-wrapper"
+                                    >
+                                      <span
+                                        class="ant-checkbox"
+                                      >
+                                        <input
+                                          class="ant-checkbox-input"
+                                          type="checkbox"
+                                        />
+                                        <span
+                                          class="ant-checkbox-inner"
+                                        />
+                                      </span>
+                                    </label>
+                                  </td>
+                                  <td
+                                    class="ant-table-cell ant-table-cell-with-append"
+                                  >
+                                    <span
+                                      class="ant-table-row-indent indent-level-0"
+                                      style="padding-left: 0px;"
+                                    />
+                                    <div
+                                      class="inline-flex flex-between file-name-container"
+                                      style="margin-left: 38px;"
+                                      title="File Name"
+                                    >
+                                      <a>
+                                        shape.shx
+                                      </a>
+                                      <span
+                                        class="file-history-container"
+                                      />
+                                    </div>
+                                  </td>
+                                  <td
+                                    class="ant-table-cell"
+                                  >
+                                    <div
+                                      class="category-column"
+                                      title="Category"
+                                    >
+                                      N/A
                                     </div>
                                   </td>
                                   <td
@@ -1355,6 +1993,11 @@ exports[`ProjectDocumentsTab renders properly 1`] = `
                                     </div>
                                   </th>
                                   <th
+                                    class="ant-table-cell"
+                                  >
+                                    Category
+                                  </th>
+                                  <th
                                     aria-label="File Type"
                                     class="ant-table-cell ant-table-column-has-sorters"
                                     tabindex="0"
@@ -1551,7 +2194,7 @@ exports[`ProjectDocumentsTab renders properly 1`] = `
                                 >
                                   <td
                                     class="ant-table-cell"
-                                    colspan="6"
+                                    colspan="7"
                                   >
                                     No Data Yet
                                   </td>
@@ -1756,6 +2399,11 @@ exports[`ProjectDocumentsTab renders properly 1`] = `
                                     </div>
                                   </th>
                                   <th
+                                    class="ant-table-cell"
+                                  >
+                                    Category
+                                  </th>
+                                  <th
                                     aria-label="File Type"
                                     class="ant-table-cell ant-table-column-has-sorters"
                                     tabindex="0"
@@ -1952,7 +2600,7 @@ exports[`ProjectDocumentsTab renders properly 1`] = `
                                 >
                                   <td
                                     class="ant-table-cell"
-                                    colspan="6"
+                                    colspan="7"
                                   >
                                     No Data Yet
                                   </td>
@@ -2066,6 +2714,11 @@ exports[`ProjectDocumentsTab renders properly 1`] = `
                                   </span>
                                 </span>
                               </div>
+                            </th>
+                            <th
+                              class="ant-table-cell"
+                            >
+                              Category
                             </th>
                             <th
                               aria-label="Last Modified"
@@ -2203,7 +2856,7 @@ exports[`ProjectDocumentsTab renders properly 1`] = `
                           >
                             <td
                               class="ant-table-cell"
-                              colspan="4"
+                              colspan="5"
                             >
                               No Data Yet
                             </td>
@@ -2394,6 +3047,11 @@ exports[`ProjectDocumentsTab renders properly 1`] = `
                                     </div>
                                   </th>
                                   <th
+                                    class="ant-table-cell"
+                                  >
+                                    Category
+                                  </th>
+                                  <th
                                     aria-label="File Type"
                                     class="ant-table-cell ant-table-column-has-sorters"
                                     tabindex="0"
@@ -2590,7 +3248,7 @@ exports[`ProjectDocumentsTab renders properly 1`] = `
                                 >
                                   <td
                                     class="ant-table-cell"
-                                    colspan="6"
+                                    colspan="7"
                                   >
                                     No Data Yet
                                   </td>
@@ -2737,11 +3395,6 @@ exports[`ProjectDocumentsTab renders properly 1`] = `
                                       </span>
                                     </span>
                                   </div>
-                                </th>
-                                <th
-                                  class="ant-table-cell"
-                                >
-                                  Category
                                 </th>
                                 <th
                                   aria-label="File Type"
@@ -2940,7 +3593,7 @@ exports[`ProjectDocumentsTab renders properly 1`] = `
                               >
                                 <td
                                   class="ant-table-cell"
-                                  colspan="6"
+                                  colspan="5"
                                 >
                                   No Data Yet
                                 </td>

--- a/services/common/src/components/projects/__snapshots__/ProjectDocumentsTabSection.spec.tsx.snap
+++ b/services/common/src/components/projects/__snapshots__/ProjectDocumentsTabSection.spec.tsx.snap
@@ -173,6 +173,11 @@ exports[`ProjectDocumentsTab renders properly 1`] = `
                             </div>
                           </th>
                           <th
+                            class="ant-table-cell"
+                          >
+                            Category
+                          </th>
+                          <th
                             aria-label="File Type"
                             class="ant-table-cell ant-table-column-has-sorters"
                             tabindex="0"
@@ -411,6 +416,16 @@ exports[`ProjectDocumentsTab renders properly 1`] = `
                             class="ant-table-cell"
                           >
                             <div
+                              class="category-column"
+                              title="Category"
+                            >
+                              N/A
+                            </div>
+                          </td>
+                          <td
+                            class="ant-table-cell"
+                          >
+                            <div
                               class="file_type-column"
                               title="File Type"
                             >
@@ -515,6 +530,16 @@ exports[`ProjectDocumentsTab renders properly 1`] = `
                               <span
                                 class="file-history-container"
                               />
+                            </div>
+                          </td>
+                          <td
+                            class="ant-table-cell"
+                          >
+                            <div
+                              class="category-column"
+                              title="Category"
+                            >
+                              N/A
                             </div>
                           </td>
                           <td
@@ -631,6 +656,16 @@ exports[`ProjectDocumentsTab renders properly 1`] = `
                             class="ant-table-cell"
                           >
                             <div
+                              class="category-column"
+                              title="Category"
+                            >
+                              N/A
+                            </div>
+                          </td>
+                          <td
+                            class="ant-table-cell"
+                          >
+                            <div
                               class="file_type-column"
                               title="File Type"
                             >
@@ -735,6 +770,16 @@ exports[`ProjectDocumentsTab renders properly 1`] = `
                               <span
                                 class="file-history-container"
                               />
+                            </div>
+                          </td>
+                          <td
+                            class="ant-table-cell"
+                          >
+                            <div
+                              class="category-column"
+                              title="Category"
+                            >
+                              N/A
                             </div>
                           </td>
                           <td
@@ -851,6 +896,16 @@ exports[`ProjectDocumentsTab renders properly 1`] = `
                             class="ant-table-cell"
                           >
                             <div
+                              class="category-column"
+                              title="Category"
+                            >
+                              N/A
+                            </div>
+                          </td>
+                          <td
+                            class="ant-table-cell"
+                          >
+                            <div
                               class="file_type-column"
                               title="File Type"
                             >
@@ -955,6 +1010,16 @@ exports[`ProjectDocumentsTab renders properly 1`] = `
                               <span
                                 class="file-history-container"
                               />
+                            </div>
+                          </td>
+                          <td
+                            class="ant-table-cell"
+                          >
+                            <div
+                              class="category-column"
+                              title="Category"
+                            >
+                              N/A
                             </div>
                           </td>
                           <td

--- a/services/common/src/interfaces/document/documentTableProps.interface.ts
+++ b/services/common/src/interfaces/document/documentTableProps.interface.ts
@@ -1,23 +1,23 @@
 import { FileOperations, MineDocument } from "@mds/common/models/documents/document";
 import { ColumnType } from "antd/es/table";
 
-interface DocumentTableProps {
+export interface GenericDocTableProps<T> {
   additionalColumnProps?: { key: string; colProps: any }[];
-  additionalColumns?: ColumnType<MineDocument>[];
+  additionalColumns?: ColumnType<T>[];
   archiveMineDocuments?: (mineGuid: string, mineDocumentGuids: string[]) => void;
   canArchiveDocuments?: boolean;
   defaultSortKeys?: string[];
   documentColumns?: ColumnType<unknown>[];
   documentParent?: string;
-  documents: MineDocument[];
+  documents: any[];
   enableBulkActions?: boolean;
   excludedColumnKeys?: string[];
   fileOperationPermissionMap?: { operation: FileOperations; permission: string | boolean }[];
-  handleRowSelectionChange?: (arg1: MineDocument[]) => void;
+  handleRowSelectionChange?: (arg1: T[]) => void;
   isLoaded?: boolean;
   isViewOnly?: boolean;
-  onArchivedDocuments?: (docs?: MineDocument[]) => void;
-  onReplaceDocument?: (document: MineDocument) => void;
+  onArchivedDocuments?: (docs?: T[]) => void;
+  onReplaceDocument?: (document: T) => void;
   openDocument?: any;
   removeDocument?: (event, doc_guid: string, mine_guid: string) => void;
   replaceAlertMessage?: string;
@@ -26,6 +26,10 @@ interface DocumentTableProps {
   view?: "standard" | "minimal";
   openModal?: (arg1: any) => void;
   closeModal?: (arg1: any) => void;
+}
+
+interface DocumentTableProps extends GenericDocTableProps<MineDocument> {
+  documents: MineDocument[];
 }
 
 export default DocumentTableProps;

--- a/services/core-api/app/api/projects/information_requirements_table/models/information_requirements_table_document_xref.py
+++ b/services/core-api/app/api/projects/information_requirements_table/models/information_requirements_table_document_xref.py
@@ -31,6 +31,7 @@ class InformationRequirementsTableDocumentXref(Base):
     mine_guid = association_proxy('mine_document', 'mine_guid')
     document_manager_guid = association_proxy('mine_document', 'document_manager_guid')
     document_name = association_proxy('mine_document', 'document_name')
+    update_timestamp = association_proxy('mine_document', 'update_timestamp')
     upload_date = association_proxy('mine_document', 'upload_date')
     create_user = association_proxy('mine_document', 'create_user')
     versions = association_proxy('mine_document', 'versions')

--- a/services/core-api/app/api/projects/project_decision_package/models/project_decision_package_document_xref.py
+++ b/services/core-api/app/api/projects/project_decision_package/models/project_decision_package_document_xref.py
@@ -31,6 +31,7 @@ class ProjectDecisionPackageDocumentXref(Base):
     mine_guid = association_proxy('mine_document', 'mine_guid')
     document_manager_guid = association_proxy('mine_document', 'document_manager_guid')
     document_name = association_proxy('mine_document', 'document_name')
+    update_timestamp = association_proxy('mine_document', 'update_timestamp')
     upload_date = association_proxy('mine_document', 'upload_date')
     create_user = association_proxy('mine_document', 'create_user')
     versions = association_proxy('mine_document', 'versions')

--- a/services/core-api/app/api/projects/project_summary/models/project_summary_authorization_document_xref.py
+++ b/services/core-api/app/api/projects/project_summary/models/project_summary_authorization_document_xref.py
@@ -28,6 +28,7 @@ class ProjectSummaryAuthorizationDocumentXref(Base):
     document_manager_guid = association_proxy('mine_document', 'document_manager_guid')
     document_name = association_proxy('mine_document', 'document_name')
     upload_date = association_proxy('mine_document', 'upload_date')
+    update_timestamp = association_proxy('mine_document', 'update_timestamp')
     versions = association_proxy('mine_document', 'versions')
     create_user = association_proxy('mine_document', 'create_user')
     is_archived = association_proxy('mine_document', 'is_archived')

--- a/services/core-api/app/api/projects/project_summary/models/project_summary_document_xref.py
+++ b/services/core-api/app/api/projects/project_summary/models/project_summary_document_xref.py
@@ -29,6 +29,7 @@ class ProjectSummaryDocumentXref(Base):
     mine_guid = association_proxy('mine_document', 'mine_guid')
     document_manager_guid = association_proxy('mine_document', 'document_manager_guid')
     document_name = association_proxy('mine_document', 'document_name')
+    update_timestamp = association_proxy('mine_document', 'update_timestamp')
     upload_date = association_proxy('mine_document', 'upload_date')
     versions = association_proxy('mine_document', 'versions')
     create_user = association_proxy('mine_document', 'create_user')

--- a/services/core-web/src/styles/components/DocumentTableWithExpandedRows.scss
+++ b/services/core-web/src/styles/components/DocumentTableWithExpandedRows.scss
@@ -63,22 +63,25 @@
     }
 }
 
-.file-version-amount {
-    color: white;
-    margin-left: 5px;
-}
-
-.table-tag-primary {
+.table-tag {
     color: $white;
-    background-color: $violet;
     border-radius: 25px;
     border: none;
 
     font-size: 11px;
     padding: 4px 8px !important;
     margin-right: -8px !important;
+    margin-left: 5px;
 
     svg.svg-inline--fa {
         margin-right: 6px;
+    }
+
+    &--primary {
+        background-color: $violet;
+    }
+
+    &--grey {
+        background-color: $gov-grey;
     }
 }

--- a/services/core-web/src/styles/components/Modal.scss
+++ b/services/core-web/src/styles/components/Modal.scss
@@ -1,9 +1,24 @@
 .modal__close {
   position: absolute;
-  top: 3px;
+  top: 7px;
   color: $violet;
   font-size: 24px;
-  right: 0;
+  right: 14px;
   z-index: 999;
   border: none;
+  padding: 0;
+  width: 40px;
+  height: 40px;
+
+  svg {
+    margin: 10px;
+  }
+}
+
+.ant-modal-wrap {
+  z-index: 1001;
+}
+
+.ant-modal-mask {
+  z-index: 1001;
 }

--- a/services/core-web/src/styles/settings/variables.scss
+++ b/services/core-web/src/styles/settings/variables.scss
@@ -14,6 +14,7 @@ $hover-violet: #392B62;
 $hover-blue: #3d6de7;
 $btn-red: #bc2929;
 $disabled-text: #a39898;
+$gov-grey: #bbbbbb;
 
 // Accent Colours
 $lime-green: #adfc4a;

--- a/services/minespace-web/src/styles/components/DocumentTableWithExpandedRows.scss
+++ b/services/minespace-web/src/styles/components/DocumentTableWithExpandedRows.scss
@@ -69,22 +69,24 @@
     }
 }
 
-.file-version-amount {
-    color: white;
-    margin-left: 5px;
-    background-color: $gov-blue;
-}
-
-.table-tag-primary {
+.table-tag {
     color: $white;
-    background-color: $gov-blue;
     border-radius: 25px;
     border: none;
 
     font-size: 11px;
     margin-right: -8px;
+    margin-left: 5px;
 
     svg.svg-inline--fa {
         margin-right: 6px;
+    }
+
+    &--primary {
+        background-color: $gov-blue;
+    }
+
+    &--grey {
+        background-color: $gov-grey;
     }
 }

--- a/services/minespace-web/src/styles/overrides/antd-overrides.scss
+++ b/services/minespace-web/src/styles/overrides/antd-overrides.scss
@@ -606,7 +606,6 @@ th.ant-descriptions-item.vertical-description {
       &:focus,
       &:hover {
         background-color: white;
-        ;
       }
     }
   }


### PR DESCRIPTION
## Objective 
Fix major issues with All Documents page
- z-index modal overlapping
- missing category column
- archived docs table had category column but never any categories
- styled the tags on the table
- sent back the update_timestamp with different documents type so that Last Modified would show data
- bonus: had fixed alignment on MS modal close button before, copied that over to CORE (it wasn't as bad as it was on MS when the fix went in, but now it's as good as MS is. :))
- some wacky looking things: extracted a generic document table props interface and then extended for document table and spatial document table (it was to get past the dataSource/columnType type mismatch, while hopefully still making it easy to add doc table functionality to spatial doc table)

[MDS-6024](https://bcmines.atlassian.net/browse/MDS-6024)

_Why are you making this change? Provide a short explanation and/or screenshots_
