### PR TITLE
[MDS-6139] Don't disable IRT/final app tab when "Start" button is enabled

### DIFF
--- a/services/core-web/src/components/mine/Projects/InformationRequirementsTableTab.tsx
+++ b/services/core-web/src/components/mine/Projects/InformationRequirementsTableTab.tsx
@@ -93,7 +93,7 @@ const InformationRequirementsTableTab = () => {
     r1.map(({ requirement_guid, sub_requirements, ...rest }) => ({
       requirement_guid,
       ...rest,
-      ...r2.find((i) => i.requirement_guid === requirement_guid),
+      ...r2?.find((i) => i.requirement_guid === requirement_guid),
       sub_requirements: deepMergeById(sub_requirements, r2),
     }));
 

--- a/services/core-web/src/components/mine/Projects/Project.tsx
+++ b/services/core-web/src/components/mine/Projects/Project.tsx
@@ -29,9 +29,8 @@ const Project: FC = () => {
   const [isValid, setIsValid] = useState(true);
   const [activeTab, setActiveTab] = useState("overview");
 
-  const { information_requirements_table, major_mine_application, project_summary } = project;
+  const { information_requirements_table, major_mine_application } = project;
 
-  const isProjectSummarySubmitted = Boolean(project_summary?.submission_date);
   const hasInformationRequirementsTable = Boolean(information_requirements_table?.irt_guid);
   const hasFinalAplication = Boolean(major_mine_application?.major_mine_application_guid);
 
@@ -132,7 +131,7 @@ const Project: FC = () => {
     {
       key: "information-requirements-table",
       label: "IRT",
-      disabled: !hasInformationRequirementsTable && !isProjectSummarySubmitted,
+      disabled: !hasInformationRequirementsTable,
       children: (
         <div className="padding-lg">
           <InformationRequirementsTableTab />
@@ -142,7 +141,7 @@ const Project: FC = () => {
     {
       key: "final-app",
       label: "Final Application",
-      disabled: !hasFinalAplication && !isProjectSummarySubmitted,
+      disabled: !hasFinalAplication,
       children: (
         <div className="padding-lg">
           <MajorMineApplicationTab />

--- a/services/core-web/src/components/mine/Projects/Project.tsx
+++ b/services/core-web/src/components/mine/Projects/Project.tsx
@@ -29,8 +29,9 @@ const Project: FC = () => {
   const [isValid, setIsValid] = useState(true);
   const [activeTab, setActiveTab] = useState("overview");
 
-  const { information_requirements_table, major_mine_application } = project;
+  const { information_requirements_table, major_mine_application, project_summary } = project;
 
+  const isProjectSummarySubmitted = Boolean(project_summary?.submission_date);
   const hasInformationRequirementsTable = Boolean(information_requirements_table?.irt_guid);
   const hasFinalAplication = Boolean(major_mine_application?.major_mine_application_guid);
 
@@ -131,7 +132,7 @@ const Project: FC = () => {
     {
       key: "information-requirements-table",
       label: "IRT",
-      disabled: !hasInformationRequirementsTable,
+      disabled: !hasInformationRequirementsTable && !isProjectSummarySubmitted,
       children: (
         <div className="padding-lg">
           <InformationRequirementsTableTab />
@@ -141,7 +142,7 @@ const Project: FC = () => {
     {
       key: "final-app",
       label: "Final Application",
-      disabled: !hasFinalAplication,
+      disabled: !hasFinalAplication && !isProjectSummarySubmitted,
       children: (
         <div className="padding-lg">
           <MajorMineApplicationTab />

--- a/services/minespace-web/src/components/dashboard/mine/projects/ProjectStagesTable.tsx
+++ b/services/minespace-web/src/components/dashboard/mine/projects/ProjectStagesTable.tsx
@@ -93,7 +93,7 @@ export const ProjectStagesTable: FC<ProjectStagesTableProps> = ({ projectStages 
         }
         if (record.project_stage === "IRT") {
           let buttonLabel: string;
-          let enableButton = Boolean(record.stage_status);
+          let enableButton = true;
           if (!record.stage_status) {
             buttonLabel = "Start";
             enableButton = isProjectSummarySubmitted;
@@ -115,7 +115,7 @@ export const ProjectStagesTable: FC<ProjectStagesTableProps> = ({ projectStages 
         }
         if (record.project_stage === "Application") {
           let buttonLabel: string;
-          let enableButton = Boolean(record.stage_status);
+          let enableButton = true;
           if (!record.stage_status) {
             buttonLabel = "Start";
             enableButton = isProjectSummarySubmitted;

--- a/services/minespace-web/src/components/dashboard/mine/projects/ProjectStagesTable.tsx
+++ b/services/minespace-web/src/components/dashboard/mine/projects/ProjectStagesTable.tsx
@@ -93,10 +93,10 @@ export const ProjectStagesTable: FC<ProjectStagesTableProps> = ({ projectStages 
         }
         if (record.project_stage === "IRT") {
           let buttonLabel: string;
-          let disableButton = Boolean(record.stage_status);
+          let enableButton = Boolean(record.stage_status);
           if (!record.stage_status) {
             buttonLabel = "Start";
-            disableButton = !isProjectSummarySubmitted;
+            enableButton = isProjectSummarySubmitted;
           } else if (record.stage_status === "APV") {
             buttonLabel = "View";
           } else {
@@ -107,7 +107,7 @@ export const ProjectStagesTable: FC<ProjectStagesTableProps> = ({ projectStages 
             <Button
               className="full-mobile margin-small"
               onClick={() => record?.navigate_forward()}
-              disabled={disableButton}
+              disabled={!enableButton}
             >
               {buttonLabel}
             </Button>
@@ -115,10 +115,10 @@ export const ProjectStagesTable: FC<ProjectStagesTableProps> = ({ projectStages 
         }
         if (record.project_stage === "Application") {
           let buttonLabel: string;
-          let disableButton = Boolean(record.stage_status);
+          let enableButton = Boolean(record.stage_status);
           if (!record.stage_status) {
             buttonLabel = "Start";
-            disableButton = !isProjectSummarySubmitted;
+            enableButton = isProjectSummarySubmitted;
           } else if (["SUB", "UNR", "APV"].includes(record.stage_status)) {
             buttonLabel = "View";
           } else {
@@ -129,7 +129,7 @@ export const ProjectStagesTable: FC<ProjectStagesTableProps> = ({ projectStages 
             <Button
               className="full-mobile margin-small"
               onClick={() => record?.navigate_forward()}
-              disabled={disableButton}
+              disabled={!enableButton}
             >
               {buttonLabel}
             </Button>

--- a/services/minespace-web/src/components/pages/Project/ProjectPage.tsx
+++ b/services/minespace-web/src/components/pages/Project/ProjectPage.tsx
@@ -57,6 +57,7 @@ const ProjectPage: FC = () => {
     mrc_review_required,
   } = project;
 
+  const isProjectSummarySubmitted = Boolean(projectSummary?.submission_date);
   const hasInformationRequirementsTable = Boolean(information_requirements_table?.irt_guid);
   const hasFinalAplication = Boolean(major_mine_application?.major_mine_application_guid);
 
@@ -238,7 +239,7 @@ const ProjectPage: FC = () => {
     {
       label: "IRT",
       key: "irt-entry",
-      disabled: !hasInformationRequirementsTable,
+      disabled: !hasInformationRequirementsTable && !isProjectSummarySubmitted,
       children: (
         <div className={pageClass}>
           <InformationRequirementsTableEntryTab
@@ -251,7 +252,7 @@ const ProjectPage: FC = () => {
     {
       label: "Application",
       key: "major-mine-application",
-      disabled: !hasFinalAplication,
+      disabled: !hasFinalAplication && !isProjectSummarySubmitted,
       children: <div className={pageClass}>{majorMineApplicationTabContent}</div>,
     },
     {

--- a/services/minespace-web/src/tests/components/project/projectOverviewTab/__snapshots__/ProjectOverviewTab.spec.tsx.snap
+++ b/services/minespace-web/src/tests/components/project/projectOverviewTab/__snapshots__/ProjectOverviewTab.spec.tsx.snap
@@ -338,7 +338,6 @@ exports[`ProjectOverviewTab renders properly 1`] = `
                         >
                           <button
                             class="ant-btn ant-btn-default full-mobile margin-small"
-                            disabled=""
                             type="button"
                           >
                             <span>


### PR DESCRIPTION
## Objective 
- made a mistake last PR!
- I kinda forgot that disabling the tab on project overview _also_ effectively disables the start button
- because it does a query selector to find the tab and does a `.click()` on it
- previously, I did try just running the same function from clicking the tab when you click start and it didn't work
- don't want to spend too much time on that rabbit hole though
- I went to CORE to make the "View" behaviour more similar (ie: able to click the tab even if button is disabled if summary was submitted) but ended up reverting it because the IRT tab behaviour was VERY confusing (first it crashed until I added that `?` and then it showed Loading because loading is dependent on the IRT having a guid and I thought it was a bad idea to play with that logic)

[MDS-6139](https://bcmines.atlassian.net/browse/MDS-6139)

_Why are you making this change? Provide a short explanation and/or screenshots_
