### PR TITLE
[MDS-6132] Fixing bugs around Project Description Overview

### DIFF
--- a/services/core-web/src/components/mine/Projects/Project.tsx
+++ b/services/core-web/src/components/mine/Projects/Project.tsx
@@ -120,7 +120,7 @@ const Project: FC = () => {
       ),
     },
     isFeatureEnabled(Feature.AMS_AGENT) &&
-      project_summary?.status_code === "SUB" && {
+      project_summary?.submission_date && {
         key: "project-description",
         label: "Project Description",
         children: (

--- a/services/core-web/src/components/mine/Projects/ProjectOverviewTab.js
+++ b/services/core-web/src/components/mine/Projects/ProjectOverviewTab.js
@@ -138,10 +138,14 @@ export class ProjectOverviewTab extends Component {
         link: (
           <Link
             data-cy="project-description-view-link"
-            to={routes.EDIT_PROJECT_SUMMARY.dynamicRoute(project_guid, project_summary_guid)}
+            to={
+              this.props?.project?.project_summary?.submission_date
+                ? routes.EDIT_PROJECT.dynamicRoute(project_guid, "project-description")
+                : routes.EDIT_PROJECT_SUMMARY.dynamicRoute(project_guid, project_summary_guid)
+            }
           >
             <Button className="full-mobile margin-small" type="secondary">
-              View
+              {this.props?.project?.project_summary?.submission_date ? "View" : "Resume"}
             </Button>
           </Link>
         ),

--- a/services/minespace-web/src/components/dashboard/mine/projects/ProjectStagesTable.js
+++ b/services/minespace-web/src/components/dashboard/mine/projects/ProjectStagesTable.js
@@ -63,24 +63,31 @@ export class ProjectStagesTable extends Component {
       render: (text, record) => {
         let link;
         if (record.project_stage === "Project description") {
-          let buttonLabel;
-          if (record.stage_status === "SUB") {
-            buttonLabel = "View";
-          } else {
-            buttonLabel = "Resume";
-          }
-          link = (
-            <Link
-              to={routes.EDIT_PROJECT_SUMMARY.dynamicRoute(
-                record.stage?.payload?.project_guid,
-                record.stage?.payload?.project_summary_guid
-              )}
-            >
-              <Button className="full-mobile margin-small" type="secondary">
-                {buttonLabel}
+          let payload = record.stage?.payload;
+          if (payload?.submission_date) {
+            link = (
+              <Button
+                className="full-mobile margin-small"
+                type="secondary"
+                onClick={() => record?.navigate_forward()}
+              >
+                View
               </Button>
-            </Link>
-          );
+            );
+          } else {
+            link = (
+              <Link
+                to={routes.EDIT_PROJECT_SUMMARY.dynamicRoute(
+                  payload?.project_guid,
+                  payload?.project_summary_guid
+                )}
+              >
+                <Button className="full-mobile margin-small" type="secondary">
+                  Resume
+                </Button>
+              </Link>
+            );
+          }
         }
         if (record.project_stage === "IRT") {
           let buttonLabel;

--- a/services/minespace-web/src/components/pages/Project/ProjectOverviewTab.js
+++ b/services/minespace-web/src/components/pages/Project/ProjectOverviewTab.js
@@ -86,6 +86,7 @@ export class ProjectOverviewTab extends Component {
         payload: this.props.projectSummary,
         statusHash: this.props.projectSummaryStatusCodesHash,
         required: true,
+        navigateForward: () => this.props.navigateForward("DES"),
       },
       {
         title: "IRT",

--- a/services/minespace-web/src/components/pages/Project/ProjectPage.tsx
+++ b/services/minespace-web/src/components/pages/Project/ProjectPage.tsx
@@ -73,6 +73,15 @@ const ProjectPage: FC = () => {
 
   const navigateFromProjectStagesTable = (source, status) => {
     switch (source) {
+      case "DES": {
+        const projectDescriptionTab = document.querySelector('[id*="project-description"]');
+        if (!projectDescriptionTab) {
+          return null;
+        }
+
+        // @ts-ignore
+        return projectDescriptionTab.click();
+      }
       case "IRT": {
         if (status === "APV") {
           return history.push({
@@ -203,7 +212,7 @@ const ProjectPage: FC = () => {
       ),
     },
     isFeatureEnabled(Feature.AMS_AGENT) &&
-      project_summary?.status_code === "SUB" && {
+      project_summary?.submission_date && {
         label: "Project Description",
         key: "project-description",
         children: (

--- a/services/minespace-web/src/tests/components/project/projectOverviewTab/__snapshots__/ProjectOverviewTab.spec.js.snap
+++ b/services/minespace-web/src/tests/components/project/projectOverviewTab/__snapshots__/ProjectOverviewTab.spec.js.snap
@@ -97,6 +97,7 @@ exports[`ProjectOverviewTab renders properly 1`] = `
         Array [
           Object {
             "key": undefined,
+            "navigateForward": [Function],
             "payload": Object {
               "documents": Array [],
               "mine_guid": "60300a07-376c-46f1-a984-88a813f91438",


### PR DESCRIPTION
## Objective 

[MDS-6132](https://bcmines.atlassian.net/browse/MDS-6132)

- For Project Description Overview tab and page, changed it's accessibility from depending on status_code to submission_date as status_code can be changed after it's submission.

- Changed so when application is submitted the "Resume" button in Project Overview is changed to "View" and redirects to the Project Description Overview page, instead of the Project Summary form. Also made this behaviour dependent on submission_date existing or not

