### PR TITLE
[MDS-6129] Project Summary emails and notification fixes

### DIFF
--- a/services/core-api/app/api/mines/documents/resources/mine_document_resource.py
+++ b/services/core-api/app/api/mines/documents/resources/mine_document_resource.py
@@ -136,24 +136,26 @@ class MineDocumentArchiveResource(Resource, UserMixin):
             project = None
             doc = documents[0]
             mine_document_guid = doc.mine_document_guid
-            isNotifiableDoc = False
+            is_notifiable_doc = False
+            status_code = None
 
             if doc.major_mine_application_document_xref:
                 project = MajorMineApplication.find_by_mine_document_guid(mine_document_guid).project
-                isNotifiableDoc = True
+                is_notifiable_doc = True
             elif doc.project_summary_document_xref:
                 project = ProjectSummary.find_by_mine_document_guid(mine_document_guid).project
-                isNotifiableDoc = True
+                is_notifiable_doc = True
+                status_code = project.project_summary.status_code
             elif doc.project_decision_package_document_xref:
                 project = ProjectDecisionPackage.find_by_mine_document_guid(mine_document_guid).project
-                isNotifiableDoc = True
+                is_notifiable_doc = True
             elif doc.information_requirements_table_document_xref:
                 project = InformationRequirementsTable.find_by_mine_document_guid(mine_document_guid).project
-                isNotifiableDoc = True
+                is_notifiable_doc = True
 
             # If one of the *xref value is not None that means the notification should be sent.
-            if isNotifiableDoc:
-                ProjectUtil.notifiy_file_updates(project, mine)
+            if is_notifiable_doc:
+                ProjectUtil.notify_file_updates(project, mine, status_code)
 
         return None, 204
 

--- a/services/core-api/app/api/mines/documents/resources/mine_document_resource.py
+++ b/services/core-api/app/api/mines/documents/resources/mine_document_resource.py
@@ -7,7 +7,7 @@ from app.api.projects.project_summary.models.project_summary import ProjectSumma
 from app.api.projects.project_decision_package.models.project_decision_package import ProjectDecisionPackage
 from app.api.projects.information_requirements_table.models.information_requirements_table import InformationRequirementsTable
 
-from flask_restx import Resource, reqparse, fields
+from flask_restx import Resource, reqparse
 from datetime import datetime
 from werkzeug.exceptions import BadRequest, NotFound
 
@@ -22,7 +22,7 @@ from app.api.mines.documents.mine_document_search_util import MineDocumentSearch
 from app.api.mines.response_models import ARCHIVE_MINE_DOCUMENT, MINE_DOCUMENT_MODEL, DOCUMENT_MANAGER_ZIP
 
 from app.api.services.document_manager_service import DocumentManagerService
-from app.api.projects.project.project_util import ProjectUtil
+from app.api.projects.project.project_util import notify_file_updates
 
 class MineDocumentListResource(Resource, UserMixin):
     @api.doc(description='Returns list of documents associated with mines')
@@ -155,7 +155,7 @@ class MineDocumentArchiveResource(Resource, UserMixin):
 
             # If one of the *xref value is not None that means the notification should be sent.
             if is_notifiable_doc:
-                ProjectUtil.notify_file_updates(project, mine, status_code)
+                notify_file_updates(project, mine, status_code)
 
         return None, 204
 

--- a/services/core-api/app/api/parties/party/models/party.py
+++ b/services/core-api/app/api/parties/party/models/party.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from flask import current_app
 import re
+from typing import Self
 
 from sqlalchemy import func, case, and_
 from sqlalchemy.schema import FetchedValue
@@ -196,7 +197,7 @@ class Party(SoftDeleteMixin, AuditMixin, Base):
                     else_=cls.party_name)
 
     @classmethod
-    def find_by_party_guid(cls, party_guid):
+    def find_by_party_guid(cls, party_guid) -> Self:
         return cls.query.filter_by(party_guid=party_guid, deleted_ind=False).one_or_none()
 
     @classmethod

--- a/services/core-api/app/api/projects/information_requirements_table/models/information_requirements_table.py
+++ b/services/core-api/app/api/projects/information_requirements_table/models/information_requirements_table.py
@@ -159,7 +159,7 @@ class InformationRequirementsTable(SoftDeleteMixin, AuditMixin, Base):
 
         if mine_doc and project:
             mine = Mine.find_by_mine_guid(mine_doc.mine_guid)
-            ProjectUtil.notifiy_file_updates(project, mine)
+            ProjectUtil.notify_file_updates(project, mine, self.status_code)
 
         return self
 

--- a/services/core-api/app/api/projects/information_requirements_table/models/information_requirements_table.py
+++ b/services/core-api/app/api/projects/information_requirements_table/models/information_requirements_table.py
@@ -11,7 +11,7 @@ from app.api.mines.documents.models.mine_document import MineDocument
 from app.api.utils.models_mixins import SoftDeleteMixin, AuditMixin, Base
 
 from app.api.mines.mine.models.mine import Mine
-from app.api.projects.project.project_util import ProjectUtil
+from app.api.projects.project.project_util import notify_file_updates
 
 class InformationRequirementsTable(SoftDeleteMixin, AuditMixin, Base):
     __tablename__ = "information_requirements_table"
@@ -159,7 +159,7 @@ class InformationRequirementsTable(SoftDeleteMixin, AuditMixin, Base):
 
         if mine_doc and project:
             mine = Mine.find_by_mine_guid(mine_doc.mine_guid)
-            ProjectUtil.notify_file_updates(project, mine, self.status_code)
+            notify_file_updates(project, mine, self.status_code)
 
         return self
 

--- a/services/core-api/app/api/projects/major_mine_application/models/major_mine_application.py
+++ b/services/core-api/app/api/projects/major_mine_application/models/major_mine_application.py
@@ -187,7 +187,7 @@ class MajorMineApplication(SoftDeleteMixin, AuditMixin, Base):
             if not mine:
                 raise NotFound('Mine not found.')
 
-            ProjectUtil.notifiy_file_updates(project, mine)
+            ProjectUtil.notify_file_updates(project, mine, status_code)
 
         return self
 

--- a/services/core-api/app/api/projects/major_mine_application/models/major_mine_application.py
+++ b/services/core-api/app/api/projects/major_mine_application/models/major_mine_application.py
@@ -1,9 +1,8 @@
 from multiprocessing.sharedctypes import Value
-from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.dialects.postgresql import UUID
 
 from sqlalchemy.schema import FetchedValue
-from werkzeug.exceptions import BadRequest, NotFound
+from werkzeug.exceptions import NotFound
 
 from app.api.mines.documents.models.mine_document_bundle import MineDocumentBundle
 from app.extensions import db
@@ -14,7 +13,7 @@ from app.api.services.email_service import EmailService
 from app.api.projects.major_mine_application.models.major_mine_application_document_xref import MajorMineApplicationDocumentXref
 from app.api.mines.documents.models.mine_document import MineDocument
 from app.api.mines.mine.models.mine import Mine
-from app.api.projects.project.project_util import ProjectUtil
+from app.api.projects.project.project_util import notify_file_updates
 
 class MajorMineApplication(SoftDeleteMixin, AuditMixin, Base):
     __tablename__ = 'major_mine_application'
@@ -187,7 +186,7 @@ class MajorMineApplication(SoftDeleteMixin, AuditMixin, Base):
             if not mine:
                 raise NotFound('Mine not found.')
 
