### PR TITLE
[MDS-6244] Switched to use gunicorn for Core API to improve performance and ease debugging of `504`s

### DIFF
--- a/services/core-api/Dockerfile.ci
+++ b/services/core-api/Dockerfile.ci
@@ -33,4 +33,5 @@ USER $USERNAME
 # Run the server
 EXPOSE 5000
 # Works only with no reload. Flas should not be reloading in prod anyway - Tech debt. 
-CMD [ "opentelemetry-instrument", "flask", "run", "--no-reload"]
+
+CMD ["./app.sh"]

--- a/services/core-api/app.sh
+++ b/services/core-api/app.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # Run the app with 3 workers and a request timeout of 200 seconds
-gunicorn -w 3  --timeout 200 --access-logfile - --error-logfile - --log-level debug --capture-output 'app:create_app()' -b 0.0.0.0:5000 -c app/gunicorn_config.py
+gunicorn -c app/gunicorn_config.py 'app:create_app()'  

--- a/services/core-api/app.sh
+++ b/services/core-api/app.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 
-uwsgi uwsgi.ini
+# Run the app with 3 workers and a request timeout of 200 seconds
+gunicorn -w 3  --timeout 200 --access-logfile - --error-logfile - --log-level debug --capture-output 'app:create_app()' -b 0.0.0.0:5000 -c app/gunicorn_config.py

--- a/services/core-api/app/gunicorn_config.py
+++ b/services/core-api/app/gunicorn_config.py
@@ -1,0 +1,22 @@
+import os
+import traceback
+
+
+def opt_env(var_name):
+    try:
+        return os.environ[var_name]
+    except KeyError:
+        return None
+
+# Print stack trace if a worker is killed (e.g. from a timeout)
+def worker_abort(worker):
+    pid = worker.pid
+    print("worker is being killed - {}".format(pid))
+    traceback.print_stack()
+
+bind = "0.0.0.0:5000"
+timeout = opt_env("GUNICORN_TIMEOUT") or 200
+workers = opt_env("GUNICORN_WORKERS") or 3
+errorlog = opt_env("GUNICORN_ERROR_LOG") or "-"
+loglevel = opt_env("GUNICORN_LOG_LEVEL") or "debug"
+accesslog = opt_env("GUNICORN_ACCESS_LOG") or "-"

--- a/services/core-api/app/gunicorn_config.py
+++ b/services/core-api/app/gunicorn_config.py
@@ -21,3 +21,8 @@ workers = opt_env("GUNICORN_WORKERS") or 3
 errorlog = opt_env("GUNICORN_ERROR_LOG") or "-"
 loglevel = opt_env("GUNICORN_LOG_LEVEL") or "debug"
 accesslog = opt_env("GUNICORN_ACCESS_LOG") or "-"
+
+# Restart a unicorn worker process after it has handled 500 - 600 requests (random to not restart all at once)
+# to protect against slow memory leaks
+max_requests = opt_env("GUNICORN_MAX_REQUESTS") or 500
+max_requests_jitter = opt_env("GUNICORN_MAX_REQUESTS_JITTER") or 100

--- a/services/core-api/app/gunicorn_config.py
+++ b/services/core-api/app/gunicorn_config.py
@@ -10,12 +10,13 @@ def opt_env(var_name):
 
 # Print stack trace if a worker is killed (e.g. from a timeout)
 def worker_abort(worker):
+    print(dir(worker))
     pid = worker.pid
     print("worker is being killed - {}".format(pid))
     traceback.print_stack()
 
 bind = "0.0.0.0:5000"
-timeout = opt_env("GUNICORN_TIMEOUT") or 200
+timeout = opt_env("GUNICORN_TIMEOUT") or 125
 workers = opt_env("GUNICORN_WORKERS") or 3
 errorlog = opt_env("GUNICORN_ERROR_LOG") or "-"
 loglevel = opt_env("GUNICORN_LOG_LEVEL") or "debug"

--- a/services/core-api/requirements.txt
+++ b/services/core-api/requirements.txt
@@ -39,7 +39,7 @@ cerberus==1.3.4
 celery[redis]==5.3.6
 celery-redbeat==2.2.0
 cachelib
-gunicorn==22.0.0
+gunicorn==23.0.0
 opentelemetry-distro==0.43b0
 opentelemetry-exporter-otlp==1.22.0
 opentelemetry-instrumentation==0.43b0


### PR DESCRIPTION
## Objective 

[MDS-6244](https://bcmines.atlassian.net/browse/MDS-6244)

Running the Core API app in production with the `flask` cli is discouraged as it's not meant to be a production-ready tool. Switched to using `gunicorn` to enable
- better handling of parallel requests
- better visibility into what happens when a request times out, as it supports printing a stack trace when that happens
