### PR TITLE
[MDS-6177] Project Summary View Bugs

### DIFF
--- a/services/common/src/components/forms/BaseInput.tsx
+++ b/services/common/src/components/forms/BaseInput.tsx
@@ -1,3 +1,4 @@
+import { EMPTY_FIELD } from "@mds/common/constants";
 import { Typography } from "antd";
 import React, { FC, ReactNode } from "react";
 import { WrappedFieldProps, WrappedFieldMetaProps, WrappedFieldInputProps } from "redux-form";
@@ -80,12 +81,13 @@ interface BaseViewInputProps {
   value: string | number;
 }
 export const BaseViewInput: FC<BaseViewInputProps> = ({ label = "", value = "" }) => {
+  const displayValue = value ? value.toString() : EMPTY_FIELD;
   return (
     <div className="view-item ant-form-item">
       {label && label !== "" && (
         <Typography.Paragraph className="view-item-label">{label}</Typography.Paragraph>
       )}
-      <Typography.Paragraph className="view-item-value">{value.toString()}</Typography.Paragraph>
+      <Typography.Paragraph className="view-item-value">{displayValue}</Typography.Paragraph>
     </div>
   );
 };

--- a/services/common/src/components/forms/RenderCheckbox.tsx
+++ b/services/common/src/components/forms/RenderCheckbox.tsx
@@ -1,6 +1,7 @@
-import React, { FC } from "react";
+import React, { FC, useContext } from "react";
 import { Checkbox, Form } from "antd";
 import { BaseInputProps } from "./BaseInput";
+import { FormContext } from "./FormWrapper";
 /**
  * @constant RenderCheckbox - Ant Design `Checkbox` component for redux-form.
  */
