### PR TITLE
[MDS-6176] Save project summary changes in Core

### DIFF
--- a/services/common/src/redux/selectors/projectSelectors.ts
+++ b/services/common/src/redux/selectors/projectSelectors.ts
@@ -10,8 +10,6 @@ import {
   SystemFlagEnum,
 } from "../..";
 import { getTransformedProjectSummaryAuthorizationTypes } from "./staticContentSelectors";
-import { getSystemFlag } from "@mds/common/redux/selectors/authenticationSelectors";
-import { getFormValues } from "redux-form";
 
 export const {
   getProjectSummary,
@@ -143,25 +141,16 @@ export const getFormattedProjectApplication = createSelector(
 );
 
 export const getFormattedProjectSummary = createSelector(
-  [
-    getProjectSummary,
-    getProject,
-    getAmsAuthorizationTypes,
-    getSystemFlag,
-    getFormValues(FORM.ADD_EDIT_PROJECT_SUMMARY),
-  ],
-  (summary, project, amsAuthTypes, systemFlag, formValues) => {
+  [getProjectSummary, getProject, getAmsAuthorizationTypes],
+  (summary, project, amsAuthTypes) => {
     const documents = formatProjectSummaryDocuments(summary.documents);
     const contacts = formatProjectContact(project.contacts);
     const agent = formatProjectSummaryParty(summary.agent);
     const facility_operator = formatProjectSummaryParty(summary.facility_operator);
     const confirmation_of_submission = summary.status_code === "SUB";
 
-    const updatedSummary =
-      systemFlag === SystemFlagEnum.core ? { ...summary, ...formValues } : summary;
-
     const formattedSummary = {
-      ...updatedSummary,
+      ...summary,
       contacts,
       agent,
       facility_operator,

--- a/services/common/src/redux/selectors/projectSelectors.ts
+++ b/services/common/src/redux/selectors/projectSelectors.ts
@@ -2,12 +2,10 @@ import { createSelector } from "reselect";
 import { uniq } from "lodash";
 import * as projectReducer from "../reducers/projectReducer";
 import {
-  FORM,
   IParty,
   IProjectContact,
   IProjectSummaryDocument,
   MAJOR_MINES_APPLICATION_DOCUMENT_TYPE_CODE,
-  SystemFlagEnum,
 } from "../..";
 import { getTransformedProjectSummaryAuthorizationTypes } from "./staticContentSelectors";
 

--- a/services/common/src/redux/selectors/projectSelectors.ts
+++ b/services/common/src/redux/selectors/projectSelectors.ts
@@ -2,12 +2,16 @@ import { createSelector } from "reselect";
 import { uniq } from "lodash";
 import * as projectReducer from "../reducers/projectReducer";
 import {
+  FORM,
   IParty,
   IProjectContact,
   IProjectSummaryDocument,
   MAJOR_MINES_APPLICATION_DOCUMENT_TYPE_CODE,
+  SystemFlagEnum,
 } from "../..";
 import { getTransformedProjectSummaryAuthorizationTypes } from "./staticContentSelectors";
+import { getSystemFlag } from "@mds/common/redux/selectors/authenticationSelectors";
+import { getFormValues } from "redux-form";
 
 export const {
   getProjectSummary,
@@ -139,16 +143,25 @@ export const getFormattedProjectApplication = createSelector(
 );
 
 export const getFormattedProjectSummary = createSelector(
-  [getProjectSummary, getProject, getAmsAuthorizationTypes],
-  (summary, project, amsAuthTypes) => {
+  [
+    getProjectSummary,
+    getProject,
+    getAmsAuthorizationTypes,
+    getSystemFlag,
+    getFormValues(FORM.ADD_EDIT_PROJECT_SUMMARY),
+  ],
+  (summary, project, amsAuthTypes, systemFlag, formValues) => {
     const documents = formatProjectSummaryDocuments(summary.documents);
     const contacts = formatProjectContact(project.contacts);
     const agent = formatProjectSummaryParty(summary.agent);
     const facility_operator = formatProjectSummaryParty(summary.facility_operator);
     const confirmation_of_submission = summary.status_code === "SUB";
 
+    const updatedSummary =
+      systemFlag === SystemFlagEnum.core ? { ...summary, ...formValues } : summary;
+
     const formattedSummary = {
-      ...summary,
+      ...updatedSummary,
       contacts,
       agent,
       facility_operator,

--- a/services/core-web/src/components/mine/Projects/ProjectSummary.tsx
+++ b/services/core-web/src/components/mine/Projects/ProjectSummary.tsx
@@ -6,7 +6,6 @@ import * as routes from "@/constants/routes";
 import { Button, Col, Row, Tag } from "antd";
 import EnvironmentOutlined from "@ant-design/icons/EnvironmentOutlined";
 import ArrowLeftOutlined from "@ant-design/icons/ArrowLeftOutlined";
-import { getSystemFlag } from "@mds/common/redux/selectors/authenticationSelectors";
 
 import {
   getFormattedProjectSummary,
@@ -80,7 +79,6 @@ export const ProjectSummary: FC = () => {
   const activeTab = tab ?? projectFormTabs[0];
   const mineName = mine?.mine_name ?? formattedProjectSummary?.mine_name ?? "";
   const formValues = useSelector(getFormValues(FORM.ADD_EDIT_PROJECT_SUMMARY));
-  const systemFlag = useSelector(getSystemFlag);
 
   const handleFetchData = async () => {
     setIsLoaded(false);

--- a/services/core-web/src/components/mine/Projects/ProjectSummary.tsx
+++ b/services/core-web/src/components/mine/Projects/ProjectSummary.tsx
@@ -18,6 +18,7 @@ import {
   AMS_STATUS_CODES_SUCCESS,
   AMS_STATUS_CODE_FAIL,
   AMS_ENVIRONMENTAL_MANAGEMENT_ACT_TYPES,
+  SystemFlagEnum,
 } from "@mds/common";
 import { getMineById } from "@mds/common/redux/reducers/mineReducer";
 import withFeatureFlag from "@mds/common/providers/featureFlags/withFeatureFlag";
@@ -36,6 +37,7 @@ import ProjectSummaryForm, {
 } from "@mds/common/components/projectSummary/ProjectSummaryForm";
 import { fetchRegions } from "@mds/common/redux/slices/regionsSlice";
 import { clearProjectSummary } from "@mds/common/redux/actions/projectActions";
+import { getSystemFlag } from "@mds/common/redux/selectors/authenticationSelectors";
 
 export const ProjectSummary: FC = () => {
   const dispatch = useDispatch();
@@ -48,6 +50,9 @@ export const ProjectSummary: FC = () => {
     tab: string;
     mode: string;
   }>();
+
+  const systemFlag = useSelector(getSystemFlag);
+  const isCore = systemFlag === SystemFlagEnum.core;
 
   const mine = useSelector((state) => getMineById(state, mineGuid));
   const formattedProjectSummary = useSelector(getFormattedProjectSummary);
@@ -212,7 +217,7 @@ export const ProjectSummary: FC = () => {
         message = null;
       }
     }
-    const values = { ...formValues, status_code: status_code };
+    const values = { ...formValues, status_code: isCore ? formValues.status_code : status_code };
 
     try {
       if (isNewProject) {

--- a/services/core-web/src/components/mine/Projects/ProjectSummary.tsx
+++ b/services/core-web/src/components/mine/Projects/ProjectSummary.tsx
@@ -211,13 +211,17 @@ export const ProjectSummary: FC = () => {
     if (!status_code || isNewProject) {
       status_code = "DFT";
     } else if (!newActiveTab) {
-      status_code = "SUB";
+      if (isCore) {
+        status_code = formValues.status_code;
+      } else {
+        status_code = "SUB";
+      }
       is_historic = false;
       if (amsFeatureEnabled) {
         message = null;
       }
     }
-    const values = { ...formValues, status_code: isCore ? formValues.status_code : status_code };
+    const values = { ...formValues, status_code };
 
     try {
       if (isNewProject) {

--- a/services/database/postgres/Dockerfile
+++ b/services/database/postgres/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgis/postgis:13-3.0
+FROM postgis/postgis:13-3.4
 
 RUN export DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get install -y --no-install-recommends \ 
     make \

--- a/services/postgres/Dockerfile
+++ b/services/postgres/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgis/postgis:13-3.0
+FROM postgis/postgis:13-3.4
 
 # The Git ref (branch/tag) specifying the version of oracle-fdw to use
 # This is referencing a specific revision (master as of 2021.06.01)


### PR DESCRIPTION
Saving project summary changes was initially set up in Minespace and utilized the redux state before submission.  In Core we need to allow users to update other aspects of the form (notably the status), so I added logic to use the form values when submitting in Core.

## Objective 

[MDS-6176](https://bcmines.atlassian.net/browse/MDS-6176)
