### PR TITLE
[MDS-6139] - Disable tabs/buttons in project overview

### DIFF
--- a/services/core-web/src/components/mine/Projects/Project.tsx
+++ b/services/core-web/src/components/mine/Projects/Project.tsx
@@ -29,7 +29,7 @@ const Project: FC = () => {
   const [isValid, setIsValid] = useState(true);
   const [activeTab, setActiveTab] = useState("overview");
 
-  const { information_requirements_table, major_mine_application, project_summary } = project;
+  const { information_requirements_table, major_mine_application } = project;
 
   const hasInformationRequirementsTable = Boolean(information_requirements_table?.irt_guid);
   const hasFinalAplication = Boolean(major_mine_application?.major_mine_application_guid);

--- a/services/core-web/src/components/mine/Projects/ProjectOverviewTab.tsx
+++ b/services/core-web/src/components/mine/Projects/ProjectOverviewTab.tsx
@@ -42,6 +42,7 @@ export const ProjectOverviewTab: FC = () => {
   } = project.project_summary;
 
   const hasInformationRequirementsTable = Boolean(project.information_requirements_table?.irt_guid);
+  const hasFinalAplication = Boolean(project.major_mine_application?.major_mine_application_guid);
 
   const project_lead_contact =
     projectLeads?.filter((lead) => lead.party_guid.includes(project.project_lead_party_guid)) ?? [];
@@ -105,7 +106,9 @@ export const ProjectOverviewTab: FC = () => {
           data-cy="final-application-view-link"
           to={routes.PROJECT_FINAL_APPLICATION.dynamicRoute(project_guid)}
         >
-          <Button className="full-mobile margin-small">View</Button>
+          <Button className="full-mobile margin-small" disabled={!hasFinalAplication}>
+            View
+          </Button>
         </Link>
       ),
     }

--- a/services/minespace-web/src/components/dashboard/mine/projects/ProjectStagesTable.tsx
+++ b/services/minespace-web/src/components/dashboard/mine/projects/ProjectStagesTable.tsx
@@ -13,6 +13,8 @@ interface ProjectStagesTableProps {
 
 export const ProjectStagesTable: FC<ProjectStagesTableProps> = ({ projectStages }) => {
   const projectSummary = useSelector(getProjectSummary);
+  const isProjectSummarySubmitted = Boolean(projectSummary?.submission_date);
+
   const transformRowData = (stages: IProjectStage[]) =>
     stages?.map((stage) => ({
       key: stage.key,
@@ -91,8 +93,10 @@ export const ProjectStagesTable: FC<ProjectStagesTableProps> = ({ projectStages 
         }
         if (record.project_stage === "IRT") {
           let buttonLabel: string;
+          let disableButton = Boolean(record.stage_status);
           if (!record.stage_status) {
             buttonLabel = "Start";
+            disableButton = !isProjectSummarySubmitted;
           } else if (record.stage_status === "APV") {
             buttonLabel = "View";
           } else {
@@ -100,15 +104,21 @@ export const ProjectStagesTable: FC<ProjectStagesTableProps> = ({ projectStages 
           }
 
           link = (
-            <Button className="full-mobile margin-small" onClick={() => record?.navigate_forward()}>
+            <Button
+              className="full-mobile margin-small"
+              onClick={() => record?.navigate_forward()}
+              disabled={disableButton}
+            >
               {buttonLabel}
             </Button>
           );
         }
         if (record.project_stage === "Application") {
-          let buttonLabel;
+          let buttonLabel: string;
+          let disableButton = Boolean(record.stage_status);
           if (!record.stage_status) {
             buttonLabel = "Start";
+            disableButton = !isProjectSummarySubmitted;
           } else if (["SUB", "UNR", "APV"].includes(record.stage_status)) {
             buttonLabel = "View";
           } else {
@@ -116,7 +126,11 @@ export const ProjectStagesTable: FC<ProjectStagesTableProps> = ({ projectStages 
           }
 
           link = (
-            <Button className="full-mobile margin-small" onClick={() => record?.navigate_forward()}>
+            <Button
+              className="full-mobile margin-small"
+              onClick={() => record?.navigate_forward()}
+              disabled={disableButton}
+            >
               {buttonLabel}
             </Button>
           );

--- a/services/minespace-web/src/components/pages/Project/ProjectPage.tsx
+++ b/services/minespace-web/src/components/pages/Project/ProjectPage.tsx
@@ -55,8 +55,10 @@ const ProjectPage: FC = () => {
     information_requirements_table,
     major_mine_application,
     mrc_review_required,
-    project_summary,
   } = project;
+
+  const hasInformationRequirementsTable = Boolean(information_requirements_table?.irt_guid);
+  const hasFinalAplication = Boolean(major_mine_application?.major_mine_application_guid);
 
   const mine = useSelector((state) => getMineById(state, mine_guid)) ?? {};
   const { mine_name } = mine;
@@ -236,6 +238,7 @@ const ProjectPage: FC = () => {
     {
       label: "IRT",
       key: "irt-entry",
+      disabled: !hasInformationRequirementsTable,
       children: (
         <div className={pageClass}>
           <InformationRequirementsTableEntryTab
@@ -248,6 +251,7 @@ const ProjectPage: FC = () => {
     {
       label: "Application",
       key: "major-mine-application",
+      disabled: !hasFinalAplication,
       children: <div className={pageClass}>{majorMineApplicationTabContent}</div>,
     },
     {

--- a/services/minespace-web/src/styles/overrides/antd-overrides.scss
+++ b/services/minespace-web/src/styles/overrides/antd-overrides.scss
@@ -223,12 +223,16 @@ h5.ant-typography,
       background-color: transparent !important;
       font-weight: normal;
 
-      &:not(.ant-tabs-tab-active) {
+      &:not(.ant-tabs-tab-active):not(.ant-tabs-tab-disabled) {
 
         &:hover,
         .ant-tabs-tab-btn:active {
           color: $font-colour !important;
         }
+      }
+
+      &.ant-tabs-tab-disabled {
+        color: rgba(0, 0, 0, 0.25) !important;
       }
 
       &.ant-tabs-tab-active {
@@ -473,7 +477,7 @@ th.ant-descriptions-item.vertical-description {
 
   &-footer {
     border: none;
-    padding: 0;
+    padding: 0 24px 24px 0;
   }
 }
 
@@ -629,11 +633,6 @@ th.ant-descriptions-item.vertical-description {
   background-color: #f2f2f2;
   align-items: center !important;
   border-bottom: none !important;
-}
-
-.ant-modal-footer {
-  padding-right: 24px;
-  padding-bottom: 24px;
 }
 
 // Collapse Component

--- a/services/minespace-web/src/tests/components/project/projectOverviewTab/__snapshots__/ProjectOverviewTab.spec.tsx.snap
+++ b/services/minespace-web/src/tests/components/project/projectOverviewTab/__snapshots__/ProjectOverviewTab.spec.tsx.snap
@@ -338,6 +338,7 @@ exports[`ProjectOverviewTab renders properly 1`] = `
                         >
                           <button
                             class="ant-btn ant-btn-default full-mobile margin-small"
+                            disabled=""
                             type="button"
                           >
                             <span>


### PR DESCRIPTION
## Objective 
- now that the button does something, limit when the button can be clicked
- the disabled styling of the tabs on MS had been overridden by a more specific rule so changed some of that styling to make it appear disabled
- it didn't like a duplicate selector for ant-modal-footer in that file so I deduplicated it by merging the padding styling into the other rule.

[MDS-6139](https://bcmines.atlassian.net/browse/MDS-6139)

_Why are you making this change? Provide a short explanation and/or screenshots_
