### PR TITLE
[MDS-6060] fix for duplicate ams records

### DIFF
--- a/services/core-api/app/api/services/ams_api_service.py
+++ b/services/core-api/app/api/services/ams_api_service.py
@@ -220,9 +220,10 @@ class AMSApiService():
             if authorization_list.__len__() > 0:
                 for authorization in authorization_list:
                     existing_ams_status_code = authorization.get('ams_status_code')
-                    if existing_ams_status_code != '200':
-                        current_project_summary_authorization_guid = authorization.get(
-                            'project_summary_authorization_guid')
+                    current_project_summary_authorization_guid = authorization.get(
+                        'project_summary_authorization_guid')
+                    
+                    if existing_ams_status_code != '200' and current_project_summary_authorization_guid:
                         current_project_summary_authorization_type = authorization.get(
                             'project_summary_authorization_type')
                         ams_authorization_data = {
@@ -361,9 +362,9 @@ class AMSApiService():
                 existing_ams_status_code = authorization.get('ams_status_code')
                 amendment_changes = authorization.get('amendment_changes', [])
                 existing_permits_authorizations = authorization.get('existing_permits_authorizations', [])
-                if existing_ams_status_code != '200':
-                    current_project_summary_authorization_guid = authorization.get(
+                current_project_summary_authorization_guid = authorization.get(
                         'project_summary_authorization_guid')
+                if existing_ams_status_code != '200' and current_project_summary_authorization_guid:
                     current_project_summary_authorization_type = authorization.get(
                         'project_summary_authorization_type')
                     ams_authorization_data = {


### PR DESCRIPTION
## Objective 

[MDS-6060](https://bcmines.atlassian.net/browse/MDS-6060)

- It was found on the AMS side there were multiple records with different tracking numbers being created when an authorization in major mine application is created.

- The fix was a small change to the condition that ends up calling the methods to call the AMS API
