### PR TITLE
[MDS-6207] Show PDF of permit amendment on Permit Conditions page + auto-focus on click

### DIFF
--- a/services/common/src/components/projects/__snapshots__/ProjectDocumentsTab.spec.tsx.snap
+++ b/services/common/src/components/projects/__snapshots__/ProjectDocumentsTab.spec.tsx.snap
@@ -328,7 +328,7 @@ exports[`ProjectDocumentsTab renders properly 1`] = `
                   style="float: right;"
                 >
                   <button
-                    class="ant-btn ant-btn-default ant-dropdown-trigger ant-btn ant-btn-primary"
+                    class="ant-btn ant-btn-primary ant-dropdown-trigger actions-dropdown-button"
                     disabled=""
                     type="button"
                   >

--- a/services/common/src/components/syncfusion/DocumentViewer.tsx
+++ b/services/common/src/components/syncfusion/DocumentViewer.tsx
@@ -51,6 +51,13 @@ const getAjaxRequestSettingsHeaders = (obj) => {
   return ajaxRequestSettingsHeaders;
 };
 
+function getAjaxRequestSettings() {
+  return {
+    ajaxHeaders: getAjaxRequestSettingsHeaders(createRequestHeader().headers),
+    withCredentials: false,
+  };
+}
+
 export const OPENABLE_DOCUMENT_TYPES = ["PDF"];
 
 export const isDocumentOpenable = (documentName) =>
@@ -85,22 +92,46 @@ interface ViewPDFProps {
   pdfViewerServiceUrl: string;
   documentPath: string;
   ajaxRequestSettings: any;
+  id?: string;
+  onInit?: (pdfViewer: any) => void;
+}
+interface PDFViewerProps {
+  documentPath: string;
+  id?: string;
+  onInit?: (pdfViewer: any) => void;
 }
 
-const ViewPdf: React.FC<ViewPDFProps> = ({
+export const PdfViewer: React.FC<PDFViewerProps> = (props: PDFViewerProps) => {
+  const ajaxSettings = getAjaxRequestSettings();
+
+  return <ViewPdf id={props.id} onInit={props.onInit} pdfViewerServiceUrl={ENVIRONMENT.pdfViewerServiceUrl} documentPath={props.documentPath} ajaxRequestSettings={ajaxSettings} />;
+};
+
+export const ViewPdf: React.FC<ViewPDFProps> = ({
   pdfViewerServiceUrl,
   documentPath,
   ajaxRequestSettings,
+  id = "pdfviewer-container",
+  onInit = null
 }) => {
+  let pdfViewer;
   return (
     <PdfViewerComponent
-      id="pdfviewer-container"
+      id={id || "pdfviewer-container"}
       serviceUrl={pdfViewerServiceUrl}
       documentPath={documentPath}
       ajaxRequestSettings={ajaxRequestSettings}
       style={{ display: "block", height: "80vh" }}
-      enableAnnotation={false}
+      enableAnnotation={true}
       enableFormDesigner={false}
+      polygonSettings={{ fillColor: 'yellow', opacity: 0.6, strokeColor: 'orange' }}
+      ref={(scope) => {
+        pdfViewer = scope;
+
+        if (onInit) {
+          onInit(pdfViewer);
+        }
+      }}
     >
       <Inject
         services={[
@@ -140,10 +171,7 @@ export const DocumentViewer: React.FC<DocumentViewerProps> = ({
   const handleOk = () => closeDocumentViewer();
   const handleCancel = () => closeDocumentViewer();
 
-  const ajaxRequestSettings = {
-    ajaxHeaders: getAjaxRequestSettingsHeaders(createRequestHeader().headers),
-    withCredentials: false,
-  };
+  const ajaxRequestSettings = getAjaxRequestSettings();
 
   useEffect(() => {
     if (isDocumentViewerOpen) {

--- a/services/common/src/components/syncfusion/DocumentViewer.tsx
+++ b/services/common/src/components/syncfusion/DocumentViewer.tsx
@@ -117,7 +117,7 @@ export const ViewPdf: React.FC<ViewPDFProps> = ({
   let pdfViewer;
   return (
     <PdfViewerComponent
-      id={id || "pdfviewer-container"}
+      id={id}
       serviceUrl={pdfViewerServiceUrl}
       documentPath={documentPath}
       ajaxRequestSettings={ajaxRequestSettings}

--- a/services/common/src/constants/environment.ts
+++ b/services/common/src/constants/environment.ts
@@ -7,6 +7,7 @@ export const DEFAULT_ENVIRONMENT = {
   matomoUrl: "https://matomo-4c2ba9-test.apps.silver.devops.gov.bc.ca/",
   environment: "development",
   filesystemProviderUrl: "http://localhost:62870/file-api/AmazonS3Provider/",
+  pdfViewerServiceUrl: "http://localhost:62870/file-api/PdfViewer",
   keycloak_resource: "mines-digital-services-mds-public-client-4414",
   keycloak_clientId: "mines-digital-services-mds-public-client-4414",
   keycloak_idpHint: "test",
@@ -22,6 +23,7 @@ export const ENVIRONMENT = {
   docManUrl: "<DOCUMENT_MANAGER_URL>",
   matomoUrl: "<MATOMO_URL>",
   filesystemProviderUrl: "<FILESYSTEM_PROVIDER_URL>",
+  pdfViewerServiceUrl: "<PDF_VIEWER_SERVICE_URL>",
   environment: "<ENV>",
   flagsmithKey: "<FLAGSMITH_KEY>",
   flagsmithUrl: "<FLAGSMITH_URL>",
@@ -29,6 +31,7 @@ export const ENVIRONMENT = {
   _loaded: false,
   geoMarkUrl: "<GEOMARK_URL_BASE>",
 };
+
 
 export const KEYCLOAK = {
   realm: "standard",
@@ -95,6 +98,12 @@ export function setupEnvironment(
   ENVIRONMENT.apiUrl = apiUrl;
   ENVIRONMENT.docManUrl = docManUrl;
   ENVIRONMENT.filesystemProviderUrl = filesystemProviderUrl;
+
+  ENVIRONMENT.pdfViewerServiceUrl = ENVIRONMENT.filesystemProviderUrl.replace(
+    "AmazonS3Provider/",
+    "PdfViewer"
+  );
+
   ENVIRONMENT.matomoUrl = matomoUrl;
   ENVIRONMENT.environment = environment || "development";
   ENVIRONMENT.flagsmithKey = flagsmithKey;

--- a/services/common/src/interfaces/permits/permitCondition.interface.ts
+++ b/services/common/src/interfaces/permits/permitCondition.interface.ts
@@ -15,7 +15,7 @@ export interface IBoundingBox {
 }
 export interface IPermitConditionMeta {
   page: number;
-  role: string;
+  role?: string;
   bounding_box?: IBoundingBox;
 }
 export interface IPermitCondition {

--- a/services/common/src/interfaces/permits/permitCondition.interface.ts
+++ b/services/common/src/interfaces/permits/permitCondition.interface.ts
@@ -7,7 +7,7 @@ export interface IPermitConditionCategory {
   step: string;
 }
 
-interface IBoundingBox {
+export interface IBoundingBox {
   top: number;
   right: number;
   bottom: number;

--- a/services/common/src/interfaces/permits/permitCondition.interface.ts
+++ b/services/common/src/interfaces/permits/permitCondition.interface.ts
@@ -1,5 +1,23 @@
 import { IMineReportPermitRequirement } from "@mds/common/interfaces";
 
+export interface IPermitConditionCategory {
+  condition_category_code: string;
+  description: string;
+  display_order: number;
+  step: string;
+}
+
+interface IBoundingBox {
+  top: number;
+  right: number;
+  bottom: number;
+  left: number;
+}
+export interface IPermitConditionMeta {
+  page: number;
+  role: string;
+  bounding_box?: IBoundingBox;
+}
 export interface IPermitCondition {
   permit_condition_id: number;
   permit_amendment_id: number;
@@ -13,6 +31,7 @@ export interface IPermitCondition {
   stepPath?: string;
   display_order: number;
   mineReportPermitRequirement?: IMineReportPermitRequirement;
+  meta?: IPermitConditionMeta
 }
 
 export interface IPermitConditionCategory {

--- a/services/common/src/interfaces/permits/permitCondition.interface.ts
+++ b/services/common/src/interfaces/permits/permitCondition.interface.ts
@@ -1,11 +1,5 @@
 import { IMineReportPermitRequirement } from "@mds/common/interfaces";
 
-export interface IPermitConditionCategory {
-  condition_category_code: string;
-  description: string;
-  display_order: number;
-  step: string;
-}
 
 export interface IBoundingBox {
   top: number;

--- a/services/common/src/redux/slices/permitServiceSlice.ts
+++ b/services/common/src/redux/slices/permitServiceSlice.ts
@@ -34,6 +34,7 @@ const permitExtractionStatusMap = {
 export interface PermitExtraction {
   task_status: PermitExtractionStatus;
   task_id: string;
+  permit_amendment_document_guid: string;
 }
 
 interface PermitServiceState {
@@ -67,10 +68,11 @@ const permitServiceSlice = createAppSlice({
       {
         fulfilled: (state, action) => {
           const { permit_amendment_id } = action.meta.arg;
-          const { task_id, task_status } = action.payload;
+          const { task_id, task_status, permit_amendment_document_guid } = action.payload;
           state.extractions[permit_amendment_id] = {
             task_id,
             task_status: permitExtractionStatusMap[task_status],
+            permit_amendment_document_guid,
           };
         },
         pending: (state, action) => {
@@ -78,6 +80,7 @@ const permitServiceSlice = createAppSlice({
           state.extractions[permit_amendment_id] = {
             task_status: PermitExtractionStatus.in_progress,
             task_id: null,
+            permit_amendment_document_guid: null,
           };
         },
         rejected: (state, action) => {
@@ -85,6 +88,7 @@ const permitServiceSlice = createAppSlice({
           state.extractions[permit_amendment_id] = {
             task_status: PermitExtractionStatus.error,
             task_id: null,
+            permit_amendment_document_guid: null,
           };
           rejectHandler(action);
         },
@@ -110,10 +114,11 @@ const permitServiceSlice = createAppSlice({
         fulfilled: (state, action) => {
           if (!action.payload) return;
           const { permit_amendment_id } = action.meta.arg;
-          const { task_id, task_status } = action.payload;
+          const { task_id, task_status, permit_amendment_document_guid } = action.payload;
           state.extractions[permit_amendment_id] = {
             task_id: task_id,
             task_status: permitExtractionStatusMap[task_status],
+            permit_amendment_document_guid
           };
         },
         rejected: (state, action) => {

--- a/services/common/src/redux/slices/permitServiceSlice.ts
+++ b/services/common/src/redux/slices/permitServiceSlice.ts
@@ -144,10 +144,11 @@ const permitServiceSlice = createAppSlice({
       {
         fulfilled: (state, action) => {
           const { permit_amendment_id } = action.meta.arg;
-          const { task_id, task_status } = action.payload;
+          const { task_id, task_status, permit_amendment_document_guid } = action.payload;
           state.extractions[permit_amendment_id] = {
             task_id: task_id,
             task_status: permitExtractionStatusMap[task_status],
+            permit_amendment_document_guid
           };
         },
         rejected: (state, action) => {
@@ -176,6 +177,7 @@ const permitServiceSlice = createAppSlice({
           state.extractions[permit_amendment_id] = {
             task_status: PermitExtractionStatus.not_started,
             task_id: null,
+            permit_amendment_document_guid: null,
           };
         },
         rejected: (state, action) => {

--- a/services/common/src/utils/featureFlag.ts
+++ b/services/common/src/utils/featureFlag.ts
@@ -22,6 +22,7 @@ export enum Feature {
   DIGITIZED_PERMITS = "digitized_permits",
   SPATIAL_BUNDLE = "spatial_bundle",
   PERMIT_CONDITIONS_PAGE = "permit_conditions_page",
+  PERMIT_CONDITIONS_PDF_SPLIT_VIEW = "permit_conditions_pdf_split_view",
   MODIFY_PERMIT_CONDITIONS = "modify_permit_conditions",
   MAJOR_PROJECT_REFACTOR = "major_project_refactor",
   HELP_GUIDE = "help_guide",

--- a/services/core-web/src/components/mine/Permit/PermitConditionLayer.tsx
+++ b/services/core-web/src/components/mine/Permit/PermitConditionLayer.tsx
@@ -16,11 +16,13 @@ interface PermitConditionLayerProps {
   conditionCount: number;
   permitAmendmentGuid: string;
   refreshData: () => Promise<void>;
+  conditionSelected?: (condition: IPermitCondition) => void;
 }
 
 const PermitConditionLayer: FC<PermitConditionLayerProps> = ({
   condition,
   isExpanded,
+  conditionSelected,
   level = 0,
   setParentExpand = () => { },
   canEditPermitConditions = false,
@@ -56,6 +58,10 @@ const PermitConditionLayer: FC<PermitConditionLayerProps> = ({
     if (canEditPermitConditions) {
       event.stopPropagation();
       setParentExpand();
+    }
+
+    if (conditionSelected) {
+      conditionSelected(condition);
     }
   };
 
@@ -107,6 +113,7 @@ const PermitConditionLayer: FC<PermitConditionLayerProps> = ({
                 currentPosition={idx}
                 conditionCount={condition.sub_conditions.length}
                 refreshData={refreshData}
+                conditionSelected={conditionSelected}
               />
             </div>
           );

--- a/services/core-web/src/components/mine/Permit/PermitConditions.spec.tsx
+++ b/services/core-web/src/components/mine/Permit/PermitConditions.spec.tsx
@@ -7,6 +7,7 @@ import ViewPermit from "./ViewPermit";
 import { BrowserRouter } from "react-router-dom";
 import { USER_ROLES } from "@mds/common/constants/environment";
 import ModalWrapper from "@/components/common/wrappers/ModalWrapper";
+
 const initialState = {
   [MINES]: MOCK.MINES,
   [PERMITS]: { permits: MOCK.PERMITS, permitAmendments: { [MOCK.PERMITS[0].permit_guid]: MOCK.PERMITS[0].permit_amendments[0] } },

--- a/services/core-web/src/components/mine/Permit/PermitConditions.tsx
+++ b/services/core-web/src/components/mine/Permit/PermitConditions.tsx
@@ -62,6 +62,7 @@ const PermitConditions: FC<PermitConditionProps> = ({
   const { isFeatureEnabled } = useFeatureFlag();
   const dispatch = useDispatch();
   const canEditPermitConditions = isFeatureEnabled(Feature.MODIFY_PERMIT_CONDITIONS) && userCanEdit;
+  const pdfSplitViewEnabled = isFeatureEnabled(Feature.PERMIT_CONDITIONS_PDF_SPLIT_VIEW);
   const { id: mineGuid, permitGuid } = useParams<{ id: string; permitGuid: string, mineGuid: string }>();
   const [isExpanded, setIsExpanded] = useState(false);
   const [viewPdf, setViewPdf] = useState(false);
@@ -269,9 +270,11 @@ const PermitConditions: FC<PermitConditionProps> = ({
     </Typography.Paragraph>
   );
 
+  const canViewPdfSplitScreen = viewPdf && pdfSplitViewEnabled && permitExtraction?.permit_amendment_document_guid;
+
   return (
     <Row>
-      <Col span={viewPdf ? 16 : 24}>
+      <Col span={canViewPdfSplitScreen ? 16 : 24}>
         <ScrollSidePageWrapper
           header={null}
           headerHeight={topOffset}
@@ -415,13 +418,17 @@ const PermitConditions: FC<PermitConditionProps> = ({
                   </Row>
                 </div>
               </Col>
-              {viewPdf && permitExtraction?.permit_amendment_document_guid ? (
-                <Col style={{ padding: '16px' }} span={8}><PreviewPermitAmendmentDocument amendment={latestAmendment} documentGuid={permitExtraction.permit_amendment_document_guid} selectedCondition={selectedCondition} /></Col>
-              ) : ''}
             </Row>
           }>
         </ScrollSidePageWrapper>
       </Col>
+      {canViewPdfSplitScreen ? (
+        <Col style={{ padding: '16px', height: 'inherit' }} span={8}>
+          <div style={{ position: 'sticky', 'top': '225px' }}>
+            <PreviewPermitAmendmentDocument amendment={latestAmendment} documentGuid={permitExtraction.permit_amendment_document_guid} selectedCondition={selectedCondition} />
+          </div>
+        </Col>
+      ) : ''}
     </Row>
   );
 };

--- a/services/core-web/src/components/mine/Permit/PermitConditions.tsx
+++ b/services/core-web/src/components/mine/Permit/PermitConditions.tsx
@@ -40,6 +40,7 @@ import { uniqBy } from "lodash";
 import { createPermitAmendmentConditionCategory, deletePermitAmendmentConditionCategory, fetchPermits, updatePermitAmendmentConditionCategory, updatePermitCondition } from "@mds/common/redux/actionCreators/permitActionCreator";
 import { EditPermitConditionCategoryInline } from "./PermitConditionCategory";
 import { searchConditionCategories } from "@mds/common/redux/slices/permitConditionCategorySlice";
+import { PreviewPermitAmendmentDocument } from "./PreviewPermitAmendmentDocument";
 import { formatPermitConditionStep } from "@mds/common/utils/helpers";
 import SubConditionForm from "./SubConditionForm";
 import { getIsFetching } from "@mds/common/redux/reducers/networkReducer";
@@ -63,6 +64,8 @@ const PermitConditions: FC<PermitConditionProps> = ({
   const canEditPermitConditions = isFeatureEnabled(Feature.MODIFY_PERMIT_CONDITIONS) && userCanEdit;
   const { id: mineGuid, permitGuid } = useParams<{ id: string; permitGuid: string, mineGuid: string }>();
   const [isExpanded, setIsExpanded] = useState(false);
+  const [viewPdf, setViewPdf] = useState(false);
+  const [selectedCondition, setSelectedCondition] = useState<IPermitCondition | null>(null);
   const [editingConditionGuid, setEditingConditionGuid] = useState<string>();
   const [addingToCategoryCode, setAddingToCategoryCode] = useState<string>();
 
@@ -176,6 +179,9 @@ const PermitConditions: FC<PermitConditionProps> = ({
     console.log("not implemented", values);
   };
 
+  const toggleViewPdf = () => {
+    setViewPdf(!viewPdf);
+  };
 
   const openCreateCategoryModal = (event) => {
     event.preventDefault();
@@ -264,151 +270,159 @@ const PermitConditions: FC<PermitConditionProps> = ({
   );
 
   return (
-    <ScrollSidePageWrapper
-      header={null}
-      headerHeight={topOffset}
-      menuProps={scrollSideMenuProps}
-      extraItems={AddConditionModalContent}
-      view={"steps"}
-      content={
-        <Row align="middle" justify="space-between" gutter={[10, 16]}>
-          <Col span={24}>
-            <Title className="margin-none" level={2}>
-              Permit Conditions
-            </Title>
-          </Col>
+    <Row>
+      <Col span={viewPdf ? 16 : 24}>
+        <ScrollSidePageWrapper
+          header={null}
+          headerHeight={topOffset}
+          menuProps={scrollSideMenuProps}
+          extraItems={AddConditionModalContent}
+          view={"steps"}
+          content={
+            <Row align="middle" justify="space-between" gutter={[10, 16]}>
+              <Col span={24}>
+                <Title className="margin-none" level={2}>
+                  Permit Conditions
+                </Title>
+              </Col>
 
-          <Col>
-            <Row gutter={10}>
+              <Col>
+                <Row gutter={10}>
+                  <Col>
+                    <CoreButton
+                      disabled={showLoading}
+                      type="tertiary"
+                      className="fa-icon-container"
+                      icon={<FontAwesomeIcon icon={isExpanded ? faArrowsToLine : faArrowsFromLine} />}
+                      onClick={() => setIsExpanded(!isExpanded)}
+                    >
+                      {isExpanded ? "Collapse" : "Expand"} All Conditions
+                    </CoreButton>
+                  </Col>
+                  <Col>
+                    <CoreButton type="tertiary" icon={<FileOutlined />} disabled={showLoading} onClick={toggleViewPdf}>
+                      Open Permit in Document Viewer
+                    </CoreButton>
+                  </Col>
+                </Row>
+              </Col>
+
               <Col>
                 <CoreButton
-                  disabled={showLoading}
                   type="tertiary"
                   className="fa-icon-container"
-                  icon={<FontAwesomeIcon icon={isExpanded ? faArrowsToLine : faArrowsFromLine} />}
-                  onClick={() => setIsExpanded(!isExpanded)}
+                  disabled={showLoading}
+                  icon={<FontAwesomeIcon icon={faBarsStaggered} />}
                 >
-                  {isExpanded ? "Collapse" : "Expand"} All Conditions
+                  Reorder
                 </CoreButton>
               </Col>
-              <Col>
-                <CoreButton type="tertiary" icon={<FileOutlined />} disabled={showLoading}>
-                  Open Permit in Document Viewer
-                </CoreButton>
-              </Col>
-            </Row>
-          </Col>
+              <Col span={24}>
+                <div className="core-page-content">
+                  <Row gutter={[16, 16]}>
+                    {
+                      showLoading && (
+                        <Skeleton active paragraph={{ rows: 10 }} />
+                      )
+                    }
 
-          <Col>
-            <CoreButton
-              type="tertiary"
-              className="fa-icon-container"
-              disabled={showLoading}
-              icon={<FontAwesomeIcon icon={faBarsStaggered} />}
-            >
-              Reorder
-            </CoreButton>
-          </Col>
-          <Col span={24}>
-            <div className="core-page-content">
-              <Row gutter={[16, 16]}>
-                {
-                  showLoading && (
-                    <Skeleton active paragraph={{ rows: 10 }} />
-                  )
-                }
-
-                {permitConditionCategories.map((category, idx) => {
-                  const conditionsWithRequirements: IPermitCondition[] =
-                    getConditionsWithRequirements(category.conditions);
-                  return (
-                    <React.Fragment key={category.href}>
-                      <Col span={24}>
-                        <Row justify="space-between">
-                          <Title level={3} className="margin-none" id={category.href}>
-                            <EditPermitConditionCategoryInline
-                              onDelete={handleDeleteConditionCategory}
-                              onChange={handleUpdateConditionCategory}
-                              moveUp={(cat) => handleMove(cat, idx - 1)}
-                              moveDown={(cat) => handleMove(cat, idx + 1)}
-                              currentPosition={idx}
-                              categoryCount={permitConditionCategories.length}
-                              category={category.condition_category}
-                              conditionCount={category?.conditions.length || 0}
-                            />
-                          </Title>
-                          {canEditPermitConditions && (
-                            <CoreButton
-                              type="primary"
-                              disabled={Boolean(addingToCategoryCode) || Boolean(editingConditionGuid)}
-                              onClick={() =>
-                                setAddingToCategoryCode(category.condition_category_code)
-                              }
-                            >
-                              Add Condition
-                            </CoreButton>
-                          )}
-                        </Row>
-                      </Col>
-                      {category.conditions.map((sc, idx) => (
-                        <Col span={24} key={sc.permit_condition_id} className="fade-in">
-                          <PermitConditionLayer
-                            permitAmendmentGuid={latestAmendment.permit_amendment_guid}
-                            condition={sc}
-                            isExpanded={isExpanded}
-                            handleMoveCondition={handleMoveCondition}
-                            currentPosition={idx}
-                            conditionCount={category.conditions.length}
-                            canEditPermitConditions={canEditPermitConditions}
-                            setEditingConditionGuid={setEditingConditionGuid}
-                            editingConditionGuid={editingConditionGuid ?? addingToCategoryCode}
-                            refreshData={refreshData}
-                          />
-                        </Col>
-                      ))}
-                      {addingToCategoryCode === category.condition_category_code &&
-                        <Col span={24}>
-                          <SubConditionForm
-                            conditionCategory={category}
-                            permitAmendmentGuid={latestAmendment.permit_amendment_guid}
-                            handleCancel={() => setAddingToCategoryCode(null)}
-                            onSubmit={handleAddCondition}
-                          /></Col>}
-                      {conditionsWithRequirements?.length > 0 && (
-                        <div className="report-collapse-container ">
-                          <Title level={4} className="primary-colour">
-                            Report Requirements
-                          </Title>
-                          <Collapse expandIconPosition="end">
-                            {conditionsWithRequirements.map((cond: IPermitCondition, index) => (
-                              <Collapse.Panel
-                                key={cond.permit_condition_id}
-                                header={
-                                  <Typography.Text strong>Report #{index + 1}{cond.mineReportPermitRequirement?.report_name ? ` - ${cond.mineReportPermitRequirement.report_name}` : ''}</Typography.Text>
-                                }
-                                className="report-collapse"
-                              >
-                                <ReportPermitRequirementForm
-                                  modalView={false}
-                                  onSubmit={handleEditReportRequirement}
-                                  condition={cond}
-                                  permitGuid={permitGuid}
-                                  mineReportPermitRequirement={cond.mineReportPermitRequirement}
+                    {permitConditionCategories.map((category, idx) => {
+                      const conditionsWithRequirements: IPermitCondition[] =
+                        getConditionsWithRequirements(category.conditions);
+                      return (
+                        <React.Fragment key={category.href}>
+                          <Col span={24}>
+                            <Row justify="space-between">
+                              <Title level={3} className="margin-none" id={category.href}>
+                                <EditPermitConditionCategoryInline
+                                  onDelete={handleDeleteConditionCategory}
+                                  onChange={handleUpdateConditionCategory}
+                                  moveUp={(cat) => handleMove(cat, idx - 1)}
+                                  moveDown={(cat) => handleMove(cat, idx + 1)}
+                                  currentPosition={idx}
+                                  categoryCount={permitConditionCategories.length}
+                                  category={category.condition_category}
+                                  conditionCount={category?.conditions.length || 0}
                                 />
-                              </Collapse.Panel>
-                            ))}
-                          </Collapse>
-                        </div>
-                      )}
-                    </React.Fragment>
-                  );
-                })}
-              </Row>
-            </div>
-          </Col>
-        </Row>
-      }>
-    </ScrollSidePageWrapper>
+                              </Title>
+                              {canEditPermitConditions && (
+                                <CoreButton
+                                  type="primary"
+                                  disabled={Boolean(addingToCategoryCode) || Boolean(editingConditionGuid)}
+                                  onClick={() =>
+                                    setAddingToCategoryCode(category.condition_category_code)
+                                  }
+                                >
+                                  Add Condition
+                                </CoreButton>
+                              )}
+                            </Row>
+                          </Col>
+                          {category.conditions.map((sc, idx) => (
+                            <Col span={24} key={sc.permit_condition_id} className="fade-in">
+                              <PermitConditionLayer
+                                permitAmendmentGuid={latestAmendment.permit_amendment_guid}
+                                condition={sc}
+                                isExpanded={isExpanded}
+                                handleMoveCondition={handleMoveCondition}
+                                currentPosition={idx}
+                                conditionCount={category.conditions.length}
+                                canEditPermitConditions={canEditPermitConditions}
+                                setEditingConditionGuid={setEditingConditionGuid}
+                                editingConditionGuid={editingConditionGuid ?? addingToCategoryCode}
+                                refreshData={refreshData}
+                                conditionSelected={setSelectedCondition}
+                              />
+                            </Col>
+                          ))}
+                          {addingToCategoryCode === category.condition_category_code &&
+                            <Col span={24}>
+                              <SubConditionForm
+                                conditionCategory={category}
+                                permitAmendmentGuid={latestAmendment.permit_amendment_guid}
+                                handleCancel={() => setAddingToCategoryCode(null)}
+                                onSubmit={handleAddCondition}
+                              /></Col>}
+                          {conditionsWithRequirements?.length > 0 && (
+                            <div className="report-collapse-container ">
+                              <Title level={4} className="primary-colour">
+                                Report Requirements
+                              </Title>
+                              <Collapse expandIconPosition="end">
+                                {conditionsWithRequirements.map((cond: IPermitCondition, index) => (
+                                  <Collapse.Panel
+                                    key={cond.permit_condition_id}
+                                    header={
+                                      <Typography.Text strong>Report #{index + 1}{cond.mineReportPermitRequirement?.report_name ? ` - ${cond.mineReportPermitRequirement.report_name}` : ''}</Typography.Text>
+                                    }
+                                    className="report-collapse"
+                                  >
+                                    <ReportPermitRequirementForm
+                                      modalView={false}
+                                      onSubmit={handleEditReportRequirement}
+                                      condition={cond}
+                                      permitGuid={permitGuid}
+                                      mineReportPermitRequirement={cond.mineReportPermitRequirement}
+                                    />
+                                  </Collapse.Panel>
+                                ))}
+                              </Collapse>
+                            </div>
+                          )}
+                        </React.Fragment>
+                      );
+                    })}
+                  </Row>
+                </div>
+              </Col>
+              {viewPdf && permitExtraction?.permit_amendment_document_guid ? (
+                <Col style={{ padding: '16px' }} span={8}><PreviewPermitAmendmentDocument amendment={latestAmendment} documentGuid={permitExtraction.permit_amendment_document_guid} selectedCondition={selectedCondition} /></Col>
+              ) : ''}
+            </Row>
+          }>
+        </ScrollSidePageWrapper>
+      </Col>
+    </Row>
   );
 };
 

--- a/services/core-web/src/components/mine/Permit/PreviewPermitAmendmentDocument.tsx
+++ b/services/core-web/src/components/mine/Permit/PreviewPermitAmendmentDocument.tsx
@@ -1,0 +1,58 @@
+import React, { useEffect } from "react";
+import { getDocument } from "@mds/common/redux/utils/actionlessNetworkCalls";
+import { PdfViewer, ViewPdf } from "@mds/common/components/syncfusion/DocumentViewer";
+import { Skeleton } from "antd";
+import { IPermitAmendment, IPermitCondition } from "@mds/common/interfaces/permits";
+
+interface IPreviewPermitAmendmentDocumentProps {
+  amendment: IPermitAmendment;
+  documentGuid: string;
+  selectedCondition?: IPermitCondition;
+}
+
+export const PreviewPermitAmendmentDocument = (props: IPreviewPermitAmendmentDocumentProps) => {
+  const [documentUrl, setDocumentUrl] = React.useState<string>(null);
+  const [pdfViewer, setPdfViewer] = React.useState(null);
+  useEffect(() => {
+    if (props.documentGuid) {
+      const amdDoc = props.amendment.related_documents.find(d => d.permit_amendment_document_guid === props.documentGuid);
+
+      if (amdDoc) {
+        const fetchDocument = async () => {
+          const docUrl = await getDocument(amdDoc.document_manager_guid);
+          setDocumentUrl(docUrl.object_store_path);
+        }
+
+        fetchDocument();
+      }
+    }
+  }, [props.documentGuid]);
+
+  useEffect(() => {
+    if (pdfViewer && props.selectedCondition) {
+      if (props.selectedCondition?.meta) {
+        pdfViewer.navigation.goToPage(props.selectedCondition?.meta.page);
+        if (props.selectedCondition?.meta.bounding_box) {
+          const { top, right, bottom, left } = props.selectedCondition?.meta.bounding_box;
+          const topPx = top * 96;
+          const rightPx = right * 96;
+          const bottomPx = bottom * 96;
+          const leftPx = left * 96;
+          pdfViewer.annotation.clear();
+          pdfViewer.annotation.addAnnotation("Polygon", {
+            offset: { x: 0, y: 0 },
+            pageNumber: props.selectedCondition.meta.page,
+            vertexPoints: [{ x: leftPx, y: topPx }, { x: rightPx, y: topPx }, { x: rightPx, y: bottomPx }, { x: leftPx, y: bottomPx }, { x: leftPx, y: topPx }]
+          });
+        }
+      }
+    }
+  }, [props.selectedCondition]);
+
+  const onInit = (pdfViewer: any) => {
+    if (pdfViewer) {
+      setPdfViewer(pdfViewer);
+    }
+  }
+  return documentUrl ? <PdfViewer id="preview-permit-amendment-pdf" documentPath={documentUrl} onInit={onInit} /> : <Skeleton />;
+};

--- a/services/core-web/src/components/mine/Permit/PreviewPermitAmendmentDocument.tsx
+++ b/services/core-web/src/components/mine/Permit/PreviewPermitAmendmentDocument.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect } from "react";
 import { getDocument } from "@mds/common/redux/utils/actionlessNetworkCalls";
-import { PdfViewer, ViewPdf } from "@mds/common/components/syncfusion/DocumentViewer";
+import { PdfViewer } from "@mds/common/components/syncfusion/DocumentViewer";
 import { Skeleton } from "antd";
-import { IPermitAmendment, IPermitCondition } from "@mds/common/interfaces/permits";
+import { IBoundingBox, IPermitAmendment, IPermitCondition } from "@mds/common/interfaces/permits";
 
 interface IPreviewPermitAmendmentDocumentProps {
   amendment: IPermitAmendment;
@@ -10,10 +10,36 @@ interface IPreviewPermitAmendmentDocumentProps {
   selectedCondition?: IPermitCondition;
 }
 
+/**
+ * PDF Viewer component for previewing permit amendment documents.
+ * Higlights the selected condition on the PDF viewer based on its bounding box.
+ */
 export const PreviewPermitAmendmentDocument = (props: IPreviewPermitAmendmentDocumentProps) => {
   const [documentUrl, setDocumentUrl] = React.useState<string>(null);
   const [pdfViewer, setPdfViewer] = React.useState(null);
+
+  /**
+  * Adds a rectangle annotation to the PDF viewer based on the bounding box and of the selected condition
+  */
+  const addAnnotationToPDFViewer = (page?: number, boundingBox?: IBoundingBox) => {
+    pdfViewer.navigation.goToPage(page || 0);
+    if (boundingBox) {
+      const { top, right, bottom, left } = boundingBox;
+      const topPx = top * 96;
+      const rightPx = right * 96;
+      const bottomPx = bottom * 96;
+      const leftPx = left * 96;
+      pdfViewer.annotation.clear();
+      pdfViewer.annotation.addAnnotation("Polygon", {
+        offset: { x: 0, y: 0 },
+        pageNumber: page || 0,
+        vertexPoints: [{ x: leftPx, y: topPx }, { x: rightPx, y: topPx }, { x: rightPx, y: bottomPx }, { x: leftPx, y: bottomPx }, { x: leftPx, y: topPx }]
+      });
+    }
+  };
+
   useEffect(() => {
+    // Fetch url of document on load
     if (props.documentGuid) {
       const amdDoc = props.amendment.related_documents.find(d => d.permit_amendment_document_guid === props.documentGuid);
 
@@ -29,23 +55,9 @@ export const PreviewPermitAmendmentDocument = (props: IPreviewPermitAmendmentDoc
   }, [props.documentGuid]);
 
   useEffect(() => {
-    if (pdfViewer && props.selectedCondition) {
-      if (props.selectedCondition?.meta) {
-        pdfViewer.navigation.goToPage(props.selectedCondition?.meta.page);
-        if (props.selectedCondition?.meta.bounding_box) {
-          const { top, right, bottom, left } = props.selectedCondition?.meta.bounding_box;
-          const topPx = top * 96;
-          const rightPx = right * 96;
-          const bottomPx = bottom * 96;
-          const leftPx = left * 96;
-          pdfViewer.annotation.clear();
-          pdfViewer.annotation.addAnnotation("Polygon", {
-            offset: { x: 0, y: 0 },
-            pageNumber: props.selectedCondition.meta.page,
-            vertexPoints: [{ x: leftPx, y: topPx }, { x: rightPx, y: topPx }, { x: rightPx, y: bottomPx }, { x: leftPx, y: bottomPx }, { x: leftPx, y: topPx }]
-          });
-        }
-      }
+    // Add annotation to PDF viewer when selected condition changes
+    if (pdfViewer && props.selectedCondition && props.selectedCondition?.meta) {
+      addAnnotationToPDFViewer(props.selectedCondition.meta.page, props.selectedCondition.meta.bounding_box);
     }
   }, [props.selectedCondition]);
 

--- a/services/core-web/src/components/mine/Permit/__snapshots__/PermitConditions.spec.tsx.snap
+++ b/services/core-web/src/components/mine/Permit/__snapshots__/PermitConditions.spec.tsx.snap
@@ -384,224 +384,293 @@ exports[`PermitConditions renders properly 1`] = `
               tabindex="0"
             >
               <div
