### PR TITLE
[FIX] Applicant address bug

### DIFF
--- a/services/core-api/app/api/projects/project_summary/models/project_summary.py
+++ b/services/core-api/app/api/projects/project_summary/models/project_summary.py
@@ -144,7 +144,7 @@ class ProjectSummary(SoftDeleteMixin, AuditMixin, Base):
     def __get_address_type_code(cls, address_data):
         if isinstance(address_data, list):
             return address_data[0].get('address_type_code')
-        return address_data.get('address_type_code')
+        return address_data.get('address_type_code', None) if address_data else None
 
     def __repr__(self):
         return f'{self.__class__.__name__} {self.project_summary_id}'
@@ -297,7 +297,7 @@ class ProjectSummary(SoftDeleteMixin, AuditMixin, Base):
                         address_type_code=addr.get('address_type_code'),
                     )
                     new_party.address.append(new_address)
-            else:
+            elif address_data is not None:
                 new_address = Address.create(
                     suite_no=address_data.get('suite_no'),
                     address_line_1=address_data.get('address_line_1'),


### PR DESCRIPTION
## Objective 
- address wasn't required for party on applicant page
- validation (FE & BE) didn't require it
- but there were no null checks in the process of creating the party
- added those null checks