### PR TITLE
[MDS-6190] Make replace file dependent on status in minespace

### DIFF
--- a/services/common/src/components/documents/DocumentTable.tsx
+++ b/services/common/src/components/documents/DocumentTable.tsx
@@ -50,6 +50,7 @@ export const DocumentTable: FC<DocumentTableProps> = ({
   defaultSortKeys = ["upload_date", "dated", "update_timestamp"],
   view = "standard",
   canArchiveDocuments = false,
+  canReplaceDocuments = true,
   removeDocument,
   replaceAlertMessage = "The replaced file will not reviewed as part of the submission.  The new file should be in the same format as the original file.",
   ...props
@@ -72,7 +73,7 @@ export const DocumentTable: FC<DocumentTableProps> = ({
     [FileOperations.View]: true,
     [FileOperations.Download]: true,
     // don't allow changes to version history where history is not shown
-    [FileOperations.Replace]: !isViewOnly && showVersionHistory,
+    [FileOperations.Replace]: !isViewOnly && showVersionHistory && canReplaceDocuments,
     [FileOperations.Archive]:
       !isViewOnly && canArchiveDocuments && isFeatureEnabled(Feature.MAJOR_PROJECT_ARCHIVE_FILE),
     [FileOperations.Delete]: !isViewOnly && removeDocument !== undefined,

--- a/services/common/src/components/projects/ArchivedDocumentsSection.tsx
+++ b/services/common/src/components/projects/ArchivedDocumentsSection.tsx
@@ -13,6 +13,7 @@ interface ArchivedDocumentsSectionProps {
   titleLevel?: 1 | 2 | 3 | 4 | 5;
   href?: string;
   showCategory?: boolean;
+  canReplace?: boolean;
 }
 
 const ArchivedDocumentsSection: FC<ArchivedDocumentsSectionProps> = ({
@@ -20,6 +21,7 @@ const ArchivedDocumentsSection: FC<ArchivedDocumentsSectionProps> = ({
   href = "archived-documents",
   documents,
   showCategory = true,
+  canReplace = true,
 }) => {
   const { isFeatureEnabled } = useFeatureFlag();
 
@@ -43,6 +45,7 @@ const ArchivedDocumentsSection: FC<ArchivedDocumentsSectionProps> = ({
       <DocumentTable
         documents={documents}
         showVersionHistory={true}
+        canReplaceDocuments={canReplace}
         additionalColumns={additionalColumns}
       />
     </div>

--- a/services/common/src/components/projects/ProjectDocumentsTab.tsx
+++ b/services/common/src/components/projects/ProjectDocumentsTab.tsx
@@ -35,6 +35,10 @@ const ProjectDocumentsTab: FC<ProjectDocumentsTabProps> = ({ project }) => {
   const systemFlag = useSelector(getSystemFlag);
   const isCore = systemFlag === SystemFlagEnum.core;
   const [isLoaded, setIsLoaded] = useState(true);
+  const statusesToDisableReplaceFor = ["UNR", "WDN", "OHD"];
+  const canReplace = isCore
+    ? true
+    : !statusesToDisableReplaceFor.includes(project?.project_summary?.status_code);
 
   const refreshData = async () => {
     setIsLoaded(false);
@@ -158,6 +162,7 @@ const ProjectDocumentsTab: FC<ProjectDocumentsTabProps> = ({ project }) => {
             title={titleText}
             key={auth.project_summary_authorization_guid}
             canArchive={false}
+            canReplace={canReplace}
             onArchivedDocuments={refreshData}
             documents={auth.amendment_documents.map(
               (d) =>
@@ -189,6 +194,7 @@ const ProjectDocumentsTab: FC<ProjectDocumentsTabProps> = ({ project }) => {
           title="Supporting Documents"
           documents={pdSupportingDocuments}
           onArchivedDocuments={refreshData}
+          canReplace={canReplace}
         />
       ),
     },
@@ -201,6 +207,7 @@ const ProjectDocumentsTab: FC<ProjectDocumentsTabProps> = ({ project }) => {
           titleLevel={3}
           onArchivedDocuments={refreshData}
           documents={irtDocuments}
+          canReplace={canReplace}
         />
       ),
     },
@@ -214,6 +221,7 @@ const ProjectDocumentsTab: FC<ProjectDocumentsTabProps> = ({ project }) => {
           key="primary-document"
           onArchivedDocuments={refreshData}
           documents={primaryDocuments}
+          canReplace={canReplace}
         />
       ),
     },
@@ -239,6 +247,7 @@ const ProjectDocumentsTab: FC<ProjectDocumentsTabProps> = ({ project }) => {
           key="supporting-documents"
           onArchivedDocuments={refreshData}
           documents={mmaSupportingDocuments}
+          canReplace={canReplace}
         />
       ),
     },
@@ -250,12 +259,19 @@ const ProjectDocumentsTab: FC<ProjectDocumentsTabProps> = ({ project }) => {
           key="ministry-decision-documentation"
           onArchivedDocuments={refreshData}
           documents={ministryDecisionDocuments}
+          canReplace={canReplace}
         />
       ),
     },
     isFeatureEnabled(Feature.MAJOR_PROJECT_ARCHIVE_FILE) && {
       href: "archived-documents",
-      content: <ArchivedDocumentsSection documents={mineDocuments} showCategory={false} />,
+      content: (
+        <ArchivedDocumentsSection
+          documents={mineDocuments}
+          showCategory={false}
+          canReplace={canReplace}
+        />
+      ),
     },
   ].filter(Boolean);
 

--- a/services/common/src/components/projects/ProjectDocumentsTabSection.tsx
+++ b/services/common/src/components/projects/ProjectDocumentsTabSection.tsx
@@ -12,6 +12,7 @@ interface ProjectDocumentsTabSectionProps {
   documents: MineDocument[];
   onArchivedDocuments: () => Promise<void>;
   canArchive?: boolean;
+  canReplace?: boolean;
 }
 const ProjectDocumentsTabSection: FC<ProjectDocumentsTabSectionProps> = ({
   documents,
@@ -20,6 +21,7 @@ const ProjectDocumentsTabSection: FC<ProjectDocumentsTabSectionProps> = ({
   title,
   titleLevel = 4,
   canArchive = true,
+  canReplace = true,
 }) => {
   const sectionTitle = title ?? formatUrlToUpperCaseString(id);
 
@@ -34,6 +36,7 @@ const ProjectDocumentsTabSection: FC<ProjectDocumentsTabSectionProps> = ({
           documentParent={title}
           additionalColumns={[renderTextColumn("category", "Category")]}
           canArchiveDocuments={canArchive}
+          canReplaceDocuments={canReplace}
           onArchivedDocuments={onArchivedDocuments}
           showVersionHistory={true}
           enableBulkActions={true}

--- a/services/common/src/interfaces/document/documentTableProps.interface.ts
+++ b/services/common/src/interfaces/document/documentTableProps.interface.ts
@@ -5,6 +5,7 @@ export interface GenericDocTableProps<T> {
   additionalColumnProps?: { key: string; colProps: any }[];
   additionalColumns?: ColumnType<T>[];
   canArchiveDocuments?: boolean;
+  canReplaceDocuments?: boolean;
   defaultSortKeys?: string[];
   documentColumns?: ColumnType<unknown>[];
   documentParent?: string;


### PR DESCRIPTION
## Objective 

[MDS-6190](https://bcmines.atlassian.net/browse/MDS-6190)

- Adjusted document tables in Minespace's All Documents section to not have replace file action when status code is “Under Review”, “Withdrawn”, or “On Hold”
