### PR TITLE
[MDS-6227] Add administrative amendments and filter to now_gis_export API

### DIFF
--- a/services/core-api/app/api/exports/now_application/models/now_application_gis_export.py
+++ b/services/core-api/app/api/exports/now_application/models/now_application_gis_export.py
@@ -16,6 +16,7 @@ class NowApplicationGisExport(Base):
     now_application_status_code = db.Column(db.String)
     now_application_status_description = db.Column(db.String)
     type_of_application = db.Column(db.String)
+    application_type_code = db.Column(db.String)
     now_application_type_code = db.Column(db.String)
     now_application_type_description = db.Column(db.String)
     now_application_submitted_date = db.Column(db.String)
@@ -134,3 +135,9 @@ class NowApplicationGisExport(Base):
     def csv_row(self):
         model = inspect(self.__class__)
         return [str(getattr(self, c.name) or "") for c in model.columns]
+    
+    @staticmethod
+    def query_by_application_type(application_type_code=None):
+        if application_type_code is not None:
+            return NowApplicationGisExport.query.filter_by(application_type_code=application_type_code)
+        return NowApplicationGisExport.query

--- a/services/core-api/app/api/exports/now_application/resources/now_application_gis_export_resource.py
+++ b/services/core-api/app/api/exports/now_application/resources/now_application_gis_export_resource.py
@@ -1,22 +1,32 @@
-import time
 from io import StringIO
 
-from flask import stream_with_context, Response, current_app
+from flask import stream_with_context, Response, request, current_app
 import csv
 from sqlalchemy.inspection import inspect
 from flask_restx import Resource
+from werkzeug.exceptions import BadRequest
 from ..models.now_application_gis_export import NowApplicationGisExport
-from app.extensions import api, cache
+from app.api.now_applications.models.application_type_code import ApplicationTypeCode
+from app.extensions import api
 from app.api.utils.access_decorators import VIEW_ALL, GIS, requires_any_of
-from app.api.constants import NOW_APPLICATION_GIS_EXPORT, TIMEOUT_60_MINUTES
 
 class NowApplicationGisExportResource(Resource):
+
     @api.doc(
         description=
-        'This endpoint returns a CSV export of Notice of Work details intended for uses by the GIS team.'
+        'This endpoint returns a CSV export of Notice of Work details intended for uses by the GIS team.',
+        params={'application_type_code': 'NOW to filter for Notice of Work or ADA for Administrative Amendments'}
     )
     @requires_any_of([VIEW_ALL, GIS])
     def get(self):
+        application_type_code = request.args.get("application_type_code", None)
+        
+        if application_type_code:
+            application_type = ApplicationTypeCode.find_by_application_type_code(application_type_code)
+            
+            if application_type is None:
+                raise BadRequest("Invalid application type code")
+
         model = inspect(NowApplicationGisExport)
         headers = [c.name or "" for c in model.columns]
 
@@ -28,10 +38,13 @@ class NowApplicationGisExportResource(Resource):
             data.seek(0)
             data.truncate(0)
 
-            for r in NowApplicationGisExport.query.yield_per(50):
+            query = NowApplicationGisExport.query_by_application_type(application_type_code)
+
+            for r in query.yield_per(50):
                 writer.writerow(r.csv_row())
                 yield data.getvalue()
                 data.seek(0)
                 data.truncate(0)
+                current_app.logger.info(r)
 
         return Response(stream_with_context(generate()), mimetype='text/csv')

--- a/services/core-api/app/api/exports/now_application/resources/now_application_gis_export_resource.py
+++ b/services/core-api/app/api/exports/now_application/resources/now_application_gis_export_resource.py
@@ -45,6 +45,5 @@ class NowApplicationGisExportResource(Resource):
                 yield data.getvalue()
                 data.seek(0)
                 data.truncate(0)
-                current_app.logger.info(r)
 
         return Response(stream_with_context(generate()), mimetype='text/csv')

--- a/services/core-api/tests/auth/test_expected_auth.py
+++ b/services/core-api/tests/auth/test_expected_auth.py
@@ -61,6 +61,7 @@ from app.api.projects.project_decision_package.resources.project_decision_packag
 from app.api.now_applications.resources.now_application_document_resource import NOWApplicationDocumentIdentityResource
 from app.api.mines.alerts.resources.mine_alert import GlobalMineAlertListResource
 from app.api.help.resources.help_resource import HelpResource, HelpListResource