-            ProjectUtil.notify_file_updates(project, mine, status_code)
+            notify_file_updates(project, mine, status_code)
 
         return self
 

--- a/services/core-api/app/api/projects/project/project_util.py
+++ b/services/core-api/app/api/projects/project/project_util.py
@@ -2,15 +2,12 @@ from app.api.activity.models.activity_notification import ActivityRecipients
 from app.api.utils.feature_flag import is_feature_enabled, Feature
 from app.api.activity.utils import trigger_notification
 from app.api.activity.models.activity_notification import ActivityType
-from flask import current_app
 
-class ProjectUtil:
 
-    @staticmethod
-    def notify_file_updates(project, mine, status_code = None):
-        status_codes = ["SUB", "ASG", "CHR"]
+def notify_file_updates(project, mine, status_code = None):
+    status_codes = ["SUB", "ASG", "CHR"]
 
-        if is_feature_enabled(Feature.MINE_APPLICATION_FILE_UDPATE_ALERTS) and status_code in status_codes:
-            renotifiy_hours = 24
-            message = f'File(s) in project {project.project_title} has been updated for mine {mine.mine_name}'
-            trigger_notification(message, ActivityType.mine_project_documents_updated, mine, 'DocumentManagement', project.project_guid, None, None, ActivityRecipients.core_users, True, renotifiy_hours*60)
+    if is_feature_enabled(Feature.MINE_APPLICATION_FILE_UDPATE_ALERTS) and status_code in status_codes:
+        renotifiy_hours = 24
+        message = f'File(s) in project {project.project_title} has been updated for mine {mine.mine_name}'
+        trigger_notification(message, ActivityType.mine_project_documents_updated, mine, 'DocumentManagement', project.project_guid, None, None, ActivityRecipients.core_users, True, renotifiy_hours*60)

--- a/services/core-api/app/api/projects/project/project_util.py
+++ b/services/core-api/app/api/projects/project/project_util.py
@@ -4,7 +4,7 @@ from app.api.activity.utils import trigger_notification
 from app.api.activity.models.activity_notification import ActivityType
 
 
-def notify_file_updates(project, mine, status_code = None):
+def notify_file_updates(project, mine, status_code = None) -> None:
     status_codes = ["SUB", "ASG", "CHR"]
 
     if is_feature_enabled(Feature.MINE_APPLICATION_FILE_UDPATE_ALERTS) and status_code in status_codes:

--- a/services/core-api/app/api/projects/project/project_util.py
+++ b/services/core-api/app/api/projects/project/project_util.py
@@ -6,8 +6,11 @@ from flask import current_app
 
 class ProjectUtil:
 
-    def notifiy_file_updates(project, mine):
-        if is_feature_enabled(Feature.MINE_APPLICATION_FILE_UDPATE_ALERTS):
+    @staticmethod
+    def notify_file_updates(project, mine, status_code = None):
+        status_codes = ["SUB", "ASG", "CHR"]
+
+        if is_feature_enabled(Feature.MINE_APPLICATION_FILE_UDPATE_ALERTS) and status_code in status_codes:
             renotifiy_hours = 24
             message = f'File(s) in project {project.project_title} has been updated for mine {mine.mine_name}'
             trigger_notification(message, ActivityType.mine_project_documents_updated, mine, 'DocumentManagement', project.project_guid, None, None, ActivityRecipients.core_users, True, renotifiy_hours*60)

--- a/services/core-api/app/api/projects/project_decision_package/models/project_decision_package.py
+++ b/services/core-api/app/api/projects/project_decision_package/models/project_decision_package.py
@@ -4,12 +4,11 @@ from sqlalchemy.schema import FetchedValue
 from app.extensions import db
 
 from app.api.utils.models_mixins import SoftDeleteMixin, AuditMixin, Base
-from app.api.projects.project.models.project import Project
 from app.api.projects.project_decision_package.models.project_decision_package_document_xref import ProjectDecisionPackageDocumentXref
 from app.api.mines.documents.models.mine_document import MineDocument
 
 from app.api.mines.mine.models.mine import Mine
-from app.api.projects.project.project_util import ProjectUtil
+from app.api.projects.project.project_util import notify_file_updates
 
 class ProjectDecisionPackage(SoftDeleteMixin, AuditMixin, Base):
     __tablename__ = 'project_decision_package'
@@ -146,7 +145,7 @@ class ProjectDecisionPackage(SoftDeleteMixin, AuditMixin, Base):
             mine_document_guid = documents[0].mine_document_guid
             project = ProjectDecisionPackage.find_by_mine_document_guid(mine_document_guid).project
             mine = Mine.find_by_mine_guid(project.mine_guid)
-            ProjectUtil.notify_file_updates(project, mine, status_code)
+            notify_file_updates(project, mine, status_code)
 
         return self
 

--- a/services/core-api/app/api/projects/project_decision_package/models/project_decision_package.py
+++ b/services/core-api/app/api/projects/project_decision_package/models/project_decision_package.py
@@ -146,7 +146,7 @@ class ProjectDecisionPackage(SoftDeleteMixin, AuditMixin, Base):
             mine_document_guid = documents[0].mine_document_guid
             project = ProjectDecisionPackage.find_by_mine_document_guid(mine_document_guid).project
             mine = Mine.find_by_mine_guid(project.mine_guid)
-            ProjectUtil.notifiy_file_updates(project, mine)
+            ProjectUtil.notify_file_updates(project, mine, status_code)
 
         return self
 

--- a/services/core-api/app/api/projects/project_summary/models/project_summary.py
+++ b/services/core-api/app/api/projects/project_summary/models/project_summary.py
@@ -26,7 +26,7 @@ from app.api.projects.project_summary.models.project_summary_authorization_docum
 from app.api.projects.project_summary.models.project_summary_permit_type import ProjectSummaryPermitType
 from app.api.parties.party.models.party import Party
 from app.api.parties.party.models.address import Address
-from app.api.constants import PROJECT_SUMMARY_EMAILS, MDS_EMAIL
+from app.api.constants import PROJECT_SUMMARY_EMAILS, MDS_EMAIL, PERM_RECL_EMAIL
 from app.api.services.email_service import EmailService
 from app.config import Config
 from cerberus import Validator
@@ -166,6 +166,11 @@ class ProjectSummary(SoftDeleteMixin, AuditMixin, Base):
         if self.project.project_lead_party_guid:
             return self.project.project_lead_party_guid
         return None
+    
+    @hybrid_property
+    def project_lead_email(self):
+        project_lead: Party = Party.find_by_party_guid(self.project_summary_lead_party_guid)
+        return project_lead.email if project_lead else None
 
     @hybrid_property
     def mine_guid(self):
@@ -226,6 +231,29 @@ class ProjectSummary(SoftDeleteMixin, AuditMixin, Base):
 
         except ValueError:
             return None
+        
+    @staticmethod
+    def has_new_documents(documents, ams_authorizations) -> bool:
+        new_documents = list(filter(lambda doc: doc.get("mine_document_guid") is None, documents))
+        has_new_docs = len(new_documents) > 0
+        
+        amendments = ams_authorizations.get('amendments', [])
+        new = ams_authorizations.get('new', [])
+        all_ams_auths = amendments + new
+        has_new_ams_docs = False
+
+        for auth in all_ams_auths:
+            docs = auth.get('amendment_documents', [])
+            for doc in docs:
+                if doc.get('mine_document_guid') is None:
+                    has_new_ams_docs = True
+                    break
+            else:
+                continue
+            break
+
+        return has_new_docs or has_new_ams_docs
+
 
     # will update the existing party and address data if it exists, else create a new one
     @classmethod
