### PR TITLE
[MDS-6118] Added failure state to permit extraction flow + fix error when conditions are not matching a category

### DIFF
--- a/services/core-api/app/api/mines/permits/permit_extraction/create_permit_conditions.py
+++ b/services/core-api/app/api/mines/permits/permit_extraction/create_permit_conditions.py
@@ -27,6 +27,9 @@ indentation_type_code_mapping = {
     5: 'LIS',
 }
 
+# For conditions that don't match any category, put them in the "General" category
+DEFAULT_CATEGORY = 'GEC'
+
 def create_permit_conditions_from_task(task: PermitExtractionTask):
     """
     Create permit conditions from the task result.
@@ -38,7 +41,19 @@ def create_permit_conditions_from_task(task: PermitExtractionTask):
 
     result = CreatePermitConditionsResult.model_validate(result)
 
-    for idx, condition in enumerate(result.conditions):
+    has_category = any([condition.is_top_level_section and bool(_map_condition_to_category(condition_categories, condition)) for condition in result.conditions])
+
+    conditions = result.conditions
+    if not has_category:
+        top_level_section = PermitConditionResult(
+            section='A',
+            condition_text='General'
+        )
+        for c in conditions:
+            c.set_section(top_level_section)
+        conditions = [top_level_section] + conditions
+
+    for idx, condition in enumerate(conditions):
         
         if condition.is_top_level_section:        
             section_category = _map_condition_to_category(condition_categories, condition)
@@ -50,11 +65,13 @@ def create_permit_conditions_from_task(task: PermitExtractionTask):
             type_code = _map_condition_to_type_code(condition)
 
             title_cond = None
+
+            category_code = current_category or DEFAULT_CATEGORY
             if condition.condition_title:
-                title_cond = _create_title_condition(task, current_category, condition, parent, idx, type_code)
+                title_cond = _create_title_condition(task, category_code, condition, parent, idx, type_code)
 
             parent_condition_id = _get_parent_condition_id(title_cond, parent)
-            cond = _create_permit_condition(task, current_category, condition, parent_condition_id, idx, type_code)
+            cond = _create_permit_condition(task, category_code, condition, parent_condition_id, idx, type_code)
 
             hierarchy_key = ".".join(condition.numbering_structure)
             last_condition_id_by_hierarchy[hierarchy_key] = cond

--- a/services/core-api/app/api/mines/permits/permit_extraction/create_permit_conditions.py
+++ b/services/core-api/app/api/mines/permits/permit_extraction/create_permit_conditions.py
@@ -12,6 +12,7 @@ from app.api.mines.permits.permit_extraction.models.permit_extraction_task impor
     PermitExtractionTask,
 )
 from app.extensions import db
+from flask import current_app
 
 from .models.permit_condition_result import (
     CreatePermitConditionsResult,
@@ -88,7 +89,11 @@ def _map_condition_to_type_code(condition: PermitConditionResult):
     """
     indentation = next((i-1 for i, x in enumerate(condition.numbering_structure) if x == ''), 0)
     type_code = indentation_type_code_mapping[indentation]