-                class="scroll-side-menu-wrapper scroll-side-menu-view--steps"
+                class="ant-row"
               >
                 <div
-                  class="side-menu"
-                  style="top: 0px;"
+                  class="ant-col ant-col-24"
                 >
-                  <div>
+                  <div
+                    class="scroll-side-menu-wrapper scroll-side-menu-view--steps"
+                  >
                     <div
-                      class="ant-anchor-wrapper"
-                      style="max-height: calc(100vh - 254px);"
+                      class="side-menu"
+                      style="top: 0px;"
                     >
-                      <div
-                        class="ant-anchor ant-anchor-fixed"
-                      >
+                      <div>
                         <div
-                          class="ant-anchor-ink"
+                          class="ant-anchor-wrapper"
+                          style="max-height: calc(100vh - 254px);"
                         >
-                          <span
-                            class="ant-anchor-ink-ball-visible ant-anchor-ink-ball"
-                            style="top: -4.5px;"
-                          />
-                        </div>
-                        <div
-                          class="ant-anchor-link now-menu-link fade-in ant-anchor-link-active"
-                        >
-                          <a
-                            class="ant-anchor-link-title ant-anchor-link-title-active"
-                            href="#hsc"
-                            title=""
+                          <div
+                            class="ant-anchor ant-anchor-fixed"
                           >
                             <div
-                              class="side-nav-title"
+                              class="ant-anchor-ink"
                             >
                               <span
-                                class="margin-medium--right side-nav-title-icon"
-                              >
-                                <svg
-                                  aria-hidden="true"
-                                  class="svg-inline--fa fa-ban "
-                                  data-icon="ban"
-                                  data-prefix="fal"
-                                  focusable="false"
-                                  role="img"
-                                  style="color: rgb(187, 187, 187); font-size: 20px;"
-                                  viewBox="0 0 512 512"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                >
-                                  <path
-                                    d="M402.7 425.3l-316-316C52.6 148.6 32 199.9 32 256c0 123.7 100.3 224 224 224c56.1 0 107.4-20.6 146.7-54.7zm22.6-22.6C459.4 363.4 480 312.1 480 256C480 132.3 379.7 32 256 32c-56.1 0-107.4 20.6-146.7 54.7l316 316zM0 256a256 256 0 1 1 512 0A256 256 0 1 1 0 256z"
-                                    fill="currentColor"
-                                  />
-                                </svg>
-                              </span>
-                              <div
-                                class="side-nav-title-content"
-                              >
-                                <span
-                                  class="ant-typography"
-                                  style="font-size: 16px; font-weight: 600;"
-                                >
-                                  A.
-                                  Health and Safety
-                                </span>
-                                <span
-                                  class="side-nav-description"
-                                >
-                                  <br />
-                                  Not Started
-                                </span>
-                              </div>
+                                class="ant-anchor-ink-ball-visible ant-anchor-ink-ball"
+                                style="top: -4.5px;"
+                              />
                             </div>
-                          </a>
-                        </div>
-                        <div
-                          class="ant-anchor-link now-menu-link fade-in"
-                        >
-                          <a
-                            class="ant-anchor-link-title"
-                            href="#rcc"
-                            title=""
-                          >
                             <div
-                              class="side-nav-title"
+                              class="ant-anchor-link now-menu-link fade-in ant-anchor-link-active"
                             >
-                              <span
-                                class="margin-medium--right side-nav-title-icon"
+                              <a
+                                class="ant-anchor-link-title ant-anchor-link-title-active"
+                                href="#hsc"
+                                title=""
                               >
