### PR TITLE
[FIX] Fix reports resource test flakiness

### DIFF
--- a/services/core-api/tests/reports/resource/test_reports_resource.py
+++ b/services/core-api/tests/reports/resource/test_reports_resource.py
@@ -2,7 +2,6 @@ import json
 import uuid
 from datetime import datetime, timedelta
 
-import pytest
 from tests.factories import MineFactory
 
 THREE_REPORTS = 3

--- a/services/core-api/tests/reports/resource/test_reports_resource.py
+++ b/services/core-api/tests/reports/resource/test_reports_resource.py
@@ -2,6 +2,7 @@ import json
 import uuid
 from datetime import datetime, timedelta
 
+import pytest
 from tests.factories import MineFactory
 
 THREE_REPORTS = 3
@@ -9,7 +10,6 @@ ONE_REPORT = 1
 GUID = str(uuid.uuid4)
 
 
-# GET
 def test_get_reports(test_client, db_session, auth_headers):
     mine = MineFactory(mine_reports=THREE_REPORTS)
     get_resp = test_client.get(
@@ -51,11 +51,12 @@ def test_get_reports(test_client, db_session, auth_headers):
     assert all(report['report_name'] == specific_report_name for report in get_data['records'])
 
     # Test filter by received date range
-    start_date = mine.mine_reports[0].received_date - timedelta(days=1)
-    end_date = mine.mine_reports[0].received_date + timedelta(days=1)
+    start_date = datetime.combine(mine.mine_reports[0].received_date, datetime.min.time()) - timedelta(days=1)
+    end_date = datetime.combine(mine.mine_reports[0].received_date, datetime.min.time()) + timedelta(days=1)
+
 
     get_resp = test_client.get(
-        f'/mines/reports?mine_reports_type=CRR&due_date_after={start_date.strftime("%Y-%m-%d")}&due_date_before={end_date.strftime("%Y-%m-%d")}',
+        f'/mines/reports?mine_reports_type=CRR&received_date_after={start_date.strftime("%Y-%m-%d")}&received_date_before={end_date.strftime("%Y-%m-%d")}',
         headers=auth_headers['full_auth_header']
     )
     get_data = json.loads(get_resp.data.decode())
@@ -64,5 +65,5 @@ def test_get_reports(test_client, db_session, auth_headers):
     for report in get_data['records']:
         received_date = datetime.strptime(report['received_date'], '%Y-%m-%d')
 
-        assert (start_date.date() <= received_date.date())
-        assert (received_date.date() <= end_date.date())
+        assert (start_date <= received_date)
+        assert (received_date <= end_date)


### PR DESCRIPTION
## Objective 

[MDS-FIX](https://bcmines.atlassian.net/browse/MDS-FIX)

Fixes flakiness in the test_get_reports test. Cause: we do the comparison that filtering worked using received_date, but performed the actual filtering on `due_date`. Also made sure we're always comparing datetimes

Before:
![image](https://github.com/user-attachments/assets/9b22bf5c-3eb0-45c2-b8cd-5c59c412d5b3)


After:

![image](https://github.com/user-attachments/assets/ac6c69a0-5209-4f26-aae8-61ee4fabe115)
