### PR TITLE
[MDS-6148] Fixed invalid date / missing create_user in spatial file bundle upload table

### DIFF
--- a/services/common/src/components/documents/spatial/AddSpatialDocumentsModal.tsx
+++ b/services/common/src/components/documents/spatial/AddSpatialDocumentsModal.tsx
@@ -165,7 +165,7 @@ const AddSpatialDocumentsModal: FC<AddSpatialDocumentsModalProps> = ({
             onRemoveFile={handleRemoveFile}
             component={RenderFileUpload}
             maxFileSize="400MB"
-            label="Upload shapefiles"
+            label="Upload Spatial File"
             abbrevLabel
             listedFileTypes={["spatial"]}
             required

--- a/services/common/src/components/documents/spatial/__snapshots__/AddSpatialDocumentsModal.spec.tsx.snap
+++ b/services/common/src/components/documents/spatial/__snapshots__/AddSpatialDocumentsModal.spec.tsx.snap
@@ -159,7 +159,7 @@ exports[`AddSpatialDocumentsModal renders properly 1`] = `
                 title=""
               >
                 <span>
-                  Upload shapefiles
+                  Upload Spatial File
                    
                   <span>
                     <span


### PR DESCRIPTION
## Objective 

[MDS-6148](https://bcmines.atlassian.net/browse/MDS-6148)

Updated the spatial file table to display default values for upload_date and create_user when missing (after you've uploaded a file, but before submitting the form)

![image](https://github.com/user-attachments/assets/e0708ae0-660c-43de-b556-01f6712e26be)

![image](https://github.com/user-attachments/assets/d649567d-18bf-46b8-bae4-441dbda1bdf0)
