### PR TITLE
[MDS-6178] CORE project summary edit mode bugs, contd

### DIFF
--- a/services/common/src/components/projectSummary/ProjectDates.tsx
+++ b/services/common/src/components/projectSummary/ProjectDates.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useSelector } from "react-redux";
 import { Field, getFormValues } from "redux-form";
-import { Typography } from "antd";
+import { Col, Row, Typography } from "antd";
 import {
   dateNotBeforeOther,
   dateNotAfterOther,
@@ -24,59 +24,75 @@ export const ProjectDates = () => {
   return (
     <>
       <Typography.Title level={3}>Project Dates</Typography.Title>
-      <Callout
-        message={
-          <>
-            These dates are for guidance and planning purposes only and do not reflect actual
-            delivery dates. The{" "}
-            <a
-              target="_blank"
-              rel="noopener noreferrer"
-              title="Major Mines Permitting Office"
-              href="https://www2.gov.bc.ca/gov/content/industry/mineral-exploration-mining/permitting/major-mines-permitting-office"
-            >
-              Major Mines Office
-            </a>{" "}
-            will work with you on a more definitive schedule.
-          </>
-        }
-      />
-      <Field
-        id="expected_draft_irt_submission_date"
-        name="expected_draft_irt_submission_date"
-        label="When do you anticipate submitting a draft Information Requirements Table?"
-        placeholder="Please select date"
-        component={RenderDate}
-        validate={[dateInFuture, dateNotAfterOther(expected_permit_application_date)]}
-        disabled={isFieldDisabled(systemFlag, formValues?.status_code)}
-      />
-      <Field
-        id="expected_permit_application_date"
-        name="expected_permit_application_date"
-        label="When do you anticipate submitting a permit application?"
-        placeholder="Please select date"
-        component={RenderDate}
-        validate={[dateInFuture, dateNotBeforeOther(expected_draft_irt_submission_date)]}
-        disabled={isFieldDisabled(systemFlag, formValues?.status_code)}
-      />
-      <Field
-        id="expected_permit_receipt_date"
-        name="expected_permit_receipt_date"
-        label="When do you hope to receive your permit/amendment(s)?"
-        placeholder="Please select date"
-        component={RenderDate}
-        validate={[dateInFuture, dateNotBeforeOther(expected_permit_application_date)]}
-        disabled={isFieldDisabled(systemFlag, formValues?.status_code)}
-      />
-      <Field
-        id="expected_project_start_date"
-        name="expected_project_start_date"
-        label="When do you anticipate starting work on this project?"
-        placeholder="Please select date"
-        component={RenderDate}
-        validate={[dateInFuture, dateNotBeforeOther(expected_permit_receipt_date)]}
-        disabled={isFieldDisabled(systemFlag, formValues?.status_code)}
-      />
+      <Row gutter={[0, 16]}>
+        <Col>
+          <Callout
+            message={
+              <>
+                These dates are for guidance and planning purposes only and do not reflect actual
+                delivery dates. The{" "}
+                <a
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  title="Major Mines Permitting Office"
+                  href="https://www2.gov.bc.ca/gov/content/industry/mineral-exploration-mining/permitting/major-mines-permitting-office"
+                >
+                  Major Mines Office
+                </a>{" "}
+                will work with you on a more definitive schedule.
+              </>
+            }
+          />
+        </Col>
+        <Col span={24}>
+          <Field
+            id="expected_draft_irt_submission_date"
+            name="expected_draft_irt_submission_date"
+            label="When do you anticipate submitting a draft Information Requirements Table?"
+            placeholder="Please select date"
+            component={RenderDate}
+            allowClear
+            validate={[dateInFuture, dateNotAfterOther(expected_permit_application_date, "the expected permit application date")]}
+            disabled={isFieldDisabled(systemFlag, formValues?.status_code)}
+          />
+        </Col>
+        <Col span={24}>
+          <Field
+            id="expected_permit_application_date"
+            name="expected_permit_application_date"
+            label="When do you anticipate submitting a permit application?"
+            placeholder="Please select date"
+            component={RenderDate}
+            allowClear
+            validate={[dateInFuture, dateNotBeforeOther(expected_draft_irt_submission_date, "the expected draft IRT submission date")]}
+            disabled={isFieldDisabled(systemFlag, formValues?.status_code)}
+          />
+        </Col>
+        <Col span={24}>
+          <Field
+            id="expected_permit_receipt_date"
+            name="expected_permit_receipt_date"
+            label="When do you hope to receive your permit/amendment(s)?"
+            placeholder="Please select date"
+            component={RenderDate}
+            allowClear
+            validate={[dateInFuture, dateNotBeforeOther(expected_permit_application_date, "the expected permit application date")]}
+            disabled={isFieldDisabled(systemFlag, formValues?.status_code)}
+          />
+        </Col>
+        <Col span={24}>
+          <Field
+            id="expected_project_start_date"
+            name="expected_project_start_date"
+            label="When do you anticipate starting work on this project?"
+            placeholder="Please select date"
+            component={RenderDate}
+            allowClear
+            validate={[dateInFuture, dateNotBeforeOther(expected_permit_receipt_date, "the expected permit receipt date")]}
+            disabled={isFieldDisabled(systemFlag, formValues?.status_code)}
+          />
+        </Col>
+      </Row>
     </>
   );
 };

--- a/services/common/src/components/projectSummary/ProjectLinks.tsx
+++ b/services/common/src/components/projectSummary/ProjectLinks.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useState } from "react";
+import React, { FC, useContext, useEffect, useState } from "react";
 import { getProject, getProjects } from "@mds/common/redux/selectors/projectSelectors";
 import { useSelector, useDispatch } from "react-redux";
 import { Field, change, getFormValues } from "redux-form";
