### PR TITLE
[CHORE] added include statement into docker-compose.M1.yaml

### DIFF
--- a/docker-compose.M1.yaml
+++ b/docker-compose.M1.yaml
@@ -1,5 +1,6 @@
 version: "3"
-
+include:
+  - ./services/permits/docker-compose.yaml
 services:
 
   ####################### Keycloak for Cypress #######################


### PR DESCRIPTION
Update the docker-compose.M1.yaml to match the regular one by including the `include` statement for the permit service docker-compose.