@@ -20,6 +21,20 @@ const RenderCheckbox: FC<CheckboxProps> = ({
   const onChange = (e) => {
     input.onChange(e.target.checked);
   };
+  const { isEditMode } = useContext(FormContext);
+
+  if (!isEditMode) {
+    return (
+      <Form.Item
+        name={input.name}
+        className="view-item"
+      >
+        <Checkbox id={id} checked={input.value} disabled={true}>
+          <div className="view-item-label ungroup-checkbox">{label}</div>
+        </Checkbox>
+      </Form.Item>
+    );
+  }
   return (
     <Form.Item
       name={input.name}

--- a/services/common/src/components/forms/RenderGroupCheckbox.tsx
+++ b/services/common/src/components/forms/RenderGroupCheckbox.tsx
@@ -1,6 +1,7 @@
-import React, { FC } from "react";
+import React, { FC, useContext } from "react";
 import { Checkbox, Form } from "antd";
 import { BaseInputProps } from "./BaseInput";
+import { FormContext } from "./FormWrapper";
 
 /**
  * @constant RenderGroupCheckbox - Ant Design `Checkbox` component for redux-form.
@@ -33,6 +34,24 @@ const RenderGroupCheckbox: FC<CheckboxProps> = ({
   required,
   ...props
 }) => {
+  const { isEditMode } = useContext(FormContext);
+  if (!isEditMode) {
+    return (
+      <Form.Item
+        name={input.name}
+        label={<div className="view-item-label">{label}</div>}
+        getValueProps={() => ({ value: input.value })}
+        className="view-item"
+      >
+        <Checkbox.Group
+          name={input.name}
+          options={options}
+          className="view-group-checkbox"
+          disabled={true}
+        />
+      </Form.Item>
+    );
+  }
   return (
     <Form.Item
       name={input.name}

--- a/services/common/src/components/forms/RenderRadioButtons.tsx
+++ b/services/common/src/components/forms/RenderRadioButtons.tsx
@@ -1,6 +1,6 @@
 import React, { FC, useContext } from "react";
 import { Form, Radio } from "antd";
-import { BaseInputProps, getFormItemLabel } from "@mds/common/components/forms/BaseInput";
+import { BaseInputProps, BaseViewInput, getFormItemLabel } from "@mds/common/components/forms/BaseInput";
 import { IOption } from "@mds/common/interfaces";
 import { FormContext } from "./FormWrapper";
 
@@ -40,6 +40,36 @@ const RenderRadioButtons: FC<RenderRadioButtonsProps> = ({
     input.onChange(e.target.value);
   };
 
+  if (!isEditMode) {
+    if (optionType !== "default") {
+      const matching = options.find((opt) => opt.value === input.value);
+      return <BaseViewInput label={label} value={matching?.label} />
+    }
+    const radioGroupClass = isVertical ? "vertical-radio-group view-item" : "view-item"
+    return (
+      <Form.Item
+        id={id}
+        getValueProps={() => ({ value: input.value })}
+        name={input.name}
+        label={<div className="view-item-label">{getFormItemLabel(label, false, labelSubtitle, false)}</div>}
+        className="view-item"
+      >
+        <>
+          <Radio.Group
+            disabled={true}
+            name={input.name}
+            value={input.value}
+            options={options}
+            optionType={optionType}
+            className={radioGroupClass}
+            buttonStyle="solid"
+          />
+          {help && <div className={`form-item-help ${input.name}-form-help`}>{help}</div>}
+        </>
+      </Form.Item>
+    );
+  }
+
   return (
     <Form.Item
       id={id}
@@ -55,7 +85,7 @@ const RenderRadioButtons: FC<RenderRadioButtonsProps> = ({
     >
       <>
         <Radio.Group
-          disabled={disabled || !isEditMode}
+          disabled={disabled}
           name={input.name}
           value={input.value}
           onChange={handleRadioChange}

--- a/services/common/src/components/forms/SteppedForm.tsx
+++ b/services/common/src/components/forms/SteppedForm.tsx
@@ -122,7 +122,7 @@ const SteppedForm: FC<SteppedFormProps> = ({
     return {
       label: formatUrlToUpperCaseString(tab),
       key: tab,
-      disabled: child?.props?.disabled || (disableTabsOnError && errors.length > 0),
+      disabled: child?.props?.disabled || (isEditMode && disableTabsOnError && errors.length > 0),
       className: "stepped-menu-item",
       onClick: () => handleTabClick(tabs[indexOf(tabs, tab)]),
     };
@@ -143,7 +143,7 @@ const SteppedForm: FC<SteppedFormProps> = ({
           <div className="stepped-form-form-container">
             <FormWrapper
               name={name}
-              onSubmit={() => {}}
+              onSubmit={() => { }}
               initialValues={initialValues}
               isEditMode={isEditMode}
               reduxFormConfig={

--- a/services/common/src/components/projectSummary/ApplicationSummary.tsx
+++ b/services/common/src/components/projectSummary/ApplicationSummary.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useState } from "react";
+import React, { FC, useContext, useEffect, useState } from "react";
 import { getFormValues } from "redux-form";
 import { useSelector } from "react-redux";
 import {
@@ -15,6 +15,7 @@ import { getPermits } from "@mds/common/redux/selectors/permitSelectors";
 import { FORM, isFieldDisabled } from "@mds/common/constants";
 import { IAuthorizationSummary } from "@mds/common/interfaces";
 import { getSystemFlag } from "@mds/common/redux/selectors/authenticationSelectors";
+import { FormContext } from "../forms/FormWrapper";
 
 export const ApplicationSummary: FC = () => {
   const permits = useSelector(getPermits);
@@ -35,6 +36,7 @@ export const ApplicationSummary: FC = () => {
   const processedEnvironmentActPermitResult: any[] = [];
   let processedOtherActPermitResult: any[] = [];
   const systemFlag = useSelector(getSystemFlag);
+  const { isEditMode } = useContext(FormContext);
 
   const minesActColumns: ColumnsType<IAuthorizationSummary> = [
     renderTextColumn("project_type", "Type", false),
@@ -227,6 +229,16 @@ export const ApplicationSummary: FC = () => {
     history.push(url);
   };
 
+  const editButton = <Col md={12} sm={24} style={{ textAlign: "right" }}>
+    <Button
+      disabled={isFieldDisabled(systemFlag, formValues?.status_code)}
+      type="default"
+      onClick={handleEditClicked}
+    >
+      {isEditMode ? "Edit" : "View"}
+    </Button>
+  </Col>;
+
   return (
     <div className="ant-form-vertical">
       <Typography.Title level={3}>Application Summary</Typography.Title>
@@ -246,15 +258,7 @@ export const ApplicationSummary: FC = () => {
         <Col md={12} sm={24}>
           <Typography.Title level={5}>Mines Act</Typography.Title>
         </Col>
-        <Col md={12} sm={24} style={{ textAlign: "right" }}>
-          <Button
-            disabled={isFieldDisabled(systemFlag, formValues?.status_code)}
-            type="default"
-            onClick={handleEditClicked}
-          >
-            Edit
-          </Button>
-        </Col>
+        {editButton}
       </Row>
       <CoreTable dataSource={minesActData} columns={minesActColumns} />
       <br />
@@ -263,15 +267,7 @@ export const ApplicationSummary: FC = () => {
         <Col md={12} sm={24}>
           <Typography.Title level={5}>Environmental Management Act</Typography.Title>
         </Col>
-        <Col md={12} sm={24} style={{ textAlign: "right" }}>
-          <Button
-            disabled={isFieldDisabled(systemFlag, formValues?.status_code)}
-            type="default"
-            onClick={handleEditClicked}
-          >
-            Edit
-          </Button>
-        </Col>
+        {editButton}
       </Row>
       <CoreTable dataSource={environmentalManagementActData} columns={otherActColumns} />
       <br />
@@ -279,15 +275,7 @@ export const ApplicationSummary: FC = () => {
         <Col md={12} sm={24}>
           <Typography.Title level={5}>Water Sustainability Act</Typography.Title>
         </Col>
-        <Col md={12} sm={24} style={{ textAlign: "right" }}>
-          <Button
-            disabled={isFieldDisabled(systemFlag, formValues?.status_code)}
-            type="default"
-            onClick={handleEditClicked}
-          >
-            Edit
-          </Button>
-        </Col>
+        {editButton}
       </Row>
       <CoreTable dataSource={waterSustainabilityActData} columns={otherActColumns} />
       <br />
@@ -295,15 +283,7 @@ export const ApplicationSummary: FC = () => {
         <Col md={12} sm={24}>
           <Typography.Title level={5}>Forestry Act</Typography.Title>
         </Col>
-        <Col md={12} sm={24} style={{ textAlign: "right" }}>
-          <Button
-            disabled={isFieldDisabled(systemFlag, formValues?.status_code)}
-            type="default"
-            onClick={handleEditClicked}
-          >
-            Edit
-          </Button>
-        </Col>
+        {editButton}
       </Row>
       <CoreTable dataSource={forestryActData} columns={otherActColumns} />
       <br />
@@ -311,15 +291,7 @@ export const ApplicationSummary: FC = () => {
         <Col md={12} sm={24}>
           <Typography.Title level={5}>Other Legislation</Typography.Title>
         </Col>
-        <Col md={12} sm={24} style={{ textAlign: "right" }}>
-          <Button
-            disabled={isFieldDisabled(systemFlag, formValues?.status_code)}
-            type="default"
-            onClick={handleEditClicked}
-          >
-            Edit
-          </Button>
-        </Col>
+        {editButton}
       </Row>
       <CoreTable dataSource={otherLegislationActData} columns={otherActColumns} />
     </div>

--- a/services/common/src/components/projectSummary/AuthorizationsInvolved.tsx
+++ b/services/common/src/components/projectSummary/AuthorizationsInvolved.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import {
   arrayPush,
@@ -57,6 +57,7 @@ import {
 } from "../..";
 import { SystemFlagEnum } from "@mds/common/constants/enums";
 import { getSystemFlag } from "@mds/common/redux/selectors/authenticationSelectors";
+import { FormContext } from "../forms/FormWrapper";
 
 const RenderEMAPermitCommonSections = ({ code, isAmendment, index, isDisabled }) => {
   const dispatch = useDispatch();
@@ -292,7 +293,7 @@ const RenderEMANewPermitSection = ({ code, isDisabled }) => {
   );
 };
 
-const RenderEMAAmendFieldArray = ({ fields, code, isDisabled }) => {
+const RenderEMAAmendFieldArray = ({ fields, code, isDisabled, isEditMode }) => {
   const handleRemoveAmendment = (index: number) => {
     fields.remove(index);
   };
@@ -317,9 +318,9 @@ const RenderEMAAmendFieldArray = ({ fields, code, isDisabled }) => {
                       </a>
                     </Typography.Text>
                   </Col>
-                  <Col>
+                  {isEditMode && <Col>
                     <Button onClick={() => handleRemoveAmendment(index)}>Cancel</Button>
-                  </Col>
+                  </Col>}
                 </Row>
               }
               name="existing_permits_authorizations[0]"
@@ -389,6 +390,7 @@ const RenderEMAAuthCodeFormSection = ({ code, isDisabled }) => {
   const hasNew = codeAuthorizations.NEW?.length > 0;
   const permitTypes = ["AMENDMENT", "NEW"];
   const dispatch = useDispatch();
+  const { isEditMode } = useContext(FormContext);
 
   const addAmendment = () => {
     dispatch(arrayPush(FORM.ADD_EDIT_PROJECT_SUMMARY, `authorizations.${code}.AMENDMENT`, {}));
@@ -437,16 +439,16 @@ const RenderEMAAuthCodeFormSection = ({ code, isDisabled }) => {
                       <FieldArray
                         name={`${code}.AMENDMENT`}
                         component={RenderEMAAmendFieldArray}
-                        props={{ code, isDisabled }}
+                        props={{ code, isDisabled, isEditMode }}
                       />
-                      <Button
+                      {isEditMode && <Button
                         disabled={isDisabled}
                         onClick={addAmendment}
                         icon={<PlusCircleFilled />}
                         className="btn-sm-padding margin-large--bottom"
                       >
                         Add another amendment
-                      </Button>
+                      </Button>}
                     </Row>
                   )}
                 </>
@@ -558,7 +560,7 @@ export const AuthorizationsInvolved = () => {
   const transformedProjectSummaryAuthorizationTypes = useSelector(
     getTransformedProjectSummaryAuthorizationTypes
   );
-
+  const { isEditMode } = useContext(FormContext);
   const amsAuthTypes = useSelector(getAmsAuthorizationTypes);
   const formValues = useSelector(getFormValues(FORM.ADD_EDIT_PROJECT_SUMMARY));
 
@@ -635,13 +637,13 @@ export const AuthorizationsInvolved = () => {
                         <Row gutter={[0, 16]}>
                           <Col>
                             <Checkbox
-                              disabled={isFieldDisabled(systemFlag, formValues?.status_code, true)}
+                              disabled={!isEditMode || isFieldDisabled(systemFlag, formValues?.status_code, true)}
                               data-cy={`checkbox-authorization-${child.code}`}
                               value={child.code}
                               checked={checked}
                               onChange={(e) => handleChange(e, child.code)}
                             >
-                              <b>{child.description}</b>
+                              <b className={!isEditMode && "view-item-label"}>{child.description}</b>
                             </Checkbox>
                             {checked && (
                               <>

--- a/services/common/src/components/projectSummary/ProjectContacts.tsx
+++ b/services/common/src/components/projectSummary/ProjectContacts.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect } from "react";
+import React, { FC, useContext, useEffect } from "react";
 import { useSelector, useDispatch } from "react-redux";
 import { isNil } from "lodash";
 import { Typography, Button, Row, Col, Popconfirm } from "antd";
@@ -20,10 +20,12 @@ import RenderField from "@mds/common/components/forms/RenderField";
 import RenderSelect from "@mds/common/components/forms/RenderSelect";
 import { getDropdownProvinceOptions } from "@mds/common/redux/selectors/staticContentSelectors";
 import { getSystemFlag } from "@mds/common/redux/selectors/authenticationSelectors";
+import { FormContext } from "../forms/FormWrapper";
 
 const RenderContacts = ({ fields, isDisabled }) => {
   const dispatch = useDispatch();
   const provinceOptions = useSelector(getDropdownProvinceOptions);
+  const { isEditMode } = useContext(FormContext);
   const handleClearProvince = (currentCountry, addressTypeCode, subDivisionCode, field) => {
     // clear out the province if country has changed and it no longer matches
     if (addressTypeCode !== currentCountry) {
@@ -64,7 +66,7 @@ const RenderContacts = ({ fields, isDisabled }) => {
                       Additional project contact #{index}
                     </Typography.Title>
                   </Col>
-                  <Col>
+                  {isEditMode && <Col>
                     <Popconfirm
                       placement="topLeft"
                       title="Are you sure you want to remove this contact?"
@@ -81,7 +83,7 @@ const RenderContacts = ({ fields, isDisabled }) => {
                         Delete
                       </Button>
                     </Popconfirm>
-                  </Col>
+                  </Col>}
                 </Row>
               </Col>
             )}
@@ -253,13 +255,13 @@ const RenderContacts = ({ fields, isDisabled }) => {
           </div>
         );
       })}
-      <LinkButton
+      {isEditMode && <LinkButton
         disabled={isDisabled}
         onClick={() => fields.push({ is_primary: false })}
         title="Add additional project contacts"
       >
         <PlusOutlined /> Add additional project contacts
-      </LinkButton>
+      </LinkButton>}
     </>
   );
 };

--- a/services/common/src/components/projectSummary/ProjectLinks.tsx
+++ b/services/common/src/components/projectSummary/ProjectLinks.tsx
@@ -174,7 +174,7 @@ const ProjectLinks: FC<ProjectLinksProps> = ({ viewProject, tableOnly = false })
         <ProjectLinksTable
           projectGuid={project.project_guid}
           projectLinks={projectLinks}
-          hasModifyPermission={hasModifyPermission && !tableOnly}
+          hasModifyPermission={hasModifyPermission && !tableOnly && isEditMode}
           viewProject={viewProject}
           isLoaded={isLoaded}
         />

--- a/services/common/src/components/reports/__snapshots__/ReportDetailsForm-view.spec.tsx.snap
+++ b/services/common/src/components/reports/__snapshots__/ReportDetailsForm-view.spec.tsx.snap
@@ -31,7 +31,7 @@ exports[`ReportDetailsForm renders view mode properly 1`] = `
           Regulatory Authority
         </h3>
         <div
-          class="ant-form-item ant-form-item-with-help"
+          class="ant-form-item view-item"
         >
           <div
             class="ant-row ant-form-item-row"
@@ -40,14 +40,17 @@ exports[`ReportDetailsForm renders view mode properly 1`] = `
               class="ant-col ant-form-item-label"
             >
               <label
-                class="ant-form-item-required"
+                class=""
                 for="VIEW_EDIT_REPORT_report_for"
                 title=""
               >
                 <div
-                  style="width: 100%;"
+                  class="view-item-label"
                 >
-                  Who is the report for?
+                  <div>
+                    Who is the report for?
+                     
+                  </div>
                 </div>
               </label>
             </div>
@@ -61,7 +64,7 @@ exports[`ReportDetailsForm renders view mode properly 1`] = `
                   class="ant-form-item-control-input-content"
                 >
                   <div
-                    class="ant-radio-group ant-radio-group-solid vertical-radio-group"
+                    class="ant-radio-group ant-radio-group-solid vertical-radio-group view-item"
                   >
                     <label
                       class="ant-radio-wrapper ant-radio-wrapper-disabled ant-radio-wrapper-in-form-item"
@@ -150,19 +153,6 @@ exports[`ReportDetailsForm renders view mode properly 1`] = `
                   </div>
                 </div>
               </div>
-              <div
-                style="display: flex; flex-wrap: nowrap;"
-              >
-                <div
-                  class="ant-form-item-explain ant-form-item-explain-connected"
-                  id="VIEW_EDIT_REPORT_report_for_help"
-                  role="alert"
-                >
-                  <div
-                    class=""
-                  />
-                </div>
-              </div>
             </div>
           </div>
         </div>
@@ -183,7 +173,7 @@ exports[`ReportDetailsForm renders view mode properly 1`] = `
         style="padding: 4px 8px 4px 8px;"
       >
         <div
-          class="ant-form-item ant-form-item-with-help"
+          class="ant-form-item view-item"
         >
           <div
             class="ant-row ant-form-item-row"
@@ -192,14 +182,17 @@ exports[`ReportDetailsForm renders view mode properly 1`] = `
               class="ant-col ant-form-item-label"
             >
               <label
-                class="ant-form-item-required"
+                class=""
                 for="VIEW_EDIT_REPORT_report_type"
                 title=""
               >
                 <div
-                  style="width: 100%;"
+                  class="view-item-label"
                 >
-                  What is the type of the report?
+                  <div>
+                    What is the type of the report?
+                     
+                  </div>
                 </div>
               </label>
             </div>
@@ -213,7 +206,7 @@ exports[`ReportDetailsForm renders view mode properly 1`] = `
                   class="ant-form-item-control-input-content"
                 >
                   <div
-                    class="ant-radio-group ant-radio-group-solid vertical-radio-group"
+                    class="ant-radio-group ant-radio-group-solid vertical-radio-group view-item"
                   >
                     <label
                       class="ant-radio-wrapper ant-radio-wrapper-checked ant-radio-wrapper-disabled ant-radio-wrapper-in-form-item"
@@ -259,19 +252,6 @@ exports[`ReportDetailsForm renders view mode properly 1`] = `
                       </span>
                     </label>
                   </div>
-                </div>
-              </div>
-              <div
-                style="display: flex; flex-wrap: nowrap;"
-              >
-                <div
-                  class="ant-form-item-explain ant-form-item-explain-connected"
-                  id="VIEW_EDIT_REPORT_report_type_help"
-                  role="alert"
-                >
-                  <div
-                    class=""
-                  />
                 </div>
               </div>
             </div>

--- a/services/common/src/interfaces/common/option.interface.ts
+++ b/services/common/src/interfaces/common/option.interface.ts
@@ -1,6 +1,6 @@
 export interface IOption {
   label: string;
-  value: string | number;
+  value: string | number | boolean;
   tooltip?: string;
 }
 

--- a/services/core-web/src/components/mine/Projects/ProjectSummary.tsx
+++ b/services/core-web/src/components/mine/Projects/ProjectSummary.tsx
@@ -263,7 +263,7 @@ export const ProjectSummary: FC = () => {
   return (
     <>
       <Prompt
-        when={anyTouched}
+        when={anyTouched && isEditMode}
         message={(location, action) => {
           if (action === "REPLACE") {
             dispatch(reset(FORM.ADD_EDIT_PROJECT_SUMMARY));

--- a/services/core-web/src/styles/components/Forms.scss
+++ b/services/core-web/src/styles/components/Forms.scss
@@ -86,8 +86,22 @@
   margin-bottom: 10px;
 }
 
-.common-form.form-view .ant-row.form-row-margin {
-  margin-bottom: 1em;
+.common-form.form-view {
+  .ant-form-item-required::before {
+    display: none !important;
+  }
+
+  .view-item-label {
+    color: $input-text;
+  }
+
+  .ant-radio-group.view-item label span {
+    color: $input-text;
+  }
+
+  .ant-row.form-row-margin {
+    margin-bottom: 1em;
+  }
 }
 
 .vertical-radio-group {
@@ -109,9 +123,26 @@
 .view-item {
   line-height: 22px;
 
-  .ant-typography.view-item-label {
+  .view-item-label {
     margin-bottom: 4px;
     font-weight: 600;
+  }
+
+  .ant-form-item-label {
+    padding-bottom: 0;
+  }
+
+  .view-group-checkbox label>span {
+    color: $input-text;
+  }
+
+  .ant-checkbox-wrapper .view-item-label {
+    margin-bottom: 4px;
+    color: $input-text;
+
+    &.ungroup-checkbox {
+      font-weight: normal;
+    }
   }
 
   .ant-typography.view-item-value {

--- a/services/core-web/src/styles/settings/variables.scss
+++ b/services/core-web/src/styles/settings/variables.scss
@@ -18,6 +18,7 @@ $hover-blue: #3d6de7;
 $btn-red: #bc2929;
 $disabled-text: #a39898;
 $gov-grey: #bbbbbb;
+$input-text: #000000D9;
 
 // Accent Colours
 $lime-green: #adfc4a;

--- a/services/core-web/src/tests/components/Forms/reports/__snapshots__/ReportPage-prr.spec.tsx.snap
+++ b/services/core-web/src/tests/components/Forms/reports/__snapshots__/ReportPage-prr.spec.tsx.snap
@@ -283,7 +283,7 @@ exports[`ReportPage renders view mode properly 1`] = `
               Regulatory Authority
             </h3>
             <div
-              class="ant-form-item ant-form-item-with-help"
+              class="ant-form-item view-item"
             >
               <div
                 class="ant-row ant-form-item-row"
@@ -292,14 +292,17 @@ exports[`ReportPage renders view mode properly 1`] = `
                   class="ant-col ant-form-item-label"
                 >
                   <label
-                    class="ant-form-item-required"
+                    class=""
                     for="VIEW_EDIT_REPORT_report_for"
                     title=""
                   >
                     <div
-                      style="width: 100%;"
+                      class="view-item-label"
                     >
-                      Who is the report for?
+                      <div>
+                        Who is the report for?
+                         
+                      </div>
                     </div>
                   </label>
                 </div>
@@ -313,7 +316,7 @@ exports[`ReportPage renders view mode properly 1`] = `
                       class="ant-form-item-control-input-content"
                     >
                       <div
-                        class="ant-radio-group ant-radio-group-solid vertical-radio-group"
+                        class="ant-radio-group ant-radio-group-solid vertical-radio-group view-item"
                       >
                         <label
                           class="ant-radio-wrapper ant-radio-wrapper-disabled ant-radio-wrapper-in-form-item"
@@ -402,19 +405,6 @@ exports[`ReportPage renders view mode properly 1`] = `
                       </div>
                     </div>
                   </div>
-                  <div
-                    style="display: flex; flex-wrap: nowrap;"
-                  >
-                    <div
-                      class="ant-form-item-explain ant-form-item-explain-connected"
-                      id="VIEW_EDIT_REPORT_report_for_help"
-                      role="alert"
-                    >
-                      <div
-                        class=""
-                      />
-                    </div>
-                  </div>
                 </div>
               </div>
             </div>
@@ -435,7 +425,7 @@ exports[`ReportPage renders view mode properly 1`] = `
             style="padding: 4px 8px 4px 8px;"
           >
             <div
-              class="ant-form-item ant-form-item-with-help"
+              class="ant-form-item view-item"
             >
               <div
                 class="ant-row ant-form-item-row"
@@ -444,14 +434,17 @@ exports[`ReportPage renders view mode properly 1`] = `
                   class="ant-col ant-form-item-label"
                 >
                   <label
-                    class="ant-form-item-required"
+                    class=""
                     for="VIEW_EDIT_REPORT_report_type"
                     title=""
                   >
                     <div
-                      style="width: 100%;"
+                      class="view-item-label"
                     >
-                      What is the type of the report?
+                      <div>
+                        What is the type of the report?
+                         
+                      </div>
                     </div>
                   </label>
                 </div>
@@ -465,7 +458,7 @@ exports[`ReportPage renders view mode properly 1`] = `
                       class="ant-form-item-control-input-content"
                     >
                       <div
-                        class="ant-radio-group ant-radio-group-solid vertical-radio-group"
+                        class="ant-radio-group ant-radio-group-solid vertical-radio-group view-item"
                       >
                         <label
                           class="ant-radio-wrapper ant-radio-wrapper-disabled ant-radio-wrapper-in-form-item"
@@ -513,19 +506,6 @@ exports[`ReportPage renders view mode properly 1`] = `
                       </div>
                     </div>
                   </div>
-                  <div
-                    style="display: flex; flex-wrap: nowrap;"
-                  >
-                    <div
-                      class="ant-form-item-explain ant-form-item-explain-connected"
-                      id="VIEW_EDIT_REPORT_report_type_help"
-                      role="alert"
-                    >
-                      <div
-                        class=""
-                      />
-                    </div>
-                  </div>
                 </div>
               </div>
             </div>
@@ -545,7 +525,7 @@ exports[`ReportPage renders view mode properly 1`] = `
               <div
                 class="ant-typography view-item-value"
               >
-                
+                N/A
               </div>
             </div>
           </div>

--- a/services/core-web/src/tests/components/Forms/reports/__snapshots__/ReportPage.spec.tsx.snap
+++ b/services/core-web/src/tests/components/Forms/reports/__snapshots__/ReportPage.spec.tsx.snap
@@ -285,7 +285,7 @@ exports[`ReportPage renders view mode properly 1`] = `
               Regulatory Authority
             </h3>
             <div
-              class="ant-form-item ant-form-item-with-help"
+              class="ant-form-item view-item"
             >
               <div
                 class="ant-row ant-form-item-row"
@@ -294,14 +294,17 @@ exports[`ReportPage renders view mode properly 1`] = `
                   class="ant-col ant-form-item-label"
                 >
                   <label
-                    class="ant-form-item-required"
+                    class=""
                     for="VIEW_EDIT_REPORT_report_for"
                     title=""
                   >
                     <div
-                      style="width: 100%;"
+                      class="view-item-label"
                     >
-                      Who is the report for?
+                      <div>
+                        Who is the report for?
+                         
+                      </div>
                     </div>
                   </label>
                 </div>
@@ -315,7 +318,7 @@ exports[`ReportPage renders view mode properly 1`] = `
                       class="ant-form-item-control-input-content"
                     >
                       <div
-                        class="ant-radio-group ant-radio-group-solid vertical-radio-group"
+                        class="ant-radio-group ant-radio-group-solid vertical-radio-group view-item"
                       >
                         <label
                           class="ant-radio-wrapper ant-radio-wrapper-disabled ant-radio-wrapper-in-form-item"
@@ -404,19 +407,6 @@ exports[`ReportPage renders view mode properly 1`] = `
                       </div>
                     </div>
                   </div>
-                  <div
-                    style="display: flex; flex-wrap: nowrap;"
-                  >
-                    <div
-                      class="ant-form-item-explain ant-form-item-explain-connected"
-                      id="VIEW_EDIT_REPORT_report_for_help"
-                      role="alert"
-                    >
-                      <div
-                        class=""
-                      />
-                    </div>
-                  </div>
                 </div>
               </div>
             </div>
@@ -437,7 +427,7 @@ exports[`ReportPage renders view mode properly 1`] = `
             style="padding: 4px 8px 4px 8px;"
           >
             <div
-              class="ant-form-item ant-form-item-with-help"
+              class="ant-form-item view-item"
             >
               <div
                 class="ant-row ant-form-item-row"
@@ -446,14 +436,17 @@ exports[`ReportPage renders view mode properly 1`] = `
                   class="ant-col ant-form-item-label"
                 >
                   <label
-                    class="ant-form-item-required"
+                    class=""
                     for="VIEW_EDIT_REPORT_report_type"
                     title=""
                   >
                     <div
-                      style="width: 100%;"
+                      class="view-item-label"
                     >
-                      What is the type of the report?
+                      <div>
+                        What is the type of the report?
+                         
+                      </div>
                     </div>
                   </label>
                 </div>
@@ -467,7 +460,7 @@ exports[`ReportPage renders view mode properly 1`] = `
                       class="ant-form-item-control-input-content"
                     >
                       <div
-                        class="ant-radio-group ant-radio-group-solid vertical-radio-group"
+                        class="ant-radio-group ant-radio-group-solid vertical-radio-group view-item"
                       >
                         <label
                           class="ant-radio-wrapper ant-radio-wrapper-checked ant-radio-wrapper-disabled ant-radio-wrapper-in-form-item"
@@ -513,19 +506,6 @@ exports[`ReportPage renders view mode properly 1`] = `
                           </span>
                         </label>
                       </div>
-                    </div>
-                  </div>
-                  <div
-                    style="display: flex; flex-wrap: nowrap;"
-                  >
-                    <div
-                      class="ant-form-item-explain ant-form-item-explain-connected"
-                      id="VIEW_EDIT_REPORT_report_type_help"
-                      role="alert"
-                    >
-                      <div
-                        class=""
-                      />
                     </div>
                   </div>
                 </div>

--- a/services/minespace-web/src/styles/components/Forms.scss
+++ b/services/minespace-web/src/styles/components/Forms.scss
@@ -131,3 +131,43 @@ form .ant-row>button+button {
 .form-item-hidden {
     max-width: 100%;
 }
+
+.common-form.form-view {
+    .ant-form-item-required::before {
+        display: none !important;
+    }
+
+    .view-item-label {
+        color: $input-text;
+    }
+
+    .ant-radio-group.view-item label span {
+        color: $input-text;
+    }
+
+    .ant-row.form-row-margin {
+        margin-bottom: 1em;
+    }
+}
+
+.view-item-label {
+    margin-bottom: 4px;
+    font-weight: 600;
+}
+
+.ant-form-item-label {
+    padding-bottom: 0;
+}
+
+.view-group-checkbox label>span {
+    color: $input-text;
+}
+
+.ant-checkbox-wrapper .view-item-label {
+    margin-bottom: 4px;
+    color: $input-text;
+
+    &.ungroup-checkbox {
+        font-weight: normal;
+    }
+}

--- a/services/minespace-web/src/styles/settings/variables.scss
+++ b/services/minespace-web/src/styles/settings/variables.scss
@@ -12,6 +12,7 @@ $violet: #5e46a1;
 $light-violet: #7c66ad;
 $hover-blue: #3d6de7;
 $btn-red: #bc2929;
+$input-text: #000000D9;
 
 // Accent Colours
 $lime-green: #adfc4a;


### PR DESCRIPTION
## Objective 
- take all the "edit" features out of the view mode for the form
- throw in `const { isEditMode } = useContext(FormContext);` _everywhere_
- create the view mode for input elements that were missing it (checkboxes, radio)
- default to showing "N/A" for empty text/text-like fields in view mode
- style everything!
- technically ticket was only for CORE, but I copied over the new styles to MS too. The project summary form is _never_ in view mode, but I did a little check by forcing it in the code and it looks nice. 🤷‍♀️ (it looks the same as it does on CORE)
- according to the snap updates it affected reports! Gave it a look and it seems a-ok (will note in ticket for QA)

[MDS-6177](https://bcmines.atlassian.net/browse/MDS-6177)

_Why are you making this change? Provide a short explanation and/or screenshots_