@@ -1253,8 +1281,53 @@ class ProjectSummary(SoftDeleteMixin, AuditMixin, Base):
             doc.mine_document.delete(False)
         return super(ProjectSummary, self).delete(commit)
 
-    def send_project_summary_email(self, mine):
-        emli_recipients = PROJECT_SUMMARY_EMAILS
+    def send_project_summary_document_email(self, mine):
+        if is_feature_enabled(Feature.MINE_APPLICATION_FILE_UDPATE_ALERTS):
+            message = f'File(s) in project {self.project.project_title} has been updated for mine {mine.mine_name}'
+            project_lead_email = self.project_lead_email
+
+            emails = {
+                'SUB': [PERM_RECL_EMAIL],
+                'ASG': [PERM_RECL_EMAIL, project_lead_email],
+                'CHR': [PERM_RECL_EMAIL, project_lead_email] 
+            }
+            email_recipients = emails.get(self.status_code)
+
+            if email_recipients is not None:
+                emli_body = open("app/templates/email/projects/emli_project_summary_email.html", "r").read()
+                subject = f'Project Description Documents Notification for {mine.mine_name}'
+                cc = [MDS_EMAIL]
+
+                emli_context = {
+                    "project_summary": {
+                        "project_summary_description": self.project_summary_description,
+                    },
+                    "mine": {
+                        "mine_name": mine.mine_name,
+                        "mine_no": mine.mine_no,
+                    },
+                    "message": message,
+                    "core_project_summary_link": f'{Config.CORE_WEB_URL}/pre-applications/{self.project.project_guid}/overview'
+                }
+                EmailService.send_template_email(subject, email_recipients, emli_body, emli_context, cc=cc)
+
+
+    def send_project_summary_email(self, mine, message):
+        current_app.logger.info(f'HI TARA Sending email with message {message}')
+
+        project_lead_email = self.project_lead_email
+
+        emli_emails = {
+            'SUB': [PERM_RECL_EMAIL] + PROJECT_SUMMARY_EMAILS,
+            'ASG': [project_lead_email],
+            'OHD': [PERM_RECL_EMAIL, project_lead_email],
+            'WDN': [PERM_RECL_EMAIL, project_lead_email],
+            'COM': [PERM_RECL_EMAIL, project_lead_email]
+        }
+
+        send_ms_email = self.status_code != "DFT"
+        
+        emli_recipients = emli_emails.get(self.status_code)
         cc = [MDS_EMAIL]
         minespace_recipients = [contact.email for contact in self.contacts if contact.is_primary]
 
@@ -1270,6 +1343,7 @@ class ProjectSummary(SoftDeleteMixin, AuditMixin, Base):
                 "mine_name": mine.mine_name,
                 "mine_no": mine.mine_no,
             },
+            "message": message,
             "core_project_summary_link": f'{Config.CORE_WEB_URL}/pre-applications/{self.project.project_guid}/overview'
         }
 
@@ -1278,9 +1352,11 @@ class ProjectSummary(SoftDeleteMixin, AuditMixin, Base):
                 "mine_name": mine.mine_name,
                 "mine_no": mine.mine_no,
             },
+            "message": message,
             "minespace_project_summary_link": f'{Config.MINESPACE_PROD_URL}/projects/{self.project.project_guid}/overview',
             "ema_auth_link": f'{Config.EMA_AUTH_LINK}',
         }
 
         EmailService.send_template_email(subject, emli_recipients, emli_body, emli_context, cc=cc)
-        EmailService.send_template_email(subject, minespace_recipients, minespace_body, minespace_context, cc=cc)
+        if send_ms_email:
+            EmailService.send_template_email(subject, minespace_recipients, minespace_body, minespace_context, cc=cc)

--- a/services/core-api/app/api/projects/project_summary/models/project_summary.py
+++ b/services/core-api/app/api/projects/project_summary/models/project_summary.py
@@ -168,8 +168,8 @@ class ProjectSummary(SoftDeleteMixin, AuditMixin, Base):
         return None
     
     @hybrid_property
-    def project_lead_email(self):
-        project_lead: Party = Party.find_by_party_guid(self.project_summary_lead_party_guid)
+    def project_lead_email(self) -> str | None:
+        project_lead = Party.find_by_party_guid(self.project_summary_lead_party_guid)
         return project_lead.email if project_lead else None
 
     @hybrid_property

--- a/services/core-api/app/api/projects/project_summary/models/project_summary.py
+++ b/services/core-api/app/api/projects/project_summary/models/project_summary.py
@@ -1281,7 +1281,7 @@ class ProjectSummary(SoftDeleteMixin, AuditMixin, Base):
             doc.mine_document.delete(False)
         return super(ProjectSummary, self).delete(commit)
 
-    def send_project_summary_document_email(self, mine):
+    def send_project_summary_document_email(self, mine) -> None:
         if is_feature_enabled(Feature.MINE_APPLICATION_FILE_UDPATE_ALERTS):
             message = f'File(s) in project {self.project.project_title} has been updated for mine {mine.mine_name}'
             project_lead_email = self.project_lead_email

--- a/services/core-api/app/api/projects/project_summary/models/project_summary.py
+++ b/services/core-api/app/api/projects/project_summary/models/project_summary.py
@@ -1307,7 +1307,7 @@ class ProjectSummary(SoftDeleteMixin, AuditMixin, Base):
                 EmailService.send_template_email(subject, email_recipients, emli_body, emli_context, cc=cc)
 
 
-    def send_project_summary_email(self, mine, message):
+    def send_project_summary_email(self, mine, message) -> None:
 
         project_lead_email = self.project_lead_email
 

--- a/services/core-api/app/api/projects/project_summary/models/project_summary.py
+++ b/services/core-api/app/api/projects/project_summary/models/project_summary.py
@@ -4,7 +4,6 @@ from sqlalchemy.dialects.postgresql import UUID
 
 from sqlalchemy.schema import FetchedValue
 from sqlalchemy import case
-from werkzeug.exceptions import BadRequest
 
 from app.api.mines.documents.models.mine_document_bundle import MineDocumentBundle
 from app.api.parties.party import PartyOrgBookEntity
@@ -13,17 +12,13 @@ from app.api.services.ams_api_service import AMSApiService
 from app.extensions import db
 
 from app.api.utils.models_mixins import SoftDeleteMixin, AuditMixin, Base
-from app.api.utils.access_decorators import is_minespace_user
 from app.api.projects.project_summary.models.project_summary_document_xref import ProjectSummaryDocumentXref
 from app.api.mines.mine.models.mine import Mine
 from app.api.mines.documents.models.mine_document import MineDocument
 from app.api.projects.project.models.project import Project
-from app.api.projects.project_contact.models.project_contact import ProjectContact
-from app.api.projects.project_summary.models.project_summary_contact import ProjectSummaryContact
 from app.api.projects.project_summary.models.project_summary_authorization import ProjectSummaryAuthorization
 from app.api.projects.project_summary.models.project_summary_authorization_document_xref import \
     ProjectSummaryAuthorizationDocumentXref
-from app.api.projects.project_summary.models.project_summary_permit_type import ProjectSummaryPermitType
 from app.api.parties.party.models.party import Party
 from app.api.parties.party.models.address import Address
 from app.api.constants import PROJECT_SUMMARY_EMAILS, MDS_EMAIL, PERM_RECL_EMAIL