-                                <svg
-                                  aria-hidden="true"
-                                  class="svg-inline--fa fa-ban "
-                                  data-icon="ban"
-                                  data-prefix="fal"
-                                  focusable="false"
-                                  role="img"
-                                  style="color: rgb(187, 187, 187); font-size: 20px;"
-                                  viewBox="0 0 512 512"
-                                  xmlns="http://www.w3.org/2000/svg"
+                                <div
+                                  class="side-nav-title"
                                 >
-                                  <path
-                                    d="M402.7 425.3l-316-316C52.6 148.6 32 199.9 32 256c0 123.7 100.3 224 224 224c56.1 0 107.4-20.6 146.7-54.7zm22.6-22.6C459.4 363.4 480 312.1 480 256C480 132.3 379.7 32 256 32c-56.1 0-107.4 20.6-146.7 54.7l316 316zM0 256a256 256 0 1 1 512 0A256 256 0 1 1 0 256z"
-                                    fill="currentColor"
-                                  />
-                                </svg>
-                              </span>
-                              <div
-                                class="side-nav-title-content"
-                              >
-                                <span
-                                  class="ant-typography"
-                                  style="font-size: 16px; font-weight: 600;"
-                                >
-                                  B.
-                                  Reclamation
-                                </span>
-                                <span
-                                  class="side-nav-description"
-                                >
-                                  <br />
-                                  Not Started
-                                </span>
-                              </div>
+                                  <span
+                                    class="margin-medium--right side-nav-title-icon"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="svg-inline--fa fa-ban "
+                                      data-icon="ban"
+                                      data-prefix="fal"
+                                      focusable="false"
+                                      role="img"
+                                      style="color: rgb(187, 187, 187); font-size: 20px;"
+                                      viewBox="0 0 512 512"
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <path
+                                        d="M402.7 425.3l-316-316C52.6 148.6 32 199.9 32 256c0 123.7 100.3 224 224 224c56.1 0 107.4-20.6 146.7-54.7zm22.6-22.6C459.4 363.4 480 312.1 480 256C480 132.3 379.7 32 256 32c-56.1 0-107.4 20.6-146.7 54.7l316 316zM0 256a256 256 0 1 1 512 0A256 256 0 1 1 0 256z"
+                                        fill="currentColor"
+                                      />
+                                    </svg>
+                                  </span>
+                                  <div
+                                    class="side-nav-title-content"
+                                  >
+                                    <span
+                                      class="ant-typography"
+                                      style="font-size: 16px; font-weight: 600;"
+                                    >
+                                      A.
+                                      Health and Safety
+                                    </span>
+                                    <span
+                                      class="side-nav-description"
+                                    >
+                                      <br />
+                                      Not Started
+                                    </span>
+                                  </div>
+                                </div>
+                              </a>
                             </div>
-                          </a>
-                        </div>
-                        <div
-                          class="ant-anchor-link now-menu-link fade-in"
-                        >
-                          <a
-                            class="ant-anchor-link-title"
-                            href="#elc"
-                            title=""
-                          >
                             <div
-                              class="side-nav-title"
+                              class="ant-anchor-link now-menu-link fade-in"
                             >
-                              <span
-                                class="margin-medium--right side-nav-title-icon"
+                              <a
+                                class="ant-anchor-link-title"
+                                href="#rcc"
+                                title=""
                               >
-                                <svg
-                                  aria-hidden="true"
-                                  class="svg-inline--fa fa-ban "
-                                  data-icon="ban"
-                                  data-prefix="fal"
-                                  focusable="false"
-                                  role="img"
-                                  style="color: rgb(187, 187, 187); font-size: 20px;"
-                                  viewBox="0 0 512 512"
-                                  xmlns="http://www.w3.org/2000/svg"
+                                <div
+                                  class="side-nav-title"
                                 >
-                                  <path
-                                    d="M402.7 425.3l-316-316C52.6 148.6 32 199.9 32 256c0 123.7 100.3 224 224 224c56.1 0 107.4-20.6 146.7-54.7zm22.6-22.6C459.4 363.4 480 312.1 480 256C480 132.3 379.7 32 256 32c-56.1 0-107.4 20.6-146.7 54.7l316 316zM0 256a256 256 0 1 1 512 0A256 256 0 1 1 0 256z"
-                                    fill="currentColor"
-                                  />
-                                </svg>
-                              </span>
-                              <div
-                                class="side-nav-title-content"
-                              >
-                                <span
-                                  class="ant-typography"
-                                  style="font-size: 16px; font-weight: 600;"
-                                >
-                                  
-                                  Environmental Land and Watercourses
-                                </span>
-                                <span
-                                  class="side-nav-description"
-                                >
-                                  <br />
-                                  Not Started
-                                </span>
-                              </div>
+                                  <span
+                                    class="margin-medium--right side-nav-title-icon"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="svg-inline--fa fa-ban "
+                                      data-icon="ban"
+                                      data-prefix="fal"
+                                      focusable="false"
+                                      role="img"
+                                      style="color: rgb(187, 187, 187); font-size: 20px;"
+                                      viewBox="0 0 512 512"
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <path
+                                        d="M402.7 425.3l-316-316C52.6 148.6 32 199.9 32 256c0 123.7 100.3 224 224 224c56.1 0 107.4-20.6 146.7-54.7zm22.6-22.6C459.4 363.4 480 312.1 480 256C480 132.3 379.7 32 256 32c-56.1 0-107.4 20.6-146.7 54.7l316 316zM0 256a256 256 0 1 1 512 0A256 256 0 1 1 0 256z"
+                                        fill="currentColor"
+                                      />
+                                    </svg>
+                                  </span>
+                                  <div
+                                    class="side-nav-title-content"
+                                  >
+                                    <span
+                                      class="ant-typography"
+                                      style="font-size: 16px; font-weight: 600;"
+                                    >
+                                      B.
+                                      Reclamation
+                                    </span>
+                                    <span
+                                      class="side-nav-description"
+                                    >
+                                      <br />
+                                      Not Started
+                                    </span>
+                                  </div>
+                                </div>
+                              </a>
                             </div>
-                          </a>
+                            <div
+                              class="ant-anchor-link now-menu-link fade-in"
+                            >
+                              <a
+                                class="ant-anchor-link-title"
+                                href="#elc"
+                                title=""
+                              >
+                                <div
+                                  class="side-nav-title"
+                                >
+                                  <span
+                                    class="margin-medium--right side-nav-title-icon"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="svg-inline--fa fa-ban "
+                                      data-icon="ban"
+                                      data-prefix="fal"
+                                      focusable="false"
+                                      role="img"
+                                      style="color: rgb(187, 187, 187); font-size: 20px;"
+                                      viewBox="0 0 512 512"
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <path
+                                        d="M402.7 425.3l-316-316C52.6 148.6 32 199.9 32 256c0 123.7 100.3 224 224 224c56.1 0 107.4-20.6 146.7-54.7zm22.6-22.6C459.4 363.4 480 312.1 480 256C480 132.3 379.7 32 256 32c-56.1 0-107.4 20.6-146.7 54.7l316 316zM0 256a256 256 0 1 1 512 0A256 256 0 1 1 0 256z"
+                                        fill="currentColor"
+                                      />
+                                    </svg>
+                                  </span>
+                                  <div
+                                    class="side-nav-title-content"
+                                  >
+                                    <span
+                                      class="ant-typography"
+                                      style="font-size: 16px; font-weight: 600;"
+                                    >
+                                      
+                                      Environmental Land and Watercourses
+                                    </span>
+                                    <span
+                                      class="side-nav-description"
+                                    >
+                                      <br />
+                                      Not Started
+                                    </span>
+                                  </div>
+                                </div>
+                              </a>
+                            </div>
+                          </div>
                         </div>
                       </div>
-                    </div>
-                  </div>
-                  <div
-                    class="ant-typography no_link_styling grey"
-                    style="font-size: 14px; text-align: center;"
-                  >
-                    <a
-                      class="ant-typography fade-in"
-                    >
-                      + Add Condition Category
-                    </a>
-                  </div>
-                </div>
-                <div
-                  class="side-menu--content"
-                  style="top: 0px;"
-                >
-                  <div
-                    class="ant-row ant-row-space-between ant-row-middle"
-                    style="margin: -8px -5px -8px -5px;"
-                  >
-                    <div
-                      class="ant-col ant-col-24"
-                      style="padding: 8px 5px 8px 5px;"
-                    >
-                      <h2
-                        class="ant-typography margin-none"
+                      <div
+                        class="ant-typography no_link_styling grey"
+                        style="font-size: 14px; text-align: center;"
                       >
-                        Permit Conditions
-                      </h2>
+                        <a
+                          class="ant-typography fade-in"
+                        >
+                          + Add Condition Category
+                        </a>
+                      </div>
                     </div>
                     <div
-                      class="ant-col"
-                      style="padding: 8px 5px 8px 5px;"
+                      class="side-menu--content"
+                      style="top: 0px;"
                     >
                       <div
-                        class="ant-row"
-                        style="margin-left: -5px; margin-right: -5px;"
+                        class="ant-row ant-row-space-between ant-row-middle"
+                        style="margin: -8px -5px -8px -5px;"
                       >
                         <div
+                          class="ant-col ant-col-24"
+                          style="padding: 8px 5px 8px 5px;"
+                        >
+                          <h2
+                            class="ant-typography margin-none"
+                          >
+                            Permit Conditions
+                          </h2>
+                        </div>
+                        <div
                           class="ant-col"
-                          style="padding-left: 5px; padding-right: 5px;"
+                          style="padding: 8px 5px 8px 5px;"
+                        >
+                          <div
+                            class="ant-row"
+                            style="margin-left: -5px; margin-right: -5px;"
+                          >
+                            <div
+                              class="ant-col"
+                              style="padding-left: 5px; padding-right: 5px;"
+                            >
+                              <button
+                                class="ant-btn ant-btn-dashed core-btn core-btn-tertiary fa-icon-container"
+                                type="button"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="svg-inline--fa fa-arrows-from-line "
+                                  data-icon="arrows-from-line"
+                                  data-prefix="fal"
+                                  focusable="false"
+                                  role="img"
+                                  viewBox="0 0 448 512"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M235.3 4.7c-3-3-7.1-4.7-11.3-4.7s-8.3 1.7-11.3 4.7l-80 80c-6.2 6.2-6.2 16.4 0 22.6s16.4 6.2 22.6 0L208 54.6V176c0 8.8 7.2 16 16 16s16-7.2 16-16V54.6l52.7 52.7c6.2 6.2 16.4 6.2 22.6 0s6.2-16.4 0-22.6l-80-80zM0 256c0 8.8 7.2 16 16 16H432c8.8 0 16-7.2 16-16s-7.2-16-16-16H16c-8.8 0-16 7.2-16 16zM224 512c4.2 0 8.3-1.7 11.3-4.7l80-80c6.2-6.2 6.2-16.4 0-22.6s-16.4-6.2-22.6 0L240 457.4 240 336c0-8.8-7.2-16-16-16s-16 7.2-16 16l0 121.4-52.7-52.7c-6.2-6.2-16.4-6.2-22.6 0s-6.2 16.4 0 22.6l80 80c3 3 7.1 4.7 11.3 4.7z"
+                                    fill="currentColor"
+                                  />
+                                </svg>
+                                <span>
+                                  Expand All Conditions
+                                </span>
+                              </button>
+                            </div>
+                            <div
+                              class="ant-col"
+                              style="padding-left: 5px; padding-right: 5px;"
+                            >
+                              <button
+                                class="ant-btn ant-btn-dashed core-btn core-btn-tertiary"
+                                type="button"
+                              >
+                                <span
+                                  aria-label="file"
+                                  class="anticon anticon-file"
+                                  role="img"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class=""
+                                    data-icon="file"
+                                    fill="currentColor"
+                                    focusable="false"
+                                    height="1em"
+                                    viewBox="64 64 896 896"
+                                    width="1em"
+                                  >
+                                    <path
+                                      d="M854.6 288.6L639.4 73.4c-6-6-14.1-9.4-22.6-9.4H192c-17.7 0-32 14.3-32 32v832c0 17.7 14.3 32 32 32h640c17.7 0 32-14.3 32-32V311.3c0-8.5-3.4-16.7-9.4-22.7zM790.2 326H602V137.8L790.2 326zm1.8 562H232V136h302v216a42 42 0 0042 42h216v494z"
+                                    />
+                                  </svg>
+                                </span>
+                                <span>
+                                  Open Permit in Document Viewer
+                                </span>
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                        <div
+                          class="ant-col"
+                          style="padding: 8px 5px 8px 5px;"
                         >
                           <button
                             class="ant-btn ant-btn-dashed core-btn core-btn-tertiary fa-icon-container"
