### PR TITLE
[MDS-6260] Add Report Type to Report requirement form, make initial submission date optional

### DIFF
--- a/services/common/src/constants/strings.tsx
+++ b/services/common/src/constants/strings.tsx
@@ -491,5 +491,6 @@ export const REPORT_FREQUENCY_HASH = {
   "Semi-Annually": 6,
   "Annually": 12,
   "Bi-Annually": 24,
+  "Every 5 Years": 60,
   "Not Specified": 0,
 };

--- a/services/common/src/interfaces/permits/mineReportPermitRequirements.interface.ts
+++ b/services/common/src/interfaces/permits/mineReportPermitRequirements.interface.ts
@@ -1,7 +1,9 @@
 export interface IMineReportPermitRequirement {
+  report_name: string;
   mine_report_permit_requirement_id: number;
   cim_or_cpo: string;
   ministry_recipient: string[];
   permit_condition_id: number;
   due_date_period_months: number;
+  initial_due_date: Date;
 }

--- a/services/core-web/src/components/Forms/reports/ReportPermitRequirementForm.tsx
+++ b/services/core-web/src/components/Forms/reports/ReportPermitRequirementForm.tsx
@@ -24,6 +24,7 @@ import RenderGroupCheckbox, {
 } from "@mds/common/components/forms/RenderGroupCheckbox";
 import { getLatestAmendmentByPermitGuid } from "@mds/common/redux/selectors/permitSelectors";
 import RenderRadioButtons from "@mds/common/components/forms/RenderRadioButtons";