@@ -1313,7 +1308,6 @@ class ProjectSummary(SoftDeleteMixin, AuditMixin, Base):
 
 
     def send_project_summary_email(self, mine, message):
-        current_app.logger.info(f'HI TARA Sending email with message {message}')
 
         project_lead_email = self.project_lead_email
 

--- a/services/core-api/app/api/projects/project_summary/resources/project_summary.py
+++ b/services/core-api/app/api/projects/project_summary/resources/project_summary.py
@@ -5,7 +5,7 @@ from werkzeug.exceptions import BadRequest, NotFound
 
 from app.extensions import api
 from app.api.activity.utils import trigger_notification
-from app.api.utils.access_decorators import MINESPACE_PROPONENT, requires_any_of, VIEW_ALL, MINE_ADMIN, is_minespace_user, EDIT_PROJECT_SUMMARIES
+from app.api.utils.access_decorators import MINESPACE_PROPONENT, requires_any_of, VIEW_ALL, MINE_ADMIN, EDIT_PROJECT_SUMMARIES
 from app.api.mines.mine.models.mine import Mine
 from app.api.utils.resources_mixins import UserMixin
 from app.api.utils.custom_reqparser import CustomReqparser
@@ -16,7 +16,7 @@ from app.api.projects.project.models.project import Project
 from app.api.activity.models.activity_notification import ActivityType
 
 from app.api.activity.utils import trigger_notification
-from app.api.projects.project.project_util import ProjectUtil
+from app.api.projects.project.project_util import notify_file_updates
 from decimal import Decimal
 
 PAGE_DEFAULT = 1
@@ -302,7 +302,7 @@ class ProjectSummaryResource(Resource, UserMixin):
 
         # notify on document updates
         if has_new_documents:
-            ProjectUtil.notify_file_updates(project, mine, project_summary.status_code)
+            notify_file_updates(project, mine, project_summary.status_code)
 
         return project_summary
 

--- a/services/core-api/app/api/projects/project_summary/resources/project_summary.py
+++ b/services/core-api/app/api/projects/project_summary/resources/project_summary.py
@@ -225,6 +225,10 @@ class ProjectSummaryResource(Resource, UserMixin):
         if data.get('status_code') == 'SUB' and prev_status == 'DFT':
             submission_date = datetime.now(tz=timezone.utc)
 
+        documents = data.get('documents', [])
+        ams_authorizations = data.get('ams_authorizations', None)
+        has_new_documents = ProjectSummary.has_new_documents(documents, ams_authorizations)
+
         # Update project summary.
         project_summary.update(project, data.get('project_summary_description'),
                                data.get('expected_draft_irt_submission_date'),
@@ -232,8 +236,8 @@ class ProjectSummaryResource(Resource, UserMixin):
                                data.get('expected_permit_receipt_date'),
                                data.get('expected_project_start_date'), data.get('status_code'),
                                data.get('project_lead_party_guid'),
-                               data.get('documents', []), data.get('authorizations',[]),
-                               data.get('ams_authorizations', None),
+                               documents, data.get('authorizations',[]),
+                               ams_authorizations,
                                submission_date, data.get('agent'), data.get('is_agent'),
                                data.get('is_legal_land_owner'), data.get('is_crown_land_federal_or_provincial'),
                                data.get('is_landowner_aware_of_discharge_application'), data.get('has_landowner_received_copy_of_application'),
@@ -258,48 +262,6 @@ class ProjectSummaryResource(Resource, UserMixin):
                                is_historic)
 
         project_summary.save()
-        if prev_status == 'DFT' and project_summary.status_code == 'SUB':
-            project_summary.send_project_summary_email(mine)
-            # Trigger notification for newly submitted Project Summary
-            message = f'A new major project description for ({project.project_title}) has been submitted for ({project.mine_name})'
-            extra_data = {'project': {'project_guid': str(project.project_guid)}}
-            trigger_notification(message, ActivityType.major_mine_desc_submitted, project.mine, 'ProjectSummary', project_summary.project_summary_guid, extra_data)
-
-        if project_summary.status_code == 'CHR':
-            project_summary.send_project_summary_email(mine)
-            # Trigger notification for changes requested Project Summary
-            message = f'Changes have been requested by the ministry for {project.project_title} at {project.mine_name}'
-            extra_data = {'project': {'project_guid': str(project.project_guid)}}
-            trigger_notification(message, ActivityType.major_mine_desc_submitted, project.mine, 'ProjectSummary',
-                                 project_summary.project_summary_guid, extra_data)
-
-        if project_summary.status_code == 'UNR':
-            project_summary.send_project_summary_email(mine)
-            message = f'{project.project_title} for {project.mine_name} is now under review'
-            extra_data = {'project': {'project_guid': str(project.project_guid)}}
-            trigger_notification(message, ActivityType.major_mine_desc_submitted, project.mine, 'ProjectSummary',
-                                 project_summary.project_summary_guid, extra_data)
-
-        if project_summary.status_code == 'OHD':
-            project_summary.send_project_summary_email(mine)
-            message = f'The project description {project.project_title} for {project.mine_name} has been updated to On Hold'
-            extra_data = {'project': {'project_guid': str(project.project_guid)}}
-            trigger_notification(message, ActivityType.major_mine_desc_submitted, project.mine, 'ProjectSummary',
-                                 project_summary.project_summary_guid, extra_data)
-
-        if project_summary.status_code == 'WDN':
-            project_summary.send_project_summary_email(mine)
-            message = f'The project description {project.project_title} for {project.mine_name} has been withdrawn'
-            extra_data = {'project': {'project_guid': str(project.project_guid)}}
-            trigger_notification(message, ActivityType.major_mine_desc_submitted, project.mine, 'ProjectSummary',
-                                 project_summary.project_summary_guid, extra_data)
-
-        if project_summary.status_code == 'COM':
-            project_summary.send_project_summary_email(mine)
-            message = f'The status of the project description {project.project_title} for {project.mine_name} has been completed'
-            extra_data = {'project': {'project_guid': str(project.project_guid)}}
-            trigger_notification(message, ActivityType.major_mine_desc_submitted, project.mine, 'ProjectSummary',
-                                 project_summary.project_summary_guid, extra_data)
 
         # Update project.
         project.update(
@@ -308,9 +270,39 @@ class ProjectSummaryResource(Resource, UserMixin):
             data.get('contacts', []))
         project.save()
 
-        if len(data.get('documents')) > 0:
-            project = Project.find_by_project_guid(project_guid)
-            ProjectUtil.notifiy_file_updates(project, mine)
+        # notify of status changes
+        if prev_status != project_summary.status_code:
+            message = ''
+            extra_data = {'project': {'project_guid': str(project.project_guid)}}
+            if prev_status == 'DFT' and project_summary.status_code == 'SUB':
+                message = f'A new major project description for ({project.project_title}) has been submitted for ({project.mine_name})'
+
+            if project_summary.status_code == 'ASG':
+                message = f'{project.project_title} for {project.mine_name} has been assigned'
+
+            if project_summary.status_code == 'CHR':
+                message = f'Changes have been requested by the ministry for {project.project_title} at {project.mine_name}'
+
+            if project_summary.status_code == 'UNR':
+                message = f'{project.project_title} for {project.mine_name} is now under review'
+
+            if project_summary.status_code == 'OHD':
+                message = f'The project description {project.project_title} for {project.mine_name} has been updated to On Hold'
+
+            if project_summary.status_code == 'WDN':
+                message = f'The project description {project.project_title} for {project.mine_name} has been withdrawn'
+
+            if project_summary.status_code == 'COM':
+                message = f'The status of the project description {project.project_title} for {project.mine_name} has been completed'
+                
+            project_summary.send_project_summary_email(mine, message)
+            trigger_notification(message, ActivityType.major_mine_desc_submitted, project.mine, 'ProjectSummary',
+                                    project_summary.project_summary_guid, extra_data)
+        
+
+        # notify on document updates
+        if has_new_documents:
+            ProjectUtil.notify_file_updates(project, mine, project_summary.status_code)
 
         return project_summary
 

