### PR TITLE
[MDS-6195] Disable ability to replace and archive for all documents IRT table

### DIFF
--- a/services/common/src/components/projects/ProjectDocumentsTab.tsx
+++ b/services/common/src/components/projects/ProjectDocumentsTab.tsx
@@ -142,7 +142,8 @@ const ProjectDocumentsTab: FC<ProjectDocumentsTabProps> = ({ project }) => {
           <Typography.Title level={3}>Project Description</Typography.Title>
           <Alert
             className={isCore ? "ant-alert-grey" : ""}
-            description="Refer back to Project Description Purpose and Authorization to see required document list."
+            description="Below are the required and supporting documents for each authorization submitted in the Project Description. 
+            Refer to the Project Description Purpose and Authorization sections for the complete list of required documents."
             showIcon
           />
         </>
@@ -207,11 +208,22 @@ const ProjectDocumentsTab: FC<ProjectDocumentsTabProps> = ({ project }) => {
           titleLevel={3}
           onArchivedDocuments={refreshData}
           documents={irtDocuments}
-          canReplace={canReplace}
+          canReplace={false}
+          canArchive={false}
+          infoText="Here is the IRT file you submitted under the Information Requirements Table.
+          To make changes to the submission, return to the IRT tab."
         />
       ),
     },
-    { href: "major-mine-application" },
+    {
+      href: "major-mine-application",
+      content: (
+        <>
+          <Typography.Title level={3}>Major Mine Application</Typography.Title>
+          <Typography.Paragraph>Below are the documents submitted as part of the Major Mine Application.</Typography.Paragraph>
+        </>
+      )
+    },
     {
       href: "mma-primary-document",
       title: <div className="sub-tab-1">Primary Document</div>,

--- a/services/common/src/components/projects/ProjectDocumentsTabSection.tsx
+++ b/services/common/src/components/projects/ProjectDocumentsTabSection.tsx
@@ -13,6 +13,7 @@ interface ProjectDocumentsTabSectionProps {
   onArchivedDocuments: () => Promise<void>;
   canArchive?: boolean;
   canReplace?: boolean;
+  infoText?: string;
 }
 const ProjectDocumentsTabSection: FC<ProjectDocumentsTabSectionProps> = ({
   documents,
@@ -22,6 +23,7 @@ const ProjectDocumentsTabSection: FC<ProjectDocumentsTabSectionProps> = ({
   titleLevel = 4,
   canArchive = true,
   canReplace = true,
+  infoText = null,
 }) => {
   const sectionTitle = title ?? formatUrlToUpperCaseString(id);
 
@@ -29,6 +31,7 @@ const ProjectDocumentsTabSection: FC<ProjectDocumentsTabSectionProps> = ({
     <Row id={id}>
       <Col span={24}>
         <Typography.Title level={titleLevel}>{sectionTitle}</Typography.Title>
+        {infoText && <Typography.Paragraph>{infoText}</Typography.Paragraph>}
       </Col>
       <Col span={24}>
         <DocumentTable

--- a/services/common/src/components/projects/__snapshots__/ProjectDocumentsTab.spec.tsx.snap
+++ b/services/common/src/components/projects/__snapshots__/ProjectDocumentsTab.spec.tsx.snap
@@ -235,7 +235,8 @@ exports[`ProjectDocumentsTab renders properly 1`] = `
               <div
                 class="ant-alert-description"
               >
-                Refer back to Project Description Purpose and Authorization to see required document list.
+                Below are the required and supporting documents for each authorization submitted in the Project Description. 
+            Refer to the Project Description Purpose and Authorization sections for the complete list of required documents.
               </div>
             </div>
           </div>
@@ -1837,6 +1838,12 @@ exports[`ProjectDocumentsTab renders properly 1`] = `
               >
                 Information Requirements Table
               </h3>
+              <div
+                class="ant-typography"
+              >
+                Here is the IRT file you submitted under the Information Requirements Table.
+          To make changes to the submission, return to the IRT tab.
+              </div>
             </div>
             <div
               class="ant-col ant-col-24"
@@ -2217,14 +2224,19 @@ exports[`ProjectDocumentsTab renders properly 1`] = `
         </div>
         <div
           class="ant-col ant-col-24"
+          id="major-mine-application"
           style="padding: 8px 8px 8px 8px;"
         >
           <h3
             class="ant-typography"
-            id="major-mine-application"
           >
             Major Mine Application
           </h3>
+          <div
+            class="ant-typography"
+          >
+            Below are the documents submitted as part of the Major Mine Application.
+          </div>
         </div>
         <div
           class="ant-col ant-col-24"


### PR DESCRIPTION
## Objective 

[MDS-6195](https://bcmines.atlassian.net/browse/MDS-6195)

- Disable replace and archive action menu options in All Document's IRT table
- Adding text included in mockup to provide more details for users
