### PR TITLE
[MDS-6260] Added missing debug flag for permit service log writing

### DIFF
--- a/services/permits/app/permit_conditions/pipelines/CachedAzureOpenAIChatGenerator.py
+++ b/services/permits/app/permit_conditions/pipelines/CachedAzureOpenAIChatGenerator.py
@@ -199,11 +199,12 @@ class CachedAzureOpenAIChatGenerator(AzureOpenAIChatGenerator):
         if reply is None:
             return None
 
-        with open(
-            f"debug/cached_azure_openai_chat_generator_output_{iteration}.txt",
-            "w",
-        ) as f:
-            f.write(reply.content)
+        if DEBUG_MODE:
+            with open(
+                f"debug/cached_azure_openai_chat_generator_output_{iteration}.txt",
+                "w",
+            ) as f:
+                f.write(reply.content)
 
         content = reply.content
         completion_tokens = reply.meta["usage"]["completion_tokens"]


### PR DESCRIPTION
## Objective 

[MDS-6260](https://bcmines.atlassian.net/browse/MDS-6260)

Missed a `DEBUG_MODE` flag for one of the debug outputs in the extraction process, which causes an error when run in test