--- a/services/core-api/app/api/services/email_service.py
+++ b/services/core-api/app/api/services/email_service.py
@@ -139,10 +139,11 @@ class EmailService():
             raise Exception('Email priority is invalid')
 
         # NOTE: Be careful when enabling emails in local/dev/test. You could possibly be sending spam emails!
+        is_not_prod = Config.ENVIRONMENT_NAME != 'prod'
         if not Config.EMAIL_ENABLED:
             current_app.logger.info('Not sending email: Emails are disabled.')
             return
-        elif Config.ENVIRONMENT_NAME != 'prod' and not Config.EMAIL_RECIPIENT_OVERRIDE:
+        elif is_not_prod and not Config.EMAIL_RECIPIENT_OVERRIDE:
             current_app.logger.info(
                 'Not sending email: Recipient override must be set when not in prod environment!')
             return
@@ -165,7 +166,7 @@ class EmailService():
         auth_token = EmailService.get_auth_token()
         headers = {'Authorization': f'Bearer {auth_token}', 'Content-Type': 'application/json'}
         data = {
-            'subject': subject,
+            'subject': f'{subject} [recipients: {original_recipients}]' if is_not_prod else subject,
             'from': sender,
             'to': recipients,
             'body': body,
@@ -223,10 +224,11 @@ class EmailService():
             raise Exception('Email priority is invalid')
 
         # NOTE: Be careful when enabling emails in local/dev/test. You could possibly be sending spam emails!
+        is_not_prod = Config.ENVIRONMENT_NAME != 'prod'
         if not Config.EMAIL_ENABLED:
             current_app.logger.info('Not sending email: Emails are disabled.')
             return
-        elif Config.ENVIRONMENT_NAME != 'prod' and not Config.EMAIL_RECIPIENT_OVERRIDE:
+        elif is_not_prod and not Config.EMAIL_RECIPIENT_OVERRIDE:
             current_app.logger.info(
                 'Not sending email: Recipient override must be set when not in prod environment!')
             return
@@ -256,7 +258,7 @@ class EmailService():
         ]
 
         data = {
-            'subject': subject,
+            'subject': f'{subject} [recipients: {original_recipients}]' if is_not_prod else subject,
             'from': sender,
             'body': body,
             'contexts': contexts,
@@ -265,7 +267,7 @@ class EmailService():
             'encoding': encoding,
             'priority': priority,
         }
-
+        
         resp = requests.post(url, json.dumps(data), headers=headers)
         try:
             resp_data = resp.json()

--- a/services/core-api/app/api/services/email_service.py
+++ b/services/core-api/app/api/services/email_service.py
@@ -267,7 +267,7 @@ class EmailService():
             'encoding': encoding,
             'priority': priority,
         }
-        
+
         resp = requests.post(url, json.dumps(data), headers=headers)
         try:
             resp_data = resp.json()

--- a/services/core-api/app/config.py
+++ b/services/core-api/app/config.py
@@ -56,6 +56,8 @@ class CustomFormatter(logging.Formatter):
 
         # Call the parent formatter to format the log message
         formatted_message = super().format(record)
+        if Config.ENVIRONMENT_NAME == 'local':
+            return f'{formatted_message}: {record.message}'
 
         # Add the traceid, keycloak client id and message to the formatted log message
         formatted_message = f'{formatted_message} [trace_id={traceid} client={KEY_CLOAK_CLIENT_ID}]: {record.message}'

--- a/services/core-api/app/templates/email/projects/emli_project_summary_email.html
+++ b/services/core-api/app/templates/email/projects/emli_project_summary_email.html
@@ -1,114 +1,144 @@
 <html>
