### PR TITLE
[FIX] Fix flaky permit condition requirement test

### DIFF
--- a/services/core-api/tests/permits/permit_extraction/test_create_permit_conditions_from_task.py
+++ b/services/core-api/tests/permits/permit_extraction/test_create_permit_conditions_from_task.py
@@ -20,12 +20,13 @@ def permit_amendment(test_client, db_session):
     mine, permit = create_mine_and_permit()
     permit_amendment = permit.permit_amendments[0]
     PermitConditions.query.delete()
+    db_session.flush()
 
     yield permit_amendment
 
 
 @pytest.fixture(scope="function")
-def permit_conditions(permit_amendment):
+def permit_conditions(permit_amendment, db_session):
     task = PermitExtractionTask(
         task_result={
             "conditions": [
@@ -128,15 +129,16 @@ def permit_conditions(permit_amendment):
     create_permit_conditions_from_task(task)
 
     # Retrieve the created permit conditions from the database
-    permit_conditions = PermitConditions.query.all()
+    permit_conditions = PermitConditions.find_by_permit_amendment_id_ordered(permit_amendment.permit_amendment_id)
 
     return permit_conditions
 
 
 def test_create_permit_conditions_from_task(
     permit_conditions, permit_amendment, db_session
-):
+): 
 
+    assert len(permit_conditions) == 7
     ### General Section
     gen_cat = permit_conditions[0]
 

--- a/services/core-api/tests/reports/resource/test_reports_resource.py
+++ b/services/core-api/tests/reports/resource/test_reports_resource.py
@@ -2,7 +2,6 @@ import json
 import uuid
 from datetime import datetime, timedelta
 
-import pytest
 from tests.factories import MineFactory
 
 THREE_REPORTS = 3

--- a/services/core-api/tests/reports/resource/test_reports_resource.py
+++ b/services/core-api/tests/reports/resource/test_reports_resource.py
@@ -2,6 +2,7 @@ import json
 import uuid
 from datetime import datetime, timedelta
 
+import pytest
 from tests.factories import MineFactory
 
 THREE_REPORTS = 3


### PR DESCRIPTION
## Objective 

[FIX](https://bcmines.atlassian.net/browse/FIX)

In a previous PR, the display_order of newly created permit condition was changed from being global for a permit amendment, to re-start from 1 for each new parent condition (to match NoW permits). Meaning `PermitConditions.query.all()` no longer can guarantee correct ordering (other than by chance or in certain situations). Added a method to return conditions in the correct order and used that instead.  