@@ -21,6 +21,7 @@ import { dateSorter } from "@mds/common/redux/utils/helpers";
 import RenderMultiSelect from "../forms/RenderMultiSelect";
 import * as Strings from "@mds/common/constants/strings";
 import { getSystemFlag } from "@mds/common/redux/selectors/authenticationSelectors";
+import { FormContext } from "../forms/FormWrapper";
 
 interface ProjectLinksProps {
   viewProject: (record: ILinkedProject) => string;
@@ -53,6 +54,7 @@ const ProjectLinkInput = ({ unrelatedProjects = [], mineGuid, projectGuid }) => 
 
   const addRelatedProjects = () => {
     dispatch(createProjectLinks(mineGuid, projectGuid, currentSelection)).then(() => {
+      setCurrentSelection([]);
       dispatch(change(formName, fieldName, []));
     });
   };
@@ -102,6 +104,7 @@ const ProjectLinks: FC<ProjectLinksProps> = ({ viewProject, tableOnly = false })
   const canEditProjects = useSelector((state) =>
     userHasRole(state, USER_ROLES.role_edit_project_summaries)
   );
+  const { isEditMode } = useContext(FormContext);
   const hasModifyPermission = isUserProponent || canEditProjects;
 
   const separateProjectLists = (projects: IProject[]): [ILinkedProject[], IProject[]] => {
@@ -160,7 +163,7 @@ const ProjectLinks: FC<ProjectLinksProps> = ({ viewProject, tableOnly = false })
       <Typography.Paragraph>
         Description of related major project applications for this mine are listed below.
       </Typography.Paragraph>
-      {!tableOnly && (
+      {!tableOnly && isEditMode && (
         <ProjectLinkInput
           unrelatedProjects={unrelatedProjects}
           mineGuid={project.mine_guid}

--- a/services/common/src/components/projectSummary/__snapshots__/ProjectDates.spec.tsx.snap
+++ b/services/common/src/components/projectSummary/__snapshots__/ProjectDates.spec.tsx.snap
@@ -12,388 +12,418 @@ exports[`ProjectDates renders properly 1`] = `
       Project Dates
     </h3>
     <div
-      class="bcgov-callout--info bcgov-callout"
-    >
-      These dates are for guidance and planning purposes only and do not reflect actual delivery dates. The
-       
-      <a
-        href="https://www2.gov.bc.ca/gov/content/industry/mineral-exploration-mining/permitting/major-mines-permitting-office"
-        rel="noopener noreferrer"
-        target="_blank"
-        title="Major Mines Permitting Office"
-      >
-        Major Mines Office
-      </a>
-       
-      will work with you on a more definitive schedule.
-    </div>
-    <div
-      class="ant-form-item ant-form-item-with-help"
+      class="ant-row"
+      style="margin-top: -8px; margin-bottom: -8px;"
     >
       <div
-        class="ant-row ant-form-item-row"
+        class="ant-col"
+        style="padding-top: 8px; padding-bottom: 8px;"
       >
         <div
-          class="ant-col ant-form-item-label"
+          class="bcgov-callout--info bcgov-callout"
         >
-          <label
-            class=""
-            for="ADD_EDIT_PROJECT_SUMMARY_expected_draft_irt_submission_date"
-            title=""
+          These dates are for guidance and planning purposes only and do not reflect actual delivery dates. The
+           
+          <a
+            href="https://www2.gov.bc.ca/gov/content/industry/mineral-exploration-mining/permitting/major-mines-permitting-office"
+            rel="noopener noreferrer"
+            target="_blank"
+            title="Major Mines Permitting Office"
           >
-            <div>
-              When do you anticipate submitting a draft Information Requirements Table?
-               
-              <span
-                class="form-item-optional"
-              >
-                 (optional)
-              </span>
-            </div>
-          </label>
+            Major Mines Office
+          </a>
+           
+          will work with you on a more definitive schedule.
         </div>
+      </div>
+      <div
+        class="ant-col ant-col-24"
+        style="padding-top: 8px; padding-bottom: 8px;"
+      >
         <div
-          class="ant-col ant-form-item-control"
+          class="ant-form-item ant-form-item-with-help"
         >
           <div
-            class="ant-form-item-control-input"
+            class="ant-row ant-form-item-row"
           >
             <div
-              class="ant-form-item-control-input-content"
+              class="ant-col ant-form-item-label"
             >
-              <div
-                class="ant-picker"
+              <label
+                class=""
+                for="ADD_EDIT_PROJECT_SUMMARY_expected_draft_irt_submission_date"
+                title=""
               >
-                <div
-                  class="ant-picker-input"
-                >
-                  <input
-                    autocomplete="off"
-                    id="expected_draft_irt_submission_date"
-                    name="expected_draft_irt_submission_date"
-                    placeholder="Please select date"
-                    readonly=""
-                    size="12"
-                    title=""
-                    value=""
-                  />
+                <div>
+                  When do you anticipate submitting a draft Information Requirements Table?
+                   
                   <span
-                    class="ant-picker-suffix"
+                    class="form-item-optional"
                   >
-                    <span
-                      aria-label="calendar"
-                      class="anticon anticon-calendar"
-                      role="img"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        data-icon="calendar"
-                        fill="currentColor"
-                        focusable="false"
-                        height="1em"
-                        viewBox="64 64 896 896"
-                        width="1em"
-                      >
-                        <path
-                          d="M880 184H712v-64c0-4.4-3.6-8-8-8h-56c-4.4 0-8 3.6-8 8v64H384v-64c0-4.4-3.6-8-8-8h-56c-4.4 0-8 3.6-8 8v64H144c-17.7 0-32 14.3-32 32v664c0 17.7 14.3 32 32 32h736c17.7 0 32-14.3 32-32V216c0-17.7-14.3-32-32-32zm-40 656H184V460h656v380zM184 392V256h128v48c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8v-48h256v48c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8v-48h128v136H184z"
-                        />
-                      </svg>
-                    </span>
+                     (optional)
                   </span>
                 </div>
-              </div>
+              </label>
             </div>
-          </div>
-          <div
-            style="display: flex; flex-wrap: nowrap;"
-          >
             <div
-              class="ant-form-item-explain ant-form-item-explain-connected"
-              id="ADD_EDIT_PROJECT_SUMMARY_expected_draft_irt_submission_date_help"
-              role="alert"
+              class="ant-col ant-form-item-control"
             >
               <div
-                class=""
-              />
+                class="ant-form-item-control-input"
+              >
+                <div
+                  class="ant-form-item-control-input-content"
+                >
+                  <div
+                    class="ant-picker"
+                  >
+                    <div
+                      class="ant-picker-input"
+                    >
+                      <input
+                        autocomplete="off"
+                        id="expected_draft_irt_submission_date"
+                        name="expected_draft_irt_submission_date"
+                        placeholder="Please select date"
+                        readonly=""
+                        size="12"
+                        title=""
+                        value=""
+                      />
+                      <span
+                        class="ant-picker-suffix"
+                      >
+                        <span
+                          aria-label="calendar"
+                          class="anticon anticon-calendar"
+                          role="img"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            data-icon="calendar"
+                            fill="currentColor"
+                            focusable="false"
+                            height="1em"
+                            viewBox="64 64 896 896"
+                            width="1em"
+                          >
+                            <path
+                              d="M880 184H712v-64c0-4.4-3.6-8-8-8h-56c-4.4 0-8 3.6-8 8v64H384v-64c0-4.4-3.6-8-8-8h-56c-4.4 0-8 3.6-8 8v64H144c-17.7 0-32 14.3-32 32v664c0 17.7 14.3 32 32 32h736c17.7 0 32-14.3 32-32V216c0-17.7-14.3-32-32-32zm-40 656H184V460h656v380zM184 392V256h128v48c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8v-48h256v48c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8v-48h128v136H184z"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                style="display: flex; flex-wrap: nowrap;"
+              >
+                <div
+                  class="ant-form-item-explain ant-form-item-explain-connected"
+                  id="ADD_EDIT_PROJECT_SUMMARY_expected_draft_irt_submission_date_help"
+                  role="alert"
+                >
+                  <div
+                    class=""
+                  />
+                </div>
+              </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
-    <div
-      class="ant-form-item ant-form-item-with-help"
-    >
       <div
-        class="ant-row ant-form-item-row"
+        class="ant-col ant-col-24"
+        style="padding-top: 8px; padding-bottom: 8px;"
       >
         <div
-          class="ant-col ant-form-item-label"
-        >
-          <label
-            class=""
-            for="ADD_EDIT_PROJECT_SUMMARY_expected_permit_application_date"
-            title=""
-          >
-            <div>
-              When do you anticipate submitting a permit application?
-               
-              <span
-                class="form-item-optional"
-              >
-                 (optional)
-              </span>
-            </div>
-          </label>
-        </div>
-        <div
-          class="ant-col ant-form-item-control"
+          class="ant-form-item ant-form-item-with-help"
         >
           <div
-            class="ant-form-item-control-input"
+            class="ant-row ant-form-item-row"
           >
             <div
-              class="ant-form-item-control-input-content"
+              class="ant-col ant-form-item-label"
             >
-              <div
-                class="ant-picker"
+              <label
+                class=""
+                for="ADD_EDIT_PROJECT_SUMMARY_expected_permit_application_date"
+                title=""
               >
-                <div
-                  class="ant-picker-input"
-                >
-                  <input
-                    autocomplete="off"
-                    id="expected_permit_application_date"
-                    name="expected_permit_application_date"
-                    placeholder="Please select date"
-                    readonly=""
-                    size="12"
-                    title=""
-                    value=""
-                  />
+                <div>
+                  When do you anticipate submitting a permit application?
+                   
                   <span
-                    class="ant-picker-suffix"
+                    class="form-item-optional"
                   >
-                    <span
-                      aria-label="calendar"
-                      class="anticon anticon-calendar"
-                      role="img"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        data-icon="calendar"
-                        fill="currentColor"
-                        focusable="false"
-                        height="1em"
-                        viewBox="64 64 896 896"
-                        width="1em"
-                      >
-                        <path
-                          d="M880 184H712v-64c0-4.4-3.6-8-8-8h-56c-4.4 0-8 3.6-8 8v64H384v-64c0-4.4-3.6-8-8-8h-56c-4.4 0-8 3.6-8 8v64H144c-17.7 0-32 14.3-32 32v664c0 17.7 14.3 32 32 32h736c17.7 0 32-14.3 32-32V216c0-17.7-14.3-32-32-32zm-40 656H184V460h656v380zM184 392V256h128v48c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8v-48h256v48c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8v-48h128v136H184z"
-                        />
-                      </svg>
-                    </span>
+                     (optional)
                   </span>
                 </div>
-              </div>
+              </label>
             </div>
-          </div>
-          <div
-            style="display: flex; flex-wrap: nowrap;"
-          >
             <div
-              class="ant-form-item-explain ant-form-item-explain-connected"
-              id="ADD_EDIT_PROJECT_SUMMARY_expected_permit_application_date_help"
-              role="alert"
+              class="ant-col ant-form-item-control"
             >
               <div
-                class=""
-              />
+                class="ant-form-item-control-input"
+              >
+                <div
+                  class="ant-form-item-control-input-content"
+                >
+                  <div
+                    class="ant-picker"
+                  >
+                    <div
+                      class="ant-picker-input"
+                    >
+                      <input
+                        autocomplete="off"
+                        id="expected_permit_application_date"
+                        name="expected_permit_application_date"
+                        placeholder="Please select date"
+                        readonly=""
+                        size="12"
+                        title=""
+                        value=""
+                      />
+                      <span
+                        class="ant-picker-suffix"
+                      >
+                        <span
+                          aria-label="calendar"
+                          class="anticon anticon-calendar"
+                          role="img"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            data-icon="calendar"
+                            fill="currentColor"
+                            focusable="false"
+                            height="1em"
+                            viewBox="64 64 896 896"
+                            width="1em"
+                          >
+                            <path
+                              d="M880 184H712v-64c0-4.4-3.6-8-8-8h-56c-4.4 0-8 3.6-8 8v64H384v-64c0-4.4-3.6-8-8-8h-56c-4.4 0-8 3.6-8 8v64H144c-17.7 0-32 14.3-32 32v664c0 17.7 14.3 32 32 32h736c17.7 0 32-14.3 32-32V216c0-17.7-14.3-32-32-32zm-40 656H184V460h656v380zM184 392V256h128v48c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8v-48h256v48c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8v-48h128v136H184z"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                style="display: flex; flex-wrap: nowrap;"
+              >
+                <div
+                  class="ant-form-item-explain ant-form-item-explain-connected"
+                  id="ADD_EDIT_PROJECT_SUMMARY_expected_permit_application_date_help"
+                  role="alert"
+                >
+                  <div
+                    class=""
+                  />
+                </div>
+              </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
-    <div
-      class="ant-form-item ant-form-item-with-help"
-    >
       <div
-        class="ant-row ant-form-item-row"
+        class="ant-col ant-col-24"
+        style="padding-top: 8px; padding-bottom: 8px;"
       >
         <div
-          class="ant-col ant-form-item-label"
-        >
-          <label
-            class=""
-            for="ADD_EDIT_PROJECT_SUMMARY_expected_permit_receipt_date"
-            title=""
-          >
-            <div>
-              When do you hope to receive your permit/amendment(s)?
-               
-              <span
-                class="form-item-optional"
-              >
-                 (optional)
-              </span>
-            </div>
-          </label>
-        </div>
-        <div
-          class="ant-col ant-form-item-control"
+          class="ant-form-item ant-form-item-with-help"
         >
           <div
-            class="ant-form-item-control-input"
+            class="ant-row ant-form-item-row"
           >
             <div
-              class="ant-form-item-control-input-content"
+              class="ant-col ant-form-item-label"
             >
-              <div
-                class="ant-picker"
+              <label
+                class=""
+                for="ADD_EDIT_PROJECT_SUMMARY_expected_permit_receipt_date"
+                title=""
               >
-                <div
-                  class="ant-picker-input"
-                >
-                  <input
-                    autocomplete="off"
-                    id="expected_permit_receipt_date"
-                    name="expected_permit_receipt_date"
-                    placeholder="Please select date"
-                    readonly=""
-                    size="12"
-                    title=""
-                    value=""
-                  />
+                <div>
+                  When do you hope to receive your permit/amendment(s)?
+                   
                   <span
-                    class="ant-picker-suffix"
+                    class="form-item-optional"
                   >
-                    <span
-                      aria-label="calendar"
-                      class="anticon anticon-calendar"
-                      role="img"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        data-icon="calendar"
-                        fill="currentColor"
-                        focusable="false"
-                        height="1em"
-                        viewBox="64 64 896 896"
-                        width="1em"
-                      >
-                        <path
-                          d="M880 184H712v-64c0-4.4-3.6-8-8-8h-56c-4.4 0-8 3.6-8 8v64H384v-64c0-4.4-3.6-8-8-8h-56c-4.4 0-8 3.6-8 8v64H144c-17.7 0-32 14.3-32 32v664c0 17.7 14.3 32 32 32h736c17.7 0 32-14.3 32-32V216c0-17.7-14.3-32-32-32zm-40 656H184V460h656v380zM184 392V256h128v48c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8v-48h256v48c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8v-48h128v136H184z"
-                        />
-                      </svg>
-                    </span>
+                     (optional)
                   </span>
                 </div>
-              </div>
+              </label>
             </div>
-          </div>
-          <div
-            style="display: flex; flex-wrap: nowrap;"
-          >
             <div
-              class="ant-form-item-explain ant-form-item-explain-connected"
-              id="ADD_EDIT_PROJECT_SUMMARY_expected_permit_receipt_date_help"
-              role="alert"
+              class="ant-col ant-form-item-control"
             >
               <div
-                class=""
-              />
+                class="ant-form-item-control-input"
+              >
+                <div
+                  class="ant-form-item-control-input-content"
+                >
+                  <div
+                    class="ant-picker"
+                  >
+                    <div
+                      class="ant-picker-input"
+                    >
+                      <input
+                        autocomplete="off"
+                        id="expected_permit_receipt_date"
+                        name="expected_permit_receipt_date"
+                        placeholder="Please select date"
+                        readonly=""
+                        size="12"
+                        title=""
+                        value=""
+                      />
+                      <span
+                        class="ant-picker-suffix"
+                      >
+                        <span
+                          aria-label="calendar"
+                          class="anticon anticon-calendar"
+                          role="img"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            data-icon="calendar"
+                            fill="currentColor"
+                            focusable="false"
+                            height="1em"
+                            viewBox="64 64 896 896"
+                            width="1em"
+                          >
+                            <path
+                              d="M880 184H712v-64c0-4.4-3.6-8-8-8h-56c-4.4 0-8 3.6-8 8v64H384v-64c0-4.4-3.6-8-8-8h-56c-4.4 0-8 3.6-8 8v64H144c-17.7 0-32 14.3-32 32v664c0 17.7 14.3 32 32 32h736c17.7 0 32-14.3 32-32V216c0-17.7-14.3-32-32-32zm-40 656H184V460h656v380zM184 392V256h128v48c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8v-48h256v48c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8v-48h128v136H184z"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                style="display: flex; flex-wrap: nowrap;"
+              >
+                <div
+                  class="ant-form-item-explain ant-form-item-explain-connected"
+                  id="ADD_EDIT_PROJECT_SUMMARY_expected_permit_receipt_date_help"
+                  role="alert"
+                >
+                  <div
+                    class=""
+                  />
+                </div>
+              </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
-    <div
-      class="ant-form-item ant-form-item-with-help"
-    >
       <div
-        class="ant-row ant-form-item-row"
+        class="ant-col ant-col-24"
+        style="padding-top: 8px; padding-bottom: 8px;"
       >
         <div
-          class="ant-col ant-form-item-label"
-        >
-          <label
-            class=""
-            for="ADD_EDIT_PROJECT_SUMMARY_expected_project_start_date"
-            title=""
-          >
-            <div>
-              When do you anticipate starting work on this project?
-               
-              <span
-                class="form-item-optional"
-              >
-                 (optional)
-              </span>
-            </div>
-          </label>
-        </div>
-        <div
-          class="ant-col ant-form-item-control"
+          class="ant-form-item ant-form-item-with-help"
         >
           <div
-            class="ant-form-item-control-input"
+            class="ant-row ant-form-item-row"
           >
             <div
-              class="ant-form-item-control-input-content"
+              class="ant-col ant-form-item-label"
             >
-              <div
-                class="ant-picker"
+              <label
+                class=""
+                for="ADD_EDIT_PROJECT_SUMMARY_expected_project_start_date"
+                title=""
               >
-                <div
-                  class="ant-picker-input"
-                >
-                  <input
-                    autocomplete="off"
-                    id="expected_project_start_date"
-                    name="expected_project_start_date"
-                    placeholder="Please select date"
-                    readonly=""
-                    size="12"
-                    title=""
-                    value=""
-                  />
+                <div>
+                  When do you anticipate starting work on this project?
+                   
                   <span
-                    class="ant-picker-suffix"
+                    class="form-item-optional"
                   >
-                    <span
-                      aria-label="calendar"
-                      class="anticon anticon-calendar"
-                      role="img"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        data-icon="calendar"
-                        fill="currentColor"
-                        focusable="false"
-                        height="1em"
-                        viewBox="64 64 896 896"
-                        width="1em"
-                      >
-                        <path
-                          d="M880 184H712v-64c0-4.4-3.6-8-8-8h-56c-4.4 0-8 3.6-8 8v64H384v-64c0-4.4-3.6-8-8-8h-56c-4.4 0-8 3.6-8 8v64H144c-17.7 0-32 14.3-32 32v664c0 17.7 14.3 32 32 32h736c17.7 0 32-14.3 32-32V216c0-17.7-14.3-32-32-32zm-40 656H184V460h656v380zM184 392V256h128v48c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8v-48h256v48c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8v-48h128v136H184z"
-                        />
-                      </svg>
-                    </span>
+                     (optional)
                   </span>
                 </div>
-              </div>
+              </label>
             </div>
-          </div>
-          <div
-            style="display: flex; flex-wrap: nowrap;"
-          >
             <div
-              class="ant-form-item-explain ant-form-item-explain-connected"
-              id="ADD_EDIT_PROJECT_SUMMARY_expected_project_start_date_help"
-              role="alert"
+              class="ant-col ant-form-item-control"
             >
               <div
-                class=""
-              />
+                class="ant-form-item-control-input"
+              >
+                <div
+                  class="ant-form-item-control-input-content"
+                >
+                  <div
+                    class="ant-picker"
+                  >
+                    <div
+                      class="ant-picker-input"
+                    >
+                      <input
+                        autocomplete="off"
+                        id="expected_project_start_date"
+                        name="expected_project_start_date"
+                        placeholder="Please select date"
+                        readonly=""
+                        size="12"
+                        title=""
+                        value=""
+                      />
+                      <span
+                        class="ant-picker-suffix"
+                      >
+                        <span
+                          aria-label="calendar"
+                          class="anticon anticon-calendar"
+                          role="img"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            data-icon="calendar"
+                            fill="currentColor"
+                            focusable="false"
+                            height="1em"
+                            viewBox="64 64 896 896"
+                            width="1em"
+                          >
+                            <path
+                              d="M880 184H712v-64c0-4.4-3.6-8-8-8h-56c-4.4 0-8 3.6-8 8v64H384v-64c0-4.4-3.6-8-8-8h-56c-4.4 0-8 3.6-8 8v64H144c-17.7 0-32 14.3-32 32v664c0 17.7 14.3 32 32 32h736c17.7 0 32-14.3 32-32V216c0-17.7-14.3-32-32-32zm-40 656H184V460h656v380zM184 392V256h128v48c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8v-48h256v48c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8v-48h128v136H184z"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                style="display: flex; flex-wrap: nowrap;"
+              >
+                <div
+                  class="ant-form-item-explain ant-form-item-explain-connected"
+                  id="ADD_EDIT_PROJECT_SUMMARY_expected_project_start_date_help"
+                  role="alert"
+                >
+                  <div
+                    class=""
+                  />
+                </div>
+              </div>
             </div>
           </div>
         </div>

--- a/services/common/src/redux/utils/Validate.ts
+++ b/services/common/src/redux/utils/Validate.ts
@@ -277,11 +277,16 @@ export const dateInFuture = (value) =>
   value && !moment(value).isAfter() ? "Date must be in the future" : undefined;
 
 // NOTE: modified from version in CORE- change from <= to <
-export const dateNotBeforeOther = memoize((other: string) => (value: string) => {
-  return value && other && value < other
-    ? `Date cannot be before ${moment(other).format("ddd MMM D YYYY")}`
-    : undefined;
-});
+// removed memoization because it was interfering with passing 2nd arg
+export const dateNotBeforeOther = memoize((other: string, otherLabel?: string) => (value: string) => {
+  const invalid = value && other && value < other;
+  if (!invalid) {
+    return undefined;
+  }
+  const otherFormattedDate = moment(other).format("ddd MMM D YYYY");
+  const otherDateText = otherLabel ? `${otherLabel} (${otherFormattedDate})` : otherFormattedDate;
+  return `Date cannot be before ${otherDateText}`
+}, (other, otherLabel) => `${other}_${otherLabel}`);
 
 export const dateNotBeforeStrictOther = memoize((other) => (value) =>
   value && other && moment(value).isBefore(other) ? `Date cannot be before ${other}` : undefined
@@ -290,21 +295,26 @@ export const dateNotBeforeStrictOther = memoize((other) => (value) =>
 export const timeNotBeforeOther = memoize(
   (comparableDate, baseDate, baseTime) => (comparableTime) =>
     baseTime &&
-    baseDate &&
-    comparableDate &&
-    comparableTime &&
-    baseDate === comparableDate &&
-    comparableTime < baseTime
+      baseDate &&
+      comparableDate &&
+      comparableTime &&
+      baseDate === comparableDate &&
+      comparableTime < baseTime
       ? `Time cannot be before ${baseTime.format("H:mm")} hrs.`
       : undefined
 );
 
 // NOTE: modified from version in CORE- change from >= to >
-export const dateNotAfterOther = memoize((other: string) => (value: string) => {
-  return value && other && value > other
-    ? `Date cannot be after ${moment(other).format("ddd MMM D YYYY")}`
-    : undefined;
-});
+export const dateNotAfterOther = memoize((other: string, otherLabel?: string) => (value: string) => {
+  const invalid = value && other && value > other;
+  if (!invalid) {
+    return undefined;
+  }
+  const otherFormattedDate = moment(other).format("ddd MMM D YYYY");
+  const otherDateText = otherLabel ? `${otherLabel} (${otherFormattedDate})` : otherFormattedDate;
+
+  return `Date cannot be after ${otherDateText}`
+}, (other, otherLabel) => `${other}_${otherLabel}`);
 
 export const yearNotInFuture = (value) =>
   value && value > new Date().getFullYear() ? "Year cannot be in the future" : undefined;
@@ -417,9 +427,8 @@ export const validateIfApplicationTypeCorrespondsToPermitNumber = (
     return permit?.permit_prefix &&
       Strings.APPLICATION_TYPES_BY_PERMIT_PREFIX[permit.permit_prefix].includes(applicationType)
       ? undefined
-      : `The ${
-          isAdminAmendment ? "Type of Administrative Amendment" : "Type of Notice of Work"
-        } does not match to the selected permit.`;
+      : `The ${isAdminAmendment ? "Type of Administrative Amendment" : "Type of Notice of Work"
+      } does not match to the selected permit.`;
   }
   return undefined;
 };

--- a/services/common/src/redux/utils/Validate.ts
+++ b/services/common/src/redux/utils/Validate.ts
@@ -277,7 +277,6 @@ export const dateInFuture = (value) =>
   value && !moment(value).isAfter() ? "Date must be in the future" : undefined;
 
 // NOTE: modified from version in CORE- change from <= to <
-// removed memoization because it was interfering with passing 2nd arg
 export const dateNotBeforeOther = memoize((other: string, otherLabel?: string) => (value: string) => {
   const invalid = value && other && value < other;
   if (!invalid) {


### PR DESCRIPTION
## Objective 
Project Dates:
- make validation messages more useful
- throw in some spacing
- allow user to clear the date
- sorry, lots of whitespace differences on this now!

Project Links:
- hide the input part of it altogether when in view mode
- doing so also fixed the state issues where (I believe) the currentSelection was staying the same between edit/view toggle, making it so that clicking the add button after toggling back to edit was adding what was previously there (even though it wasn't in the select box anymore). The re-render fixed it.
- and make sure that after adding the related project that the selection was cleared.

General Project summary form:
- reset the form on cancel edit

[MDS-6178](https://bcmines.atlassian.net/browse/MDS-6178)

_Why are you making this change? Provide a short explanation and/or screenshots_
![image](https://github.com/user-attachments/assets/1bc0a760-6d01-4a33-ab2b-7a7bd85407b1)
