### PR TITLE
[MDS-6273] Project file deletion

### DIFF
--- a/services/common/src/components/documents/DocumentTable.tsx
+++ b/services/common/src/components/documents/DocumentTable.tsx
@@ -82,18 +82,13 @@ export const DocumentTable: FC<DocumentTableProps> = ({
   const isMinimalView: boolean = view === "minimal";
 
   const parseDocuments = (docs: any[]): MineDocument[] => {
-    let parsedDocs: MineDocument[];
     if (docs.length && docs[0] instanceof MineDocument) {
-      parsedDocs = docs;
+      return docs;
     } else {
-      parsedDocs = docs.map((doc) => new MineDocument(doc));
+      return docs.map((doc) => new MineDocument(doc));
     }
-    return parsedDocs.map((doc) => {
-      doc.setAllowedActions(userRoles);
-      return doc;
-    });
   };
-
+ 
   const [documents, setDocuments] = useState<MineDocument[]>(parseDocuments(props.documents ?? []));
 
   useEffect(() => {

--- a/services/common/src/components/projectSummary/AuthorizationsInvolved.tsx
+++ b/services/common/src/components/projectSummary/AuthorizationsInvolved.tsx
@@ -85,10 +85,10 @@ const RenderEMAPermitCommonSections = ({ code, isAmendment, index, isDisabled })
     setShowExemptionSection(value);
   };
 
-  const onDeleteDocument = async (event, key: string)  =>{
+  const onDeleteDocument = (event, key: string) => {
     const document = tableDocuments.find( (doc) => key === doc.key);
     if(document){
-      await dispatch(
+      dispatch(
         removeDocumentFromProjectSummary(
           project_guid,
           project_summary_guid,

--- a/services/common/src/components/projectSummary/AuthorizationsInvolved.tsx
+++ b/services/common/src/components/projectSummary/AuthorizationsInvolved.tsx
@@ -58,7 +58,7 @@ import { SystemFlagEnum } from "@mds/common/constants/enums";
 import { getSystemFlag } from "@mds/common/redux/selectors/authenticationSelectors";
 import { FormContext } from "../forms/FormWrapper";
 import { ProjectSummaryFormComponentProps } from "./ProjectSummaryForm";
-import { areAuthEnvFieldsDisabled, areDocumentFieldsDisabled } from "../projects/projectUtils";
+import { areAuthEnvFieldsDisabled, areDocumentFieldsDisabled, isDocumentDeletionEnabled } from "../projects/projectUtils";
 import { removeDocumentFromProjectSummary } from "@mds/common/redux/actionCreators/projectActionCreator";
 
 const RenderEMAPermitCommonSections = ({ code, isAmendment, index, isDisabled }) => {
@@ -81,6 +81,7 @@ const RenderEMAPermitCommonSections = ({ code, isAmendment, index, isDisabled })
   const projectSummaryDocumentTypesHash = useSelector(getProjectSummaryDocumentTypesHash);
   const docFieldsDisabled = areDocumentFieldsDisabled(systemFlag, status_code);
   const { isEditMode } = useContext(FormContext);
+  const deletionEnabled = isDocumentDeletionEnabled(systemFlag, status_code);
 
   const onChange = (value) => {
     setShowExemptionSection(value);
@@ -247,7 +248,7 @@ const RenderEMAPermitCommonSections = ({ code, isAmendment, index, isDisabled })
         documents={tableDocuments}
         documentParent="project summary authorization"
         documentColumns={documentColumns}
-        removeDocument={!isDisabled && isEditMode ? onDeleteDocument : undefined}
+        removeDocument={deletionEnabled && isEditMode ? onDeleteDocument : undefined}
       />
     </>
   );

--- a/services/common/src/components/projectSummary/AuthorizationsInvolved.tsx
+++ b/services/common/src/components/projectSummary/AuthorizationsInvolved.tsx
@@ -246,7 +246,7 @@ const RenderEMAPermitCommonSections = ({ code, isAmendment, index, isDisabled })
         documents={tableDocuments}
         documentParent="project summary authorization"
         documentColumns={documentColumns}
-        removeDocument={!docFieldsDisabled ? onDeleteDocument : null}
+        removeDocument={!isDisabled ? onDeleteDocument : undefined}
       />
     </>
   );

--- a/services/common/src/components/projectSummary/AuthorizationsInvolved.tsx
+++ b/services/common/src/components/projectSummary/AuthorizationsInvolved.tsx
@@ -80,6 +80,7 @@ const RenderEMAPermitCommonSections = ({ code, isAmendment, index, isDisabled })
 
   const projectSummaryDocumentTypesHash = useSelector(getProjectSummaryDocumentTypesHash);
   const docFieldsDisabled = areDocumentFieldsDisabled(systemFlag, status_code);
+  const { isEditMode } = useContext(FormContext);
 
   const onChange = (value) => {
     setShowExemptionSection(value);
@@ -246,7 +247,7 @@ const RenderEMAPermitCommonSections = ({ code, isAmendment, index, isDisabled })
         documents={tableDocuments}
         documentParent="project summary authorization"
         documentColumns={documentColumns}
-        removeDocument={!isDisabled ? onDeleteDocument : undefined}
+        removeDocument={!isDisabled && isEditMode ? onDeleteDocument : undefined}
       />
     </>
   );

--- a/services/common/src/components/projectSummary/AuthorizationsInvolved.tsx
+++ b/services/common/src/components/projectSummary/AuthorizationsInvolved.tsx
@@ -59,6 +59,7 @@ import { getSystemFlag } from "@mds/common/redux/selectors/authenticationSelecto
 import { FormContext } from "../forms/FormWrapper";
 import { ProjectSummaryFormComponentProps } from "./ProjectSummaryForm";
 import { areAuthEnvFieldsDisabled, areDocumentFieldsDisabled } from "../projects/projectUtils";
+import { removeDocumentFromProjectSummary } from "@mds/common/redux/actionCreators/projectActionCreator";
 
 const RenderEMAPermitCommonSections = ({ code, isAmendment, index, isDisabled }) => {
   const dispatch = useDispatch();
@@ -83,6 +84,20 @@ const RenderEMAPermitCommonSections = ({ code, isAmendment, index, isDisabled })
   const onChange = (value) => {
     setShowExemptionSection(value);
   };
+
+  const onDeleteDocument = async (event, key: string)  =>{
+    const document = tableDocuments.find( (doc) => key === doc.key);
+    if(document){
+      await dispatch(
+        removeDocumentFromProjectSummary(
+          project_guid,
+          project_summary_guid,
+          document.mine_document_guid
+      )).then( () => {
+        removeAmendmentDocument(tableDocuments.indexOf(document),document.category,document.document_manager_guid)
+      })
+    }
+  }
 
   const removeAmendmentDocument = (
     amendmentDocumentsIndex: number,
@@ -231,6 +246,7 @@ const RenderEMAPermitCommonSections = ({ code, isAmendment, index, isDisabled })
         documents={tableDocuments}
         documentParent="project summary authorization"
         documentColumns={documentColumns}
+        removeDocument={!docFieldsDisabled ? onDeleteDocument : null}
       />
     </>
   );

--- a/services/common/src/components/projectSummary/DocumentUpload.spec.tsx
+++ b/services/common/src/components/projectSummary/DocumentUpload.spec.tsx
@@ -28,7 +28,7 @@ describe("DocumentUpload", () => {
           initialValues={MOCK.PROJECT_SUMMARY}
           onSubmit={() => { }}
         >
-          <DocumentUpload docFieldsDisabled={false} />
+          <DocumentUpload docFieldsDisabled={false} fieldsDisabled={false}/>
         </FormWrapper>
       </ReduxWrapper>
     );

--- a/services/common/src/components/projectSummary/DocumentUpload.spec.tsx
+++ b/services/common/src/components/projectSummary/DocumentUpload.spec.tsx
@@ -28,7 +28,7 @@ describe("DocumentUpload", () => {
           initialValues={MOCK.PROJECT_SUMMARY}
           onSubmit={() => { }}
         >
-          <DocumentUpload docFieldsDisabled={false} fieldsDisabled={false}/>
+          <DocumentUpload docFieldsDisabled={false} deleteEnabled={false}/>
         </FormWrapper>
       </ReduxWrapper>
     );

--- a/services/common/src/components/projectSummary/DocumentUpload.tsx
+++ b/services/common/src/components/projectSummary/DocumentUpload.tsx
@@ -172,10 +172,10 @@ export const DocumentUpload: FC<DocumentUploadProps> = ({ docFieldsDisabled, fie
     }
   };
 
-  const onDeleteDocument = async (event, key: string)  =>{
+  const onDeleteDocument = (event, key: string) => {
     const document = documents.find( (doc) => key === doc.mine_document_guid);
     if(document){
-      await dispatch(
+      dispatch(
         removeDocumentFromProjectSummary(
           project_guid,
           project_summary_guid,

--- a/services/common/src/components/projectSummary/DocumentUpload.tsx
+++ b/services/common/src/components/projectSummary/DocumentUpload.tsx
@@ -24,6 +24,7 @@ import SpatialDocumentTable from "../documents/spatial/SpatialDocumentTable";
 import { FormContext } from "../forms/FormWrapper";
 import { useFeatureFlag } from "@mds/common/providers/featureFlags/useFeatureFlag";
 import { Feature, IProjectSummaryForm } from "../..";
+import { removeDocumentFromProjectSummary } from "@mds/common/redux/actionCreators/projectActionCreator";
 
 const RenderOldDocuments = ({
   documents,
@@ -145,28 +146,44 @@ export const DocumentUpload: FC<DocumentUploadProps> = ({ docFieldsDisabled }) =
     }
   };
 
+  const removeFile = (document) => {
+    if (document.project_summary_document_type_code === PROJECT_SUMMARY_DOCUMENT_TYPE_CODE.SPATIAL) {
+      const newSpatialDocuments = [...spatial_documents].filter(
+        (file) => document.document_manager_guid !== file.document_manager_guid
+      );
+      dispatch(change(FORM.ADD_EDIT_PROJECT_SUMMARY, "spatial_documents", newSpatialDocuments));
+    } else if (document.project_summary_document_type_code === PROJECT_SUMMARY_DOCUMENT_TYPE_CODE.SUPPORTING) {
+      const newSupportDocuments = [...support_documents].filter(
+        (file) => document.document_manager_guid !== file.document_manager_guid
+      );
+      dispatch(change(FORM.ADD_EDIT_PROJECT_SUMMARY, "support_documents", newSupportDocuments));
+    }
+  }
+
   const onRemoveFile = (err, fileItem) => {
     if (err) {
       console.log(err);
     }
-
     if (fileItem.serverId) {
-      const document_type_code = documents.find(
+      removeFile(documents.find(
         (file) => fileItem.serverId === file.document_manager_guid
-      )?.project_summary_document_type_code;
-      if (document_type_code === PROJECT_SUMMARY_DOCUMENT_TYPE_CODE.SPATIAL) {
-        const newSpatialDocuments = [...spatial_documents].filter(
-          (file) => fileItem.serverId !== file.document_manager_guid
-        );
-        dispatch(change(FORM.ADD_EDIT_PROJECT_SUMMARY, "spatial_documents", newSpatialDocuments));
-      } else if (document_type_code === PROJECT_SUMMARY_DOCUMENT_TYPE_CODE.SUPPORTING) {
-        const newSupportDocuments = [...support_documents].filter(
-          (file) => fileItem.serverId !== file.document_manager_guid
-        );
-        dispatch(change(FORM.ADD_EDIT_PROJECT_SUMMARY, "support_documents", newSupportDocuments));
-      }
+      ));
     }
   };
+
+  const onDeleteDocument = async (event, key: string)  =>{
+    const document = documents.find( (doc) => key === doc.mine_document_guid);
+    if(document){
+      await dispatch(
+        removeDocumentFromProjectSummary(
+          project_guid,
+          project_summary_guid,
+          document.mine_document_guid
+      )).then( () => {
+        removeFile(document);
+      })
+    }
+  }
 
   const downloadIRTTemplate = (url) => {
     const anchor = document.createElement("a");
@@ -283,6 +300,7 @@ export const DocumentUpload: FC<DocumentUploadProps> = ({ docFieldsDisabled }) =
         documents={support_documents}
         documentParent="project summary"
         documentColumns={documentColumns}
+        removeDocument={!docFieldsDisabled ? onDeleteDocument : null}
       />
     </>
   );

--- a/services/common/src/components/projectSummary/DocumentUpload.tsx
+++ b/services/common/src/components/projectSummary/DocumentUpload.tsx
@@ -68,10 +68,10 @@ const RenderOldDocuments = ({
 
 interface DocumentUploadProps {
   docFieldsDisabled: boolean;
-  fieldsDisabled: boolean;
+  deleteEnabled: boolean;
 }
 
-export const DocumentUpload: FC<DocumentUploadProps> = ({ docFieldsDisabled, fieldsDisabled }) => {
+export const DocumentUpload: FC<DocumentUploadProps> = ({ docFieldsDisabled, deleteEnabled }) => {
   const dispatch = useDispatch();
   const {
     spatial_documents = [],
@@ -301,7 +301,7 @@ export const DocumentUpload: FC<DocumentUploadProps> = ({ docFieldsDisabled, fie
         documents={support_documents}
         documentParent="project summary"
         documentColumns={documentColumns}
-        removeDocument={!fieldsDisabled && isEditMode ? onDeleteDocument : undefined}
+        removeDocument={deleteEnabled && isEditMode ? onDeleteDocument : undefined}
       />
     </>
   );

--- a/services/common/src/components/projectSummary/DocumentUpload.tsx
+++ b/services/common/src/components/projectSummary/DocumentUpload.tsx
@@ -301,7 +301,7 @@ export const DocumentUpload: FC<DocumentUploadProps> = ({ docFieldsDisabled, fie
         documents={support_documents}
         documentParent="project summary"
         documentColumns={documentColumns}
-        removeDocument={!fieldsDisabled ? onDeleteDocument : undefined}
+        removeDocument={!fieldsDisabled && isEditMode ? onDeleteDocument : undefined}
       />
     </>
   );

--- a/services/common/src/components/projectSummary/DocumentUpload.tsx
+++ b/services/common/src/components/projectSummary/DocumentUpload.tsx
@@ -68,9 +68,10 @@ const RenderOldDocuments = ({
 
 interface DocumentUploadProps {
   docFieldsDisabled: boolean;
+  fieldsDisabled: boolean;
 }
 
-export const DocumentUpload: FC<DocumentUploadProps> = ({ docFieldsDisabled }) => {
+export const DocumentUpload: FC<DocumentUploadProps> = ({ docFieldsDisabled, fieldsDisabled }) => {
   const dispatch = useDispatch();
   const {
     spatial_documents = [],
@@ -300,7 +301,7 @@ export const DocumentUpload: FC<DocumentUploadProps> = ({ docFieldsDisabled }) =
         documents={support_documents}
         documentParent="project summary"
         documentColumns={documentColumns}
-        removeDocument={!docFieldsDisabled ? onDeleteDocument : null}
+        removeDocument={!fieldsDisabled ? onDeleteDocument : undefined}
       />
     </>
   );

--- a/services/common/src/components/projectSummary/ProjectSummaryFileUpload.tsx
+++ b/services/common/src/components/projectSummary/ProjectSummaryFileUpload.tsx
@@ -69,7 +69,7 @@ export const ProjectSummaryFileUpload: FC<WrappedFieldProps & ProjectSummaryFile
   }
 
   useEffect(() => {
-    if (existingFiles.length === 0) {
+    if (existingFiles.length === 0 || props.documents.length < existingFiles.length) {
       setExistingFiles(props.documents);
     }
   }, [props.documents]);

--- a/services/common/src/components/projectSummary/ProjectSummaryForm.tsx
+++ b/services/common/src/components/projectSummary/ProjectSummaryForm.tsx
@@ -24,7 +24,7 @@ import { ProjectManagement } from "./ProjectManagement";
 import { getSystemFlag } from "@mds/common/redux/selectors/authenticationSelectors";
 import { SystemFlagEnum } from "../..";
 import { formatProjectPayload } from "@mds/common/utils/helpers";
-import { areAuthFieldsDisabled, areDocumentFieldsDisabled, areFieldsDisabled } from "../projects/projectUtils";
+import { areAuthFieldsDisabled, areDocumentFieldsDisabled, areFieldsDisabled, isDocumentDeletionEnabled } from "../projects/projectUtils";
 
 interface ProjectSummaryFormProps {
   initialValues: IProjectSummary;
@@ -104,6 +104,7 @@ export const ProjectSummaryForm: FC<ProjectSummaryFormProps> = ({
   const fieldsDisabled = areFieldsDisabled(systemFlag, status_code, confirmation_of_submission);
   const docFieldsDisabled = areDocumentFieldsDisabled(systemFlag, status_code);
   const authFieldsDisabled = areAuthFieldsDisabled(systemFlag, status_code, confirmation_of_submission);
+  const deleteEnabled = isDocumentDeletionEnabled(systemFlag, status_code);
 
   const handleTransformPayload = (valuesFromForm: any) => {
     return formatProjectPayload(valuesFromForm, { projectSummaryAuthorizationTypesArray });
@@ -128,7 +129,7 @@ export const ProjectSummaryForm: FC<ProjectSummaryFormProps> = ({
     "representing-agent": <Agent fieldsDisabled={fieldsDisabled} />,
     "mine-components-and-offsite-infrastructure": <FacilityOperator fieldsDisabled={fieldsDisabled} />,
     "purpose-and-authorization": <AuthorizationsInvolved fieldsDisabled={authFieldsDisabled} />,
-    "document-upload": <DocumentUpload docFieldsDisabled={docFieldsDisabled} fieldsDisabled={authFieldsDisabled} />,
+    "document-upload": <DocumentUpload docFieldsDisabled={docFieldsDisabled} deleteEnabled={deleteEnabled} />,
     "application-summary": <ApplicationSummary fieldsDisabled={fieldsDisabled} />,
     declaration: <Declaration />,
   }[tab]);

--- a/services/common/src/components/projectSummary/ProjectSummaryForm.tsx
+++ b/services/common/src/components/projectSummary/ProjectSummaryForm.tsx
@@ -128,7 +128,7 @@ export const ProjectSummaryForm: FC<ProjectSummaryFormProps> = ({
     "representing-agent": <Agent fieldsDisabled={fieldsDisabled} />,
     "mine-components-and-offsite-infrastructure": <FacilityOperator fieldsDisabled={fieldsDisabled} />,
     "purpose-and-authorization": <AuthorizationsInvolved fieldsDisabled={authFieldsDisabled} />,
-    "document-upload": <DocumentUpload docFieldsDisabled={docFieldsDisabled} />,
+    "document-upload": <DocumentUpload docFieldsDisabled={docFieldsDisabled} fieldsDisabled={authFieldsDisabled} />,
     "application-summary": <ApplicationSummary fieldsDisabled={fieldsDisabled} />,
     declaration: <Declaration />,
   }[tab]);

--- a/services/common/src/components/projectSummary/ProjectSummaryFormComponents.spec.tsx
+++ b/services/common/src/components/projectSummary/ProjectSummaryFormComponents.spec.tsx
@@ -20,6 +20,7 @@ import Declaration from "./Declaration";
 import DocumentUpload from "./DocumentUpload";
 import { FacilityOperator } from "./FacilityOperator";
 import { BrowserRouter } from "react-router-dom";
+import { isDocumentDeletionEnabled } from "../projects/projectUtils";
 
 const { formatProjectSummary } = exportForTesting;
 
@@ -62,12 +63,14 @@ const mockFields = jest.fn();
 const mockDocFields = jest.fn();
 const mockAuthFields = jest.fn();
 const mockEnvFields = jest.fn();
+const mockDocDeletion = jest.fn();
 
 jest.mock("@mds/common/components/projects/projectUtils", () => ({
     areFieldsDisabled: () => mockFields(),
     areDocumentFieldsDisabled: () => mockDocFields(),
     areAuthFieldsDisabled: () => mockAuthFields(),
     areAuthEnvFieldsDisabled: () => mockEnvFields(),
+    isDocumentDeletionEnabled: () => mockDocDeletion(),
     getProjectStatusDescription: () => jest.fn().mockReturnValue("Status Description")
 }));
 
@@ -112,6 +115,7 @@ describe("ProjectSummaryForm components disable accurately accoring to functions
         mockDocFields.mockReturnValue(docFieldsDisabled);
         mockAuthFields.mockReturnValue(authFieldsDisabled);
         mockEnvFields.mockReturnValue(envFieldsDisabled);
+        mockDocDeletion.mockReturnValue(false);
 
         return <BrowserRouter>
             <FormWrapper name={FORM.ADD_EDIT_PROJECT_SUMMARY} onSubmit={jest.fn()}>
@@ -125,7 +129,7 @@ describe("ProjectSummaryForm components disable accurately accoring to functions
                 <Agent fieldsDisabled={fieldsDisabled} />
                 <FacilityOperator fieldsDisabled={fieldsDisabled} />
                 <AuthorizationsInvolved fieldsDisabled={authFieldsDisabled} />
-                <DocumentUpload docFieldsDisabled={docFieldsDisabled} fieldsDisabled={fieldsDisabled}/>
+                <DocumentUpload docFieldsDisabled={docFieldsDisabled} deleteEnabled={false} />
                 <ApplicationSummary fieldsDisabled={fieldsDisabled} />
                 <Declaration />
             </FormWrapper>

--- a/services/common/src/components/projectSummary/ProjectSummaryFormComponents.spec.tsx
+++ b/services/common/src/components/projectSummary/ProjectSummaryFormComponents.spec.tsx
@@ -20,7 +20,6 @@ import Declaration from "./Declaration";
 import DocumentUpload from "./DocumentUpload";
 import { FacilityOperator } from "./FacilityOperator";
 import { BrowserRouter } from "react-router-dom";
-import { isDocumentDeletionEnabled } from "../projects/projectUtils";
 
 const { formatProjectSummary } = exportForTesting;
 

--- a/services/common/src/components/projectSummary/ProjectSummaryFormComponents.spec.tsx
+++ b/services/common/src/components/projectSummary/ProjectSummaryFormComponents.spec.tsx
@@ -285,12 +285,16 @@ describe("ProjectSummaryForm components disable accurately according to function
         };
 
         const openModalSpy = jest.spyOn(modalActions, "openModal");
-        const keys = MOCK.PROJECT_SUMMARY.authorizations.flatMap(auth => auth.amendment_documents.map(doc => doc.document_manager_guid));
+        const keys = [
+            ...MOCK.PROJECT_SUMMARY.authorizations.flatMap(auth => auth.amendment_documents.map(doc => doc.document_manager_guid)),
+            ...MOCK.PROJECT_SUMMARY.documents.filter(doc => doc.project_summary_document_type_code === "SPR").map(doc => doc.document_manager_guid)
+        ];
+        
         afterEach(() => {
             jest.clearAllMocks();
         });
 
-        test("Amendment document deletion enabled", async () => {
+        test("Document deletion enabled", async () => {
             const params = {
                 deletionEnabled: true
             };
@@ -313,7 +317,7 @@ describe("ProjectSummaryForm components disable accurately according to function
             expect(openModalSpy).toHaveBeenCalledTimes(keys.length)
         });
 
-        test("Amendment document deletion disabled", async () => {
+        test("Document deletion disabled", async () => {
             const params = {
                 deletionEnabled: false
             };

--- a/services/common/src/components/projectSummary/ProjectSummaryFormComponents.spec.tsx
+++ b/services/common/src/components/projectSummary/ProjectSummaryFormComponents.spec.tsx
@@ -125,7 +125,7 @@ describe("ProjectSummaryForm components disable accurately accoring to functions
                 <Agent fieldsDisabled={fieldsDisabled} />
                 <FacilityOperator fieldsDisabled={fieldsDisabled} />
                 <AuthorizationsInvolved fieldsDisabled={authFieldsDisabled} />
-                <DocumentUpload docFieldsDisabled={docFieldsDisabled} />
+                <DocumentUpload docFieldsDisabled={docFieldsDisabled} fieldsDisabled={fieldsDisabled}/>
                 <ApplicationSummary fieldsDisabled={fieldsDisabled} />
                 <Declaration />
             </FormWrapper>

--- a/services/common/src/components/projectSummary/ProjectSummaryFormComponents.spec.tsx
+++ b/services/common/src/components/projectSummary/ProjectSummaryFormComponents.spec.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render } from "@testing-library/react";
+import { render, fireEvent } from "@testing-library/react";
 import FormWrapper from "../forms/FormWrapper";
 import { FORM, SystemFlagEnum } from "@mds/common/constants";
 import { ProjectManagement } from "./ProjectManagement";
@@ -20,9 +20,9 @@ import Declaration from "./Declaration";
 import DocumentUpload from "./DocumentUpload";
 import { FacilityOperator } from "./FacilityOperator";
 import { BrowserRouter } from "react-router-dom";
+import * as modalActions from "@mds/common/redux/actions/modalActions";
 
 const { formatProjectSummary } = exportForTesting;
-
 
 const amsAuthTypes = ['AIR_EMISSIONS_DISCHARGE_PERMIT', 'EFFLUENT_DISCHARGE_PERMIT', 'REFUSE_DISCHARGE_PERMIT'];
 const project = { project_lead_party_guid: "project_lead_party_guid" };
@@ -108,7 +108,7 @@ const isEnvMatch = (id: string) => {
     return match && !isDoc;
 };
 
-describe("ProjectSummaryForm components disable accurately accoring to functions", () => {
+describe("ProjectSummaryForm components disable accurately according to functions", () => {
     const renderedComponents = ({ fieldsDisabled, authFieldsDisabled, docFieldsDisabled, envFieldsDisabled }) => {
         mockFields.mockReturnValue(fieldsDisabled);
         mockDocFields.mockReturnValue(docFieldsDisabled);
@@ -270,5 +270,69 @@ describe("ProjectSummaryForm components disable accurately accoring to functions
         const enabledAuthIds = filteredEnabledIds.filter((id) => id.startsWith("authorization") && !isDocField(id));
 
         expect(enabledAuthIds).toEqual([]);
+    });
+
+    describe("ProjectSummaryForm document deletion disables accurately according to functions", () => {
+        const renderedComponents = ({ deletionEnabled }) => {
+            mockDocDeletion.mockReturnValue(deletionEnabled);
+    
+            return <BrowserRouter>
+                <FormWrapper name={FORM.ADD_EDIT_PROJECT_SUMMARY} onSubmit={jest.fn()}>
+                    <AuthorizationsInvolved fieldsDisabled={false} /> 
+                    <DocumentUpload docFieldsDisabled={false} deleteEnabled={deletionEnabled}/>
+                </FormWrapper>
+            </BrowserRouter>
+        };
+
+        const openModalSpy = jest.spyOn(modalActions, "openModal");
+        const keys = MOCK.PROJECT_SUMMARY.authorizations.flatMap(auth => auth.amendment_documents.map(doc => doc.document_manager_guid));
+        afterEach(() => {
+            jest.clearAllMocks();
+        });
+
+        test("Amendment document deletion enabled", async () => {
+            const params = {
+                deletionEnabled: true
+            };
+    
+            const { container, findByTestId} = render(
+                <ReduxWrapper initialState={initialState}>
+                    {renderedComponents(params)}
+                </ReduxWrapper>
+            );
+
+            for (const key of keys){
+                const row = container.querySelector(`tr[data-row-key="${key}"]`)
+                expect(row).toBeInTheDocument();
+                const actionsButton = row.querySelector('button[data-cy="menu-actions-button"]')
+                fireEvent.mouseEnter(actionsButton);
+                const deleteAction = await findByTestId("action-button-delete");
+                expect(deleteAction).toBeInTheDocument();
+                fireEvent.click(deleteAction)
+            }
+            expect(openModalSpy).toHaveBeenCalledTimes(keys.length)
+        });
+
+        test("Amendment document deletion disabled", async () => {
+            const params = {
+                deletionEnabled: false
+            };
+    
+            const { container } = render(
+                <ReduxWrapper initialState={initialState}>
+                    {renderedComponents(params)}
+                </ReduxWrapper>
+            );
+
+            for (const key of keys){
+                const row = container.querySelector(`tr[data-row-key="${key}"]`)
+                expect(row).toBeInTheDocument();
+                const actionsButton = row.querySelector('button[data-cy="menu-actions-button"]')
+                fireEvent.mouseEnter(actionsButton);
+                const deleteAction = container.querySelector('[data-testid="action-button-delete"]');
+                expect(deleteAction).not.toBeInTheDocument();
+            }
+            expect(openModalSpy).toHaveBeenCalledTimes(0)
+        });
     });
 });

--- a/services/common/src/components/projects/__snapshots__/ProjectDocumentsTab.spec.tsx.snap
+++ b/services/common/src/components/projects/__snapshots__/ProjectDocumentsTab.spec.tsx.snap
@@ -49,6 +49,29 @@ exports[`ProjectDocumentsTab renders properly 1`] = `
             >
               <a
                 class="ant-anchor-link-title"
+                href="#air-emissions-discharge-permit"
+                title=""
+              >
+                <div
+                  class="side-nav-title"
+                >
+                  <div
+                    class="side-nav-title-content"
+                  >
+                    <div
+                      class="sub-tab-1"
+                    >
+                      Air Emissions Discharge Permit
+                    </div>
+                  </div>
+                </div>
+              </a>
+            </div>
+            <div
+              class="ant-anchor-link now-menu-link fade-in"
+            >
+              <a
+                class="ant-anchor-link-title"
                 href="#pd-spatial-components"
                 title=""
               >
@@ -274,6 +297,630 @@ exports[`ProjectDocumentsTab renders properly 1`] = `
               >
                 Below are the required and supporting documents for each authorization submitted in the Project Description. 
             Refer to the Project Description Purpose and Authorization sections for the complete list of required documents.
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="ant-col ant-col-24"
+          id="air-emissions-discharge-permit"
+          style="padding: 8px 8px 8px 8px;"
+        >
+          <div
+            class="ant-row"
+            id="air-emissions-discharge-permit"
+          >
+            <div
+              class="ant-col ant-col-24"
+            >
+              <h4
+                class="ant-typography"
+              >
+                Air Emissions Discharge Permit
+              </h4>
+            </div>
+            <div
+              class="ant-col ant-col-24"
+            >
+              <div>
+                <div />
+                <div
+                  style="float: right;"
+                >
+                  <button
+                    class="ant-btn ant-btn-default ant-dropdown-trigger ant-btn ant-btn-primary"
+                    disabled=""
+                    type="button"
+                  >
+                    <span>
+                      Action
+                    </span>
+                    <span
+                      aria-label="down"
+                      class="anticon anticon-down"
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class=""
+                        data-icon="down"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                        />
+                      </svg>
+                    </span>
+                  </button>
+                </div>
+                <div
+                  class="ant-table-wrapper  core-table"
+                >
+                  <div
+                    class="ant-spin-nested-loading"
+                  >
+                    <div
+                      class="ant-spin-container"
+                    >
+                      <div
+                        class="ant-table ant-table-has-fix-right"
+                      >
+                        <div
+                          class="ant-table-container"
+                        >
+                          <div
+                            class="ant-table-content"
+                          >
+                            <table
+                              style="table-layout: auto;"
+                            >
+                              <colgroup>
+                                <col
+                                  class="ant-table-selection-col"
+                                />
+                              </colgroup>
+                              <thead
+                                class="ant-table-thead"
+                              >
+                                <tr>
+                                  <th
+                                    class="ant-table-cell ant-table-selection-column"
+                                  >
+                                    <div
+                                      class="ant-table-selection"
+                                    >
+                                      <label
+                                        class="ant-checkbox-wrapper"
+                                      >
+                                        <span
+                                          class="ant-checkbox"
+                                        >
+                                          <input
+                                            aria-label="Select all"
+                                            class="ant-checkbox-input"
+                                            type="checkbox"
+                                          />
+                                          <span
+                                            class="ant-checkbox-inner"
+                                          />
+                                        </span>
+                                      </label>
+                                    </div>
+                                  </th>
+                                  <th
+                                    aria-label=""
+                                    class="ant-table-cell ant-table-column-has-sorters"
+                                    tabindex="0"
+                                  >
+                                    <div
+                                      class="ant-table-column-sorters"
+                                    >
+                                      <span
+                                        class="ant-table-column-title"
+                                      >
+                                        <span
+                                          style="margin-left: 38px;"
+                                        >
+                                          File Name
+                                        </span>
+                                      </span>
+                                      <span
+                                        class="ant-table-column-sorter ant-table-column-sorter-full"
+                                      >
+                                        <span
+                                          class="ant-table-column-sorter-inner"
+                                        >
+                                          <span
+                                            aria-label="caret-up"
+                                            class="anticon anticon-caret-up ant-table-column-sorter-up"
+                                            role="presentation"
+                                          >
+                                            <svg
+                                              aria-hidden="true"
+                                              data-icon="caret-up"
+                                              fill="currentColor"
+                                              focusable="false"
+                                              height="1em"
+                                              viewBox="0 0 1024 1024"
+                                              width="1em"
+                                            >
+                                              <path
+                                                d="M858.9 689L530.5 308.2c-9.4-10.9-27.5-10.9-37 0L165.1 689c-12.2 14.2-1.2 35 18.5 35h656.8c19.7 0 30.7-20.8 18.5-35z"
+                                              />
+                                            </svg>
+                                          </span>
+                                          <span
+                                            aria-label="caret-down"
+                                            class="anticon anticon-caret-down ant-table-column-sorter-down"
+                                            role="presentation"
+                                          >
+                                            <svg
+                                              aria-hidden="true"
+                                              data-icon="caret-down"
+                                              fill="currentColor"
+                                              focusable="false"
+                                              height="1em"
+                                              viewBox="0 0 1024 1024"
+                                              width="1em"
+                                            >
+                                              <path
+                                                d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
+                                              />
+                                            </svg>
+                                          </span>
+                                        </span>
+                                      </span>
+                                    </div>
+                                  </th>
+                                  <th
+                                    class="ant-table-cell"
+                                  >
+                                    Category
+                                  </th>
+                                  <th
+                                    aria-label="File Type"
+                                    class="ant-table-cell ant-table-column-has-sorters"
+                                    tabindex="0"
+                                  >
+                                    <div
+                                      class="ant-table-column-sorters"
+                                    >
+                                      <span
+                                        class="ant-table-column-title"
+                                      >
+                                        File Type
+                                      </span>
+                                      <span
+                                        class="ant-table-column-sorter ant-table-column-sorter-full"
+                                      >
+                                        <span
+                                          class="ant-table-column-sorter-inner"
+                                        >
+                                          <span
+                                            aria-label="caret-up"
+                                            class="anticon anticon-caret-up ant-table-column-sorter-up"
+                                            role="presentation"
+                                          >
+                                            <svg
+                                              aria-hidden="true"
+                                              data-icon="caret-up"
+                                              fill="currentColor"
+                                              focusable="false"
+                                              height="1em"
+                                              viewBox="0 0 1024 1024"
+                                              width="1em"
+                                            >
+                                              <path
+                                                d="M858.9 689L530.5 308.2c-9.4-10.9-27.5-10.9-37 0L165.1 689c-12.2 14.2-1.2 35 18.5 35h656.8c19.7 0 30.7-20.8 18.5-35z"
+                                              />
+                                            </svg>
+                                          </span>
+                                          <span
+                                            aria-label="caret-down"
+                                            class="anticon anticon-caret-down ant-table-column-sorter-down"
+                                            role="presentation"
+                                          >
+                                            <svg
+                                              aria-hidden="true"
+                                              data-icon="caret-down"
+                                              fill="currentColor"
+                                              focusable="false"
+                                              height="1em"
+                                              viewBox="0 0 1024 1024"
+                                              width="1em"
+                                            >
+                                              <path
+                                                d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
+                                              />
+                                            </svg>
+                                          </span>
+                                        </span>
+                                      </span>
+                                    </div>
+                                  </th>
+                                  <th
+                                    aria-sort="descending"
+                                    class="ant-table-cell ant-table-column-sort ant-table-column-has-sorters"
+                                    tabindex="0"
+                                  >
+                                    <div
+                                      class="ant-table-column-sorters"
+                                    >
+                                      <span
+                                        class="ant-table-column-title"
+                                      >
+                                        Last Modified
+                                      </span>
+                                      <span
+                                        class="ant-table-column-sorter ant-table-column-sorter-full"
+                                      >
+                                        <span
+                                          class="ant-table-column-sorter-inner"
+                                        >
+                                          <span
+                                            aria-label="caret-up"
+                                            class="anticon anticon-caret-up ant-table-column-sorter-up"
+                                            role="presentation"
+                                          >
+                                            <svg
+                                              aria-hidden="true"
+                                              data-icon="caret-up"
+                                              fill="currentColor"
+                                              focusable="false"
+                                              height="1em"
+                                              viewBox="0 0 1024 1024"
+                                              width="1em"
+                                            >
+                                              <path
+                                                d="M858.9 689L530.5 308.2c-9.4-10.9-27.5-10.9-37 0L165.1 689c-12.2 14.2-1.2 35 18.5 35h656.8c19.7 0 30.7-20.8 18.5-35z"
+                                              />
+                                            </svg>
+                                          </span>
+                                          <span
+                                            aria-label="caret-down"
+                                            class="anticon anticon-caret-down ant-table-column-sorter-down active"
+                                            role="presentation"
+                                          >
+                                            <svg
+                                              aria-hidden="true"
+                                              data-icon="caret-down"
+                                              fill="currentColor"
+                                              focusable="false"
+                                              height="1em"
+                                              viewBox="0 0 1024 1024"
+                                              width="1em"
+                                            >
+                                              <path
+                                                d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
+                                              />
+                                            </svg>
+                                          </span>
+                                        </span>
+                                      </span>
+                                    </div>
+                                  </th>
+                                  <th
+                                    aria-label="Created By"
+                                    class="ant-table-cell ant-table-column-has-sorters"
+                                    tabindex="0"
+                                  >
+                                    <div
+                                      class="ant-table-column-sorters"
+                                    >
+                                      <span
+                                        class="ant-table-column-title"
+                                      >
+                                        Created By
+                                      </span>
+                                      <span
+                                        class="ant-table-column-sorter ant-table-column-sorter-full"
+                                      >
+                                        <span
+                                          class="ant-table-column-sorter-inner"
+                                        >
+                                          <span
+                                            aria-label="caret-up"
+                                            class="anticon anticon-caret-up ant-table-column-sorter-up"
+                                            role="presentation"
+                                          >
+                                            <svg
+                                              aria-hidden="true"
+                                              data-icon="caret-up"
+                                              fill="currentColor"
+                                              focusable="false"
+                                              height="1em"
+                                              viewBox="0 0 1024 1024"
+                                              width="1em"
+                                            >
+                                              <path
+                                                d="M858.9 689L530.5 308.2c-9.4-10.9-27.5-10.9-37 0L165.1 689c-12.2 14.2-1.2 35 18.5 35h656.8c19.7 0 30.7-20.8 18.5-35z"
+                                              />
+                                            </svg>
+                                          </span>
+                                          <span
+                                            aria-label="caret-down"
+                                            class="anticon anticon-caret-down ant-table-column-sorter-down"
+                                            role="presentation"
+                                          >
+                                            <svg
+                                              aria-hidden="true"
+                                              data-icon="caret-down"
+                                              fill="currentColor"
+                                              focusable="false"
+                                              height="1em"
+                                              viewBox="0 0 1024 1024"
+                                              width="1em"
+                                            >
+                                              <path
+                                                d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
+                                              />
+                                            </svg>
+                                          </span>
+                                        </span>
+                                      </span>
+                                    </div>
+                                  </th>
+                                  <th
+                                    class="ant-table-cell actions-column ant-table-cell-fix-right ant-table-cell-fix-right-first"
+                                    style="position: sticky; right: 0px;"
+                                  />
+                                </tr>
+                              </thead>
+                              <tbody
+                                class="ant-table-tbody"
+                              >
+                                <tr
+                                  class="ant-table-row ant-table-row-level-0 table-row-align-middle no-sub-table-expandable-rows fade-in"
+                                  data-row-key="5066b2b5-6f92-4a4b-9771-22f8a13e3297"
+                                >
+                                  <td
+                                    class="ant-table-cell ant-table-selection-column"
+                                  >
+                                    <label
+                                      class="ant-checkbox-wrapper"
+                                    >
+                                      <span
+                                        class="ant-checkbox"
+                                      >
+                                        <input
+                                          class="ant-checkbox-input"
+                                          type="checkbox"
+                                        />
+                                        <span
+                                          class="ant-checkbox-inner"
+                                        />
+                                      </span>
+                                    </label>
+                                  </td>
+                                  <td
+                                    class="ant-table-cell ant-table-cell-with-append"
+                                  >
+                                    <span
+                                      class="ant-table-row-indent indent-level-0"
+                                      style="padding-left: 0px;"
+                                    />
+                                    <div
+                                      class="inline-flex flex-between file-name-container"
+                                      style="margin-left: 38px;"
+                                      title="File Name"
+                                    >
+                                      <a>
+                                        Location Document.png
+                                      </a>
+                                      <span
+                                        class="file-history-container"
+                                      />
+                                    </div>
+                                  </td>
+                                  <td
+                                    class="ant-table-cell"
+                                  >
+                                    <div
+                                      class="category-column"
+                                      title="Category"
+                                    >
+                                      N/A
+                                    </div>
+                                  </td>
+                                  <td
+                                    class="ant-table-cell"
+                                  >
+                                    <div
+                                      class="file_type-column"
+                                      title="File Type"
+                                    >
+                                      .png
+                                    </div>
+                                  </td>
+                                  <td
+                                    class="ant-table-cell ant-table-column-sort"
+                                  >
+                                    <div
+                                      title="Last Modified"
+                                    >
+                                      Dec 12 2024
+                                    </div>
+                                  </td>
+                                  <td
+                                    class="ant-table-cell"
+                                  >
+                                    <div
+                                      class="create_user-column"
+                                      title="Created By"
+                                    >
+                                      idir\\username
+                                    </div>
+                                  </td>
+                                  <td
+                                    class="ant-table-cell actions-column ant-table-cell-fix-right ant-table-cell-fix-right-first"
+                                    style="position: sticky; right: 0px;"
+                                  >
+                                    <div>
+                                      <button
+                                        class="ant-btn ant-btn-text ant-dropdown-trigger actions-dropdown-button"
+                                        data-cy="menu-actions-button"
+                                        type="button"
+                                      >
+                                        <span>
+                                          Actions
+                                        </span>
+                                        <span
+                                          alt="Menu"
+                                          aria-label="caret-down"
+                                          class="anticon anticon-caret-down"
+                                          role="img"
+                                        >
+                                          <svg
+                                            aria-hidden="true"
+                                            class=""
+                                            data-icon="caret-down"
+                                            fill="currentColor"
+                                            focusable="false"
+                                            height="1em"
+                                            viewBox="0 0 1024 1024"
+                                            width="1em"
+                                          >
+                                            <path
+                                              d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
+                                            />
+                                          </svg>
+                                        </span>
+                                      </button>
+                                    </div>
+                                  </td>
+                                </tr>
+                                <tr
+                                  class="ant-table-row ant-table-row-level-0 table-row-align-middle no-sub-table-expandable-rows fade-in"
+                                  data-row-key="1de57298-0583-46f6-8f3d-29044bd6aeb3"
+                                >
+                                  <td
+                                    class="ant-table-cell ant-table-selection-column"
+                                  >
+                                    <label
+                                      class="ant-checkbox-wrapper"
+                                    >
+                                      <span
+                                        class="ant-checkbox"
+                                      >
+                                        <input
+                                          class="ant-checkbox-input"
+                                          type="checkbox"
+                                        />
+                                        <span
+                                          class="ant-checkbox-inner"
+                                        />
+                                      </span>
+                                    </label>
+                                  </td>
+                                  <td
+                                    class="ant-table-cell ant-table-cell-with-append"
+                                  >
+                                    <span
+                                      class="ant-table-row-indent indent-level-0"
+                                      style="padding-left: 0px;"
+                                    />
+                                    <div
+                                      class="inline-flex flex-between file-name-container"
+                                      style="margin-left: 38px;"
+                                      title="File Name"
+                                    >
+                                      <a>
+                                        Discharge Document.pdf
+                                      </a>
+                                      <span
+                                        class="file-history-container"
+                                      />
+                                    </div>
+                                  </td>
+                                  <td
+                                    class="ant-table-cell"
+                                  >
+                                    <div
+                                      class="category-column"
+                                      title="Category"
+                                    >
+                                      N/A
+                                    </div>
+                                  </td>
+                                  <td
+                                    class="ant-table-cell"
+                                  >
+                                    <div
+                                      class="file_type-column"
+                                      title="File Type"
+                                    >
+                                      .pdf
+                                    </div>
+                                  </td>
+                                  <td
+                                    class="ant-table-cell ant-table-column-sort"
+                                  >
+                                    <div
+                                      title="Last Modified"
+                                    >
+                                      Dec 12 2024
+                                    </div>
+                                  </td>
+                                  <td
+                                    class="ant-table-cell"
+                                  >
+                                    <div
+                                      class="create_user-column"
+                                      title="Created By"
+                                    >
+                                      idir\\username
+                                    </div>
+                                  </td>
+                                  <td
+                                    class="ant-table-cell actions-column ant-table-cell-fix-right ant-table-cell-fix-right-first"
+                                    style="position: sticky; right: 0px;"
+                                  >
+                                    <div>
+                                      <button
+                                        class="ant-btn ant-btn-text ant-dropdown-trigger actions-dropdown-button"
+                                        data-cy="menu-actions-button"
+                                        type="button"
+                                      >
+                                        <span>
+                                          Actions
+                                        </span>
+                                        <span
+                                          alt="Menu"
+                                          aria-label="caret-down"
+                                          class="anticon anticon-caret-down"
+                                          role="img"
+                                        >
+                                          <svg
+                                            aria-hidden="true"
+                                            class=""
+                                            data-icon="caret-down"
+                                            fill="currentColor"
+                                            focusable="false"
+                                            height="1em"
+                                            viewBox="0 0 1024 1024"
+                                            width="1em"
+                                          >
+                                            <path
+                                              d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
+                                            />
+                                          </svg>
+                                        </span>
+                                      </button>
+                                    </div>
+                                  </td>
+                                </tr>
+                              </tbody>
+                            </table>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
               </div>
             </div>
           </div>

--- a/services/common/src/components/projects/projectUtils.ts
+++ b/services/common/src/components/projects/projectUtils.ts
@@ -38,6 +38,10 @@ export const areAuthEnvFieldsDisabled = memoize((systemFlag: SystemFlagEnum, pro
     return envDisabled;
 }, (systemFlag: SystemFlagEnum, projectSummaryStatusCode: string) => `${systemFlag}_${projectSummaryStatusCode}`);
 
+export const isDocumentDeletionEnabled = memoize((systemFlag: SystemFlagEnum, projectSummaryStatusCode: string) => {
+    return systemFlag === SystemFlagEnum.ms && projectSummaryStatusCode == PROJECT_STATUS_CODES.DFT;
+}, (systemFlag: SystemFlagEnum, projectSummaryStatusCode: string) => `${systemFlag}_${projectSummaryStatusCode}`);
+
 export const areDocumentFieldsDisabled = memoize((systemFlag: SystemFlagEnum, projectSummaryStatusCode: string) => {
     // Return false (enabled) if status = "" => "Not Started"
     const isStatusInEnum = (<any>Object).values(PROJECT_STATUS_CODES).includes(projectSummaryStatusCode)

--- a/services/common/src/redux/actionCreators/projectActionCreator.ts
+++ b/services/common/src/redux/actionCreators/projectActionCreator.ts
@@ -167,7 +167,7 @@ export const removeDocumentFromProjectSummary = (
     )
     .then((response: AxiosResponse<string>) => {
       notification.success({
-        message: "Successfully deleted project description document.",
+        message: "Successfully deleted project document.",
         duration: 10,
       });
       dispatch(success(NetworkReducerTypes.REMOVE_DOCUMENT_FROM_PROJECT_SUMMARY));

--- a/services/common/src/tests/mocks/dataMocks.tsx
+++ b/services/common/src/tests/mocks/dataMocks.tsx
@@ -7716,12 +7716,82 @@ export const PROJECT_SUMMARY: IProjectSummary = {
       new_type: "PER",
       authorization_description: "sdfa",
       exemption_reason: "zxczxczx",
-      amendment_documents: [],
       exemption_requested: false,
       ams_tracking_number: null,
       ams_outcome: null,
       ams_status_code: null,
       ams_submission_timestamp: "2024-05-24T19:10:09.825194+00:00",
+      amendment_documents: [
+        {
+          project_summary_id: null,
+          project_summary_document_type_code: "MAP",
+          mine_document_guid: "1bf1884f-84b0-44a1-ba76-2c8aa2403480",
+          mine_guid: "83a8045c-37be-4ec4-8888-f633af902472",
+          document_manager_guid: "5066b2b5-6f92-4a4b-9771-22f8a13e3297",
+          document_name: "Location Document.png",
+          upload_date: "2024-12-12 22:00:35.119953+00:00",
+          update_timestamp: "2024-12-12 22:00:35.119943+00:00",
+          create_user: "idir\\username",
+          is_archived: false,
+          archived_date: null,
+          archived_by: null,
+          mine_document_bundle_id: null,
+          versions: []
+        },
+        {
+          project_summary_id: null,
+          project_summary_document_type_code: "DFA",
+          mine_document_guid: "c00f29ce-4507-4f5b-b822-8c6a4c7af676",
+          mine_guid: "83a8045c-37be-4ec4-8888-f633af902472",
+          document_manager_guid: "1de57298-0583-46f6-8f3d-29044bd6aeb3",
+          document_name: "Discharge Document.pdf",
+          upload_date: "2024-12-12 22:00:35.119968+00:00",
+          update_timestamp: "2024-12-12 22:00:35.119968+00:00",
+          create_user: "idir\\username",
+          is_archived: false,
+          archived_date: null,
+          archived_by: null,
+          mine_document_bundle_id: null,
+          versions: []
+        }
+      ],
+      discharge_documents: [
+        {
+          project_summary_id: null,
+          project_summary_document_type_code: "DFA",
+          mine_document_guid: "c00f29ce-4507-4f5b-b822-8c6a4c7af676",
+          mine_guid: "83a8045c-37be-4ec4-8888-f633af902472",
+          document_manager_guid: "1de57298-0583-46f6-8f3d-29044bd6aeb3",
+          document_name: "Discharge Document.pdf",
+          upload_date: "2024-12-12 22:00:35.119968+00:00",
+          update_timestamp: "2024-12-12 22:00:35.119968+00:00",
+          create_user: "idir\\username",
+          is_archived: false,
+          archived_date: null,
+          archived_by: null,
+          mine_document_bundle_id: null,
+          versions: []
+        }
+      ],
+      location_documents: [
+        {
+          project_summary_id: null,
+          project_summary_document_type_code: "MAP",
+          mine_document_guid: "1bf1884f-84b0-44a1-ba76-2c8aa2403480",
+          mine_guid: "83a8045c-37be-4ec4-8888-f633af902472",
+          document_manager_guid: "5066b2b5-6f92-4a4b-9771-22f8a13e3297",
+          document_name: "Location Document.png",
+          upload_date: "2024-12-12 22:00:35.119953+00:00",
+          update_timestamp: "2024-12-12 22:00:35.119943+00:00",
+          create_user: "idir\\username",
+          is_archived: false,
+          archived_date: null,
+          archived_by: null,
+          mine_document_bundle_id: null,
+          versions: []
+        }
+      ],
+      support_documents: []
     },
     {
       project_summary_authorization_guid: "624d3acc-b62b-491e-82a3-67ef3b1bbf88",
@@ -7858,6 +7928,9 @@ export const PROJECT: IProject = {
     major_mine_application_guid: "305ea694-e601-44a4-8994-fc2604c8c19e",
     project_guid: "35633148-57f8-4967-be35-7f89abfbd02e",
     status_code: MAJOR_MINE_APPLICATION_AND_IRT_STATUS_CODE_CODES.CHR,
+    primary_documents: [],
+    spatial_documents: [],
+    supporting_documents: [],
     documents: [
       {
         major_mine_application_id: 2,

--- a/services/core-api/app/api/projects/project_summary/resources/project_summary_uploaded_document.py
+++ b/services/core-api/app/api/projects/project_summary/resources/project_summary_uploaded_document.py
@@ -1,8 +1,8 @@
-from werkzeug.exceptions import NotFound
+from werkzeug.exceptions import NotFound, Forbidden
 from flask_restx import Resource
 from app.extensions import api
 
-from app.api.utils.access_decorators import (requires_any_of, MINE_ADMIN, EDIT_PROJECT_SUMMARIES)
+from app.api.utils.access_decorators import (requires_any_of, MINE_ADMIN, EDIT_PROJECT_SUMMARIES,MINESPACE_PROPONENT)
 from app.api.utils.resources_mixins import UserMixin
 
 from app.api.mines.documents.models.mine_document import MineDocument
@@ -12,7 +12,7 @@ from app.api.projects.project_summary.models.project_summary import ProjectSumma
 class ProjectSummaryUploadedDocumentResource(Resource, UserMixin):
     @api.doc(description='Delete a document from a project description.')
     @api.response(204, 'Successfully deleted.')
-    @requires_any_of([MINE_ADMIN, EDIT_PROJECT_SUMMARIES])
+    @requires_any_of([MINE_ADMIN, EDIT_PROJECT_SUMMARIES, MINESPACE_PROPONENT])
     def delete(self, project_guid, project_summary_guid, mine_document_guid):
         project_summary = ProjectSummary.find_by_project_summary_guid(project_summary_guid)
         mine_document = MineDocument.find_by_mine_document_guid(mine_document_guid)
@@ -21,10 +21,20 @@ class ProjectSummaryUploadedDocumentResource(Resource, UserMixin):
             raise NotFound('Project Description not found.')
         if mine_document is None:
             raise NotFound('Mine document not found.')
+                    
         if mine_document not in project_summary.mine_documents:
+
+            for auth in project_summary.authorizations:
+                for doc in auth.amendment_documents:
+                    if doc.mine_document == mine_document:
+                        if project_summary.status_code != "DFT":
+                            raise Forbidden('Cannot delete document unless project is in a draft state')
+                        doc.delete()
+                        mine_document.delete()
+                        return None, 204
+
             raise NotFound('Mine document not found on Project Description.')
 
         project_summary.mine_documents.remove(mine_document)
         project_summary.save()
-
         return None, 204

--- a/services/core-api/app/api/projects/project_summary/resources/project_summary_uploaded_document.py
+++ b/services/core-api/app/api/projects/project_summary/resources/project_summary_uploaded_document.py
@@ -28,7 +28,7 @@ class ProjectSummaryUploadedDocumentResource(Resource, UserMixin):
                 for doc in auth.amendment_documents:
                     if doc.mine_document == mine_document:
                         if project_summary.status_code != "DFT":
-                            raise Forbidden('Cannot delete document unless project is in a draft state')
+                            raise Forbidden('Cannot delete document unless project is in draft state')
                         doc.delete()
                         mine_document.delete()
                         return None, 204

--- a/services/core-api/app/api/projects/project_summary/resources/project_summary_uploaded_document.py
+++ b/services/core-api/app/api/projects/project_summary/resources/project_summary_uploaded_document.py
@@ -28,7 +28,7 @@ class ProjectSummaryUploadedDocumentResource(Resource, UserMixin):
                 for doc in auth.amendment_documents:
                     if doc.mine_document == mine_document:
                         if project_summary.status_code != "DFT":
-                            raise Forbidden('Cannot delete document unless project is in draft state')
+                            raise Forbidden('Cannot delete document unless project application is in draft state')
                         doc.delete()
                         mine_document.delete()
                         return None, 204

--- a/services/core-api/tests/factories.py
+++ b/services/core-api/tests/factories.py
@@ -59,6 +59,7 @@ from app.api.projects.project_summary.models.project_summary import ProjectSumma
 from app.api.projects.project_summary.models.project_summary_contact import ProjectSummaryContact
 from app.api.projects.project_summary.models.project_summary_authorization import ProjectSummaryAuthorization
 from app.api.projects.project_summary.models.project_summary_document_xref import ProjectSummaryDocumentXref
+from app.api.projects.project_summary.models.project_summary_authorization_document_xref import ProjectSummaryAuthorizationDocumentXref
 from app.api.projects.information_requirements_table.models.information_requirements_table import InformationRequirementsTable
 from app.api.projects.information_requirements_table.models.information_requirements_table_document_xref import InformationRequirementsTableDocumentXref
 from app.api.projects.project_decision_package.models.project_decision_package_document_xref import ProjectDecisionPackageDocumentXref
@@ -380,6 +381,20 @@ class ProjectSummaryDocumentFactory(BaseFactory):
     project_summary_id = factory.SelfAttribute('project_summary.project_summary_id')
     project_summary_document_type_code = factory.LazyFunction(RandomProjectSummaryDocumentTypeCode)
 
+class ProjectSummaryAuthorizationDocumentFactory(BaseFactory):
+
+    class Meta:
+        model = ProjectSummaryAuthorizationDocumentXref
+
+    class Params:
+        project_summary = factory.SubFactory('tests.factories.ProjectSummaryFactory')
+        project_summary_authorization = factory.SubFactory('tests.factories.ProjectSummaryAuthorizationFactory')
+        mine_document = factory.SubFactory(MineDocumentFactory,mine_guid=factory.SelfAttribute('..project_summary.mine_guid'))
+
+    project_summary_authorization_document_xref_guid = GUID
+    project_summary_authorization_guid = factory.SelfAttribute('project_summary_authorization.project_summary_authorization_guid')
+    mine_document_guid = factory.SelfAttribute('mine_document.mine_document_guid')
+    project_summary_document_type_code = factory.LazyFunction(RandomProjectSummaryDocumentTypeCode)
 
 class InformationRequirementsTableDocumentFactory(BaseFactory):
 
@@ -1412,7 +1427,6 @@ class ProjectSummaryAuthorizationFactory(BaseFactory):
     project_summary_authorization_type = 'MINES_ACT_PERMIT'
     existing_permits_authorizations = []
     deleted_ind = False
-
 
 class EMLIContactTypeFactory(BaseFactory):
 

--- a/services/core-api/tests/projects/project_summaries/resources/test_project_summary_uploaded_document_resource.py
+++ b/services/core-api/tests/projects/project_summaries/resources/test_project_summary_uploaded_document_resource.py
@@ -3,7 +3,7 @@ import json
 import uuid
 
 from tests.factories import (ProjectSummaryFactory, MineFactory, MineDocumentFactory,
-                             ProjectSummaryDocumentFactory)
+                             ProjectSummaryAuthorizationDocumentFactory,ProjectSummaryAuthorizationFactory)
 
 
 # DELETE
@@ -19,6 +19,38 @@ def test_delete_file(test_client, db_session, auth_headers):
     assert delete_resp.status_code == 204
     assert len(project_summary.documents) == document_count - 1
 
+def test_delete_amendment_file(test_client, db_session, auth_headers):
+    project_summary = ProjectSummaryFactory()
+    project_summary.status_code = 'DFT'
+    project_summary_authorization = ProjectSummaryAuthorizationFactory(project_summary=project_summary)
+    project_summary.authorizations.append(project_summary_authorization)
+    amendment_document = ProjectSummaryAuthorizationDocumentFactory(project_summary=project_summary,project_summary_authorization=project_summary_authorization)
+
+    document_count = len(project_summary_authorization.amendment_documents)
+    assert amendment_document.mine_document_guid is not None
+
+    delete_resp = test_client.delete(
+        f'/projects/{project_summary.project_guid}/project-summaries/{project_summary.project_summary_guid}/documents/{amendment_document.mine_document_guid}',
+        headers=auth_headers['full_auth_header'])
+    assert delete_resp.status_code == 204
+    assert len(project_summary_authorization.amendment_documents) == document_count - 1
+
+
+def test_delete_amendment_not_in_draft(test_client, db_session, auth_headers):
+    project_summary = ProjectSummaryFactory()
+    project_summary.status_code = 'APR'
+    project_summary_authorization = ProjectSummaryAuthorizationFactory(project_summary=project_summary)
+    project_summary.authorizations.append(project_summary_authorization)
+    amendment_document = ProjectSummaryAuthorizationDocumentFactory(project_summary=project_summary,project_summary_authorization=project_summary_authorization)
+
+    document_count = len(project_summary_authorization.amendment_documents)
+    assert amendment_document.mine_document_guid is not None
+
+    delete_resp = test_client.delete(
+        f'/projects/{project_summary.project_guid}/project-summaries/{project_summary.project_summary_guid}/documents/{amendment_document.mine_document_guid}',
+        headers=auth_headers['full_auth_header'])
+    assert delete_resp.status_code == 403
+    assert len(project_summary_authorization.amendment_documents) == document_count
 
 def test_delete_file_not_on_project_summary(test_client, db_session, auth_headers):
     project_summary = ProjectSummaryFactory()

--- a/services/minespace-web/src/styles/components/SteppedForm.scss
+++ b/services/minespace-web/src/styles/components/SteppedForm.scss
@@ -30,10 +30,6 @@
   line-height: 25px;
 }
 
-.ant-dropdown-menu-item:hover, .ant-dropdown-menu-item button:hover{
-  cursor: pointer;
-}
-
 .stepped-menu-item:hover {
   background-color: $gov-blue !important;
   color: $white !important;

--- a/services/minespace-web/src/styles/components/SteppedForm.scss
+++ b/services/minespace-web/src/styles/components/SteppedForm.scss
@@ -30,6 +30,10 @@
   line-height: 25px;
 }
 
+.ant-dropdown-menu-item:hover, .ant-dropdown-menu-item button:hover{
+  cursor: pointer;
+}
+
 .stepped-menu-item:hover {
   background-color: $gov-blue !important;
   color: $white !important;

--- a/services/minespace-web/src/styles/components/Tables.scss
+++ b/services/minespace-web/src/styles/components/Tables.scss
@@ -33,6 +33,10 @@
   font-size: 16px;
 }
 
+.ant-dropdown-menu-item:hover, .ant-dropdown-menu-item button:hover{
+  cursor: pointer;
+}
+
 @include screen-md {
   .ant-table table {
     min-width: 100%;


### PR DESCRIPTION
## Objective 

Allow users when the application is still in draft status to delete documents on both the 'Purpose and Authorization' and 'Document Upload' tabs of the project application process in both CORE & Minespace.

[MDS-6273](https://bcmines.atlassian.net/browse/MDS-6273)

![image](https://github.com/user-attachments/assets/f0982293-4c30-42a3-bdec-57f5fa81d9ee)


- Added onDeleteDocument methods to both the AuthorizationsInvolved and DocumentUpload components.
- When project is not in a draft status or edit mode then the delete option is not shown.
- When a document is deleted a friendly message is shown, and the document is removed from the document table.
- Updated the project summary delete document endpoint and tests to support amended documents
- Minor change to project uploader to update existing files on file removal to fix the replace functionality.
- Minor change to DocumentTable to remove mutating code.
- Minor scss fix