+from app.api.exports.now_application.resources.now_application_gis_export_resource import NowApplicationGisExportResource
 
 @pytest.mark.parametrize(
     "resource,method,expected_roles",
@@ -173,6 +174,7 @@ from app.api.help.resources.help_resource import HelpResource, HelpListResource
      (HelpResource, 'post', [EDIT_HELPDESK]),
      (HelpResource, 'put', [EDIT_HELPDESK]),
      (HelpResource, 'delete', [EDIT_HELPDESK]),
+     (NowApplicationGisExportResource, 'get', [VIEW_ALL, GIS])
      ])
         
 def test_endpoint_auth(resource, method, expected_roles):

--- a/services/core-api/tests/exports/test_export_success.py
+++ b/services/core-api/tests/exports/test_export_success.py
@@ -5,13 +5,13 @@ from app.api.exports.mines.resources.mine_summary_resource import PAGE_DEFAULT, 
 
 def test_mine_summary_export_success(test_client, db_session, auth_headers):
     get_resp = test_client.get(
-        f'/exports/mine-summary-csv', headers=auth_headers['full_auth_header'])
+        '/exports/mine-summary-csv', headers=auth_headers['full_auth_header'])
 
     assert get_resp.status_code == 200
 
 def test_mine_summary_export_paginated(test_client, db_session, auth_headers):
     get_resp = test_client.get(
-        f'/exports/mine-summary', headers=auth_headers['full_auth_header'])
+        '/exports/mine-summary', headers=auth_headers['full_auth_header'])
 
     assert get_resp.status_code == 200
 
@@ -24,6 +24,21 @@ def test_mine_summary_export_paginated(test_client, db_session, auth_headers):
 
 def test_core_static_content_success(test_client, db_session, auth_headers):
     get_resp = test_client.get(
-        f'/exports/core-static-content', headers=auth_headers['full_auth_header'])
+        '/exports/core-static-content', headers=auth_headers['full_auth_header'])
 
     assert get_resp.status_code == 200
+
+def test_now_application_gis_export_success_no_filter(test_client, db_session, auth_headers):
+    get_resp = test_client.get('/exports/now-application-gis-export', headers=auth_headers['full_auth_header'])
+
+    assert get_resp.status_code == 200
+
+def test_now_application_gis_export_success_ada_filter(test_client, db_session, auth_headers):
+    get_resp = test_client.get('/exports/now-application-gis-export?application_type_code=ADA', headers=auth_headers['full_auth_header'])
+
+    assert get_resp.status_code == 200
+
+def test_now_application_gis_export_failure_bad_filter(test_client, db_session, auth_headers):
+    get_resp = test_client.get('/exports/now-application-gis-export?application_type_code=ZZZ', headers=auth_headers['full_auth_header'])
+
+    assert get_resp.status_code == 400


### PR DESCRIPTION
## Objective 
- remove the filtering out of administrative amendments from now gis view
- add it as a column in the view, so it can be filtered _for_
- add it as a parameter on the now gis endpoint

[MDS-6227](https://bcmines.atlassian.net/browse/MDS-6227)

_Testing considerations_
- the automatic tests that I added can only look at the status code of the response, once you try to look at the _data_ everything kind of falls apart because the view depends on tables that don't exist in the test context
- so it was all tested manually/locally
1. changed 2/800 now_application_identity records to have an application_type_code of `ADA` instead of `NOW`
2. recreated the view locally (basically ran the migration in Postico, taking out `materialized`, `with data`, and `TABLESPACE pg_default`, and simplified the first statement to just a `DROP VIEW`)
3. added a console log in `now_application_gis_export_resource.py-> get-> generate` (logged `r`)
4. made a call in postman to `http://localhost:5000/exports/now-application-gis-export?application_type_code=ADA` and watched the logs in core-api container (postman can't easily handle _streaming_ responses and so only the header is visible!)
5. Saw that the two results (and only the two results) that I had changed to `ADA` were logged