-  <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-    <style>
-@media only screen and (max-width: 620px) {
 
-  table.body .wrapper,s
-table.body .article {
-    padding: 10px !important;
-  }
+<head>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <style>
+    @media only screen and (max-width: 620px) {
 
-  table.body .content {
-    padding: 0 !important;
-  }
+      table.body .wrapper,
+      s table.body .article {
+        padding: 10px !important;
+      }
 
-  table.body .container {
-    padding: 0 !important;
-    width: 100% !important;
-  }
+      table.body .content {
+        padding: 0 !important;
+      }
 
-  table.body .main {
-    border-left-width: 0 !important;
-    border-radius: 0 !important;
-    border-right-width: 0 !important;
-  }
+      table.body .container {
+        padding: 0 !important;
+        width: 100% !important;
+      }
 
-  table.body .btn table {
-    width: 100% !important;
-  }
+      table.body .main {
+        border-left-width: 0 !important;
+        border-radius: 0 !important;
+        border-right-width: 0 !important;
+      }
 
-  table.body .btn a {
-    width: 100% !important;
-  }
+      table.body .btn table {
+        width: 100% !important;
+      }
 
-  table.body .img-responsive {
-    height: auto !important;
-    max-width: 100% !important;
-    width: auto !important;
-  }
-}
-</style>
-  </head>
-  <body style="background-color: #ffffff; font-family: sans-serif; -webkit-font-smoothing: antialiased; font-size: 14px; line-height: 1.4; margin: 0; padding: 0; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%;">
-    <table role="presentation" cellpadding="0" cellspacing="0" class="body" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; background-color: #ffffff; width: 100%;" width="100%">
-      <tr>
-        <td style="font-family: sans-serif; font-size: 14px; vertical-align: top;" valign="top">&nbsp;</td>
-        <td class="container" style="font-family: sans-serif; font-size: 14px; vertical-align: top; display: block; max-width: 580px; padding: 10px; width: 580px; margin: 0 auto;" width="580" valign="top">
-          <div class="content" style="box-sizing: border-box; display: block; margin: 0 auto; max-width: 580px; padding: 10px;">
-            <div class="content-block" style="font-family: sans-serif; vertical-align: top; padding-bottom: 36px; padding-top: 10px; font-size: 12px; text-align: center;" valign="top">
-              <img src="{{core_logo}}" width="25%" style="object-fit: contain;">
-            </div>
-            <!-- START CENTERED WHITE CONTAINER -->
-            <table role="presentation" class="main" style=" border-width:1px; border-style:solid; border-color:#DED9D9; border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; background: #ffffff; border-radius: 3px; width: 100%;" width="100%">
-              
-              <!-- START MAIN CONTENT AREA -->
-              <tr>
-                <td class="wrapper" style="vertical-align: top; box-sizing: border-box; padding: 20px;" valign="top">
-                  <table role="presentation" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;" width="100%">
-                    <tr>
-                      <td style="vertical-align: top; text-align: center; font-family: sans-serif; font-size: 24px; font-weight: 700; line-height: 30px; color: #5E46A1; padding: 16px 0px 24px;" valign="top">
-                        A new project description has been submitted to CORE
-                      </td>
-                    </tr>
-                    <tr>
-                      <td style="vertical-align: top; font-family: sans-serif; font-size: 16px; font-weight: 400; line-height: 20px; color: #6B6363; margin: 0px; margin-bottom: 15px;" valign="top">
-                        <p>
-                            {{mine.mine_name}} (Mine no: {{mine.mine_no}}) has submitted Project Description data in MineSpace
-                        </p>
-                        <p>
-                          <b>Overview:</b> {{project_summary.project_summary_description}}
-                        </p>
-                      </td>
-                     </tr>
-                      <tr>
-                        <td>
-                          <div style="text-align:center; padding-top: 16px;">
-                            <a href ="{{ core_project_summary_link }}" type="button" style="border: solid 1px #5e46a1; border-radius: 5px; box-sizing: border-box; cursor: pointer; display: inline-block; font-size: 14px; font-weight: bold; margin: 0; padding: 12px 25px; text-decoration: none; text-transform: capitalize; background-color: #5e46a1; border-color: #5e46a1; color: #ffffff;">
-                              View Project Description in CORE
-                            </a> 
-                          </div>
-                        </td>   
-                    </tr>
-                  </table>
-                </td>
-              </tr>
+      table.body .btn a {
+        width: 100% !important;
+      }
+
+      table.body .img-responsive {
+        height: auto !important;
+        max-width: 100% !important;
+        width: auto !important;
+      }
+    }
+  </style>
+</head>
+
+<body
+  style="background-color: #ffffff; font-family: sans-serif; -webkit-font-smoothing: antialiased; font-size: 14px; line-height: 1.4; margin: 0; padding: 0; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%;">
+  <table role="presentation" cellpadding="0" cellspacing="0" class="body"
+    style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; background-color: #ffffff; width: 100%;"
+    width="100%">
+    <tr>
+      <td style="font-family: sans-serif; font-size: 14px; vertical-align: top;" valign="top">&nbsp;</td>
+      <td class="container"
+        style="font-family: sans-serif; font-size: 14px; vertical-align: top; display: block; max-width: 580px; padding: 10px; width: 580px; margin: 0 auto;"
+        width="580" valign="top">
+        <div class="content"
+          style="box-sizing: border-box; display: block; margin: 0 auto; max-width: 580px; padding: 10px;">
+          <div class="content-block"
+            style="font-family: sans-serif; vertical-align: top; padding-bottom: 36px; padding-top: 10px; font-size: 12px; text-align: center;"
+            valign="top">
+            <img src="{{core_logo}}" width="25%" style="object-fit: contain;">
+          </div>
+          <!-- START CENTERED WHITE CONTAINER -->
+          <table role="presentation" class="main"
+            style=" border-width:1px; border-style:solid; border-color:#DED9D9; border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; background: #ffffff; border-radius: 3px; width: 100%;"
+            width="100%">
+
+            <!-- START MAIN CONTENT AREA -->
+            <tr>
+              <td class="wrapper" style="vertical-align: top; box-sizing: border-box; padding: 20px;" valign="top">
+                <table role="presentation" cellpadding="0" cellspacing="0"
+                  style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;"
+                  width="100%">
+                  <tr>
+                    <td
+                      style="vertical-align: top; text-align: center; font-family: sans-serif; font-size: 24px; font-weight: 700; line-height: 30px; color: #5E46A1; padding: 16px 0px 24px;"
+                      valign="top">
+                      {{message}}
+                    </td>
+                  </tr>
+                  <tr>
+                    <td
+                      style="vertical-align: top; font-family: sans-serif; font-size: 16px; font-weight: 400; line-height: 20px; color: #6B6363; margin: 0px; margin-bottom: 15px;"
+                      valign="top">
+                      <p>
+                        {{mine.mine_name}} (Mine no: {{mine.mine_no}}) has submitted Project Description data in
+                        MineSpace
+                      </p>
+                      <p>
+                        <b>Overview:</b> {{project_summary.project_summary_description}}
+                      </p>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <div style="text-align:center; padding-top: 16px;">
+                        <a href="{{ core_project_summary_link }}" type="button"
+                          style="border: solid 1px #5e46a1; border-radius: 5px; box-sizing: border-box; cursor: pointer; display: inline-block; font-size: 14px; font-weight: bold; margin: 0; padding: 12px 25px; text-decoration: none; text-transform: capitalize; background-color: #5e46a1; border-color: #5e46a1; color: #ffffff;">
+                          View Project Description in CORE
+                        </a>
+                      </div>
+                    </td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
 
             <!-- END MAIN CONTENT AREA -->
-            </table>
-            <!-- END CENTERED WHITE CONTAINER -->
+          </table>
+          <!-- END CENTERED WHITE CONTAINER -->
 
-            <!-- START FOOTER -->
-            <div class="footer" style="clear: both; margin-top: 10px; text-align: center; width: 100%;">
-              <table role="presentation" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;" width="100%">
-                <tr>
-                  <td class="content-block" style="font-family: sans-serif; vertical-align: top; padding-bottom: 10px; padding-top: 10px; font-size: 12px; text-align: center;" valign="top">
-                    <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; margin-bottom: 15px; font-weight: 400; line-height: 20px;">Please note: This e-mail was sent from a notification-only address that cannot accept incoming e-mail. Please do not reply to this message.</p>
-                  </td>
-                </tr>
-            </td>
-              </table>
-              <div class="content-block" style="font-family: sans-serif; vertical-align: top; padding-top: 36px; padding-top: 10px; font-size: 12px; text-align: center;" valign="top">
-                <img src="{{bc_gov_logo}}" width="25%" style="object-fit: contain;">
-              </div>
-            </div>
-            <!-- END FOOTER -->
+          <!-- START FOOTER -->
+          <div class="footer" style="clear: both; margin-top: 10px; text-align: center; width: 100%;">
+            <table role="presentation" cellpadding="0" cellspacing="0"
+              style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;"
+              width="100%">
+              <tr>
+                <td class="content-block"
+                  style="font-family: sans-serif; vertical-align: top; padding-bottom: 10px; padding-top: 10px; font-size: 12px; text-align: center;"
+                  valign="top">
+                  <p
+                    style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; margin-bottom: 15px; font-weight: 400; line-height: 20px;">
+                    Please note: This e-mail was sent from a notification-only address that cannot accept incoming
+                    e-mail. Please do not reply to this message.</p>
+                </td>
+              </tr>
+      </td>
+  </table>
+  <div class="content-block"
+    style="font-family: sans-serif; vertical-align: top; padding-top: 36px; padding-top: 10px; font-size: 12px; text-align: center;"
+    valign="top">
+    <img src="{{bc_gov_logo}}" width="25%" style="object-fit: contain;">
+  </div>
+  </div>
+  <!-- END FOOTER -->
 
-          </div>
-        </td>
-        <td style="font-family: sans-serif; font-size: 14px; vertical-align: top;" valign="top">&nbsp;</td>
-      </tr>
-    </table>
-  </body>
+  </div>
+  </td>
+  <td style="font-family: sans-serif; font-size: 14px; vertical-align: top;" valign="top">&nbsp;</td>
+  </tr>
+  </table>
+</body>
+
 </html>

--- a/services/core-api/app/templates/email/projects/minespace_project_summary_email.html
+++ b/services/core-api/app/templates/email/projects/minespace_project_summary_email.html
@@ -1,118 +1,149 @@
 <html>
