### PR TITLE
[MDS-6194] Major project duplication

### DIFF
--- a/services/minespace-web/src/components/pages/Project/ProjectSummaryPage.tsx
+++ b/services/minespace-web/src/components/pages/Project/ProjectSummaryPage.tsx
@@ -36,9 +36,11 @@ import {
   AMS_STATUS_CODES_SUCCESS,
   AMS_STATUS_CODE_FAIL,
   AMS_ENVIRONMENTAL_MANAGEMENT_ACT_TYPES,
+  SystemFlagEnum,
 } from "@mds/common";
 import { useFeatureFlag } from "@mds/common/providers/featureFlags/useFeatureFlag";
 import { fetchRegions } from "@mds/common/redux/slices/regionsSlice";
+import { getSystemFlag } from "@mds/common/redux/selectors/authenticationSelectors";
 
 interface IParams {
   mineGuid?: string;
@@ -51,6 +53,8 @@ export const ProjectSummaryPage = () => {
   const dispatch = useDispatch();
   const history = useHistory();
   const location = useLocation();
+  const systemFlag = useSelector(getSystemFlag);
+  const isCore = systemFlag === SystemFlagEnum.core;
 
   const { mineGuid, projectGuid, projectSummaryGuid, tab } = useParams<IParams>();
   const anyTouched = useSelector(
@@ -71,7 +75,11 @@ export const ProjectSummaryPage = () => {
     : mine?.mine_guid === mineGuid;
   const [isLoaded, setIsLoaded] = useState(isDefaultLoaded);
   const [isEditMode, setIsEditMode] = useState(isDefaultEditMode);
-  const projectFormTabs = null;
+  const projectFormTabs = getProjectFormTabs(
+    amsFeatureEnabled,
+    isCore,
+    isFeatureEnabled(Feature.MAJOR_PROJECT_REFACTOR)
+  );
   const activeTab = tab ?? projectFormTabs[0];
 
   const handleFetchData = async () => {


### PR DESCRIPTION
## Objective 

On the `ProjectSummaryPage` in Minespace the `projectFormTabs` variable was null.  As a result, when the system attempted to replace the current url with one containing the new project and project summary guids it would pass in that null value as part of the route and fail.

Loaded the projectFormTabs properly and it seems to work fine.

[MDS-6194](https://bcmines.atlassian.net/browse/MDS-6194)

![major-project-duplicate](https://github.com/user-attachments/assets/5db1d2a0-98b6-4331-9cc4-642bd881bf54)