@@ -609,744 +678,683 @@ exports[`PermitConditions renders properly 1`] = `
                           >
                             <svg
                               aria-hidden="true"
-                              class="svg-inline--fa fa-arrows-from-line "
-                              data-icon="arrows-from-line"
+                              class="svg-inline--fa fa-bars-staggered "
+                              data-icon="bars-staggered"
                               data-prefix="fal"
                               focusable="false"
                               role="img"
-                              viewBox="0 0 448 512"
+                              viewBox="0 0 512 512"
                               xmlns="http://www.w3.org/2000/svg"
                             >
                               <path
-                                d="M235.3 4.7c-3-3-7.1-4.7-11.3-4.7s-8.3 1.7-11.3 4.7l-80 80c-6.2 6.2-6.2 16.4 0 22.6s16.4 6.2 22.6 0L208 54.6V176c0 8.8 7.2 16 16 16s16-7.2 16-16V54.6l52.7 52.7c6.2 6.2 16.4 6.2 22.6 0s6.2-16.4 0-22.6l-80-80zM0 256c0 8.8 7.2 16 16 16H432c8.8 0 16-7.2 16-16s-7.2-16-16-16H16c-8.8 0-16 7.2-16 16zM224 512c4.2 0 8.3-1.7 11.3-4.7l80-80c6.2-6.2 6.2-16.4 0-22.6s-16.4-6.2-22.6 0L240 457.4 240 336c0-8.8-7.2-16-16-16s-16 7.2-16 16l0 121.4-52.7-52.7c-6.2-6.2-16.4-6.2-22.6 0s-6.2 16.4 0 22.6l80 80c3 3 7.1 4.7 11.3 4.7z"
+                                d="M0 80c0-8.8 7.2-16 16-16H432c8.8 0 16 7.2 16 16s-7.2 16-16 16H16C7.2 96 0 88.8 0 80zM64 240c0-8.8 7.2-16 16-16H496c8.8 0 16 7.2 16 16s-7.2 16-16 16H80c-8.8 0-16-7.2-16-16zM448 400c0 8.8-7.2 16-16 16H16c-8.8 0-16-7.2-16-16s7.2-16 16-16H432c8.8 0 16 7.2 16 16z"
                                 fill="currentColor"
                               />
                             </svg>
                             <span>
-                              Expand All Conditions
+                              Reorder
                             </span>
                           </button>
                         </div>
                         <div
-                          class="ant-col"
-                          style="padding-left: 5px; padding-right: 5px;"
-                        >
-                          <button
-                            class="ant-btn ant-btn-dashed core-btn core-btn-tertiary"
-                            type="button"
-                          >
-                            <span
-                              aria-label="file"
-                              class="anticon anticon-file"
-                              role="img"
-                            >
-                              <svg
-                                aria-hidden="true"
-                                class=""
-                                data-icon="file"
-                                fill="currentColor"
-                                focusable="false"
-                                height="1em"
-                                viewBox="64 64 896 896"
-                                width="1em"
-                              >
-                                <path
-                                  d="M854.6 288.6L639.4 73.4c-6-6-14.1-9.4-22.6-9.4H192c-17.7 0-32 14.3-32 32v832c0 17.7 14.3 32 32 32h640c17.7 0 32-14.3 32-32V311.3c0-8.5-3.4-16.7-9.4-22.7zM790.2 326H602V137.8L790.2 326zm1.8 562H232V136h302v216a42 42 0 0042 42h216v494z"
-                                />
-                              </svg>
-                            </span>
-                            <span>
-                              Open Permit in Document Viewer
-                            </span>
-                          </button>
-                        </div>
-                      </div>
-                    </div>
-                    <div
-                      class="ant-col"
-                      style="padding: 8px 5px 8px 5px;"
-                    >
-                      <button
-                        class="ant-btn ant-btn-dashed core-btn core-btn-tertiary fa-icon-container"
-                        type="button"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          class="svg-inline--fa fa-bars-staggered "
-                          data-icon="bars-staggered"
-                          data-prefix="fal"
-                          focusable="false"
-                          role="img"
-                          viewBox="0 0 512 512"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M0 80c0-8.8 7.2-16 16-16H432c8.8 0 16 7.2 16 16s-7.2 16-16 16H16C7.2 96 0 88.8 0 80zM64 240c0-8.8 7.2-16 16-16H496c8.8 0 16 7.2 16 16s-7.2 16-16 16H80c-8.8 0-16-7.2-16-16zM448 400c0 8.8-7.2 16-16 16H16c-8.8 0-16-7.2-16-16s7.2-16 16-16H432c8.8 0 16 7.2 16 16z"
-                            fill="currentColor"
-                          />
-                        </svg>
-                        <span>
-                          Reorder
-                        </span>
-                      </button>
-                    </div>
-                    <div
-                      class="ant-col ant-col-24"
-                      style="padding: 8px 5px 8px 5px;"
-                    >
-                      <div
-                        class="core-page-content"
-                      >
-                        <div
-                          class="ant-row"
-                          style="margin: -8px -8px -8px -8px;"
+                          class="ant-col ant-col-24"
+                          style="padding: 8px 5px 8px 5px;"
                         >
                           <div
-                            class="ant-col ant-col-24"
-                            style="padding: 8px 8px 8px 8px;"
+                            class="core-page-content"
                           >
                             <div
-                              class="ant-row ant-row-space-between"
-                            >
-                              <h3
-                                class="ant-typography margin-none"
-                                id="hsc"
-                              >
-                                <div>
-                                  <h3
-                                    class="ant-typography"
-                                    style="margin-bottom: 0px;"
-                                  >
-                                    A.. 
-                                    Health and Safety
-                                     (
-                                    1
-                                    )
-                                  </h3>
-                                </div>
-                              </h3>
-                              <button
-                                class="ant-btn ant-btn-primary core-btn core-btn-primary"
-                                type="button"
-                              >
-                                <span>
-                                  Add Condition
-                                </span>
-                              </button>
-                            </div>
-                          </div>
-                          <div
-                            class="ant-col ant-col-24 fade-in"
-                            style="padding: 8px 8px 8px 8px;"
-                          >
-                            <div
-                              class="condition-layer condition-layer--0 condition-SEC fade-in "
+                              class="ant-row"
+                              style="margin: -8px -8px -8px -8px;"
                             >
                               <div
-                                class="condition-collapsed"
+                                class="ant-col ant-col-24"
+                                style="padding: 8px 8px 8px 8px;"
                               >
-                                <form
-                                  class="ant-form ant-form-vertical common-form common-form-EDIT_PERMIT_CONDITION_1639 form-view"
-                                  id="EDIT_PERMIT_CONDITION_1639"
+                                <div
+                                  class="ant-row ant-row-space-between"
                                 >
-                                  <div
-                                    class="ant-row ant-row-no-wrap condition-content editable"
+                                  <h3
+                                    class="ant-typography margin-none"
+                                    id="hsc"
                                   >
-                                    <div
-                                      class="ant-col step-column"
-                                      style="flex-shrink: 0;"
-                                    >
-                                      <div
-                                        class="view-item ant-form-item"
+                                    <div>
+                                      <h3
+                                        class="ant-typography"
+                                        style="margin-bottom: 0px;"
                                       >
-                                        
-                                        <div
-                                          class="ant-typography view-item-value"
-                                        >
-                                          1.
-                                        </div>
-                                      </div>
+                                        A.. 
+                                        Health and Safety
+                                         (
+                                        1
+                                        )
+                                      </h3>
                                     </div>
-                                    <div
-                                      aria-label="Edit Condition"
-                                      class="ant-col condition-column"
-                                      title="Edit Condition"
-                                    >
-                                      <div
-                                        class="view-item ant-form-item"
-                                      >
-                                        
-                                        <div
-                                          class="ant-typography view-item-value"
-                                        >
-                                          Section decade check including.
-                                        </div>
-                                      </div>
-                                    </div>
-                                  </div>
-                                </form>
+                                  </h3>
+                                  <button
+                                    class="ant-btn ant-btn-primary core-btn core-btn-primary"
+                                    type="button"
+                                  >
+                                    <span>
+                                      Add Condition
+                                    </span>
+                                  </button>
+                                </div>
                               </div>
-                            </div>
-                          </div>
-                          <div
-                            class="ant-col ant-col-24"
-                            style="padding: 8px 8px 8px 8px;"
-                          >
-                            <div
-                              class="ant-row ant-row-space-between"
-                            >
-                              <h3
-                                class="ant-typography margin-none"
-                                id="rcc"
-                              >
-                                <div>
-                                  <h3
-                                    class="ant-typography"
-                                    style="margin-bottom: 0px;"
-                                  >
-                                    B.. 
-                                    Reclamation
-                                     (
-                                    1
-                                    )
-                                  </h3>
-                                </div>
-                              </h3>
-                              <button
-                                class="ant-btn ant-btn-primary core-btn core-btn-primary"
-                                type="button"
-                              >
-                                <span>
-                                  Add Condition
-                                </span>
-                              </button>
-                            </div>
-                          </div>
-                          <div
-                            class="ant-col ant-col-24 fade-in"
-                            style="padding: 8px 8px 8px 8px;"
-                          >
-                            <div
-                              class="condition-layer condition-layer--0 condition-SEC fade-in "
-                            >
                               <div
-                                class="condition-collapsed"
+                                class="ant-col ant-col-24 fade-in"
+                                style="padding: 8px 8px 8px 8px;"
                               >
-                                <form
-                                  class="ant-form ant-form-vertical common-form common-form-EDIT_PERMIT_CONDITION_1646 form-view"
-                                  id="EDIT_PERMIT_CONDITION_1646"
+                                <div
+                                  class="condition-layer condition-layer--0 condition-SEC fade-in "
                                 >
                                   <div
-                                    class="ant-row ant-row-no-wrap condition-content editable"
+                                    class="condition-collapsed"
                                   >
-                                    <div
-                                      class="ant-col step-column"
-                                      style="flex-shrink: 0;"
+                                    <form
+                                      class="ant-form ant-form-vertical common-form common-form-EDIT_PERMIT_CONDITION_1639 form-view"
+                                      id="EDIT_PERMIT_CONDITION_1639"
                                     >
                                       <div
-                                        class="view-item ant-form-item"
+                                        class="ant-row ant-row-no-wrap condition-content editable"
                                       >
-                                        
                                         <div
-                                          class="ant-typography view-item-value"
+                                          class="ant-col step-column"
+                                          style="flex-shrink: 0;"
                                         >
-                                          1.
+                                          <div
+                                            class="view-item ant-form-item"
+                                          >
+                                            
+                                            <div
+                                              class="ant-typography view-item-value"
+                                            >
+                                              1.
+                                            </div>
+                                          </div>
+                                        </div>
+                                        <div
+                                          aria-label="Edit Condition"
+                                          class="ant-col condition-column"
+                                          title="Edit Condition"
+                                        >
+                                          <div
+                                            class="view-item ant-form-item"
+                                          >
+                                            
+                                            <div
+                                              class="ant-typography view-item-value"
+                                            >
+                                              Section decade check including.
+                                            </div>
+                                          </div>
                                         </div>
                                       </div>
-                                    </div>
-                                    <div
-                                      aria-label="Edit Condition"
-                                      class="ant-col condition-column"
-                                      title="Edit Condition"
-                                    >
-                                      <div
-                                        class="view-item ant-form-item"
-                                      >
-                                        
-                                        <div
-                                          class="ant-typography view-item-value"
-                                        >
-                                          Reflect miss police tough such single force.
-                                        </div>
-                                      </div>
-                                    </div>
+                                    </form>
                                   </div>
-                                </form>
+                                </div>
                               </div>
-                            </div>
-                          </div>
-                          <div
-                            class="ant-col ant-col-24"
-                            style="padding: 8px 8px 8px 8px;"
-                          >
-                            <div
-                              class="ant-row ant-row-space-between"
-                            >
-                              <h3
-                                class="ant-typography margin-none"
-                                id="elc"
-                              >
-                                <div>
-                                  <h3
-                                    class="ant-typography"
-                                    style="margin-bottom: 0px;"
-                                  >
-                                    
-                                    Environmental Land and Watercourses
-                                     (
-                                    2
-                                    )
-                                  </h3>
-                                </div>
-                              </h3>
-                              <button
-                                class="ant-btn ant-btn-primary core-btn core-btn-primary"
-                                type="button"
-                              >
-                                <span>
-                                  Add Condition
-                                </span>
-                              </button>
-                            </div>
-                          </div>
-                          <div
-                            class="ant-col ant-col-24 fade-in"
-                            style="padding: 8px 8px 8px 8px;"
-                          >
-                            <div
-                              class="condition-layer condition-layer--0 condition-SEC fade-in "
-                            >
                               <div
-                                class="condition-collapsed"
+                                class="ant-col ant-col-24"
+                                style="padding: 8px 8px 8px 8px;"
                               >
-                                <form
-                                  class="ant-form ant-form-vertical common-form common-form-EDIT_PERMIT_CONDITION_1650 form-view"
-                                  id="EDIT_PERMIT_CONDITION_1650"
+                                <div
+                                  class="ant-row ant-row-space-between"
+                                >
+                                  <h3
+                                    class="ant-typography margin-none"
+                                    id="rcc"
+                                  >
+                                    <div>
+                                      <h3
+                                        class="ant-typography"
+                                        style="margin-bottom: 0px;"
+                                      >
+                                        B.. 
+                                        Reclamation
+                                         (
+                                        1
+                                        )
+                                      </h3>
+                                    </div>
+                                  </h3>
+                                  <button
+                                    class="ant-btn ant-btn-primary core-btn core-btn-primary"
+                                    type="button"
+                                  >
+                                    <span>
+                                      Add Condition
+                                    </span>
+                                  </button>
+                                </div>
+                              </div>
+                              <div
+                                class="ant-col ant-col-24 fade-in"
+                                style="padding: 8px 8px 8px 8px;"
+                              >
+                                <div
+                                  class="condition-layer condition-layer--0 condition-SEC fade-in "
                                 >
                                   <div
-                                    class="ant-row ant-row-no-wrap condition-content editable"
+                                    class="condition-collapsed"
                                   >
-                                    <div
-                                      class="ant-col step-column"
-                                      style="flex-shrink: 0;"
+                                    <form
+                                      class="ant-form ant-form-vertical common-form common-form-EDIT_PERMIT_CONDITION_1646 form-view"
+                                      id="EDIT_PERMIT_CONDITION_1646"
                                     >
                                       <div
-                                        class="view-item ant-form-item"
-                                      >
-                                        
-                                        <div
-                                          class="ant-typography view-item-value"
-                                        >
-                                          1.
-                                        </div>
-                                      </div>
-                                    </div>
-                                    <div
-                                      aria-label="Edit Condition"
-                                      class="ant-col condition-column"
-                                      title="Edit Condition"
-                                    >
-                                      <div
-                                        class="view-item ant-form-item"
-                                      >
-                                        
-                                        <div
-                                          class="ant-typography view-item-value"
-                                        >
-                                          International clear those TV individual look.
-                                        </div>
-                                      </div>
-                                    </div>
-                                  </div>
-                                </form>
-                                <div>
-                                  <div
-                                    class="condition-layer condition-layer--1 condition-CON fade-in "
-                                  >
-                                    <div
-                                      class="condition-collapsed"
-                                    >
-                                      <form
-                                        class="ant-form ant-form-vertical common-form common-form-EDIT_PERMIT_CONDITION_1641 form-view"
-                                        id="EDIT_PERMIT_CONDITION_1641"
+                                        class="ant-row ant-row-no-wrap condition-content editable"
                                       >
                                         <div
-                                          class="ant-row ant-row-no-wrap condition-content editable"
+                                          class="ant-col step-column"
+                                          style="flex-shrink: 0;"
                                         >
                                           <div
-                                            class="ant-col step-column"
-                                            style="flex-shrink: 0;"
+                                            class="view-item ant-form-item"
                                           >
+                                            
                                             <div
-                                              class="view-item ant-form-item"
+                                              class="ant-typography view-item-value"
                                             >
-                                              
-                                              <div
-                                                class="ant-typography view-item-value"
-                                              >
-                                                a.
-                                              </div>
-                                            </div>
-                                          </div>
-                                          <div
-                                            aria-label="Edit Condition"
-                                            class="ant-col condition-column"
-                                            title="Edit Condition"
-                                          >
-                                            <div
-                                              class="view-item ant-form-item"
-                                            >
-                                              
-                                              <div
-                                                class="ant-typography view-item-value"
-                                              >
-                                                See store understand company interview value factor.
-                                              </div>
+                                              1.
                                             </div>
                                           </div>
                                         </div>
-                                      </form>
-                                      <div>
                                         <div
-                                          class="condition-layer condition-layer--2 condition-LIS fade-in "
+                                          aria-label="Edit Condition"
+                                          class="ant-col condition-column"
+                                          title="Edit Condition"
                                         >
                                           <div
-                                            class="condition-collapsed"
+                                            class="view-item ant-form-item"
                                           >
-                                            <form
-                                              class="ant-form ant-form-vertical common-form common-form-EDIT_PERMIT_CONDITION_1644 form-view"
-                                              id="EDIT_PERMIT_CONDITION_1644"
+                                            
+                                            <div
+                                              class="ant-typography view-item-value"
                                             >
-                                              <div
-                                                class="ant-row ant-row-no-wrap condition-content editable"
-                                              >
-                                                <div
-                                                  class="ant-col step-column"
-                                                  style="flex-shrink: 0;"
-                                                >
-                                                  <div
-                                                    class="view-item ant-form-item"
-                                                  >
-                                                    
-                                                    <div
-                                                      class="ant-typography view-item-value"
-                                                    >
-                                                      i.
-                                                    </div>
-                                                  </div>
-                                                </div>
-                                                <div
-                                                  aria-label="Edit Condition"
-                                                  class="ant-col condition-column"
-                                                  title="Edit Condition"
-                                                >
-                                                  <div
-                                                    class="view-item ant-form-item"
-                                                  >
-                                                    
-                                                    <div
-                                                      class="ant-typography view-item-value"
-                                                    >
-                                                      Mr item fall study although.
-                                                    </div>
-                                                  </div>
-                                                </div>
-                                              </div>
-                                            </form>
+                                              Reflect miss police tough such single force.
+                                            </div>
                                           </div>
                                         </div>
                                       </div>
-                                    </div>
+                                    </form>
                                   </div>
                                 </div>
-                                <div>
-                                  <div
-                                    class="condition-layer condition-layer--1 condition-SEC fade-in "
+                              </div>
+                              <div
+                                class="ant-col ant-col-24"
+                                style="padding: 8px 8px 8px 8px;"
+                              >
+                                <div
+                                  class="ant-row ant-row-space-between"
+                                >
+                                  <h3
+                                    class="ant-typography margin-none"
+                                    id="elc"
                                   >
-                                    <div
-                                      class="condition-collapsed"
+                                    <div>
+                                      <h3
+                                        class="ant-typography"
+                                        style="margin-bottom: 0px;"
+                                      >
+                                        
+                                        Environmental Land and Watercourses
+                                         (
+                                        2
+                                        )
+                                      </h3>
+                                    </div>
+                                  </h3>
+                                  <button
+                                    class="ant-btn ant-btn-primary core-btn core-btn-primary"
+                                    type="button"
+                                  >
+                                    <span>
+                                      Add Condition
+                                    </span>
+                                  </button>
+                                </div>
+                              </div>
+                              <div
+                                class="ant-col ant-col-24 fade-in"
+                                style="padding: 8px 8px 8px 8px;"
+                              >
+                                <div
+                                  class="condition-layer condition-layer--0 condition-SEC fade-in "
+                                >
+                                  <div
+                                    class="condition-collapsed"
+                                  >
+                                    <form
+                                      class="ant-form ant-form-vertical common-form common-form-EDIT_PERMIT_CONDITION_1650 form-view"
+                                      id="EDIT_PERMIT_CONDITION_1650"
                                     >
-                                      <form
-                                        class="ant-form ant-form-vertical common-form common-form-EDIT_PERMIT_CONDITION_12507 form-view"
-                                        id="EDIT_PERMIT_CONDITION_12507"
+                                      <div
+                                        class="ant-row ant-row-no-wrap condition-content editable"
                                       >
                                         <div
-                                          class="ant-row ant-row-no-wrap condition-content editable"
+                                          class="ant-col step-column"
+                                          style="flex-shrink: 0;"
                                         >
                                           <div
-                                            class="ant-col step-column"
-                                            style="flex-shrink: 0;"
+                                            class="view-item ant-form-item"
                                           >
+                                            
                                             <div
-                                              class="view-item ant-form-item"
+                                              class="ant-typography view-item-value"
                                             >
-                                              
-                                              <div
-                                                class="ant-typography view-item-value"
-                                              >
-                                                b.
-                                              </div>
+                                              1.
                                             </div>
                                           </div>
+                                        </div>
+                                        <div
+                                          aria-label="Edit Condition"
+                                          class="ant-col condition-column"
+                                          title="Edit Condition"
+                                        >
                                           <div
-                                            aria-label="Edit Condition"
-                                            class="ant-col condition-column"
-                                            title="Edit Condition"
+                                            class="view-item ant-form-item"
+                                          >
+                                            
+                                            <div
+                                              class="ant-typography view-item-value"
+                                            >
+                                              International clear those TV individual look.
+                                            </div>
+                                          </div>
+                                        </div>
+                                      </div>
+                                    </form>
+                                    <div>
+                                      <div
+                                        class="condition-layer condition-layer--1 condition-CON fade-in "
+                                      >
+                                        <div
+                                          class="condition-collapsed"
+                                        >
+                                          <form
+                                            class="ant-form ant-form-vertical common-form common-form-EDIT_PERMIT_CONDITION_1641 form-view"
+                                            id="EDIT_PERMIT_CONDITION_1641"
                                           >
                                             <div
-                                              class="view-item ant-form-item"
+                                              class="ant-row ant-row-no-wrap condition-content editable"
                                             >
-                                              
                                               <div
-                                                class="ant-typography view-item-value"
+                                                class="ant-col step-column"
+                                                style="flex-shrink: 0;"
                                               >
-                                                words words words sub-section
+                                                <div
+                                                  class="view-item ant-form-item"
+                                                >
+                                                  
+                                                  <div
+                                                    class="ant-typography view-item-value"
+                                                  >
+                                                    a.
+                                                  </div>
+                                                </div>
+                                              </div>
+                                              <div
+                                                aria-label="Edit Condition"
+                                                class="ant-col condition-column"
+                                                title="Edit Condition"
+                                              >
+                                                <div
+                                                  class="view-item ant-form-item"
+                                                >
+                                                  
+                                                  <div
+                                                    class="ant-typography view-item-value"
+                                                  >
+                                                    See store understand company interview value factor.
+                                                  </div>
+                                                </div>
+                                              </div>
+                                            </div>
+                                          </form>
+                                          <div>
+                                            <div
+                                              class="condition-layer condition-layer--2 condition-LIS fade-in "
+                                            >
+                                              <div
+                                                class="condition-collapsed"
+                                              >
+                                                <form
+                                                  class="ant-form ant-form-vertical common-form common-form-EDIT_PERMIT_CONDITION_1644 form-view"
+                                                  id="EDIT_PERMIT_CONDITION_1644"
+                                                >
+                                                  <div
+                                                    class="ant-row ant-row-no-wrap condition-content editable"
+                                                  >
+                                                    <div
+                                                      class="ant-col step-column"
+                                                      style="flex-shrink: 0;"
+                                                    >
+                                                      <div
+                                                        class="view-item ant-form-item"
+                                                      >
+                                                        
+                                                        <div
+                                                          class="ant-typography view-item-value"
+                                                        >
+                                                          i.
+                                                        </div>
+                                                      </div>
+                                                    </div>
+                                                    <div
+                                                      aria-label="Edit Condition"
+                                                      class="ant-col condition-column"
+                                                      title="Edit Condition"
+                                                    >
+                                                      <div
+                                                        class="view-item ant-form-item"
+                                                      >
+                                                        
+                                                        <div
+                                                          class="ant-typography view-item-value"
+                                                        >
+                                                          Mr item fall study although.
+                                                        </div>
+                                                      </div>
+                                                    </div>
+                                                  </div>
+                                                </form>
                                               </div>
                                             </div>
                                           </div>
                                         </div>
-                                      </form>
-                                      <div>
+                                      </div>
+                                    </div>
+                                    <div>
+                                      <div
+                                        class="condition-layer condition-layer--1 condition-SEC fade-in "
+                                      >
                                         <div
-                                          class="condition-layer condition-layer--2 condition-CON fade-in "
+                                          class="condition-collapsed"
                                         >
-                                          <div
-                                            class="condition-collapsed"
+                                          <form
+                                            class="ant-form ant-form-vertical common-form common-form-EDIT_PERMIT_CONDITION_12507 form-view"
+                                            id="EDIT_PERMIT_CONDITION_12507"
                                           >
-                                            <form
-                                              class="ant-form ant-form-vertical common-form common-form-EDIT_PERMIT_CONDITION_12509 form-view"
-                                              id="EDIT_PERMIT_CONDITION_12509"
+                                            <div
+                                              class="ant-row ant-row-no-wrap condition-content editable"
                                             >
                                               <div
-                                                class="ant-row ant-row-no-wrap condition-content editable"
+                                                class="ant-col step-column"
+                                                style="flex-shrink: 0;"
                                               >
                                                 <div
-                                                  class="ant-col step-column"
-                                                  style="flex-shrink: 0;"
+                                                  class="view-item ant-form-item"
                                                 >
+                                                  
                                                   <div
-                                                    class="view-item ant-form-item"
+                                                    class="ant-typography view-item-value"
                                                   >
-                                                    
-                                                    <div
-                                                      class="ant-typography view-item-value"
-                                                    >
-                                                      i.
-                                                    </div>
-                                                  </div>
-                                                </div>
-                                                <div
-                                                  aria-label="Edit Condition"
-                                                  class="ant-col condition-column"
-                                                  title="Edit Condition"
-                                                >
-                                                  <div
-                                                    class="view-item ant-form-item"
-                                                  >
-                                                    
-                                                    <div
-                                                      class="ant-typography view-item-value"
-                                                    >
-                                                      a condition added underneath the section, with a lot of detail added to it, which is probably important for documents like permits
-                                                    </div>
+                                                    b.
                                                   </div>
                                                 </div>
                                               </div>
-                                            </form>
-                                            <div>
                                               <div
-                                                class="condition-layer condition-layer--3 condition-LIS fade-in "
+                                                aria-label="Edit Condition"
+                                                class="ant-col condition-column"
+                                                title="Edit Condition"
                                               >
                                                 <div
-                                                  class="condition-collapsed"
+                                                  class="view-item ant-form-item"
                                                 >
-                                                  <form
-                                                    class="ant-form ant-form-vertical common-form common-form-EDIT_PERMIT_CONDITION_12510 form-view"
-                                                    id="EDIT_PERMIT_CONDITION_12510"
+                                                  
+                                                  <div
+                                                    class="ant-typography view-item-value"
                                                   >
-                                                    <div
-                                                      class="ant-row ant-row-no-wrap condition-content editable"
-                                                    >
-                                                      <div
-                                                        class="ant-col step-column"
-                                                        style="flex-shrink: 0;"
-                                                      >
-                                                        <div
-                                                          class="view-item ant-form-item"
-                                                        >
-                                                          
-                                                          <div
-                                                            class="ant-typography view-item-value"
-                                                          >
-                                                            1.
-                                                          </div>
-                                                        </div>
-                                                      </div>
-                                                      <div
-                                                        aria-label="Edit Condition"
-                                                        class="ant-col condition-column"
-                                                        title="Edit Condition"
-                                                      >
-                                                        <div
-                                                          class="view-item ant-form-item"
-                                                        >
-                                                          
-                                                          <div
-                                                            class="ant-typography view-item-value"
-                                                          >
-                                                            a detailed list item desribing exactly what must be done to accomplish the parent condition
-                                                          </div>
-                                                        </div>
-                                                      </div>
-                                                    </div>
-                                                  </form>
+                                                    words words words sub-section
+                                                  </div>
                                                 </div>
                                               </div>
                                             </div>
-                                            <div>
+                                          </form>
+                                          <div>
+                                            <div
+                                              class="condition-layer condition-layer--2 condition-CON fade-in "
+                                            >
                                               <div
-                                                class="condition-layer condition-layer--3 condition-LIS fade-in "
+                                                class="condition-collapsed"
                                               >
-                                                <div
-                                                  class="condition-collapsed"
+                                                <form
+                                                  class="ant-form ant-form-vertical common-form common-form-EDIT_PERMIT_CONDITION_12509 form-view"
+                                                  id="EDIT_PERMIT_CONDITION_12509"
                                                 >
-                                                  <form
-                                                    class="ant-form ant-form-vertical common-form common-form-EDIT_PERMIT_CONDITION_12511 form-view"
-                                                    id="EDIT_PERMIT_CONDITION_12511"
+                                                  <div
+                                                    class="ant-row ant-row-no-wrap condition-content editable"
                                                   >
                                                     <div
-                                                      class="ant-row ant-row-no-wrap condition-content editable"
+                                                      class="ant-col step-column"
+                                                      style="flex-shrink: 0;"
                                                     >
                                                       <div
-                                                        class="ant-col step-column"
-                                                        style="flex-shrink: 0;"
+                                                        class="view-item ant-form-item"
                                                       >
+                                                        
                                                         <div
-                                                          class="view-item ant-form-item"
+                                                          class="ant-typography view-item-value"
                                                         >
-                                                          
-                                                          <div
-                                                            class="ant-typography view-item-value"
-                                                          >
-                                                            2.
-                                                          </div>
-                                                        </div>
-                                                      </div>
-                                                      <div
-                                                        aria-label="Edit Condition"
-                                                        class="ant-col condition-column"
-                                                        title="Edit Condition"
-                                                      >
-                                                        <div
-                                                          class="view-item ant-form-item"
-                                                        >
-                                                          
-                                                          <div
-                                                            class="ant-typography view-item-value"
-                                                          >
-                                                            but, that wasn't quite enough information, another list item will expand on other responsibilities associated with this permit
-                                                          </div>
+                                                          i.
                                                         </div>
                                                       </div>
                                                     </div>
-                                                  </form>
-                                                </div>
-                                              </div>
-                                            </div>
-                                            <div>
-                                              <div
-                                                class="condition-layer condition-layer--3 condition-LIS fade-in "
-                                              >
-                                                <div
-                                                  class="condition-collapsed"
-                                                >
-                                                  <form
-                                                    class="ant-form ant-form-vertical common-form common-form-EDIT_PERMIT_CONDITION_12512 form-view"
-                                                    id="EDIT_PERMIT_CONDITION_12512"
-                                                  >
                                                     <div
-                                                      class="ant-row ant-row-no-wrap condition-content editable"
+                                                      aria-label="Edit Condition"
+                                                      class="ant-col condition-column"
+                                                      title="Edit Condition"
                                                     >
                                                       <div
-                                                        class="ant-col step-column"
-                                                        style="flex-shrink: 0;"
+                                                        class="view-item ant-form-item"
                                                       >
+                                                        
                                                         <div
-                                                          class="view-item ant-form-item"
+                                                          class="ant-typography view-item-value"
                                                         >
-                                                          
-                                                          <div
-                                                            class="ant-typography view-item-value"
-                                                          >
-                                                            3.
-                                                          </div>
-                                                        </div>
-                                                      </div>
-                                                      <div
-                                                        aria-label="Edit Condition"
-                                                        class="ant-col condition-column"
-                                                        title="Edit Condition"
-                                                      >
-                                                        <div
-                                                          class="view-item ant-form-item"
-                                                        >
-                                                          
-                                                          <div
-                                                            class="ant-typography view-item-value"
-                                                          >
-                                                            good things come in 3s, so another list item is added to the condition
-                                                          </div>
+                                                          a condition added underneath the section, with a lot of detail added to it, which is probably important for documents like permits
                                                         </div>
                                                       </div>
                                                     </div>
-                                                  </form>
-                                                  <div>
+                                                  </div>
+                                                </form>
+                                                <div>
+                                                  <div
+                                                    class="condition-layer condition-layer--3 condition-LIS fade-in "
+                                                  >
                                                     <div
-                                                      class="condition-layer condition-layer--4 condition-LIS fade-in "
+                                                      class="condition-collapsed"
                                                     >
-                                                      <div
-                                                        class="condition-collapsed"
+                                                      <form
+                                                        class="ant-form ant-form-vertical common-form common-form-EDIT_PERMIT_CONDITION_12510 form-view"
+                                                        id="EDIT_PERMIT_CONDITION_12510"
                                                       >
-                                                        <form
-                                                          class="ant-form ant-form-vertical common-form common-form-EDIT_PERMIT_CONDITION_12513 form-view"
-                                                          id="EDIT_PERMIT_CONDITION_12513"
+                                                        <div
+                                                          class="ant-row ant-row-no-wrap condition-content editable"
                                                         >
                                                           <div
-                                                            class="ant-row ant-row-no-wrap condition-content editable"
+                                                            class="ant-col step-column"
+                                                            style="flex-shrink: 0;"
                                                           >
                                                             <div
-                                                              class="ant-col step-column"
-                                                              style="flex-shrink: 0;"
+                                                              class="view-item ant-form-item"
                                                             >
+                                                              
                                                               <div
-                                                                class="view-item ant-form-item"
+                                                                class="ant-typography view-item-value"
                                                               >
-                                                                
-                                                                <div
-                                                                  class="ant-typography view-item-value"
-                                                                >
-                                                                  a.
-                                                                </div>
-                                                              </div>
-                                                            </div>
-                                                            <div
-                                                              aria-label="Edit Condition"
-                                                              class="ant-col condition-column"
-                                                              title="Edit Condition"
-                                                            >
-                                                              <div
-                                                                class="view-item ant-form-item"
-                                                              >
-                                                                
-                                                                <div
-                                                                  class="ant-typography view-item-value"
-                                                                >
-                                                                  we want to show nesting to 5 levels, so one list item gets a child
-                                                                </div>
+                                                                1.
                                                               </div>
                                                             </div>
                                                           </div>
-                                                        </form>
+                                                          <div
+                                                            aria-label="Edit Condition"
+                                                            class="ant-col condition-column"
+                                                            title="Edit Condition"
+                                                          >
+                                                            <div
+                                                              class="view-item ant-form-item"
+                                                            >
+                                                              
+                                                              <div
+                                                                class="ant-typography view-item-value"
+                                                              >
+                                                                a detailed list item desribing exactly what must be done to accomplish the parent condition
+                                                              </div>
+                                                            </div>
+                                                          </div>
+                                                        </div>
+                                                      </form>
+                                                    </div>
+                                                  </div>
+                                                </div>
+                                                <div>
+                                                  <div
+                                                    class="condition-layer condition-layer--3 condition-LIS fade-in "
+                                                  >
+                                                    <div
+                                                      class="condition-collapsed"
+                                                    >
+                                                      <form
+                                                        class="ant-form ant-form-vertical common-form common-form-EDIT_PERMIT_CONDITION_12511 form-view"
+                                                        id="EDIT_PERMIT_CONDITION_12511"
+                                                      >
+                                                        <div
+                                                          class="ant-row ant-row-no-wrap condition-content editable"
+                                                        >
+                                                          <div
+                                                            class="ant-col step-column"
+                                                            style="flex-shrink: 0;"
+                                                          >
+                                                            <div
+                                                              class="view-item ant-form-item"
+                                                            >
+                                                              
+                                                              <div
+                                                                class="ant-typography view-item-value"
+                                                              >
+                                                                2.
+                                                              </div>
+                                                            </div>
+                                                          </div>
+                                                          <div
+                                                            aria-label="Edit Condition"
+                                                            class="ant-col condition-column"
+                                                            title="Edit Condition"
+                                                          >
+                                                            <div
+                                                              class="view-item ant-form-item"
+                                                            >
+                                                              
+                                                              <div
+                                                                class="ant-typography view-item-value"
+                                                              >
+                                                                but, that wasn't quite enough information, another list item will expand on other responsibilities associated with this permit
+                                                              </div>
+                                                            </div>
+                                                          </div>
+                                                        </div>
+                                                      </form>
+                                                    </div>
+                                                  </div>
+                                                </div>
+                                                <div>
+                                                  <div
+                                                    class="condition-layer condition-layer--3 condition-LIS fade-in "
+                                                  >
+                                                    <div
+                                                      class="condition-collapsed"
+                                                    >
+                                                      <form
+                                                        class="ant-form ant-form-vertical common-form common-form-EDIT_PERMIT_CONDITION_12512 form-view"
+                                                        id="EDIT_PERMIT_CONDITION_12512"
+                                                      >
+                                                        <div
+                                                          class="ant-row ant-row-no-wrap condition-content editable"
+                                                        >
+                                                          <div
+                                                            class="ant-col step-column"
+                                                            style="flex-shrink: 0;"
+                                                          >
+                                                            <div
+                                                              class="view-item ant-form-item"
+                                                            >
+                                                              
+                                                              <div
+                                                                class="ant-typography view-item-value"
+                                                              >
+                                                                3.
+                                                              </div>
+                                                            </div>
+                                                          </div>
+                                                          <div
+                                                            aria-label="Edit Condition"
+                                                            class="ant-col condition-column"
+                                                            title="Edit Condition"
+                                                          >
+                                                            <div
+                                                              class="view-item ant-form-item"
+                                                            >
+                                                              
+                                                              <div
+                                                                class="ant-typography view-item-value"
+                                                              >
+                                                                good things come in 3s, so another list item is added to the condition
+                                                              </div>
+                                                            </div>
+                                                          </div>
+                                                        </div>
+                                                      </form>
+                                                      <div>
+                                                        <div
+                                                          class="condition-layer condition-layer--4 condition-LIS fade-in "
+                                                        >
+                                                          <div
+                                                            class="condition-collapsed"
+                                                          >
+                                                            <form
+                                                              class="ant-form ant-form-vertical common-form common-form-EDIT_PERMIT_CONDITION_12513 form-view"
+                                                              id="EDIT_PERMIT_CONDITION_12513"
+                                                            >
+                                                              <div
+                                                                class="ant-row ant-row-no-wrap condition-content editable"
+                                                              >
+                                                                <div
+                                                                  class="ant-col step-column"
+                                                                  style="flex-shrink: 0;"
+                                                                >
+                                                                  <div
+                                                                    class="view-item ant-form-item"
+                                                                  >
+                                                                    
+                                                                    <div
+                                                                      class="ant-typography view-item-value"
+                                                                    >
+                                                                      a.
+                                                                    </div>
+                                                                  </div>
+                                                                </div>
+                                                                <div
+                                                                  aria-label="Edit Condition"
+                                                                  class="ant-col condition-column"
+                                                                  title="Edit Condition"
+                                                                >
+                                                                  <div
+                                                                    class="view-item ant-form-item"
+                                                                  >
+                                                                    
+                                                                    <div
+                                                                      class="ant-typography view-item-value"
+                                                                    >
+                                                                      we want to show nesting to 5 levels, so one list item gets a child
+                                                                    </div>
+                                                                  </div>
+                                                                </div>
+                                                              </div>
+                                                            </form>
+                                                          </div>
+                                                        </div>
                                                       </div>
                                                     </div>
                                                   </div>
@@ -1360,105 +1368,105 @@ exports[`PermitConditions renders properly 1`] = `
                                   </div>
                                 </div>
                               </div>