-  <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-    <style>
-@media only screen and (max-width: 620px) {
 
-  table.body .wrapper,s
-table.body .article {
-    padding: 10px !important;
-  }
+<head>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <style>
+    @media only screen and (max-width: 620px) {
 
-  table.body .content {
-    padding: 0 !important;
-  }
+      table.body .wrapper,
+      s table.body .article {
+        padding: 10px !important;
+      }
 
-  table.body .container {
-    padding: 0 !important;
-    width: 100% !important;
-  }
+      table.body .content {
+        padding: 0 !important;
+      }
 
-  table.body .main {
-    border-left-width: 0 !important;
-    border-radius: 0 !important;
-    border-right-width: 0 !important;
-  }
+      table.body .container {
+        padding: 0 !important;
+        width: 100% !important;
+      }
 
-  table.body .btn table {
-    width: 100% !important;
-  }
+      table.body .main {
+        border-left-width: 0 !important;
+        border-radius: 0 !important;
+        border-right-width: 0 !important;
+      }
 
-  table.body .btn a {
-    width: 100% !important;
-  }
+      table.body .btn table {
+        width: 100% !important;
+      }
 
-  table.body .img-responsive {
-    height: auto !important;
-    max-width: 100% !important;
-    width: auto !important;
-  }
-}
+      table.body .btn a {
+        width: 100% !important;
+      }
 
-</style>
-  </head>
-  <body style="background-color: #ffffff; font-family: sans-serif; -webkit-font-smoothing: antialiased; font-size: 14px; line-height: 1.4; margin: 0; padding: 0; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%;">
-    <table role="presentation" cellpadding="0" cellspacing="0" class="body" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; background-color: #ffffff; width: 100%;" width="100%">
-      <tr>
-        <td style="font-family: sans-serif; font-size: 14px; vertical-align: top;" valign="top">&nbsp;</td>
-        <td class="container" style="font-family: sans-serif; font-size: 14px; vertical-align: top; display: block; max-width: 580px; padding: 10px; width: 580px; margin: 0 auto;" width="580" valign="top">
-          <div class="content" style="box-sizing: border-box; display: block; margin: 0 auto; max-width: 580px; padding: 10px;">
-            <div class="content-block" style="font-family: sans-serif; vertical-align: top; padding-bottom: 36px; padding-top: 10px; font-size: 12px; text-align: center;" valign="top">
-              <img src="{{minespace_logo}}" width="60%" style="object-fit: contain;">
-            </div>
-            <!-- START CENTERED WHITE CONTAINER -->
-            <table role="presentation" class="main" style=" border-width:1px; border-style:solid; border-color:#DED9D9; border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; background: #ffffff; border-radius: 3px; width: 100%;" width="100%">
-              
-              <!-- START MAIN CONTENT AREA -->
-              <tr>
-                <td class="wrapper" style="vertical-align: top; box-sizing: border-box; padding: 20px;" valign="top">
-                  <table role="presentation" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;" width="100%">
-                    <tr>
-                      <td style="vertical-align: top; text-align: center; font-family: sans-serif; font-size: 24px; font-weight: 700; line-height: 30px; color: #003366;  padding: 10px 0px 16px;" valign="top">
-                        A new project description has been submitted to ministry staff
-                      </td>
-                    </tr>
-                    <tr>
-                      <td style="vertical-align: top; font-family: sans-serif; font-size: 16px; font-weight: 400; line-height: 20px; color: #6B6363; margin: 0; margin-bottom: 15px;" valign="top">
-                        <p style="margin-top: 16px;">
-                            A project description has been submitted for {{mine.mine_name}} (Mine no: {{mine.mine_no}}) in Minespace. The Major Mines Office will be in
-                            contact with you regarding your submission.
-                        </p>
-                        <p style="margin-top: 16px;">
-                            If you indicated that your project involves a permit under the Environmental Management Act,
-                            you will also need to complete pre-application forms and pay an application fee for each of the permits you require.
-                        </p>
-                        <p>Learn more about <a href="{{ema_auth_link}}">EMA authorizations or submit an application</a></p>
-                      </td>
-                     </tr>
-                      <tr>
-                        <td>
-                          <div style="text-align:center; padding-top: 16px;">
-                            <a href ="{{ minespace_project_summary_link }}" type="button" style="border: solid 1px #003366; border-radius: 5px; box-sizing: border-box; cursor: pointer; display: inline-block; font-size: 14px; font-weight: bold; margin: 0; padding: 12px 25px; text-decoration: none; text-transform: capitalize; background-color: #003366; border-color: #003366; color: #ffffff;">
-                              View Project Description
-                            </a> 
-                          </div>
-                        </td>   
-                    </tr>
-                  </table>
-                </td>
-              </tr>
+      table.body .img-responsive {
+        height: auto !important;
+        max-width: 100% !important;
+        width: auto !important;
+      }
+    }
+  </style>
+</head>
+
+<body
+  style="background-color: #ffffff; font-family: sans-serif; -webkit-font-smoothing: antialiased; font-size: 14px; line-height: 1.4; margin: 0; padding: 0; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%;">
+  <table role="presentation" cellpadding="0" cellspacing="0" class="body"
+    style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; background-color: #ffffff; width: 100%;"
+    width="100%">
+    <tr>
+      <td style="font-family: sans-serif; font-size: 14px; vertical-align: top;" valign="top">&nbsp;</td>
+      <td class="container"
+        style="font-family: sans-serif; font-size: 14px; vertical-align: top; display: block; max-width: 580px; padding: 10px; width: 580px; margin: 0 auto;"
+        width="580" valign="top">
+        <div class="content"
+          style="box-sizing: border-box; display: block; margin: 0 auto; max-width: 580px; padding: 10px;">
+          <div class="content-block"
+            style="font-family: sans-serif; vertical-align: top; padding-bottom: 36px; padding-top: 10px; font-size: 12px; text-align: center;"
+            valign="top">
+            <img src="{{minespace_logo}}" width="60%" style="object-fit: contain;">
+          </div>
+          <!-- START CENTERED WHITE CONTAINER -->
+          <table role="presentation" class="main"
+            style=" border-width:1px; border-style:solid; border-color:#DED9D9; border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; background: #ffffff; border-radius: 3px; width: 100%;"
+            width="100%">
+
+            <!-- START MAIN CONTENT AREA -->
+            <tr>
+              <td class="wrapper" style="vertical-align: top; box-sizing: border-box; padding: 20px;" valign="top">
+                <table role="presentation" cellpadding="0" cellspacing="0"
+                  style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;"
+                  width="100%">
+                  <tr>
+                    <td
+                      style="vertical-align: top; text-align: center; font-family: sans-serif; font-size: 24px; font-weight: 700; line-height: 30px; color: #003366;  padding: 10px 0px 16px;"
+                      valign="top">
+                      {{message}}
+                    </td>
+                  </tr>
+                  <tr>
+                    <td
+                      style="vertical-align: top; font-family: sans-serif; font-size: 16px; font-weight: 400; line-height: 20px; color: #6B6363; margin: 0; margin-bottom: 15px;"
+                      valign="top">
+                      <p style="margin-top: 16px;">
+                        A project description has been submitted for {{mine.mine_name}} (Mine no: {{mine.mine_no}}) in
+                        Minespace. The Major Mines Office will be in
+                        contact with you regarding your submission.
+                      </p>
+                      <p style="margin-top: 16px;">
+                        If you indicated that your project involves a permit under the Environmental Management Act,
+                        you will also need to complete pre-application forms and pay an application fee for each of the
+                        permits you require.
+                      </p>
+                      <p>Learn more about <a href="{{ema_auth_link}}">EMA authorizations or submit an application</a>
+                      </p>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <div style="text-align:center; padding-top: 16px;">
+                        <a href="{{ minespace_project_summary_link }}" type="button"
+                          style="border: solid 1px #003366; border-radius: 5px; box-sizing: border-box; cursor: pointer; display: inline-block; font-size: 14px; font-weight: bold; margin: 0; padding: 12px 25px; text-decoration: none; text-transform: capitalize; background-color: #003366; border-color: #003366; color: #ffffff;">
+                          View Project Description
+                        </a>
+                      </div>
+                    </td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
 
             <!-- END MAIN CONTENT AREA -->
