### PR TITLE
[MDS-6191] - Rename "Final Application" to "Application"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ gitops/tenant-gitops-4c2ba9
 .vscode/settings.json
 services/document-manager/document-manager.iml
 /services/filesystem-provider/ej2-amazon-s3-aspcore-file-provider/Folder.DotSettings.user
+/services/core-api/core-api.iml

--- a/services/core-web/src/components/mine/Projects/MajorMineApplicationTab.js
+++ b/services/core-web/src/components/mine/Projects/MajorMineApplicationTab.js
@@ -76,7 +76,7 @@ export class MajorMineApplicationTab extends Component {
   componentDidUpdate(nextProps) {
     if (
       nextProps.match.params.tab !== this.props.match.params.tab &&
-      this.props.match.params.tab === "final-app"
+      this.props.match.params.tab === "app"
     ) {
       this.fetchData();
     }
@@ -204,7 +204,7 @@ export class MajorMineApplicationTab extends Component {
         <div className={this.state.fixedTop ? "side-menu--fixed" : "side-menu"}>
           <ScrollSideMenu
             menuOptions={menuOptions}
-            featureUrlRoute={routes.PROJECT_FINAL_APPLICATION.hashRoute}
+            featureUrlRoute={routes.PROJECT_APPLICATION.hashRoute}
             featureUrlRouteArguments={[project_guid]}
           />
         </div>

--- a/services/core-web/src/components/mine/Projects/Project.tsx
+++ b/services/core-web/src/components/mine/Projects/Project.tsx
@@ -65,7 +65,7 @@ const Project: FC = () => {
 
     switch (newActiveTab) {
       case "final-app":
-        url = routes.PROJECT_FINAL_APPLICATION.dynamicRoute(projectGuid);
+        url = routes.PROJECT_APPLICATION.dynamicRoute(projectGuid);
         break;
       case "decision-package":
         url = routes.PROJECT_DECISION_PACKAGE.dynamicRoute(projectGuid);
@@ -139,8 +139,8 @@ const Project: FC = () => {
       ),
     },
     {
-      key: "final-app",
-      label: "Final Application",
+      key: "app",
+      label: "Application",
       disabled: !hasFinalAplication,
       children: (
         <div className="padding-lg">

--- a/services/core-web/src/components/mine/Projects/ProjectOverviewTab.tsx
+++ b/services/core-web/src/components/mine/Projects/ProjectOverviewTab.tsx
@@ -97,14 +97,14 @@ export const ProjectOverviewTab: FC = () => {
       ),
     },
     {
-      title: "Final Application",
+      title: "Application",
       key: `ps-${project.major_mine_application.major_mine_application_id}`,
       status: project.major_mine_application.status_code,
       statusHash: majorMineApplicationStatusCodeHash,
       link: (
         <Link
           data-cy="final-application-view-link"
-          to={routes.PROJECT_FINAL_APPLICATION.dynamicRoute(project_guid)}
+          to={routes.PROJECT_APPLICATION.dynamicRoute(project_guid)}
         >
           <Button className="full-mobile margin-small" disabled={!hasFinalAplication}>
             View

--- a/services/core-web/src/constants/routes.ts
+++ b/services/core-web/src/constants/routes.ts
@@ -268,10 +268,10 @@ export const MAJOR_MINE_APPLICATION = {
   helpKey: "Major-Mine-Application",
 };
 
-export const PROJECT_FINAL_APPLICATION = {
-  route: "/pre-applications/:projectGuid/final-app",
-  dynamicRoute: (projectGuid) => `/pre-applications/${projectGuid}/final-app`,
-  hashRoute: (projectGuid, link) => `/pre-applications/${projectGuid}/final-app/${link}`,
+export const PROJECT_APPLICATION = {
+  route: "/pre-applications/:projectGuid/app",
+  dynamicRoute: (projectGuid) => `/pre-applications/${projectGuid}/app`,
+  hashRoute: (projectGuid, link) => `/pre-applications/${projectGuid}/app/${link}`,
   component: MajorMineApplicationTab,
   helpKey: "Major-Mine-Application",
 };

--- a/services/core-web/src/tests/components/mine/Projects/__snapshots__/ProjectOverviewTab.spec.tsx.snap
+++ b/services/core-web/src/tests/components/mine/Projects/__snapshots__/ProjectOverviewTab.spec.tsx.snap
@@ -337,7 +337,7 @@ exports[`ProjectOverviewTab renders properly 1`] = `
                             title="Project Stage"
                           >
                             <b>
-                              Final Application
+                              Application
                             </b>
                           </div>
                         </td>
@@ -360,7 +360,7 @@ exports[`ProjectOverviewTab renders properly 1`] = `
                         >
                           <a
                             data-cy="final-application-view-link"
-                            href="/pre-applications/35633148-57f8-4967-be35-7f89abfbd02e/final-app"
+                            href="/pre-applications/35633148-57f8-4967-be35-7f89abfbd02e/app"
                           >
                             <button
                               class="ant-btn ant-btn-default full-mobile margin-small"

--- a/services/core-web/src/tests/routes/__snapshots__/DashboardRoutes.spec.js.snap
+++ b/services/core-web/src/tests/routes/__snapshots__/DashboardRoutes.spec.js.snap
@@ -340,8 +340,8 @@ exports[`DashboardRoutes  renders properly 1`] = `
   <Route
     component={[Function]}
     exact={true}
-    key="/pre-applications/:projectGuid/final-app"
-    path="/pre-applications/:projectGuid/final-app"
+    key="/pre-applications/:projectGuid/app"
+    path="/pre-applications/:projectGuid/app"
   />
   <Route
     component={[Function]}


### PR DESCRIPTION
Updated code references and URLs to change "Final Application" to "Application" in the major projects section. This includes link paths, titles, and switch cases to maintain consistency across the project.

## Objective 

[MDS-6191](https://bcmines.atlassian.net/browse/MDS-6191)

<img width="1710" alt="image" src="https://github.com/user-attachments/assets/4755903b-000d-43ed-a0e4-bbe6de1c6458">
<img width="744" alt="image" src="https://github.com/user-attachments/assets/586ea906-7772-4577-8309-9e6c08864a4e">