-    return type_code
+    
+    if not type_code:
+        current_app.logger.error(f"Could not determine type code for condition {condition}")
+
+    return type_code or 'LIS'
 
 def _create_title_condition(task, current_category, condition, parent, idx, type_code) -> PermitConditionResult:
     condition = PermitConditions(

--- a/services/core-api/app/api/mines/permits/permit_extraction/models/permit_condition_result.py
+++ b/services/core-api/app/api/mines/permits/permit_extraction/models/permit_condition_result.py
@@ -34,6 +34,15 @@ class PermitConditionResult(BaseModel):
         # Numbering is the last non-empty value in the numbering structure.
         # E.g. if the numbering structure is ['A', '1', 'a', 'i', ''], the numbering is 'i'
         return next(cond for cond in reversed(self.numbering_structure) if cond and cond != '')
+    
+    def set_section(self, section):
+        self.subsubclause = self.subclause
+        self.subclause = self.clause
+        self.clause = self.subparagraph
+        self.subparagraph = self.paragraph
+        self.paragraph = self.section
+        self.section = section.section
+
 
 class CreatePermitConditionsResult(BaseModel):
     conditions: List[PermitConditionResult]

--- a/services/core-api/app/api/mines/permits/permit_extraction/tasks.py
+++ b/services/core-api/app/api/mines/permits/permit_extraction/tasks.py
@@ -1,12 +1,44 @@
 
+import json
+
 from app.api.mines.permits.permit_extraction.create_permit_conditions import (
     create_permit_conditions_from_task,
 )
+from app.api.mines.permits.permit_extraction.models.permit_extraction_task import (
+    PermitExtractionTask,
+)
 from app.api.search.search.permit_search_service import PermitSearchService
 from app.tasks.celery import celery
+from celery import Task
+from werkzeug.exceptions import InternalServerError
 
 
-@celery.task(max_retries=360)
+class PermitExtractionTaskBase(Task):
+    """
+    This task base class is used to ensure that a Celery task failure is recorded in the database.
+    - The on_failure method is called when a task fails AFTER all retries have been exhausted or on an exception.
+    """
+
+    def __call__(self, *args, **kwargs):
+        from app.tasks.celery_entrypoint import celery_app
+
+        # Make sure app context is set up when running the task so we can access the database
+        with celery_app.app_context():
+            return Task.__call__(self, *args, **kwargs)
+
+    def on_failure(self, exc, task_id, args, kwargs, einfo):
+        from app.tasks.celery_entrypoint import celery_app
+        with celery_app.app_context():
+            task = PermitExtractionTask.query.filter_by(core_status_task_id=task_id).first()
+
+            if not task:
+                raise InternalServerError('Task not found')
+
+            task.task_status = 'FAILURE'
+            task.save()
+
+
+@celery.task(base=PermitExtractionTaskBase, max_retries=360)
 def poll_update_permit_extraction_status(permit_extraction_task_id):
     """
     Poll the permit conditions service for the status of the extraction task every 10s

--- a/services/core-api/app/tasks/celery_entrypoint.py
+++ b/services/core-api/app/tasks/celery_entrypoint.py
@@ -1,4 +1,6 @@
+
 from app import create_app
+
 from .celery import celery
 
-create_app()
+celery_app = create_app()

--- a/services/core-web/src/components/mine/Permit/PermitConditionExtraction.tsx
+++ b/services/core-web/src/components/mine/Permit/PermitConditionExtraction.tsx
@@ -2,6 +2,8 @@ import React, { FC } from "react";
 import { Col, Row, Typography } from "antd";
 import { PERMIT } from "@/constants/assets";
 import LoadingOutlined from "@ant-design/icons/LoadingOutlined";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faCircleX } from "@fortawesome/pro-light-svg-icons";
 
 const { Title } = Typography;
 
@@ -47,6 +49,32 @@ export const RenderExtractionProgress: FC = () => (
             <p>
               We are extracing the permit conditions. This process may take anywhere from a few
               minutes to an hour. Feel free to leave and return later to continue your work.
+            </p>
+          </div>
+        </div>
+      </Row>
+    </Col>
+  </Row>
+);
+
+export const RenderExtractionError: FC = () => (
+  <Row align="middle" justify="space-between" gutter={[10, 16]}>
+    <Col span={24}>
+      <Title className="margin-none" level={2}>
+        Permit Conditions
+      </Title>
+    </Col>
+    <Col span={24}>
+      <Row gutter={10} style={{ background: "#fff" }} justify={"center"}>
+        <div className="null-screen fade-in" style={{ maxWidth: "728px" }}>
+          <div>
+            <p className="margin-medium--bottom">
+              <FontAwesomeIcon icon={faCircleX} size="5x" color="red" />
+            </p>
+            <h3>Failed to extract permit conditions</h3>
+            <p>
+              We encountered an issue while extracting the permit conditions. Please try again. if
+              the problem persists, check the file and ensure it meets the required format.
             </p>
           </div>
         </div>

--- a/services/core-web/src/components/mine/Permit/PermitConditionExtraction.tsx
+++ b/services/core-web/src/components/mine/Permit/PermitConditionExtraction.tsx
@@ -19,13 +19,13 @@ export const RenderExtractionStart: FC = () => (
         <div className="null-screen fade-in" style={{ maxWidth: "1024px" }}>
           <div>
             <img alt="mine_img" src={PERMIT} />
-            <h3>Start extracting permit conditions</h3>
-            <p>
+            <Typography.Title level={3}>Start extracting permit conditions</Typography.Title>
+            <Typography.Text>
               Start extracting the latest permit conditions. This process supports the ministry in
               permit drafting and compliance by building a comprehensive condition repository,
               adding report requirements, and making it easier to track, update, and share permit
               conditions accross your team.
-            </p>
+            </Typography.Text>
           </div>
         </div>
       </Row>
@@ -45,11 +45,11 @@ export const RenderExtractionProgress: FC = () => (
         <div className="null-screen fade-in" style={{ maxWidth: "1024px" }}>
           <div>
             <LoadingOutlined style={{ fontSize: 120 }} />
-            <h3>Extracting permit conditions</h3>
-            <p>
+            <Typography.Title level={3}>Extracting permit conditions</Typography.Title>
+            <Typography.Text>
               We are extracing the permit conditions. This process may take anywhere from a few
               minutes to an hour. Feel free to leave and return later to continue your work.
-            </p>
+            </Typography.Text>
           </div>
         </div>
       </Row>
@@ -68,14 +68,14 @@ export const RenderExtractionError: FC = () => (
       <Row gutter={10} style={{ background: "#fff" }} justify={"center"}>
         <div className="null-screen fade-in" style={{ maxWidth: "728px" }}>
           <div>
-            <p className="margin-medium--bottom">
+            <Typography.Text className="margin-medium--bottom">
               <FontAwesomeIcon icon={faCircleX} size="5x" color="red" />
-            </p>
-            <h3>Failed to extract permit conditions</h3>
-            <p>
+            </Typography.Text>
+            <Typography.Title level={3}>Failed to extract permit conditions</Typography.Title>
+            <Typography.Text>
               We encountered an issue while extracting the permit conditions. Please try again. if
               the problem persists, check the file and ensure it meets the required format.
-            </p>
+            </Typography.Text>
           </div>
         </div>
       </Row>

--- a/services/core-web/src/components/mine/Permit/PermitConditions.tsx
+++ b/services/core-web/src/components/mine/Permit/PermitConditions.tsx
@@ -22,7 +22,11 @@ import {
   getPermitExtractionByGuid,
   PermitExtractionStatus,
 } from "@mds/common/redux/slices/permitServiceSlice";
-import { RenderExtractionProgress, RenderExtractionStart } from "./PermitConditionExtraction";
+import {
+  RenderExtractionError,
+  RenderExtractionProgress,
+  RenderExtractionStart,
+} from "./PermitConditionExtraction";
 
 const { Title } = Typography;
 
@@ -93,8 +97,8 @@ const PermitConditions: FC<PermitConditionProps> = ({
   if (isExtractionInProgress) {
     return <RenderExtractionProgress />;
   }
-  if (!isExtractionComplete && permitExtraction?.task_status) {
-    return <div>Permit extraction status: {permitExtraction?.task_status}</div>;
+  if (!isExtractionComplete && permitExtraction?.task_status === "Error Extracting") {
+    return <RenderExtractionError />;
   }
   if (canStartExtraction) {
     return <RenderExtractionStart />;

--- a/services/core-web/src/styles/components/PermitConditions.scss
+++ b/services/core-web/src/styles/components/PermitConditions.scss
@@ -12,6 +12,10 @@ div.condition-layer {
             font-weight: 600;
         }
 
+        p.condition-layer {
+            white-space: pre-wrap;
+        }
+
         >.condition-collapsed {
             display: -webkit-box;
             -webkit-box-orient: vertical;

--- a/services/permits/app/permit_conditions/validator/parse_hierarchy.py
+++ b/services/permits/app/permit_conditions/validator/parse_hierarchy.py
@@ -147,6 +147,11 @@ def build_hierarchy(paragraphs):
     level = 0
 
     for idx, paragraph in enumerate(paragraphs):
+
+        if paragraph['text'].startswith('The Permittee must store all waste rock mined after November'):
+            logger.info(f"Paragraph: {paragraph['text']}")
+            logger.info(hierarchy_state)
+
         regx = paragraph["regex"]
 
         if regx:
@@ -199,6 +204,8 @@ def _update_level(paragraphs, structure, last_paragraph, level, idx, p, regx):
         paragraphs[idx - 1], p
     ):
         return level, False
+    elif level_of_last_matching_numbering < level and _has_indent_increased(paragraphs[idx - 1], p):
+        return level + 1, True
     else:
         return level_of_last_matching_numbering, False
 

--- a/services/permits/app/permit_conditions/validator/parse_hierarchy.py
+++ b/services/permits/app/permit_conditions/validator/parse_hierarchy.py
@@ -147,11 +147,6 @@ def build_hierarchy(paragraphs):
     level = 0
 
     for idx, paragraph in enumerate(paragraphs):
-
-        if paragraph['text'].startswith('The Permittee must store all waste rock mined after November'):
-            logger.info(f"Paragraph: {paragraph['text']}")
-            logger.info(hierarchy_state)
-
         regx = paragraph["regex"]
 
         if regx:

--- a/services/permits/app/permit_conditions/validator/permit_condition_section_combiner.py
+++ b/services/permits/app/permit_conditions/validator/permit_condition_section_combiner.py
@@ -116,10 +116,14 @@ class PermitConditionSectionCombiner:
                     matching_cond.condition_text = p["text"]
                     matching_cond.id = p["id"]
 
-                    if matching_cond.meta["bounding_box"] and p["meta"]["bounding_box"]:
-                        self._combine_bounding_boxes(p, matching_cond)
+                else:
+                    matching_cond.condition_text = f"{matching_cond.condition_text}\n{p['text']}"
 
-                    matching_cond.meta = {**p["meta"], **matching_cond.meta}
+                if matching_cond.meta["bounding_box"] and p["meta"]["bounding_box"]:
+                    self._combine_bounding_boxes(p, matching_cond)
+
+                matching_cond.meta = {**p["meta"], **matching_cond.meta}
+
             else:
                 conditions.append(
                     PermitCondition(

--- a/services/permits/tests/test_parse_hierarchy.py
+++ b/services/permits/tests/test_parse_hierarchy.py
@@ -613,3 +613,105 @@ def test_parse_text():
     result = parse_hierarchy(paragraphs)
 
     assert [x["text"] for x in result] == expected_result
+
+def test_parse_subsubclause_same():
+    paragraphs = [
+        {"text": "A. Section 1", "meta": {"bounding_box": {"left": 1.232}}},
+        {"text": "1). Paragraph 1", "meta": {"bounding_box": {"left": 1.2506}}},
+        {"text": "a) Subparagraph a", "meta": {"bounding_box": {"left": 1.6284}}},
+        {"text": "i. Subclause i", "meta": {"bounding_box": {"left": 2.0293}}},
+        {"text": "a. Subsubclause a", "meta": {"bounding_box": {"left": 2.4115}}},
+        {"text": "ii. Subclause ii", "meta": {"bounding_box": {"left": 2.0293}}},
+        {"text": "a. Anothersubclause", "meta": {"bounding_box": {"left": 2.4105}}},
+    ]
+
+    expected_result = [
+        {
+            "text": "Section 1",
+            "section": "A",
+            "paragraph": None,
+            "subparagraph": None,
+            "clause": None,
+            "subclause": None,
+            "subsubclause": None,
+            "numbering": "A",
+            "regex": "uppercase_letter",
+            "meta": {"bounding_box": {"left": 1.232}},
+        },
+        {
+            "text": "Paragraph 1",
+            "section": "A",
+            "paragraph": "1",
+            "subparagraph": None,
+            "clause": None,
+            "subclause": None,
+            "subsubclause": None,
+            "numbering": "1",
+            "regex": "number",
+            "meta": {"bounding_box": {"left": 1.2506}},
+        },
+        {
+            "text": "Subparagraph a",
+            "section": "A",
+            "paragraph": "1",
+            "subparagraph": "a",
+            "clause": None,
+            "subclause": None,
+            "subsubclause": None,
+            "numbering": "a",
+            "regex": "lowercase_letter",
+            "meta": {"bounding_box": {"left": 1.6284}},
+        },
+        {
+            "text": "Subclause i",
+            "section": "A",
+            "paragraph": "1",
+            "subparagraph": "a",
+            "clause": "i",
+            "subclause": None,
+            "subsubclause": None,
+            "numbering": "i",
+            "regex": "roman_numeral",
+            "meta": {"bounding_box": {"left": 2.0293}},
+        },
+        {
+            "text": "Subsubclause a",
+            "section": "A",
+            "paragraph": "1",
+            "subparagraph": "a",
+            "clause": "i",
+            "subclause": "a",
+            "subsubclause": None,
+            "numbering": "a",
+            "regex": "lowercase_letter",
+            "meta": {"bounding_box": {"left": 2.4115}},
+        },
+        {
+            "text": "Subclause ii",
+            "section": "A",
+            "paragraph": "1",
+            "subparagraph": "a",
+            "clause": "ii",
+            "subclause": None,
+            "subsubclause": None,
+            "numbering": "ii",
+            "regex": "roman_numeral",
+            "meta": {"bounding_box": {"left": 2.0293}},
+        },
+        {
+            "text": "Anothersubclause",
+            "section": "A",
+            "paragraph": "1",
+            "subparagraph": "a",
+            "clause": "ii",
+            "subclause": "a",
+            "subsubclause": None,
+            "numbering": "a",
+            "regex": "lowercase_letter",
+            "meta": {"bounding_box": {"left": 2.4105}},
+        },
+    ]
+
+    result = parse_hierarchy(paragraphs)
+
+    assert result == expected_result

--- a/services/permits/tests/test_permit_condition_section_combiner.py
+++ b/services/permits/tests/test_permit_condition_section_combiner.py
@@ -24,6 +24,12 @@ def test_permit_condition_section_combiner_run(combiner):
         Document(
             content='{"text": "This is another.", "id": "3"}',
             meta={"bounding_box": {"left": 1, "bottom": 5, "right": 4, "top": 3}},
+            
+        ),
+        Document(
+            content='{"text": "This is a combined section.", "id": "31"}',
+            meta={"bounding_box": {"left": 1, "bottom": 5, "right": 4, "top": 3}},
+            
         ),
         Document(
             content='{"text": "(a) This is yet another test.", "id": "4"}',
@@ -64,7 +70,7 @@ def test_permit_condition_section_combiner_run(combiner):
     assert condition2.subclause is None
     assert condition2.subsubclause is None
     assert condition2.condition_title == "This is a title."
-    assert condition2.condition_text == "This is another."
+    assert condition2.condition_text == "This is another.\nThis is a combined section."
     assert condition2.page_number == 1
     assert condition2.id == "3"
     assert condition2.meta == {


### PR DESCRIPTION

## Objective 

[MDS-6118](https://bcmines.atlassian.net/browse/MDS-6118)

1. Update permit conditions with the general category if no sections could be matched to one (the case for old permits). Without it, an error is produced
2. Update the state of the extraction task stored in the core DB when an extraction task actually fails (for any reason)
3. Added an error state if extraction failed