+import { maxLength } from "@common/utils/Validate";
 
 interface ReportPermitRequirementProps {
   onSubmit: (values: Partial<IMineReport>) => void | Promise<void>;
@@ -54,19 +55,19 @@ export const ReportPermitRequirementForm: FC<ReportPermitRequirementProps> = ({
         initialValues={
           mineReportPermitRequirement
             ? {
-                ...mineReportPermitRequirement,
-                stepPath: condition.stepPath,
-                permit_amendment_id: latestPermitAmendment.permit_amendment_id,
-              }
+              ...mineReportPermitRequirement,
+              stepPath: condition.stepPath,
+              permit_amendment_id: latestPermitAmendment.permit_amendment_id,
+            }
             : {
-                mine_report_status_code: MINE_REPORT_SUBMISSION_CODES.NON,
-                stepPath: condition.stepPath,
-                permit_condition_category_code: condition.condition_category_code,
-                permit_condition_type_code: REPORT_TYPE_CODES.PRR,
-                permit_condition_id: condition.permit_condition_id,
-                permit_guid: permitGuid,
-                permit_amendment_id: latestPermitAmendment.permit_amendment_id,
-              }
+              mine_report_status_code: MINE_REPORT_SUBMISSION_CODES.NON,
+              stepPath: condition.stepPath,
+              permit_condition_category_code: condition.condition_category_code,
+              permit_condition_type_code: REPORT_TYPE_CODES.PRR,
+              permit_condition_id: condition.permit_condition_id,
+              permit_guid: permitGuid,
+              permit_amendment_id: latestPermitAmendment.permit_amendment_id,
+            }
         }
       >
         <Row gutter={[16, 16]}>
@@ -78,6 +79,14 @@ export const ReportPermitRequirementForm: FC<ReportPermitRequirementProps> = ({
               validate={required}
               component={RenderField}
               disabled
+            />
+          </Col>
+          <Col span={24}>
+            <Field
+              name="report_name"
+              label="Report Type"
+              validate={[maxLength(255)]}
+              component={RenderField}
             />
           </Col>
           <Col span={12}>
@@ -100,8 +109,6 @@ export const ReportPermitRequirementForm: FC<ReportPermitRequirementProps> = ({
               name="initial_due_date"
               label="Initial Due Date"
               placeholder="Select date"
-              required
-              validate={[required]}
               formatViewDate
               component={RenderDate}
             />

--- a/services/core-web/src/components/Forms/reports/ReportPermitRequirementForm.tsx
+++ b/services/core-web/src/components/Forms/reports/ReportPermitRequirementForm.tsx
@@ -13,7 +13,7 @@ import {
   REPORT_REGULATORY_AUTHORITY_CODES_HASH,
   REPORT_TYPE_CODES,
 } from "@mds/common";
-import { required, requiredRadioButton } from "@mds/common/redux/utils/Validate";
+import { required, requiredRadioButton, maxLength } from "@mds/common/redux/utils/Validate";
 import FormWrapper from "@mds/common/components/forms/FormWrapper";
 import RenderSelect from "@mds/common/components/forms/RenderSelect";
 import RenderDate from "@mds/common/components/forms/RenderDate";
@@ -24,7 +24,6 @@ import RenderGroupCheckbox, {
 } from "@mds/common/components/forms/RenderGroupCheckbox";
 import { getLatestAmendmentByPermitGuid } from "@mds/common/redux/selectors/permitSelectors";
 import RenderRadioButtons from "@mds/common/components/forms/RenderRadioButtons";
-import { maxLength } from "@common/utils/Validate";
 
 interface ReportPermitRequirementProps {
   onSubmit: (values: Partial<IMineReport>) => void | Promise<void>;

--- a/services/core-web/src/components/mine/Permit/PermitConditions.tsx
+++ b/services/core-web/src/components/mine/Permit/PermitConditions.tsx
@@ -339,7 +339,7 @@ const PermitConditions: FC<PermitConditionProps> = ({
                               <Collapse.Panel
                                 key={cond.permit_condition_id}
                                 header={
-                                  <Typography.Text strong>Report #{index + 1}</Typography.Text>
+                                  <Typography.Text strong>Report #{index + 1}{cond.mineReportPermitRequirement?.report_name ? ` - ${cond.mineReportPermitRequirement.report_name}` : ''}</Typography.Text>
                                 }
                                 className="report-collapse"
                               >

--- a/services/core-web/src/tests/components/Forms/reports/__snapshots__/ReportPermitRequirementForm.spec.tsx.snap
+++ b/services/core-web/src/tests/components/Forms/reports/__snapshots__/ReportPermitRequirementForm.spec.tsx.snap
@@ -74,6 +74,70 @@ exports[`RequestReportForm renders form properly 1`] = `
         </div>
       </div>
       <div
+        class="ant-col ant-col-24"
+        style="padding: 8px 8px 8px 8px;"
+      >
+        <div
+          class="ant-form-item ant-form-item-with-help"
+        >
+          <div
+            class="ant-row ant-form-item-row"
+          >
+            <div
+              class="ant-col ant-form-item-label"
+            >
+              <label
+                class=""
+                for="ADD_REPORT_TO_PERMIT_CONDITION-1639_report_name"
+                title=""
+              >
+                <div>
+                  Report Type
+                   
+                  <span
+                    class="form-item-optional"
+                  >
+                     (optional)
+                  </span>
+                </div>
+              </label>
+            </div>
+            <div
+              class="ant-col ant-form-item-control"
+            >
+              <div
+                class="ant-form-item-control-input"
+              >
+                <div
+                  class="ant-form-item-control-input-content"
+                >
+                  <input
+                    aria-label="report_name"
+                    class="ant-input"
+                    name="report_name"
+                    type="text"
+                    value=""
+                  />
+                </div>
+              </div>
+              <div
+                style="display: flex; flex-wrap: nowrap;"
+              >
+                <div
+                  class="ant-form-item-explain ant-form-item-explain-connected"
+                  id="ADD_REPORT_TO_PERMIT_CONDITION-1639_report_name_help"
+                  role="alert"
+                >
+                  <div
+                    class=""
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
         class="ant-col ant-col-12"
         style="padding: 8px 8px 8px 8px;"
       >
@@ -199,14 +263,18 @@ exports[`RequestReportForm renders form properly 1`] = `
               class="ant-col ant-form-item-label"
             >
               <label
-                class="ant-form-item-required"
+                class=""
                 for="ADD_REPORT_TO_PERMIT_CONDITION-1639_initial_due_date"
                 title=""
               >
-                <div
-                  style="width: 100%;"
-                >
+                <div>
                   Initial Due Date
+                   
+                  <span
+                    class="form-item-optional"
+                  >
+                     (optional)
+                  </span>
                 </div>
               </label>
             </div>
@@ -226,7 +294,6 @@ exports[`RequestReportForm renders form properly 1`] = `
                       class="ant-picker-input"
                     >
                       <input
-                        aria-required="true"
                         autocomplete="off"
                         id="ADD_REPORT_TO_PERMIT_CONDITION-1639_initial_due_date"
                         name="initial_due_date"


### PR DESCRIPTION
## Objective 

[MDS-6260](https://bcmines.atlassian.net/browse/MDS-6260)

Added Report Type to the Report requirement form
Made initial submission date optional as a lot of reports do not have one, for example ones that are triggered by an incident

![image](https://github.com/user-attachments/assets/3b3b9e00-9a65-4fc4-a017-2307d138251e)
![image](https://github.com/user-attachments/assets/d62de033-260e-483c-bd25-32eb3de4b95e)