-                            </div>
-                          </div>
-                          <div
-                            class="ant-col ant-col-24 fade-in"
-                            style="padding: 8px 8px 8px 8px;"
-                          >
-                            <div
-                              class="condition-layer condition-layer--0 condition-SEC fade-in "
-                            >
                               <div
-                                class="condition-collapsed"
+                                class="ant-col ant-col-24 fade-in"
+                                style="padding: 8px 8px 8px 8px;"
                               >
-                                <form
-                                  class="ant-form ant-form-vertical common-form common-form-EDIT_PERMIT_CONDITION_12514 form-view"
-                                  id="EDIT_PERMIT_CONDITION_12514"
+                                <div
+                                  class="condition-layer condition-layer--0 condition-SEC fade-in "
                                 >
                                   <div
-                                    class="ant-row ant-row-no-wrap condition-content editable"
+                                    class="condition-collapsed"
                                   >
-                                    <div
-                                      class="ant-col step-column"
-                                      style="flex-shrink: 0;"
+                                    <form
+                                      class="ant-form ant-form-vertical common-form common-form-EDIT_PERMIT_CONDITION_12514 form-view"
+                                      id="EDIT_PERMIT_CONDITION_12514"
                                     >
                                       <div
-                                        class="view-item ant-form-item"
-                                      >
-                                        
-                                        <div
-                                          class="ant-typography view-item-value"
-                                        >
-                                          2.
-                                        </div>
-                                      </div>
-                                    </div>
-                                    <div
-                                      aria-label="Edit Condition"
-                                      class="ant-col condition-column"
-                                      title="Edit Condition"
-                                    >
-                                      <div
-                                        class="view-item ant-form-item"
-                                      >
-                                        
-                                        <div
-                                          class="ant-typography view-item-value"
-                                        >
-                                          Another condition under the ELC condition category code, and it may even be long enough to take up 2 lines
-                                        </div>
-                                      </div>
-                                    </div>
-                                  </div>
-                                </form>
-                                <div>
-                                  <div
-                                    class="condition-layer condition-layer--1 condition-CON fade-in "
-                                  >
-                                    <div
-                                      class="condition-collapsed"
-                                    >
-                                      <form
-                                        class="ant-form ant-form-vertical common-form common-form-EDIT_PERMIT_CONDITION_12515 form-view"
-                                        id="EDIT_PERMIT_CONDITION_12515"
+                                        class="ant-row ant-row-no-wrap condition-content editable"
                                       >
                                         <div
-                                          class="ant-row ant-row-no-wrap condition-content editable"
+                                          class="ant-col step-column"
+                                          style="flex-shrink: 0;"
                                         >
                                           <div
-                                            class="ant-col step-column"
-                                            style="flex-shrink: 0;"
+                                            class="view-item ant-form-item"
                                           >
+                                            
                                             <div
-                                              class="view-item ant-form-item"
+                                              class="ant-typography view-item-value"
                                             >
-                                              
-                                              <div
-                                                class="ant-typography view-item-value"
-                                              >
-                                                a.
-                                              </div>
-                                            </div>
-                                          </div>
-                                          <div
-                                            aria-label="Edit Condition"
-                                            class="ant-col condition-column"
-                                            title="Edit Condition"
-                                          >
-                                            <div
-                                              class="view-item ant-form-item"
-                                            >
-                                              
-                                              <div
-                                                class="ant-typography view-item-value"
-                                              >
-                                                It should probably have a sub-item because that's pretty fun and normal for permit conditions. Really it should be long enough to have it cut off at some point if we just add more words, but the question is how many will be necessary?
-                                              </div>
+                                              2.
                                             </div>
                                           </div>
                                         </div>
-                                      </form>
+                                        <div
+                                          aria-label="Edit Condition"
+                                          class="ant-col condition-column"
+                                          title="Edit Condition"
+                                        >
+                                          <div
+                                            class="view-item ant-form-item"
+                                          >
+                                            
+                                            <div
+                                              class="ant-typography view-item-value"
+                                            >
+                                              Another condition under the ELC condition category code, and it may even be long enough to take up 2 lines
+                                            </div>
+                                          </div>
+                                        </div>
+                                      </div>
+                                    </form>
+                                    <div>
+                                      <div
+                                        class="condition-layer condition-layer--1 condition-CON fade-in "
+                                      >
+                                        <div
+                                          class="condition-collapsed"
+                                        >
+                                          <form
+                                            class="ant-form ant-form-vertical common-form common-form-EDIT_PERMIT_CONDITION_12515 form-view"
+                                            id="EDIT_PERMIT_CONDITION_12515"
+                                          >
+                                            <div
+                                              class="ant-row ant-row-no-wrap condition-content editable"
+                                            >
+                                              <div
+                                                class="ant-col step-column"
+                                                style="flex-shrink: 0;"
+                                              >
+                                                <div
+                                                  class="view-item ant-form-item"
+                                                >
+                                                  
+                                                  <div
+                                                    class="ant-typography view-item-value"
+                                                  >
+                                                    a.
+                                                  </div>
+                                                </div>
+                                              </div>
+                                              <div
+                                                aria-label="Edit Condition"
+                                                class="ant-col condition-column"
+                                                title="Edit Condition"
+                                              >
+                                                <div
+                                                  class="view-item ant-form-item"
+                                                >
+                                                  
+                                                  <div
+                                                    class="ant-typography view-item-value"
+                                                  >
+                                                    It should probably have a sub-item because that's pretty fun and normal for permit conditions. Really it should be long enough to have it cut off at some point if we just add more words, but the question is how many will be necessary?
+                                                  </div>
+                                                </div>
+                                              </div>
+                                            </div>
+                                          </form>
+                                        </div>
+                                      </div>
                                     </div>
                                   </div>
                                 </div>