-            </table>
-            <!-- END CENTERED WHITE CONTAINER -->
+          </table>
+          <!-- END CENTERED WHITE CONTAINER -->
 
-            <!-- START FOOTER -->
-            <div class="footer" style="clear: both; margin-top: 10px; text-align: center; width: 100%;">
-              <table role="presentation" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;" width="100%">
-                <tr>
-                  <td class="content-block" style="font-family: sans-serif; vertical-align: top; padding-bottom: 10px; padding-top: 16px; font-size: 12px; text-align: center;" valign="top">
-                    <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; margin-bottom: 15px; font-weight: 400; line-height: 20px;">Please note: This e-mail was sent from a notification-only address that cannot accept incoming e-mail. Please do not reply to this message.</p>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="content-block" style="font-family: sans-serif; vertical-align: top; padding-bottom: 10px; padding-top: 10px; font-size: 12px; text-align: center;" valign="top">
+          <!-- START FOOTER -->
+          <div class="footer" style="clear: both; margin-top: 10px; text-align: center; width: 100%;">
+            <table role="presentation" cellpadding="0" cellspacing="0"
+              style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;"
+              width="100%">
+              <tr>
+                <td class="content-block"
+                  style="font-family: sans-serif; vertical-align: top; padding-bottom: 10px; padding-top: 16px; font-size: 12px; text-align: center;"
+                  valign="top">
+                  <p
+                    style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; margin-bottom: 15px; font-weight: 400; line-height: 20px;">
+                    Please note: This e-mail was sent from a notification-only address that cannot accept incoming
+                    e-mail. Please do not reply to this message.</p>
+                </td>
               </tr>
-            </td>
-              </table>
-            </div>
-            <!-- END FOOTER -->
+              <tr>
+                <td class="content-block"
+                  style="font-family: sans-serif; vertical-align: top; padding-bottom: 10px; padding-top: 10px; font-size: 12px; text-align: center;"
+                  valign="top">
+              </tr>
+      </td>
+  </table>
+  </div>
+  <!-- END FOOTER -->
 
-          </div>
-        </td>
-        <td style="font-family: sans-serif; font-size: 14px; vertical-align: top;" valign="top">&nbsp;</td>
-      </tr>
-    </table>
-  </body>
+  </div>
+  </td>
+  <td style="font-family: sans-serif; font-size: 14px; vertical-align: top;" valign="top">&nbsp;</td>
+  </tr>
+  </table>
+</body>
+
 </html>

--- a/services/core-api/tests/factories.py
+++ b/services/core-api/tests/factories.py
@@ -1244,10 +1244,11 @@ class ProjectSummaryFactory(BaseFactory):
 
     class Params:
         project = factory.SubFactory(ProjectFactory)
+        set_status_code = "SUB"
 
     project_guid = factory.SelfAttribute('project.project_guid')
     project_summary_guid = GUID
-    status_code = 'SUB'
+    status_code = factory.SelfAttribute('set_status_code')
     project_summary_description = factory.Faker('paragraph', nb_sentences=5, variable_nb_sentences=True, ext_word_list=None)
     documents = []
     authorizations = []

--- a/services/core-api/tests/projects/project_summaries/resources/test_project_summary_emails.py
+++ b/services/core-api/tests/projects/project_summaries/resources/test_project_summary_emails.py
@@ -1,0 +1,60 @@
+from tests.factories import ProjectSummaryFactory
+from app.api.constants import MDS_EMAIL
+from app.config import Config
+
+from unittest.mock import patch, mock_open, call, ANY
+
+@patch("app.api.services.email_service.EmailService.send_template_email")
+@patch("builtins.open", mock_open(read_data='email content'))
+
+def test_sub_to_asg(mock_send_template_email, test_client, db_session, auth_headers):
+    project_summary = ProjectSummaryFactory(set_status_code='SUB')
+
+    # TODO: ams_authorizations and documents should both have documents in order to test document emails
+
+    updated_project_summary_title = 'Test Project Title - Updated'
+    data = {}
+    data['contacts'] = []    
+    data['ams_authorizations'] = {}
+    data['authorizations'] = []
+    data['documents'] = []
+    data['mine_guid'] = project_summary.project.mine_guid
+    data['project_summary_title'] = updated_project_summary_title
+    data['project_summary_description'] = project_summary.project_summary_description
+    data['status_code'] = 'ASG'
+    data['is_historic'] = False
+
+    put_resp = test_client.put(
+        f'/projects/{project_summary.project.project_guid}/project-summaries/{project_summary.project_summary_guid}',
+        headers=auth_headers['full_auth_header'],
+        json=data
+    )
+    emli_context = {
+            "project_summary": {
+                "project_summary_description": project_summary.project_summary_description,
+            },
+            "mine": {
+                "mine_name": project_summary.mine_name,
+                "mine_no": project_summary.project.mine_no,
+            },
+            "message": f'{updated_project_summary_title} for {project_summary.project.mine_name} has been assigned',
+            "core_project_summary_link": f'{Config.CORE_WEB_URL}/pre-applications/{project_summary.project.project_guid}/overview'
+        }
+
+    minespace_context = {
+        "mine": {
+            "mine_name": project_summary.mine_name,
+            "mine_no": project_summary.project.mine_no,
+        },
+        "message": f'{updated_project_summary_title} for {project_summary.project.mine_name} has been assigned',
+        "minespace_project_summary_link": f'{Config.MINESPACE_PROD_URL}/projects/{project_summary.project.project_guid}/overview',
+        "ema_auth_link": f'{Config.EMA_AUTH_LINK}',
+    }
+    
+    # ARGS: subject, recipients, body, context, cc (ignore comparison with ANY)
+    emli_call = call(f'Project Description Notification for {project_summary.mine_name}', ANY, ANY, emli_context, cc=[MDS_EMAIL])
+    ms_call = call(f'Project Description Notification for {project_summary.mine_name}', ANY, ANY, minespace_context, cc=[MDS_EMAIL])
+
+    assert put_resp.status_code == 200
+    calls = [emli_call, ms_call]
+    mock_send_template_email.assert_has_calls(calls, True)


### PR DESCRIPTION
## Objective 
- in status update emails, only send when status has changed, and make the email specific to the new status
- send emails when there's new documents
- check properly if there's _new_ documents
- send email/notification updates only when the status indicates, and only to those recipients that should be getting them
- fix a spelling error and non-pythonic variable name
- these changes would have possibly/likely broken the notifications for mine applications and IRT (by requiring the status code in the notify function), but that ticket is coming up, soo.... 
- BONUS: include the "original recipients" in email subject line (except for prod) so that logs don't have to be checked to confirm
- BONUS: make BE logs readable on local (ie: don't include trace id and keycloak id)

[MDS-6129](https://bcmines.atlassian.net/browse/MDS-6129)

_Why are you making this change? Provide a short explanation and/or screenshots_
