### PR TITLE
[FIX] don't check for permit extraction status without permit conditions page feature flag enabled

### DIFF
--- a/services/core-web/src/components/mine/Permit/ViewPermit.tsx
+++ b/services/core-web/src/components/mine/Permit/ViewPermit.tsx
@@ -83,7 +83,7 @@ const ViewPermit: FC = () => {
   }, [permitExtraction?.task_status, isNewImport]);
 
   useEffect(() => {
-    if (latestAmendment) {
+    if (enablePermitConditionsTab && latestAmendment) {
       dispatch(
         fetchPermitExtractionTasks({ permit_amendment_id: latestAmendment.permit_amendment_id })
       );


### PR DESCRIPTION
## Objective
- suppress the error that pops up 