@@ -1470,6 +1478,7 @@ exports[`PermitConditions renders properly 1`] = `
                     </div>
                   </div>
                 </div>
+                
               </div>
             </div>
           </div>

--- a/services/core-web/src/styles/tools/syncfusion.scss
+++ b/services/core-web/src/styles/tools/syncfusion.scss
@@ -41,7 +41,8 @@ $error-font: theme.$error-color; //#f44336;
 }
 
 #pdfviewer-container_fileUploadElement,
-#pdfviewer-container_annotationContainer {
+#pdfviewer-container_annotationContainer,
+#preview-permit-amendment-pdf_fileUploadElement {
   display: none;
 }
 

--- a/services/core-web/src/styles/tools/syncfusion.scss
+++ b/services/core-web/src/styles/tools/syncfusion.scss
@@ -46,6 +46,11 @@ $error-font: theme.$error-color; //#f44336;
   display: none;
 }
 
+#preview-permit-amendment-pdf {
+  width: 100%;
+  height: calc(100v - 240px);
+}
+
 #pdfviewer-container_zoomDropDownContainer {
   width: 108px;
 }

--- a/services/core-web/src/styles/tools/syncfusion.scss
+++ b/services/core-web/src/styles/tools/syncfusion.scss
@@ -48,7 +48,7 @@ $error-font: theme.$error-color; //#f44336;
 
 #preview-permit-amendment-pdf {
   width: 100%;
-  height: calc(100v - 240px);
+  height: calc(100vh - 240px);
 }
 
 #pdfviewer-container_zoomDropDownContainer {

--- a/services/core-web/src/tests/components/mine/Permit/PreviewPermitAmendmentDocument.spec.tsx
+++ b/services/core-web/src/tests/components/mine/Permit/PreviewPermitAmendmentDocument.spec.tsx
@@ -4,6 +4,7 @@ import { getDocument } from "@mds/common/redux/utils/actionlessNetworkCalls";
 import { ReduxWrapper } from "@mds/common/tests/utils/ReduxWrapper";
 import { PreviewPermitAmendmentDocument } from "@/components/mine/Permit/PreviewPermitAmendmentDocument";
 import * as MOCK from "@mds/common/tests/mocks/dataMocks";
+import { IPermitCondition } from "@mds/common/interfaces";
 
 jest.mock("@mds/common/redux/utils/actionlessNetworkCalls", () => ({
     getDocument: jest.fn()
@@ -11,7 +12,7 @@ jest.mock("@mds/common/redux/utils/actionlessNetworkCalls", () => ({
 
 const mockPermitAmendment = MOCK.PERMITS[0].permit_amendments[0];
 
-const mockSelectedCondition = {
+const mockSelectedCondition: IPermitCondition = {
     ...MOCK.PERMITS[0].permit_amendments[0].conditions[0],
     permit_condition_guid: "test-condition",
     meta: {

--- a/services/core-web/src/tests/components/mine/Permit/PreviewPermitAmendmentDocument.spec.tsx
+++ b/services/core-web/src/tests/components/mine/Permit/PreviewPermitAmendmentDocument.spec.tsx
@@ -1,0 +1,97 @@
+import React from "react";
+import { render, waitFor } from "@testing-library/react";
+import { getDocument } from "@mds/common/redux/utils/actionlessNetworkCalls";
+import { ReduxWrapper } from "@mds/common/tests/utils/ReduxWrapper";
+import { PreviewPermitAmendmentDocument } from "@/components/mine/Permit/PreviewPermitAmendmentDocument";
+import * as MOCK from "@mds/common/tests/mocks/dataMocks";
+
+jest.mock("@mds/common/redux/utils/actionlessNetworkCalls", () => ({
+    getDocument: jest.fn()
+}));
+
+const mockPermitAmendment = MOCK.PERMITS[0].permit_amendments[0];
+
+const mockSelectedCondition = {
+    ...MOCK.PERMITS[0].permit_amendments[0].conditions[0],
+    permit_condition_guid: "test-condition",
+    meta: {
+        page: 1,
+        bounding_box: {
+            top: 100,
+            right: 200,
+            bottom: 300,
+            left: 50
+        }
+    }
+};
+
+describe("PreviewPermitAmendmentDocument", () => {
+    beforeEach(() => {
+        (getDocument as jest.Mock).mockReset();
+        (getDocument as jest.Mock).mockResolvedValue({ object_store_path: "test-url" });
+    });
+
+    it("renders skeleton while loading document", () => {
+        const { container } = render(
+            <ReduxWrapper>
+                <PreviewPermitAmendmentDocument
+                    amendment={mockPermitAmendment}
+                    documentGuid="test-doc-guid"
+                />
+            </ReduxWrapper>
+        );
+
+        expect(container.querySelector(".ant-skeleton")).toBeTruthy();
+        expect(container.querySelector("#preview-permit-amendment-pdf")).toBeFalsy();
+    });
+
+    it("fetches and displays document when documentGuid is provided", async () => {
+        const { container } = render(
+            <ReduxWrapper>
+                <PreviewPermitAmendmentDocument
+                    amendment={mockPermitAmendment}
+                    documentGuid="31204ba5-5207-4fb5-b6c3-d47e55a0971c"
+                />
+            </ReduxWrapper>
+        );
+
+        await waitFor(() => {
+            expect(getDocument).toHaveBeenCalledWith("64caef0e-060d-4875-a470-6c225b242723");
+            expect(container.querySelector("#preview-permit-amendment-pdf")).toBeTruthy();
+            expect(container.querySelector(".ant-skeleton")).toBeFalsy();
+
+            expect(container).toMatchSnapshot();
+        });
+    });
+
+    it("adds annotation when selected condition changes", async () => {
+        const { rerender } = render(
+            <ReduxWrapper>
+                <PreviewPermitAmendmentDocument
+                    amendment={mockPermitAmendment}
+                    documentGuid="31204ba5-5207-4fb5-b6c3-d47e55a0971c"
+                    selectedCondition={mockSelectedCondition}
+                />
+            </ReduxWrapper>
+        );
+
+        await waitFor(() => {
+            expect(getDocument).toHaveBeenCalled();
+        });
+
+        rerender(
+            <ReduxWrapper>
+                <PreviewPermitAmendmentDocument
+                    amendment={mockPermitAmendment}
+                    documentGuid="31204ba5-5207-4fb5-b6c3-d47e55a0971c"
+                    selectedCondition={{
+                        ...mockSelectedCondition,
+                        permit_condition_guid: "new-condition"
+                    }}
+                />
+            </ReduxWrapper>
+        );
+
+    });
+
+});

--- a/services/core-web/src/tests/components/mine/Permit/__snapshots__/PreviewPermitAmendmentDocument.spec.tsx.snap
+++ b/services/core-web/src/tests/components/mine/Permit/__snapshots__/PreviewPermitAmendmentDocument.spec.tsx.snap
@@ -1567,29 +1567,3 @@ exports[`PreviewPermitAmendmentDocument fetches and displays document when docum
   </div>
 </div>
 `;
-
-exports[`PreviewPermitAmendmentDocument matches snapshot 1`] = `
-<div>
-  <div
-    class="ant-skeleton"
-  >
-    <div
-      class="ant-skeleton-content"
-    >
-      <h3
-        class="ant-skeleton-title"
-        style="width: 38%;"
-      />
-      <ul
-        class="ant-skeleton-paragraph"
-      >
-        <li />
-        <li />
-        <li
-          style="width: 61%;"
-        />
-      </ul>
-    </div>
-  </div>
-</div>
-`;

--- a/services/core-web/src/tests/components/mine/Permit/__snapshots__/PreviewPermitAmendmentDocument.spec.tsx.snap
+++ b/services/core-web/src/tests/components/mine/Permit/__snapshots__/PreviewPermitAmendmentDocument.spec.tsx.snap
@@ -1,0 +1,1595 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PreviewPermitAmendmentDocument fetches and displays document when documentGuid is provided 1`] = `
+<div>
+  <div
+    class="e-control e-pdfviewer e-lib"
+    id="preview-permit-amendment-pdf"
+    style="display: block; height: 80vh; min-height: 500px;"
+  >
+    <div
+      class="e-pv-main-container"
+      id="preview-permit-amendment-pdf_mainContainer"
+    >
+      <div
+        class="e-pv-viewer-main-container"
+        id="preview-permit-amendment-pdf_viewerMainContainer"
+      >
+        <div
+          aria-disabled="false"
+          aria-label="Toolbar"
+          aria-orientation="horizontal"
+          class="e-pv-toolbar e-control e-toolbar e-lib e-pv-toolbar-scroll e-toolpop e-keyboard"
+          id="preview-permit-amendment-pdf_toolbarContainer"
+          role="toolbar"
+          style="display: block;"
+        >
+          <div
+            class="e-toolbar-items e-tbar-pos"
+            id="preview-permit-amendment-pdf_toolbarItemsContainer"
+          >
+            <div
+              class="e-toolbar-left"
+            >
+              <div
+                class="e-toolbar-item e-pv-open-document-container e-popup-text"
+                id="preview-permit-amendment-pdf_openContainer"
+              >
+                <button
+                  aria-disabled="false"
+                  aria-label="Open file (Ctrl+O)"
+                  class="e-tbar-btn e-tbtn-txt e-control e-btn e-lib e-pv-open-document e-pv-tbar-btn e-tooltip"
+                  data-tabindex="-1"
+                  id="preview-permit-amendment-pdf_open"
+                  style=""
+                  tabindex="0"
+                  type="button"
+                >
+                  <span
+                    class="e-pv-open-document-icon e-pv-icon e-icon-left"
+                    id="preview-permit-amendment-pdf_openIcon"
+                  />
+                  <span
+                    class="e-tbar-btn-text"
+                    id="preview-permit-amendment-pdf_openText"
+                  >
+                    Open
+                  </span>
+                </button>
+              </div>
+              <div
+                class="e-toolbar-item e-pv-open-separator-container e-separator"
+              />
+              <div
+                class="e-toolbar-item e-pv-first-page-navigation-container e-popup-text e-overlay"
+                id="preview-permit-amendment-pdf_firstPageContainer"
+              >
+                <button
+                  aria-disabled="true"
+                  aria-label="Show first page (Ctrl+← or Ctrl+↑)"
+                  class="e-tbar-btn e-tbtn-txt e-control e-btn e-lib e-pv-first-page-navigation e-pv-tbar-btn e-tooltip"
+                  data-tabindex="-1"
+                  id="preview-permit-amendment-pdf_firstPage"
+                  style=""
+                  tabindex="-1"
+                  type="button"
+                >
+                  <span
+                    class="e-pv-first-page-navigation-icon e-pv-icon e-icon-left"
+                    id="preview-permit-amendment-pdf_firstPageIcon"
+                  />
+                  <span
+                    class="e-tbar-btn-text"
+                    id="preview-permit-amendment-pdf_firstPageText"
+                  >
+                    First Page
+                  </span>
+                </button>
+              </div>
+              <div
+                class="e-toolbar-item e-pv-previous-page-navigation-container e-popup-text e-overlay"
+                id="preview-permit-amendment-pdf_previousPageContainer"
+              >
+                <button
+                  aria-disabled="true"
+                  aria-label="Show previous page (←)"
+                  class="e-tbar-btn e-tbtn-txt e-control e-btn e-lib e-pv-previous-page-navigation e-pv-tbar-btn e-tooltip"
+                  data-tabindex="-1"
+                  id="preview-permit-amendment-pdf_previousPage"
+                  style=""
+                  tabindex="-1"
+                  type="button"
+                >
+                  <span
+                    class="e-pv-previous-page-navigation-icon e-pv-icon e-icon-left"
+                    id="preview-permit-amendment-pdf_previousPageIcon"
+                  />
+                  <span
+                    class="e-tbar-btn-text"
+                    id="preview-permit-amendment-pdf_previousPageText"
+                  >
+                    Previous Page
+                  </span>
+                </button>
+              </div>
+              <div
+                class="e-toolbar-item e-pv-next-page-navigation-container e-popup-text e-overlay"
+                id="preview-permit-amendment-pdf_nextPageContainer"
+              >
+                <button
+                  aria-disabled="true"
+                  aria-label="Show next page (→)"
+                  class="e-tbar-btn e-tbtn-txt e-control e-btn e-lib e-pv-next-page-navigation e-pv-tbar-btn e-tooltip"
+                  data-tabindex="-1"
+                  id="preview-permit-amendment-pdf_nextPage"
+                  style=""
+                  tabindex="-1"
+                  type="button"
+                >
+                  <span
+                    class="e-pv-next-page-navigation-icon e-pv-icon e-icon-left"
+                    id="preview-permit-amendment-pdf_nextPageIcon"
+                  />
+                  <span
+                    class="e-tbar-btn-text"
+                    id="preview-permit-amendment-pdf_nextPageText"
+                  >
+                    Next Page
+                  </span>
+                </button>
+              </div>
+              <div
+                class="e-toolbar-item e-pv-last-page-navigation-container e-popup-text e-overlay"
+                id="preview-permit-amendment-pdf_lastPageContainer"
+              >
+                <button
+                  aria-disabled="true"
+                  aria-label="Show last page (Ctrl+→ or Ctrl+↓)"
+                  class="e-tbar-btn e-tbtn-txt e-control e-btn e-lib e-pv-last-page-navigation e-pv-tbar-btn e-tooltip"
+                  data-tabindex="-1"
+                  id="preview-permit-amendment-pdf_lastPage"
+                  style=""
+                  tabindex="-1"
+                  type="button"
+                >
+                  <span
+                    class="e-pv-last-page-navigation-icon e-pv-icon e-icon-left"
+                    id="preview-permit-amendment-pdf_lastPageIcon"
+                  />
+                  <span
+                    class="e-tbar-btn-text"
+                    id="preview-permit-amendment-pdf_lastPageText"
+                  >
+                    Last Page
+                  </span>
+                </button>
+              </div>
+              <div
+                class="e-toolbar-item e-pv-current-page-container e-template e-popup-text e-overlay"
+                id="preview-permit-amendment-pdf_currentPageInputContainer"
+                style="min-width: 20px;"
+              >
+                <span
+                  aria-disabled="true"
+                  class="e-control-wrapper e-numeric e-input-group e-pv-current-page-box e-valid-input"
+                >
+                  <input
+                    aria-label="Current page number"
+                    aria-valuenow="0"
+                    autocomplete="off"
+                    class="e-control e-numerictextbox e-lib e-input e-tooltip"
+                    data-tabindex="-1"
+                    id="preview-permit-amendment-pdf_currentPageInput"
+                    role="spinbutton"
+                    tabindex="0"
+                    type="text"
+                  />
+                  <input
+                    aria-label="hidden"
+                    class="e-numeric-hidden"
+                    data-tabindex="-1"
+                    name="preview-permit-amendment-pdf_currentPageInput"
+                    type="text"
+                    validatehidden="true"
+                  />
+                </span>
+              </div>
+              <div
+                class="e-toolbar-item e-pv-total-page-container e-template e-popup-text"
+                id="preview-permit-amendment-pdf_totalPageContainer"
+              >
+                <span
+                  class="e-pv-total-page"
+                  data-tabindex="-1"
+                  id="preview-permit-amendment-pdf_totalPage"
+                  tabindex="-1"
+                >
+                  of 0
+                </span>
+              </div>
+              <div
+                class="e-toolbar-item e-pv-navigation-separator-container e-separator"
+              />
+              <div
+                class="e-toolbar-item e-pv-zoom-out-container e-popup-text e-overlay"
+                id="preview-permit-amendment-pdf_zoomOutContainer"
+              >
+                <button
+                  aria-disabled="true"
+                  aria-label="Zoom out (Ctrl+Minus)"
+                  class="e-tbar-btn e-tbtn-txt e-control e-btn e-lib e-pv-zoom-out e-pv-tbar-btn e-tooltip"
+                  data-tabindex="-1"
+                  id="preview-permit-amendment-pdf_zoomOut"
+                  style=""
+                  tabindex="-1"
+                  type="button"
+                >
+                  <span
+                    class="e-pv-zoom-out-icon e-pv-icon e-icon-left"
+                    id="preview-permit-amendment-pdf_zoomOutIcon"
+                  />
+                  <span
+                    class="e-tbar-btn-text"
+                    id="preview-permit-amendment-pdf_zoomOutText"
+                  >
+                    Zoom Out
+                  </span>
+                </button>
+              </div>
+              <div
+                class="e-toolbar-item e-pv-zoom-in-container e-popup-text e-overlay"
+                id="preview-permit-amendment-pdf_zoomInContainer"
+              >
+                <button
+                  aria-disabled="true"
+                  aria-label="Zoom in (Ctrl+Plus)"
+                  class="e-tbar-btn e-tbtn-txt e-control e-btn e-lib e-pv-zoom-in e-pv-tbar-btn e-tooltip"
+                  data-tabindex="-1"
+                  id="preview-permit-amendment-pdf_zoomIn"
+                  style=""
+                  tabindex="-1"
+                  type="button"
+                >
+                  <span
+                    class="e-pv-zoom-in-icon e-pv-icon e-icon-left"
+                    id="preview-permit-amendment-pdf_zoomInIcon"
+                  />
+                  <span
+                    class="e-tbar-btn-text"
+                    id="preview-permit-amendment-pdf_zoomInText"
+                  >
+                    Zoom In
+                  </span>
+                </button>
+              </div>
+              <div
+                class="e-toolbar-item e-pv-zoom-drop-down-container e-template e-popup-text e-overlay"
+                id="preview-permit-amendment-pdf_zoomDropDownContainer"
+              >
+                <span
+                  aria-disabled="true"
+                  aria-labelledby="preview-permit-amendment-pdf_zoomDropDown_hidden"
+                  class="e-input-group e-control-wrapper e-pv-zoom-drop-down e-readonly e-ddl e-valid-input"
+                  style="width: 100%;"
+                >
+                  <select
+                    aria-hidden="true"
+                    aria-label="combobox"
+                    class="e-ddl-hidden"
+                    data-tabindex="-1"
+                    id="preview-permit-amendment-pdf_zoomDropDown_hidden"
+                    name="preview-permit-amendment-pdf_zoomDropDown"
+                    tabindex="-1"
+                  >
+                    <option
+                      selected=""
+                      value="4"
+                    >
+                      100%
+                    </option>
+                  </select>
+                  <input
+                    aria-autocomplete="both"
+                    aria-describedby="preview-permit-amendment-pdf_zoomDropDown"
+                    aria-disabled="false"
+                    aria-expanded="false"
+                    aria-label="Zoom"
+                    aria-readonly="true"
+                    autocapitalize="off"
+                    autocomplete="off"
+                    class="e-control e-combobox e-lib e-input e-keyboard e-tooltip"
+                    data-tabindex="-1"
+                    id="preview-permit-amendment-pdf_zoomDropDown"
+                    readonly=""
+                    role="combobox"
+                    spellcheck="false"
+                    style=""
+                    tabindex="-1"
+                    type="text"
+                    value="100%"
+                  />
+                  <span
+                    class="e-input-group-icon e-ddl-icon e-search-icon"
+                  />
+                </span>
+              </div>
+              <div
+                class="e-toolbar-item e-pv-magnification-separator-container e-separator"
+              />
+              <div
+                class="e-toolbar-item e-pv-text-select-tool-container e-popup-text e-overlay"
+                id="preview-permit-amendment-pdf_selectToolContainer"
+              >
+                <button
+                  aria-disabled="true"
+                  aria-label="Text selection tool (Shift+V)"
+                  class="e-tbar-btn e-tbtn-txt e-control e-btn e-lib e-pv-text-select-tool e-pv-tbar-btn e-tooltip e-pv-select"
+                  data-tabindex="-1"
+                  id="preview-permit-amendment-pdf_selectTool"
+                  style=""
+                  tabindex="-1"
+                  type="button"
+                >
+                  <span
+                    class="e-pv-text-select-tool-icon e-pv-icon e-icon-left"
+                    id="preview-permit-amendment-pdf_selectToolIcon"
+                  />
+                  <span
+                    class="e-tbar-btn-text"
+                    id="preview-permit-amendment-pdf_selectToolText"
+                  >
+                    Selection
+                  </span>
+                </button>
+              </div>
+              <div
+                class="e-toolbar-item e-pv-pan-tool-container e-popup-text e-overlay"
+                id="preview-permit-amendment-pdf_handToolContainer"
+              >
+                <button
+                  aria-disabled="true"
+                  aria-label="Pan mode (Shift+H)"
+                  class="e-tbar-btn e-tbtn-txt e-control e-btn e-lib e-pv-pan-tool e-pv-tbar-btn e-tooltip"
+                  data-tabindex="-1"
+                  id="preview-permit-amendment-pdf_handTool"
+                  style=""
+                  tabindex="-1"
+                  type="button"
+                >
+                  <span
+                    class="e-pv-pan-tool-icon e-pv-icon e-icon-left"
+                    id="preview-permit-amendment-pdf_handToolIcon"
+                  />
+                  <span
+                    class="e-tbar-btn-text"
+                    id="preview-permit-amendment-pdf_handToolText"
+                  >
+                    Pan
+                  </span>
+                </button>
+              </div>
+              <div
+                class="e-toolbar-item e-pv-pan-separator-container e-separator"
+              />
+              <div
+                class="e-toolbar-item e-pv-undo-container e-popup-text e-overlay"
+                id="preview-permit-amendment-pdf_undoContainer"
+              >
+                <button
+                  aria-disabled="true"
+                  aria-label="Undo (Ctrl+Z)"
+                  class="e-tbar-btn e-tbtn-txt e-control e-btn e-lib e-pv-undo e-pv-tbar-btn e-tooltip"
+                  data-tabindex="-1"
+                  id="preview-permit-amendment-pdf_undo"
+                  style=""
+                  tabindex="-1"
+                  type="button"
+                >
+                  <span
+                    class="e-pv-undo-icon e-pv-icon e-icon-left"
+                    id="preview-permit-amendment-pdf_undoIcon"
+                  />
+                  <span
+                    class="e-tbar-btn-text"
+                    id="preview-permit-amendment-pdf_undoText"
+                  >
+                    Undo
+                  </span>
+                </button>
+              </div>
+              <div
+                class="e-toolbar-item e-pv-redo-container e-popup-text e-overlay"
+                id="preview-permit-amendment-pdf_redoContainer"
+              >
+                <button
+                  aria-disabled="true"
+                  aria-label="Redo (Ctrl+Y)"
+                  class="e-tbar-btn e-tbtn-txt e-control e-btn e-lib e-pv-redo e-pv-tbar-btn e-tooltip"
+                  data-tabindex="-1"
+                  id="preview-permit-amendment-pdf_redo"
+                  style=""
+                  tabindex="-1"
+                  type="button"
+                >
+                  <span
+                    class="e-pv-redo-icon e-pv-icon e-icon-left"
+                    id="preview-permit-amendment-pdf_redoIcon"
+                  />
+                  <span
+                    class="e-tbar-btn-text"
+                    id="preview-permit-amendment-pdf_redoText"
+                  >
+                    Redo
+                  </span>
+                </button>
+              </div>
+              <div
+                class="e-toolbar-item e-pv-undo-separator-container e-separator"
+              />
+              <div
+                class="e-toolbar-item e-pv-comment-container e-popup-text e-overlay"
+                id="preview-permit-amendment-pdf_commentContainer"
+              >
+                <button
+                  aria-disabled="true"
+                  aria-label="Add Comments"
+                  class="e-tbar-btn e-tbtn-txt e-control e-btn e-lib e-pv-comment e-pv-tbar-btn e-tooltip"
+                  data-tabindex="-1"
+                  id="preview-permit-amendment-pdf_comment"
+                  style=""
+                  tabindex="-1"
+                  type="button"
+                >
+                  <span
+                    class="e-pv-comment-icon e-pv-icon e-icon-left"
+                    id="preview-permit-amendment-pdf_commentIcon"
+                  />
+                  <span
+                    class="e-tbar-btn-text"
+                    id="preview-permit-amendment-pdf_commentText"
+                  >
+                    Add Comments
+                  </span>
+                </button>
+              </div>
+              <div
+                class="e-toolbar-item e-pv-comment-separator-container e-separator"
+              />
+              <div
+                class="e-toolbar-item e-pv-submit e-template e-popup-text e-overlay"
+                id="preview-permit-amendment-pdf_submitFormContainer"
+              >
+                <button
+                  aria-disabled="true"
+                  aria-label="Submit Form"
+                  class="e-tbar-btn e-control e-tooltip e-lib"
+                  data-tabindex="-1"
+                  id="preview-permit-amendment-pdf_submitForm"
+                  style="font-size:15px"
+                  tabindex="-1"
+                >
+                  <span
+                    class="e-tbar-btn-text e-pv-submitform-text"
+                    id="preview-permit-amendment-pdf_submitFormSpan"
+                  >
+                    Submit Form
+                  </span>
+                </button>
+              </div>
+            </div>
+            <div
+              class="e-toolbar-center"
+            />
+            <div
+              class="e-toolbar-right"
+            >
+              <div
+                class="e-toolbar-item e-pv-text-search-container e-popup-text e-overlay"
+                id="preview-permit-amendment-pdf_searchContainer"
+              >
+                <button
+                  aria-disabled="true"
+                  aria-label="Search"
+                  class="e-tbar-btn e-tbtn-txt e-control e-btn e-lib e-pv-text-search e-pv-tbar-btn e-tooltip"
+                  data-tabindex="-1"
+                  id="preview-permit-amendment-pdf_search"
+                  style=""
+                  tabindex="-1"
+                  type="button"
+                >
+                  <span
+                    class="e-pv-text-search-icon e-pv-icon e-icon-left"
+                    id="preview-permit-amendment-pdf_searchIcon"
+                  />
+                  <span
+                    class="e-tbar-btn-text"
+                    id="preview-permit-amendment-pdf_searchText"
+                  >
+                    Search
+                  </span>
+                </button>
+              </div>
+              <div
+                class="e-toolbar-item e-pv-annotation-container e-popup-text e-overlay"
+                id="preview-permit-amendment-pdf_annotationContainer"
+              >
+                <button
+                  aria-disabled="true"
+                  aria-label="Edit Annotation"
+                  class="e-tbar-btn e-tbtn-txt e-control e-btn e-lib e-pv-annotation e-pv-tbar-btn e-tooltip"
+                  data-tabindex="-1"
+                  id="preview-permit-amendment-pdf_annotation"
+                  style=""
+                  tabindex="-1"
+                  type="button"
+                >
+                  <span
+                    class="e-pv-annotation-icon e-pv-icon e-icon-left"
+                    id="preview-permit-amendment-pdf_annotationIcon"
+                  />
+                  <span
+                    class="e-tbar-btn-text"
+                    id="preview-permit-amendment-pdf_annotationText"
+                  >
+                    Edit Annotation
+                  </span>
+                </button>
+              </div>
+              <div
+                class="e-toolbar-item e-pv-formdesigner-container e-popup-text e-overlay"
+                id="preview-permit-amendment-pdf_formdesignerContainer"
+              >
+                <button
+                  aria-disabled="true"
+                  aria-label="Add and Edit Form Fields"
+                  class="e-tbar-btn e-tbtn-txt e-control e-btn e-lib e-pv-formdesigner e-pv-tbar-btn e-tooltip"
+                  data-tabindex="-1"
+                  id="preview-permit-amendment-pdf_formdesigner"
+                  style=""
+                  tabindex="-1"
+                  type="button"
+                >
+                  <span
+                    class="e-pv-formdesigner-icon e-pv-icon e-icon-left"
+                    id="preview-permit-amendment-pdf_formdesignerIcon"
+                  />
+                  <span
+                    class="e-tbar-btn-text"
+                    id="preview-permit-amendment-pdf_formdesignerText"
+                  >
+                    Add and Edit Form Fields
+                  </span>
+                </button>
+              </div>
+              <div
+                class="e-toolbar-item e-pv-print-document-container e-popup-text e-overlay"
+                id="preview-permit-amendment-pdf_printContainer"
+              >
+                <button
+                  aria-disabled="true"
+                  aria-label="Print file (Ctrl+P)"
+                  class="e-tbar-btn e-tbtn-txt e-control e-btn e-lib e-pv-print-document e-pv-tbar-btn e-tooltip"
+                  data-tabindex="-1"
+                  id="preview-permit-amendment-pdf_print"
+                  style=""
+                  tabindex="-1"
+                  type="button"
+                >
+                  <span
+                    class="e-pv-print-document-icon e-pv-icon e-icon-left"
+                    id="preview-permit-amendment-pdf_printIcon"
+                  />
+                  <span
+                    class="e-tbar-btn-text"
+                    id="preview-permit-amendment-pdf_printText"
+                  >
+                    Print
+                  </span>
+                </button>
+              </div>
+              <div
+                class="e-toolbar-item e-pv-download-document-container e-popup-text e-overlay"
+                id="preview-permit-amendment-pdf_downloadContainer"
+              >
+                <button
+                  aria-disabled="true"
+                  aria-label="Download file (Ctrl+S)"
+                  class="e-tbar-btn e-tbtn-txt e-control e-btn e-lib e-pv-download-document e-pv-tbar-btn e-tooltip"
+                  data-tabindex="-1"
+                  id="preview-permit-amendment-pdf_download"
+                  style=""
+                  tabindex="-1"
+                  type="button"
+                >
+                  <span
+                    class="e-pv-download-document-icon e-pv-icon e-icon-left"
+                    id="preview-permit-amendment-pdf_downloadIcon"
+                  />
+                  <span
+                    class="e-tbar-btn-text"
+                    id="preview-permit-amendment-pdf_downloadText"
+                  >
+                    Download
+                  </span>
+                </button>
+              </div>
+            </div>
+          </div>
+          <input
+            accept=".pdf"
+            aria-label="file upload element"
+            id="preview-permit-amendment-pdf_fileUploadElement"
+            style="position:fixed; left:-100em"
+            tabindex="-1"
+            type="file"
+          />
+        </div>
+        <div
+          aria-disabled="false"
+          aria-label="Annotation Toolbar"
+          aria-orientation="horizontal"
+          class="e-pv-annotation-toolbar e-control e-toolbar e-lib e-pv-toolbar-scroll e-toolpop e-keyboard"
+          id="preview-permit-amendment-pdf_annotation_toolbar"
+          role="toolbar"
+          style="display: none;"
+        >
+          <div
+            class="e-toolbar-items e-tbar-pos"
+          >
+            <div
+              class="e-toolbar-left"
+            >
+              <div
+                class="e-toolbar-item e-tbtn-align e-pv-highlight-container e-popup-text"
+                id="preview-permit-amendment-pdf_highlightContainer"
+              >
+                <button
+                  aria-disabled="false"
+                  aria-label="Highlight Text"
+                  class="e-tbar-btn e-control e-btn e-lib e-icon-btn e-pv-highlight e-pv-tbar-btn e-tooltip"
+                  data-tabindex="0"
+                  id="preview-permit-amendment-pdf_highlight"
+                  style=""
+                  tabindex="0"
+                  type="button"
+                >
+                  <span
+                    class="e-pv-highlight-icon e-pv-icon"
+                    id="preview-permit-amendment-pdf_highlightIcon"
+                  />
+                </button>
+              </div>
+              <div
+                class="e-toolbar-item e-tbtn-align e-pv-underline-container e-popup-text"
+                id="preview-permit-amendment-pdf_underlineContainer"
+              >
+                <button
+                  aria-disabled="false"
+                  aria-label="Underline Text"
+                  class="e-tbar-btn e-control e-btn e-lib e-icon-btn e-pv-underline e-pv-tbar-btn e-tooltip"
+                  data-tabindex="0"
+                  id="preview-permit-amendment-pdf_underline"
+                  style=""
+                  tabindex="0"
+                  type="button"
+                >
+                  <span
+                    class="e-pv-underline-icon e-pv-icon"
+                    id="preview-permit-amendment-pdf_underlineIcon"
+                  />
+                </button>
+              </div>
+              <div
+                class="e-toolbar-item e-tbtn-align e-pv-strikethrough-container e-popup-text"
+                id="preview-permit-amendment-pdf_strikethroughContainer"
+              >
+                <button
+                  aria-disabled="false"
+                  aria-label="Strikethrough Text"
+                  class="e-tbar-btn e-control e-btn e-lib e-icon-btn e-pv-strikethrough e-pv-tbar-btn e-tooltip"
+                  data-tabindex="0"
+                  id="preview-permit-amendment-pdf_strikethrough"
+                  style=""
+                  tabindex="0"
+                  type="button"
+                >
+                  <span
+                    class="e-pv-strikethrough-icon e-pv-icon"
+                    id="preview-permit-amendment-pdf_strikethroughIcon"
+                  />
+                </button>
+              </div>
+              <div
+                class="e-toolbar-item e-pv-hightlight-separator-container e-separator"
+              />
+              <div
+                class="e-toolbar-item e-pv-shape-template-container e-template"
+              >
+                <button
+                  aria-disabled="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
+                  aria-label="Add Shapes"
+                  class="e-pv-annotation-shapes-container e-control e-dropdown-btn e-lib e-btn e-icon-btn e-tooltip"
+                  data-tabindex="0"
+                  id="preview-permit-amendment-pdf_annotation_shapes"
+                  tabindex="0"
+                  type="button"
+                >
+                  <span
+                    class="e-btn-icon e-pv-annotation-shape-icon e-pv-icon"
+                  />
+                  <span
+                    class="e-btn-icon e-icons e-icon-right e-caret"
+                  />
+                </button>
+              </div>
+              <div
+                class="e-toolbar-item e-pv-shape-separator-container e-separator"
+              />
+              <div
+                class="e-toolbar-item e-pv-calibrate-template-container e-template"
+              >
+                <button
+                  aria-disabled="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
+                  aria-label="Calibrate"
+                  class="e-pv-annotation-calibrate-container e-control e-dropdown-btn e-lib e-btn e-icon-btn e-tooltip"
+                  data-tabindex="0"
+                  id="preview-permit-amendment-pdf_annotation_calibrate"
+                  tabindex="0"
+                  type="button"
+                >
+                  <span
+                    class="e-btn-icon e-pv-annotation-calibrate-icon e-pv-icon"
+                  />
+                  <span
+                    class="e-btn-icon e-icons e-icon-right e-caret"
+                  />
+                </button>
+              </div>
+              <div
+                class="e-toolbar-item e-pv-calibrate-separator-container e-separator"
+              />
+              <div
+                class="e-toolbar-item e-tbtn-align e-pv-annotation-freeTextEdit-container e-popup-text"
+                id="preview-permit-amendment-pdf_annotation_freeTextEditContainer"
+              >
+                <button
+                  aria-disabled="false"
+                  aria-label="Free Text"
+                  class="e-tbar-btn e-control e-btn e-lib e-icon-btn e-pv-annotation-freeTextEdit e-pv-tbar-btn e-tooltip"
+                  data-tabindex="0"
+                  id="preview-permit-amendment-pdf_annotation_freeTextEdit"
+                  style=""
+                  tabindex="0"
+                  type="button"
+                >
+                  <span
+                    class="e-pv-freetext-icon e-pv-icon"
+                    id="preview-permit-amendment-pdf_annotation_freeTextEditIcon"
+                  />
+                </button>
+              </div>
+              <div
+                class="e-toolbar-item e-pv-freetext-separator-container e-separator"
+              />
+              <div
+                class="e-toolbar-item e-pv-stamp-template-container e-template"
+              >
+                <span
+                  aria-disabled="false"
+                  aria-expanded="false"
+                  aria-label="Add Stamp"
+                  class="e-pv-annotation-stamp-container e-control e-tooltip e-lib"
+                  data-tabindex="-1"
+                  id="preview-permit-amendment-pdf_annotation_stamp"
+                  role="combobox"
+                  tabindex="-1"
+                >
+                  <div
+                    class="e-menu-wrapper e-custom-scroll e-lib e-keyboard e-pv-stamp"
+                  >
+                    <ul
+                      class="e-lib e-menu e-control e-menu-parent"
+                      id="preview-permit-amendment-pdfcontextMenuElement"
+                      role="menubar"
+                      tabindex="0"
+                    >
+                      <li
+                        aria-expanded="false"
+                        aria-haspopup="true"
+                        aria-label="menuitem_14"
+                        class="e-menu-item e-menu-caret-icon"
+                        data-value="null"
+                        id="menuitem_14"
+                        role="menuitem"
+                        tabindex="-1"
+                      >
+                        <span
+                          class="e-menu-icon e-pv-stamp-icon e-pv-icon"
+                        />
+                        
+                        <span
+                          class="e-icons e-caret"
+                        />
+                      </li>
+                    </ul>
+                  </div>
+                </span>
+              </div>
+              <div
+                class="e-toolbar-item e-pv-stamp-separator-container e-separator"
+              />
+              <div
+                class="e-toolbar-item e-pv-sign-template-container e-template"
+              >
+                <button
+                  aria-disabled="false"
+                  aria-expanded="false"
+                  aria-haspopup="true"
+                  aria-label="dropdownbutton"
+                  class="e-pv-annotation-handwritten-container e-control e-tooltip e-lib e-dropdown-btn e-btn e-pv-handwritten-popup e-icon-btn"
+                  data-tabindex="0"
+                  id="preview-permit-amendment-pdf_annotation_signature"
+                  tabindex="0"
+                  type="button"
+                >
+                  <span
+                    class="e-btn-icon e-pv-handwritten-icon e-pv-icon"
+                  />
+                  <span
+                    class="e-btn-icon e-icons e-icon-right e-caret"
+                  />
+                </button>
+              </div>
+              <div
+                class="e-toolbar-item e-pv-sign-separator-container e-separator"
+              />
+              <div
+                class="e-toolbar-item e-tbtn-align e-pv-annotation-ink-container e-popup-text"
+                id="preview-permit-amendment-pdf_annotation_inkContainer"
+              >
+                <button
+                  aria-disabled="false"
+                  aria-label="Draw Ink"
+                  class="e-tbar-btn e-control e-btn e-lib e-icon-btn e-pv-annotation-ink e-pv-tbar-btn e-tooltip"
+                  data-tabindex="0"
+                  id="preview-permit-amendment-pdf_annotation_ink"
+                  style=""
+                  tabindex="0"
+                  type="button"
+                >
+                  <span
+                    class="e-pv-inkannotation-icon e-pv-icon"
+                    id="preview-permit-amendment-pdf_annotation_inkIcon"
+                  />
+                </button>
+              </div>
+              <div
+                class="e-toolbar-item e-pv-ink-separator-container e-separator"
+              />
+              <div
+                class="e-toolbar-item e-pv-fontfamily-container e-template"
+              >
+                <span
+                  class="e-input-group e-control-wrapper e-pv-prop-dropdown e-ddl e-valid-input e-control e-tooltip e-lib e-overlay"
+                  style="width: 110px;"
+                >
+                  <select
+                    aria-disabled="true"
+                    aria-hidden="true"
+                    aria-label="combobox"
+                    class="e-ddl-hidden"
+                    data-tabindex="-1"
+                    id="preview-permit-amendment-pdf_annotation_fontname_hidden"
+                    name="preview-permit-amendment-pdf_annotation_fontname"
+                    tabindex="-1"
+                  >
+                    <option
+                      selected=""
+                      value="Helvetica"
+                    >
+                      Helvetica
+                    </option>
+                  </select>
+                  <button
+                    aria-disabled="false"
+                    aria-label="Font Family"
+                    class="e-pv-annotation-fontname-container e-control e-combobox e-lib"
+                    data-tabindex="-1"
+                    id="preview-permit-amendment-pdf_annotation_fontname"
+                    style="display: none;"
+                  />
+                  <input
+                    aria-autocomplete="both"
+                    aria-describedby="preview-permit-amendment-pdf_annotation_fontname"
+                    aria-expanded="false"
+                    aria-label="combobox"
+                    aria-readonly="false"
+                    autocapitalize="off"
+                    autocomplete="off"
+                    class="e-input e-lib e-keyboard"
+                    role="combobox"
+                    spellcheck="false"
+                    tabindex="-1"
+                    type="text"
+                    value="Helvetica"
+                  />
+                  <span
+                    class="e-input-group-icon e-ddl-icon e-search-icon"
+                  />
+                </span>
+              </div>
+              <div
+                class="e-toolbar-item e-pv-fontsize-container e-template"
+              >
+                <span
+                  class="e-input-group e-control-wrapper e-pv-prop-dropdown e-ddl e-valid-input e-control e-tooltip e-lib e-overlay"
+                  style="width: 80px;"
+                >
+                  <select
+                    aria-disabled="true"
+                    aria-hidden="true"
+                    aria-label="combobox"
+                    class="e-ddl-hidden"
+                    data-tabindex="-1"
+                    id="preview-permit-amendment-pdf_annotation_fontsize_hidden"
+                    name="preview-permit-amendment-pdf_annotation_fontsize"
+                    tabindex="-1"
+                  >
+                    <option
+                      selected=""
+                      value="16px"
+                    >
+                      16px
+                    </option>
+                  </select>
+                  <button
+                    aria-disabled="false"
+                    aria-label="Font Size"
+                    class="e-pv-annotation-fontsize-container e-control e-combobox e-lib"
+                    data-tabindex="-1"
+                    id="preview-permit-amendment-pdf_annotation_fontsize"
+                    style="display: none;"
+                  />
+                  <input
+                    aria-autocomplete="both"
+                    aria-describedby="preview-permit-amendment-pdf_annotation_fontsize"
+                    aria-expanded="false"
+                    aria-label="combobox"
+                    aria-readonly="false"
+                    autocapitalize="off"
+                    autocomplete="off"
+                    class="e-input e-lib e-keyboard"
+                    role="combobox"
+                    spellcheck="false"
+                    tabindex="-1"
+                    type="text"
+                    value="16px"
+                  />
+                  <span
+                    class="e-input-group-icon e-ddl-icon e-search-icon"
+                  />
+                </span>
+              </div>
+              <div
+                class="e-toolbar-item e-pv-text-color-container e-template e-overlay"
+              >
+                <button
+                  aria-disabled="true"
+                  aria-expanded="false"
+                  aria-haspopup="true"
+                  aria-label="Font Color"
+                  class="e-pv-annotation-textcolor-container e-control e-dropdown-btn e-lib e-btn e-icon-btn e-tooltip"
+                  data-tabindex="-1"
+                  id="preview-permit-amendment-pdf_annotation_textcolor"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <span
+                    class="e-btn-icon e-pv-annotation-textcolor-icon e-pv-icon"
+                    style="border-bottom-color: #000000;"
+                  />
+                  <span
+                    class="e-btn-icon e-icons e-icon-right e-caret"
+                  />
+                </button>
+              </div>
+              <div
+                class="e-toolbar-item e-pv-alignment-container e-template e-overlay"
+              >
+                <button
+                  aria-disabled="true"
+                  aria-expanded="false"
+                  aria-haspopup="true"
+                  aria-label="Text Align"
+                  class="e-pv-annotation-textalign-container e-control e-dropdown-btn e-lib e-btn e-icon-btn e-tooltip"
+                  data-tabindex="-1"
+                  id="preview-permit-amendment-pdf_annotation_textalign"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <span
+                    class="e-btn-icon e-pv-annotation-textalign-icon e-pv-icon"
+                  />
+                  <span
+                    class="e-btn-icon e-icons e-icon-right e-caret"
+                  />
+                </button>
+              </div>
+              <div
+                class="e-toolbar-item e-pv-text-properties-container e-template e-overlay"
+              >
+                <button
+                  aria-disabled="true"
+                  aria-expanded="false"
+                  aria-haspopup="true"
+                  aria-label="Font Style"
+                  class="e-pv-annotation-textprop-container e-control e-dropdown-btn e-lib e-btn e-caret-hide e-icon-btn e-tooltip"
+                  data-tabindex="-1"
+                  id="preview-permit-amendment-pdf_annotation_textproperties"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <span
+                    class="e-btn-icon e-pv-annotation-textprop-icon e-pv-icon"
+                  />
+                  <span
+                    class="e-btn-icon e-icons e-icon-right e-caret"
+                  />
+                </button>
+              </div>
+              <div
+                class="e-toolbar-item e-pv-text-separator-container e-separator"
+              />
+              <div
+                class="e-toolbar-item e-pv-color-template-container e-template e-overlay"
+              >
+                <button
+                  aria-disabled="true"
+                  aria-expanded="false"
+                  aria-haspopup="true"
+                  aria-label="Change Color"
+                  class="e-pv-annotation-color-container e-control e-dropdown-btn e-lib e-btn e-icon-btn e-tooltip"
+                  data-tabindex="-1"
+                  id="preview-permit-amendment-pdf_annotation_color"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <span
+                    class="e-btn-icon e-pv-annotation-color-icon e-pv-icon"
+                    style="border-bottom-color: #000000;"
+                  />
+                  <span
+                    class="e-btn-icon e-icons e-icon-right e-caret"
+                  />
+                </button>
+              </div>
+              <div
+                class="e-toolbar-item e-pv-stroke-template-container e-template e-overlay"
+              >
+                <button
+                  aria-disabled="true"
+                  aria-expanded="false"
+                  aria-haspopup="true"
+                  aria-label="Change Stroke Color"
+                  class="e-pv-annotation-stroke-container e-control e-dropdown-btn e-lib e-btn e-icon-btn e-tooltip"
+                  data-tabindex="-1"
+                  id="preview-permit-amendment-pdf_annotation_stroke"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <span
+                    class="e-btn-icon e-pv-annotation-stroke-icon e-pv-icon"
+                    style="border-bottom-color: #000000;"
+                  />
+                  <span
+                    class="e-btn-icon e-icons e-icon-right e-caret"
+                  />
+                </button>
+              </div>
+              <div
+                class="e-toolbar-item e-pv-thickness-template-container e-template e-overlay"
+              >
+                <button
+                  aria-disabled="true"
+                  aria-expanded="false"
+                  aria-haspopup="true"
+                  aria-label="Change Border Thickness"
+                  class="e-pv-annotation-thickness-container e-control e-dropdown-btn e-lib e-btn e-icon-btn e-tooltip"
+                  data-tabindex="-1"
+                  id="preview-permit-amendment-pdf_annotation_thickness"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <span
+                    class="e-btn-icon e-pv-annotation-thickness-icon e-pv-icon"
+                  />
+                  <span
+                    class="e-btn-icon e-icons e-icon-right e-caret"
+                  />
+                </button>
+              </div>
+              <div
+                class="e-toolbar-item e-pv-opacity-template-container e-template e-overlay"
+              >
+                <button
+                  aria-disabled="true"
+                  aria-expanded="false"
+                  aria-haspopup="true"
+                  aria-label="Change Opacity"
+                  class="e-pv-annotation-opacity-container e-control e-dropdown-btn e-lib e-btn e-icon-btn e-tooltip"
+                  data-tabindex="-1"
+                  id="preview-permit-amendment-pdf_annotation_opacity"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <span
+                    class="e-btn-icon e-pv-annotation-opacity-icon e-pv-icon"
+                  />
+                  <span
+                    class="e-btn-icon e-icons e-icon-right e-caret"
+                  />
+                </button>
+              </div>
+              <div
+                class="e-toolbar-item e-pv-opacity-separator-container e-separator"
+              />
+              <div
+                class="e-toolbar-item e-tbtn-align e-pv-annotation-delete-container e-popup-text e-overlay"
+                id="preview-permit-amendment-pdf_annotation_deleteContainer"
+              >
+                <button
+                  aria-disabled="true"
+                  aria-label="Delete annotation (delete)"
+                  class="e-tbar-btn e-control e-btn e-lib e-icon-btn e-pv-annotation-delete e-pv-tbar-btn e-tooltip"
+                  data-tabindex="-1"
+                  id="preview-permit-amendment-pdf_annotation_delete"
+                  style=""
+                  tabindex="-1"
+                  type="button"
+                >
+                  <span
+                    class="e-pv-annotation-delete-icon e-pv-icon"
+                    id="preview-permit-amendment-pdf_annotation_deleteIcon"
+                  />
+                </button>
+              </div>
+            </div>
+            <div
+              class="e-toolbar-center"
+            />
+            <div
+              class="e-toolbar-right"
+            >
+              <div
+                class="e-toolbar-item e-tbtn-align e-pv-annotation-comment-panel-container e-popup-text"
+                id="preview-permit-amendment-pdf_annotation_commentPanelContainer"
+              >
+                <button
+                  aria-disabled="false"
+                  aria-label="Comment Panel (Ctrl+Alt+0)"
+                  class="e-tbar-btn e-control e-btn e-lib e-icon-btn e-pv-annotation-comment-panel e-pv-tbar-btn e-tooltip"
+                  data-tabindex="0"
+                  id="preview-permit-amendment-pdf_annotation_commentPanel"
+                  style=""
+                  tabindex="0"
+                  type="button"
+                >
+                  <span
+                    class="e-pv-comment-panel-icon e-pv-icon"
+                    id="preview-permit-amendment-pdf_annotation_commentPanelIcon"
+                  />
+                </button>
+              </div>
+              <div
+                class="e-toolbar-item e-tbtn-align e-pv-annotation-tools-close-container e-popup-text"
+                id="preview-permit-amendment-pdf_annotation_closeContainer"
+              >
+                <button
+                  aria-disabled="false"
+                  aria-label="Close Annotation Toolbar"
+                  class="e-tbar-btn e-control e-btn e-lib e-icon-btn e-pv-annotation-tools-close e-pv-tbar-btn"
+                  data-tabindex="-1"
+                  id="preview-permit-amendment-pdf_annotation_close"
+                  style=""
+                  tabindex="0"
+                  type="button"
+                >
+                  <span
+                    class="e-pv-annotation-tools-close-icon e-pv-icon"
+                    id="preview-permit-amendment-pdf_annotation_closeIcon"
+                  />
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="e-pv-viewer-container e-enable-text-selection"
+          id="preview-permit-amendment-pdf_viewerContainer"
+          style="left: 0px; right: 0px; width: 0px; height: 0px; cursor: auto;"
+          tabindex="-1"
+        >
+          <div
+            class="e-pv-page-container"
+            id="preview-permit-amendment-pdf_pageViewContainer"
+            role="document"
+            style="width: 0px;"
+          />
+          <div
+            id="preview-permit-amendment-pdf_loadingIndicator"
+            style="display: block;"
+          >
+            <div
+              class="e-spinner-pane e-spin-center e-spin-hide"
+            >
+              <div
+                class="e-spinner-inner"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        aria-label="Sidebar Toolbar"
+        aria-orientation="vertical"
+        class="e-pv-sidebar-toolbar"
+        id="preview-permit-amendment-pdf_sideBarToolbar"
+        role="toolbar"
+        style="display: block;"
+        tabindex="-1"
+      >
+        <button
+          aria-label="Page Thumbnails"
+          class="e-pv-tbar-btn e-pv-thumbnail-view-button e-btn e-control e-tooltip e-lib"
+          disabled="disabled"
+          id="preview-permit-amendment-pdf_thumbnail-view"
+          tabindex="-1"
+          type="button"
+        >
+          <span
+            class="e-pv-thumbnail-view-disable-icon e-pv-icon"
+            id="preview-permit-amendment-pdf_thumbnail-view_icon"
+          />
+        </button>
+        <button
+          aria-label="Bookmarks"
+          class="e-pv-tbar-btn e-pv-bookmark-button e-btn e-control e-tooltip e-lib"
+          disabled="disabled"
+          id="preview-permit-amendment-pdf_bookmark"
+          tabindex="-1"
+          type="button"
+        >
+          <span
+            class="e-pv-bookmark-disable-icon e-pv-icon e-pv-bookmark-icon"
+            id="preview-permit-amendment-pdf_bookmark_icon"
+          />
+        </button>
+      </div>
+      <div
+        class="e-pv-sidebar-toolbar-splitter e-left"
+        id="preview-permit-amendment-pdf_sideBarToolbarSplitter"
+        style="display: block;"
+      />
+      <div
+        class="e-pv-sidebar-content-container e-left"
+        id="preview-permit-amendment-pdf_sideBarContentContainer"
+        style="display: none;"
+      >
+        <div
+          class="e-pv-sidebar-content-splitter"
+          id="preview-permit-amendment-pdf_sideBarContentSplitter"
+        />
+        <div
+          class="e-pv-sidebar-content"
+          id="preview-permit-amendment-pdf_sideBarContent"
+        >
+          <div
+            class="e-pv-thumbnail-view e-pv-thumbnail-row"
+            id="preview-permit-amendment-pdf_thumbnail_view"
+          />
+        </div>
+        <div
+          class="e-pv-sidebar-title-container"
+          id="preview-permit-amendment-pdf_sideBarTitleContainer"
+        >
+          <div
+            class="e-pv-sidebar-title e-left"
+            id="preview-permit-amendment-pdf_sideBarTitle"
+            tabindex="-1"
+          />
+          <button
+            aria-label="close button"
+            class="e-btn e-pv-tbar-btn e-pv-title-close-div e-btn"
+            id="preview-permit-amendment-pdf_close_btn"
+            style="left: 170px;"
+            type="button"
+          >
+            <span
+              class="e-pv-title-close-icon e-pv-icon"
+              id="preview-permit-amendment-pdf_close_icon"
+            />
+          </button>
+        </div>
+        <div
+          class="e-pv-sidebar-resizer e-left"
+          id="preview-permit-amendment-pdf_sideBarResizer"
+        >
+          <div
+            class="e-pv-resize-icon e-pv-icon"
+            id="preview-permit-amendment-pdf_resize"
+            style="position: absolute;"
+          />
+        </div>
+      </div>
+      <div
+        class="e-pv-comment-panel"
+        id="preview-permit-amendment-pdf_commantPanel"
+        style="right: 0px; bottom: 0px; display: none;"
+      >
+        <div
+          class="e-pv-comment-panel-title-container"
+          id="preview-permit-amendment-pdf_commentPanelTitleContainer"
+        >
+          <div
+            class="e-pv-comment-panel-title"
+            id="preview-permit-amendment-pdf_commentPanelTitle"
+            tabindex="-1"
+          />
+          <button
+            aria-label="annotation button"
+            class="e-btn e-pv-tbar-btn e-pv-comment-panel-title-close-div e-btn"
+            id="preview-permit-amendment-pdf_annotations_btn"
+            type="button"
+          >
+            <span
+              class="e-pv-more-icon e-pv-icon"
+              id="preview-permit-amendment-pdf_annotation_more_icon"
+            />
+          </button>
+        </div>
+        <div
+          class="e-pv-comments-content-container"
+          id="preview-permit-amendment-pdf_commentscontentcontainer"
+        />
+        <input
+          accept=".json"
+          aria-label="upload elements"
+          id="preview-permit-amendment-pdf_annotationUploadElement"
+          style="position:fixed; left:-100em"
+          type="file"
+        />
+        <input
+          accept=".xfdf"
+          aria-label="upload elements"
+          id="preview-permit-amendment-pdf_annotationXFdfUploadElement"
+          style="position:fixed; left:-100em"
+          type="file"
+        />
+      </div>
+      <div
+        class="e-pv-comment-panel-resizer e-right"
+        id="preview-permit-amendment-pdf_commentPanelResizer"
+        style="display: none;"
+      >
+        <div
+          class="e-pv-resize-icon e-pv-icon"
+          id="preview-permit-amendment-pdf_commentPanel_resize"
+          style="position: absolute;"
+        />
+      </div>
+      <div
+        class="e-pv-text-search-bar"
+        id="preview-permit-amendment-pdf_search_box"
+        style="top: 0px; display: none; right: 88.3px;"
+      >
+        <div
+          class="e-pv-text-search-bar-elements"
+          id="preview-permit-amendment-pdf_search_box_elements"
+        >
+          <div
+            class="e-input-group e-pv-text-search-input"
+            id="preview-permit-amendment-pdf_search_input_container"
+          >
+            <span
+              aria-labelledby="preview-permit-amendment-pdf_search_input_hidden"
+              class="e-input-group e-control-wrapper e-ddl"
+              style="width: 100%;"
+            >
+              <select
+                aria-hidden="true"
+                aria-label="autocomplete"
+                class="e-ddl-hidden"
+                id="preview-permit-amendment-pdf_search_input_hidden"
+                name="preview-permit-amendment-pdf_search_input"
+                tabindex="-1"
+              />
+              <input
+                aria-autocomplete="both"
+                aria-disabled="false"
+                aria-expanded="false"
+                aria-label="autocomplete"
+                aria-readonly="false"
+                autocapitalize="off"
+                autocomplete="off"
+                class="e-input e-pv-search-input-ele e-control e-autocomplete e-lib e-keyboard"
+                id="preview-permit-amendment-pdf_search_input"
+                placeholder="Find in document"
+                role="combobox"
+                spellcheck="false"
+                style=""
+                tabindex="0"
+                type="text"
+              />
+              <span
+                aria-label="close"
+                class="e-clear-icon e-clear-icon-hide"
+                role="button"
+              />
+            </span>
+            <div
+              id="preview-permit-amendment-pdf_textSearchLoadingIndicator"
+              style="position: absolute; top: 15px; left: -46px;"
+            >
+              <div
+                class="e-spinner-pane e-spin-center e-spin-hide"
+              >
+                <div
+                  class="e-spinner-inner"
+                />
+              </div>
+            </div>
+          </div>
+          <span
+            class="e-pv-search-count"
+            id="preview-permit-amendment-pdf_search_count"
+            style="display: none;"
+          />
+          <button
+            aria-label="Previous Search text"
+            class="e-btn e-icon-btn e-pv-text-search-btn e-pv-prev-search"
+            disabled=""
+            id="preview-permit-amendment-pdf_prev_occurrence"
+            type="button"
+          >
+            <span
+              class="e-pv-icon-search e-pv-prev-search-icon"
+              id="preview-permit-amendment-pdf_prev_occurrenceIcon"
+            />
+          </button>
+          <button
+            aria-label="Next Search text"
+            class="e-btn e-icon-btn e-pv-text-search-btn e-pv-next-search"
+            disabled=""
+            id="preview-permit-amendment-pdf_next_occurrence"
+            type="button"
+          >
+            <span
+              class="e-pv-icon-search e-pv-next-search-icon"
+              id="preview-permit-amendment-pdf_next_occurrenceIcon"
+            />
+          </button>
+        </div>
+        <div
+          class="e-pv-textsearch-match-case-container"
+          id="preview-permit-amendment-pdf_match_case_container"
+        >
+          <div
+            class="e-checkbox-wrapper e-wrapper e-pv-match-case"
+          >
+            <label
+              for="preview-permit-amendment-pdf_match_case"
+            >
+              <input
+                class="e-control e-checkbox e-lib"
+                id="preview-permit-amendment-pdf_match_case"
+                tabindex="0"
+                type="checkbox"
+              />
+              <span
+                class="e-icons e-frame"
+              />
+              <span
+                class="e-label"
+              >
+                Match case
+              </span>
+            </label>
+          </div>
+          <div
+            class="e-checkbox-wrapper e-wrapper e-pv-match-any-word"
+          >
+            <label
+              for="preview-permit-amendment-pdf_match_any_word"
+            >
+              <input
+                class="e-control e-checkbox e-lib"
+                id="preview-permit-amendment-pdf_match_any_word"
+                tabindex="0"
+                type="checkbox"
+              />
+              <span
+                class="e-icons e-frame"
+              />
+              <span
+                class="e-label"
+              >
+                Match any word
+              </span>
+            </label>
+          </div>
+        </div>
+      </div>
+      <div
+        class="e-pv-annotation-note"
+        id="preview-permit-amendment-pdf_annotation_note"
+        style="display:none"
+      >
+        <div
+          class="e-pv-annotation-note-author"
+          id="preview-permit-amendment-pdf_annotation_note_author"
+        />
+        <div
+          class="e-pv-annotation-note-content"
+          id="preview-permit-amendment-pdf_annotation_note_content"
+        />
+      </div>
+    </div>
+    <ul
+      id="contextmenu_0"
+      style="display: none;"
+    />
+    <div
+      class="e-pv-print-popup-container"
+      id="preview-permit-amendment-pdf_printcontainer"
+      style="display: none;"
+    >
+      <div
+        class="e-pv-print-loading-container"
+        id="preview-permit-amendment-pdf_printLoadingIndicator"
+      >
+        <div
+          class="e-spinner-pane e-spin-center e-spin-hide"
+        >
+          <div
+            class="e-spinner-inner"
+          />
+        </div>
+      </div>
+    </div>
+    <ul
+      id="contextmenu_15"
+      style="display: none;"
+    />
+  </div>
+</div>
+`;
+
+exports[`PreviewPermitAmendmentDocument matches snapshot 1`] = `
+<div>
+  <div
+    class="ant-skeleton"
+  >
+    <div
+      class="ant-skeleton-content"
+    >
+      <h3
+        class="ant-skeleton-title"
+        style="width: 38%;"
+      />
+      <ul
+        class="ant-skeleton-paragraph"
+      >
+        <li />
+        <li />
+        <li
+          style="width: 61%;"
+        />
+      </ul>
+    </div>
+  </div>
+</div>
+`;

--- a/services/minespace-web/src/styles/tools/syncfusion.scss
+++ b/services/minespace-web/src/styles/tools/syncfusion.scss
@@ -41,7 +41,8 @@ $error-font: $error-color; //#f44336;
 }
 
 #pdfviewer-container_fileUploadElement,
-#pdfviewer-container_annotationContainer {
+#pdfviewer-container_annotationContainer,
+#preview-permit-amendment-pdf_fileUploadElement {
   display: none;
 }
 


### PR DESCRIPTION
## Objective 

[MDS-6207](https://bcmines.atlassian.net/browse/MDS-6207)

With all the data about a permit condition now coming over from the permit service, we now have access to the bounding box of where it came from in the original PDF. This PR adds a side-by-side view of the conditions when you click "Open Permit in Document Viewer", where we also highlight the condition in the original PDF on click. Note: This is behind a feature flag, and just added so we can see how well it works/ if it's worth polishing.

![image](https://github.com/user-attachments/assets/5fd8ff14-cd07-4f49-b1ed-f8ce9afd14dc)

