### PR TITLE
[MDS-6304] Tighten up Archive/Replace docs for Major Mine Application

### DIFF
--- a/services/common/src/components/documents/DocumentTable.tsx
+++ b/services/common/src/components/documents/DocumentTable.tsx
@@ -15,7 +15,7 @@ import { some } from "lodash";
 import { closeModal, openModal } from "@mds/common/redux/actions/modalActions";
 import DocumentCompression from "@mds/common/components/documents/DocumentCompression";
 import { archiveMineDocuments } from "@mds/common/redux/actionCreators/mineActionCreator";
-import { useDispatch, useSelector } from "react-redux";
+import { useDispatch } from "react-redux";
 import { Feature } from "@mds/common/utils/featureFlag";
 import { SizeType } from "antd/lib/config-provider/SizeContext";
 import { ColumnsType } from "antd/es/table";
@@ -23,13 +23,11 @@ import { FileOperations, MineDocument } from "@mds/common/models/documents/docum
 
 import DeleteOutlined from "@ant-design/icons/DeleteOutlined";
 import DownloadOutlined from "@ant-design/icons/DownloadOutlined";
-import DownOutlined from "@ant-design/icons/DownOutlined";
 import FileOutlined from "@ant-design/icons/FileOutlined";
 import InboxOutlined from "@ant-design/icons/InboxOutlined";
 import SyncOutlined from "@ant-design/icons/SyncOutlined";
 import { openDocument } from "@mds/common/components/syncfusion/DocumentViewer";
-import { getUserAccessData } from "@mds/common/redux/selectors/authenticationSelectors";
-import { Button, Dropdown, MenuProps } from "antd";
+import { Button, Col, Row } from "antd";
 import { useFeatureFlag } from "@mds/common/providers/featureFlags/useFeatureFlag";
 import DocumentTableProps from "@mds/common/interfaces/document/documentTableProps.interface";
 import ArchiveDocumentModal from "./ArchiveDocumentModal";
@@ -58,7 +56,6 @@ export const DocumentTable: FC<DocumentTableProps> = ({
 }: DocumentTableProps) => {
   // differences from bringing over from CORE (vs the MS version): this file has doc compression & bulk actions
   const dispatch = useDispatch();
-  const userRoles = useSelector(getUserAccessData);
 
   const handleCloseModal = () => {
     dispatch(closeModal());
@@ -89,11 +86,11 @@ export const DocumentTable: FC<DocumentTableProps> = ({
       return docs.map((doc) => new MineDocument(doc));
     }
   };
- 
+
   const [documents, setDocuments] = useState<MineDocument[]>(parseDocuments(props.documents ?? []));
 
   useEffect(() => {
-    const isBulkArchive = documents.every((doc) =>
+    const isBulkArchive = canArchiveDocuments && documents.every((doc) =>
       doc.allowed_actions.find((a) => a === FileOperations.Archive)
     );
 
@@ -306,7 +303,12 @@ export const DocumentTable: FC<DocumentTableProps> = ({
       );
     }
 
-    return enableBulkActions && <div style={{ float: "right" }}>{element}</div>;
+    const hasHeader = Boolean(props.header);
+
+    return (enableBulkActions || hasHeader) && <Row justify={hasHeader ? "space-between" : "end"} align="bottom" className="document-table-header">
+      {hasHeader && <Col>{props.header}</Col>}
+      {enableBulkActions && <Col className="document-table-actions">{element}</Col>}
+    </Row>;
   };
 
   const handleRowSelectionChange = (value) => {

--- a/services/common/src/components/projects/ProjectDocumentsTab.tsx
+++ b/services/common/src/components/projects/ProjectDocumentsTab.tsx
@@ -83,8 +83,8 @@ const ProjectDocumentsTab: FC<ProjectDocumentsTabProps> = ({ project }) => {
       .toLowerCase();
   };
 
-  const canModifySummaryDocs = areDocumentFieldsDisabled(systemFlag, project?.project_summary?.status_code);
-  const canModifyMmaDocs = areDocumentFieldsDisabled(systemFlag, project?.major_mine_application?.status_code);
+  const canModifySummaryDocs = !areDocumentFieldsDisabled(systemFlag, project?.project_summary?.status_code);
+  const canModifyMmaDocs = !areDocumentFieldsDisabled(systemFlag, project?.major_mine_application?.status_code);
 
   const projectSummaryDocs =
     project?.project_summary?.documents?.map(

--- a/services/common/src/components/projects/__snapshots__/ProjectDocumentsTab.spec.tsx.snap
+++ b/services/common/src/components/projects/__snapshots__/ProjectDocumentsTab.spec.tsx.snap
@@ -325,37 +325,21 @@ exports[`ProjectDocumentsTab renders properly 1`] = `
               <div>
                 <div />
                 <div
-                  style="float: right;"
+                  class="ant-row ant-row-end ant-row-bottom document-table-header"
                 >
-                  <button
-                    class="ant-btn ant-btn-default ant-dropdown-trigger ant-btn ant-btn-primary"
-                    disabled=""
-                    type="button"
+                  <div
+                    class="ant-col document-table-actions"
                   >
-                    <span>
-                      Action
-                    </span>
-                    <span
-                      aria-label="down"
-                      class="anticon anticon-down"
-                      role="img"
+                    <button
+                      class="ant-btn ant-btn-primary"
+                      disabled=""
+                      type="button"
                     >
-                      <svg
-                        aria-hidden="true"
-                        class=""
-                        data-icon="down"
-                        fill="currentColor"
-                        focusable="false"
-                        height="1em"
-                        viewBox="64 64 896 896"
-                        width="1em"
-                      >
-                        <path
-                          d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
-                        />
-                      </svg>
-                    </span>
-                  </button>
+                      <div>
+                        Download
+                      </div>
+                    </button>
+                  </div>
                 </div>
                 <div
                   class="ant-table-wrapper  core-table"
@@ -1425,37 +1409,21 @@ exports[`ProjectDocumentsTab renders properly 1`] = `
               <div>
                 <div />
                 <div
-                  style="float: right;"
+                  class="ant-row ant-row-end ant-row-bottom document-table-header"
                 >
-                  <button
-                    class="ant-btn ant-btn-primary ant-dropdown-trigger actions-dropdown-button"
-                    disabled=""
-                    type="button"
+                  <div
+                    class="ant-col document-table-actions"
                   >
-                    <span>
-                      Action
-                    </span>
-                    <span
-                      aria-label="down"
-                      class="anticon anticon-down"
-                      role="img"
+                    <button
+                      class="ant-btn ant-btn-primary"
+                      disabled=""
+                      type="button"
                     >
-                      <svg
-                        aria-hidden="true"
-                        class=""
-                        data-icon="down"
-                        fill="currentColor"
-                        focusable="false"
-                        height="1em"
-                        viewBox="64 64 896 896"
-                        width="1em"
-                      >
-                        <path
-                          d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
-                        />
-                      </svg>
-                    </span>
-                  </button>
+                      <div>
+                        Download
+                      </div>
+                    </button>
+                  </div>
                 </div>
                 <div
                   class="ant-table-wrapper  core-table"
@@ -2535,37 +2503,21 @@ exports[`ProjectDocumentsTab renders properly 1`] = `
               <div>
                 <div />
                 <div
-                  style="float: right;"
+                  class="ant-row ant-row-end ant-row-bottom document-table-header"
                 >
-                  <button
-                    class="ant-btn ant-btn-primary ant-dropdown-trigger actions-dropdown-button"
-                    disabled=""
-                    type="button"
+                  <div
+                    class="ant-col document-table-actions"
                   >
-                    <span>
-                      Action
-                    </span>
-                    <span
-                      aria-label="down"
-                      class="anticon anticon-down"
-                      role="img"
+                    <button
+                      class="ant-btn ant-btn-primary"
+                      disabled=""
+                      type="button"
                     >
-                      <svg
-                        aria-hidden="true"
-                        class=""
-                        data-icon="down"
-                        fill="currentColor"
-                        focusable="false"
-                        height="1em"
-                        viewBox="64 64 896 896"
-                        width="1em"
-                      >
-                        <path
-                          d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
-                        />
-                      </svg>
-                    </span>
-                  </button>
+                      <div>
+                        Download
+                      </div>
+                    </button>
+                  </div>
                 </div>
                 <div
                   class="ant-table-wrapper  core-table"
@@ -2946,37 +2898,21 @@ exports[`ProjectDocumentsTab renders properly 1`] = `
               <div>
                 <div />
                 <div
-                  style="float: right;"
+                  class="ant-row ant-row-end ant-row-bottom document-table-header"
                 >
-                  <button
-                    class="ant-btn ant-btn-primary ant-dropdown-trigger actions-dropdown-button"
-                    disabled=""
-                    type="button"
+                  <div
+                    class="ant-col document-table-actions"
                   >
-                    <span>
-                      Action
-                    </span>
-                    <span
-                      aria-label="down"
-                      class="anticon anticon-down"
-                      role="img"
+                    <button
+                      class="ant-btn ant-btn-primary"
+                      disabled=""
+                      type="button"
                     >
-                      <svg
-                        aria-hidden="true"
-                        class=""
-                        data-icon="down"
-                        fill="currentColor"
-                        focusable="false"
-                        height="1em"
-                        viewBox="64 64 896 896"
-                        width="1em"
-                      >
-                        <path
-                          d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
-                        />
-                      </svg>
-                    </span>
-                  </button>
+                      <div>
+                        Download
+                      </div>
+                    </button>
+                  </div>
                 </div>
                 <div
                   class="ant-table-wrapper  core-table"
@@ -3926,37 +3862,21 @@ exports[`ProjectDocumentsTab renders properly 1`] = `
               <div>
                 <div />
                 <div
-                  style="float: right;"
+                  class="ant-row ant-row-end ant-row-bottom document-table-header"
                 >
-                  <button
-                    class="ant-btn ant-btn-primary ant-dropdown-trigger actions-dropdown-button"
-                    disabled=""
-                    type="button"
+                  <div
+                    class="ant-col document-table-actions"
                   >
-                    <span>
-                      Action
-                    </span>
-                    <span
-                      aria-label="down"
-                      class="anticon anticon-down"
-                      role="img"
+                    <button
+                      class="ant-btn ant-btn-primary"
+                      disabled=""
+                      type="button"
                     >
-                      <svg
-                        aria-hidden="true"
-                        class=""
-                        data-icon="down"
-                        fill="currentColor"
-                        focusable="false"
-                        height="1em"
-                        viewBox="64 64 896 896"
-                        width="1em"
-                      >
-                        <path
-                          d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
-                        />
-                      </svg>
-                    </span>
-                  </button>
+                      <div>
+                        Download
+                      </div>
+                    </button>
+                  </div>
                 </div>
                 <div
                   class="ant-table-wrapper  core-table"

--- a/services/common/src/components/projects/__snapshots__/ProjectDocumentsTab.spec.tsx.snap
+++ b/services/common/src/components/projects/__snapshots__/ProjectDocumentsTab.spec.tsx.snap
@@ -1415,13 +1415,33 @@ exports[`ProjectDocumentsTab renders properly 1`] = `
                     class="ant-col document-table-actions"
                   >
                     <button
-                      class="ant-btn ant-btn-primary"
+                      class="ant-btn ant-btn-primary ant-dropdown-trigger actions-dropdown-button"
                       disabled=""
                       type="button"
                     >
-                      <div>
-                        Download
-                      </div>
+                      <span>
+                        Action
+                      </span>
+                      <span
+                        aria-label="down"
+                        class="anticon anticon-down"
+                        role="img"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class=""
+                          data-icon="down"
+                          fill="currentColor"
+                          focusable="false"
+                          height="1em"
+                          viewBox="64 64 896 896"
+                          width="1em"
+                        >
+                          <path
+                            d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                          />
+                        </svg>
+                      </span>
                     </button>
                   </div>
                 </div>
@@ -2904,13 +2924,33 @@ exports[`ProjectDocumentsTab renders properly 1`] = `
                     class="ant-col document-table-actions"
                   >
                     <button
-                      class="ant-btn ant-btn-primary"
+                      class="ant-btn ant-btn-primary ant-dropdown-trigger actions-dropdown-button"
                       disabled=""
                       type="button"
                     >
-                      <div>
-                        Download
-                      </div>
+                      <span>
+                        Action
+                      </span>
+                      <span
+                        aria-label="down"
+                        class="anticon anticon-down"
+                        role="img"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class=""
+                          data-icon="down"
+                          fill="currentColor"
+                          focusable="false"
+                          height="1em"
+                          viewBox="64 64 896 896"
+                          width="1em"
+                        >
+                          <path
+                            d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                          />
+                        </svg>
+                      </span>
                     </button>
                   </div>
                 </div>
@@ -3868,13 +3908,33 @@ exports[`ProjectDocumentsTab renders properly 1`] = `
                     class="ant-col document-table-actions"
                   >
                     <button
-                      class="ant-btn ant-btn-primary"
+                      class="ant-btn ant-btn-primary ant-dropdown-trigger actions-dropdown-button"
                       disabled=""
                       type="button"
                     >
-                      <div>
-                        Download
-                      </div>
+                      <span>
+                        Action
+                      </span>
+                      <span
+                        aria-label="down"
+                        class="anticon anticon-down"
+                        role="img"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class=""
+                          data-icon="down"
+                          fill="currentColor"
+                          focusable="false"
+                          height="1em"
+                          viewBox="64 64 896 896"
+                          width="1em"
+                        >
+                          <path
+                            d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                          />
+                        </svg>
+                      </span>
                     </button>
                   </div>
                 </div>

--- a/services/common/src/components/projects/__snapshots__/ProjectDocumentsTabSection.spec.tsx.snap
+++ b/services/common/src/components/projects/__snapshots__/ProjectDocumentsTabSection.spec.tsx.snap
@@ -21,37 +21,41 @@ exports[`ProjectDocumentsTab renders properly 1`] = `
       <div>
         <div />
         <div
-          style="float: right;"
+          class="ant-row ant-row-end ant-row-bottom document-table-header"
         >
-          <button
-            class="ant-btn ant-btn-primary ant-dropdown-trigger actions-dropdown-button"
-            disabled=""
-            type="button"
+          <div
+            class="ant-col document-table-actions"
           >
-            <span>
-              Action
-            </span>
-            <span
-              aria-label="down"
-              class="anticon anticon-down"
-              role="img"
+            <button
+              class="ant-btn ant-btn-primary ant-dropdown-trigger actions-dropdown-button"
+              disabled=""
+              type="button"
             >
-              <svg
-                aria-hidden="true"
-                class=""
-                data-icon="down"
-                fill="currentColor"
-                focusable="false"
-                height="1em"
-                viewBox="64 64 896 896"
-                width="1em"
+              <span>
+                Action
+              </span>
+              <span
+                aria-label="down"
+                class="anticon anticon-down"
+                role="img"
               >
-                <path
-                  d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
-                />
-              </svg>
-            </span>
-          </button>
+                <svg
+                  aria-hidden="true"
+                  class=""
+                  data-icon="down"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                  />
+                </svg>
+              </span>
+            </button>
+          </div>
         </div>
         <div
           class="ant-table-wrapper  core-table"

--- a/services/common/src/interfaces/document/documentTableProps.interface.ts
+++ b/services/common/src/interfaces/document/documentTableProps.interface.ts
@@ -1,6 +1,7 @@
 import { FileOperations, MineDocument } from "@mds/common/models/documents/document";
 import { ColumnType } from "antd/es/table";
 import { IMineDocument } from "../mineDocument.interface";
+import { ReactNode } from "react";
 
 export interface GenericDocTableProps<T> {
   additionalColumnProps?: { key: string; colProps: any }[];
@@ -24,6 +25,7 @@ export interface GenericDocTableProps<T> {
   showVersionHistory?: boolean;
   userRoles?: string[];
   view?: "standard" | "minimal";
+  header?: string | ReactNode;
 }
 
 interface DocumentTableProps extends GenericDocTableProps<MineDocument> {

--- a/services/core-api/app/api/mines/documents/models/mine_document_bundle.py
+++ b/services/core-api/app/api/mines/documents/models/mine_document_bundle.py
@@ -32,6 +32,15 @@ class MineDocumentBundle(SoftDeleteMixin, AuditMixin, Base):
     @classmethod
     def find_by_docman_bundle_guid(cls, docman_bundle_guid):
         return cls.query.filter_by(docman_bundle_guid=docman_bundle_guid).first()
+    
+    @staticmethod
+    def parse_and_update_spatial_documents(documents):
+        spatial_docs = [doc for doc in documents if doc.get('docman_bundle_guid') is not None]
+        updated_spatial_docs = MineDocumentBundle.update_spatial_mine_document_with_bundle_id(spatial_docs)
+
+        all_documents = [doc for doc in documents if doc.get('docman_bundle_guid') is None]
+        all_documents.extend(updated_spatial_docs)
+        return all_documents
 
     @staticmethod
     def update_spatial_mine_document_with_bundle_id(spatial_docs):

--- a/services/core-api/app/api/projects/major_mine_application/models/major_mine_application_document_xref.py
+++ b/services/core-api/app/api/projects/major_mine_application/models/major_mine_application_document_xref.py
@@ -1,22 +1,14 @@
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.schema import FetchedValue
-from sqlalchemy.ext.associationproxy import association_proxy
 
-from app.api.utils.models_mixins import Base
-from app.api.mines.documents.models.mine_document import MineDocument
+from app.api.utils.models_mixins import Base, DocumentXrefMixin
 from app.extensions import db
 
-
-class MajorMineApplicationDocumentXref(Base):
+class MajorMineApplicationDocumentXref(Base, DocumentXrefMixin):
     __tablename__ = 'major_mine_application_document_xref'
 
     major_mine_application_document_xref_guid = db.Column(
         UUID(as_uuid=True), primary_key=True, server_default=FetchedValue())
-    mine_document_guid = db.Column(
-        UUID(as_uuid=True),
-        db.ForeignKey('mine_document.mine_document_guid'),
-        nullable=False,
-        unique=True)
     major_mine_application_id = db.Column(
         db.Integer,
         db.ForeignKey('major_mine_application.major_mine_application_id'),
@@ -27,20 +19,5 @@ class MajorMineApplicationDocumentXref(Base):
             'major_mine_application_document_type.major_mine_application_document_type_code'),
         nullable=False)
 
-    mine_document = db.relationship('MineDocument', lazy='select', overlaps='major_mine_application_document_xref')
-    mine_guid = association_proxy('mine_document', 'mine_guid')
-    document_manager_guid = association_proxy('mine_document', 'document_manager_guid')
-    document_name = association_proxy('mine_document', 'document_name')
-    upload_date = association_proxy('mine_document', 'upload_date')
-    create_user = association_proxy('mine_document', 'create_user')
-    versions = association_proxy('mine_document', 'versions')
-    update_timestamp = association_proxy('mine_document', 'update_timestamp')
-    mine_document_bundle_id = association_proxy('mine_document', 'mine_document_bundle_id')
-
     def __repr__(self):
         return f'{self.__class__.__name__} {self.major_mine_application_document_xref_guid}'
-
-    @classmethod
-    def find_by_mine_document_guid(cls, mine_document_guid):
-        return cls.query.filter_by(mine_document_guid=mine_document_guid).filter(
-            MineDocument.deleted_ind == False).one_or_none()

--- a/services/core-api/app/api/utils/models_mixins.py
+++ b/services/core-api/app/api/utils/models_mixins.py
@@ -478,6 +478,33 @@ class AuditMixin(object):
     update_timestamp = db.Column(
         db.DateTime, nullable=False, default=datetime.utcnow, onupdate=datetime.utcnow)
 
+class DocumentXrefMixin(object):
+    @declared_attr
+    def mine_document(cls):
+        return db.relationship('MineDocument', lazy='select')
+    
+    @declared_attr
+    def mine_document_guid(cls):
+        return db.Column(
+        UUID(as_uuid=True),
+        db.ForeignKey('mine_document.mine_document_guid'),
+        nullable=False,
+        unique=True)
+    
+    mine_guid = association_proxy('mine_document', 'mine_guid')
+    document_manager_guid = association_proxy('mine_document', 'document_manager_guid')
+    document_name = association_proxy('mine_document', 'document_name')
+    upload_date = association_proxy('mine_document', 'upload_date')
+    create_user = association_proxy('mine_document', 'create_user')
+    versions = association_proxy('mine_document', 'versions')
+    update_timestamp = association_proxy('mine_document', 'update_timestamp')
+    mine_document_bundle_id = association_proxy('mine_document', 'mine_document_bundle_id')
+    deleted_ind = association_proxy('mine_document', 'deleted_ind')
+
+    @classmethod
+    def find_by_mine_document_guid(cls, mine_document_guid):
+        return cls.query.filter_by(mine_document_guid=mine_document_guid).filter( # type: ignore
+            cls.deleted_ind == False).one_or_none()
 
 class SoftDeleteMixin(object):
     deleted_ind = db.Column(db.Boolean, nullable=False, server_default=FetchedValue())

--- a/services/core-web/src/styles/components/PermitConditions.scss
+++ b/services/core-web/src/styles/components/PermitConditions.scss
@@ -8,7 +8,7 @@ div.condition-layer {
   .condition-content {
     &.editable:hover {
       cursor: pointer;
-      background-color: lightgrey;
+      background-color: #F4F0F0;
     }
 
     .view-item {

--- a/services/minespace-web/src/components/Forms/projects/majorMineApplication/MajorMineApplicationForm.tsx
+++ b/services/minespace-web/src/components/Forms/projects/majorMineApplication/MajorMineApplicationForm.tsx
@@ -14,6 +14,7 @@ import {
   MODERN_EXCEL,
   SPATIAL,
   SPATIAL_DATA_STANDARDS_URL,
+  SystemFlagEnum,
 } from "@mds/common";
 import * as routes from "@/constants/routes";
 import MajorMineApplicationFileUpload from "@/components/Forms/projects/majorMineApplication/MajorMineApplicationFileUpload";
@@ -27,6 +28,7 @@ import DocumentTable from "@mds/common/components/documents/DocumentTable";
 import RenderField from "@mds/common/components/forms/RenderField";
 import ArchivedDocumentsSection from "@mds/common/components/projects/ArchivedDocumentsSection";
 import { required } from "@mds/common/redux/utils/Validate";
+import { areDocumentFieldsDisabled } from "@mds/common/components/projects/projectUtils";
 
 interface MajorMineApplicationFormProps {
   project: IProject;
@@ -41,6 +43,11 @@ const MajorMineApplicationForm: React.FC<MajorMineApplicationFormProps> = ({
 
   const { primary_documents, spatial_documents, supporting_documents } =
     useSelector(getFormValues(FORM.ADD_MINE_MAJOR_APPLICATION)) || {};
+  const canModifyMmaDocs = areDocumentFieldsDisabled(
+    SystemFlagEnum.ms,
+    project?.major_mine_application?.status_code
+  );
+
   const mineDocuments = useSelector(getMineDocuments);
   const [uploadedFiles, setUploadedFiles] = useState<any[]>([]);
 
@@ -219,7 +226,8 @@ const MajorMineApplicationForm: React.FC<MajorMineApplicationFormProps> = ({
         <DocumentTable
           documents={primaryDocument}
           documentParent="Major Mine Application"
-          canArchiveDocuments={true}
+          canArchiveDocuments={canModifyMmaDocs}
+          canReplaceDocuments={canModifyMmaDocs}
           onArchivedDocuments={refreshData}
           enableBulkActions={true}
           showVersionHistory={true}
@@ -290,7 +298,8 @@ const MajorMineApplicationForm: React.FC<MajorMineApplicationFormProps> = ({
         <DocumentTable
           documents={supportDocuments}
           documentParent="Major Mine Application"
-          canArchiveDocuments={true}
+          canArchiveDocuments={canModifyMmaDocs}
+          canReplaceDocuments={canModifyMmaDocs}
           onArchivedDocuments={refreshData}
           enableBulkActions={true}
           showVersionHistory={true}

--- a/services/minespace-web/src/components/Forms/projects/majorMineApplication/MajorMineApplicationForm.tsx
+++ b/services/minespace-web/src/components/Forms/projects/majorMineApplication/MajorMineApplicationForm.tsx
@@ -43,7 +43,7 @@ const MajorMineApplicationForm: React.FC<MajorMineApplicationFormProps> = ({
 
   const { primary_documents, spatial_documents, supporting_documents } =
     useSelector(getFormValues(FORM.ADD_MINE_MAJOR_APPLICATION)) || {};
-  const canModifyMmaDocs = areDocumentFieldsDisabled(
+  const canModifyMmaDocs = !areDocumentFieldsDisabled(
     SystemFlagEnum.ms,
     project?.major_mine_application?.status_code
   );

--- a/services/minespace-web/src/components/Forms/projects/majorMineApplication/MajorMineApplicationReviewSubmit.tsx
+++ b/services/minespace-web/src/components/Forms/projects/majorMineApplication/MajorMineApplicationReviewSubmit.tsx
@@ -14,6 +14,7 @@ import { getFormattedProjectApplication } from "@mds/common/redux/selectors/proj
 import ProjectCallout from "@mds/common/components/projects/ProjectCallout";
 import { areDocumentFieldsDisabled } from "@mds/common/components/projects/projectUtils";
 import { SystemFlagEnum } from "@mds/common";
+import SpatialDocumentTable from "@mds/common/components/documents/spatial/SpatialDocumentTable";
 
 const inputStyle = { width: "100%" };
 
@@ -110,15 +111,8 @@ export const MajorMineApplicationReviewSubmit: FC<MajorMineApplicationReviewSubm
             showVersionHistory={true}
             enableBulkActions={true}
           />
-          <DocumentTable
-            header={<Typography.Title level={4}>Spatial Components</Typography.Title>}
-            documents={spatial_documents}
-            documentParent="Major Mine Application"
-            canArchiveDocuments={false}
-            canReplaceDocuments={false}
-            showVersionHistory={true}
-            enableBulkActions={true}
-          />
+          <Typography.Title level={4}>Spatial Components</Typography.Title>
+          <SpatialDocumentTable documents={spatial_documents} />
           <DocumentTable
             header={<Typography.Title level={4}>Supporting Documents</Typography.Title>}
             documents={supporting_documents}

--- a/services/minespace-web/src/components/Forms/projects/majorMineApplication/MajorMineApplicationReviewSubmit.tsx
+++ b/services/minespace-web/src/components/Forms/projects/majorMineApplication/MajorMineApplicationReviewSubmit.tsx
@@ -101,8 +101,8 @@ export const MajorMineApplicationReviewSubmit: FC<MajorMineApplicationReviewSubm
         <Col span={24} {...columnStyleConfig}>
           <br />
           <Typography.Title level={3}>Application Files</Typography.Title>
-          <Typography.Title level={4}>Primary Document</Typography.Title>
           <DocumentTable
+            header={<Typography.Title level={4}>Primary Document</Typography.Title>}
             documents={primary_documents}
             documentParent="Major Mine Application"
             canArchiveDocuments={false}
@@ -110,16 +110,17 @@ export const MajorMineApplicationReviewSubmit: FC<MajorMineApplicationReviewSubm
             showVersionHistory={true}
             enableBulkActions={true}
           />
-          <Typography.Title level={4}>Spatial Components</Typography.Title>
           <DocumentTable
+            header={<Typography.Title level={4}>Spatial Components</Typography.Title>}
             documents={spatial_documents}
             documentParent="Major Mine Application"
             canArchiveDocuments={false}
+            canReplaceDocuments={false}
             showVersionHistory={true}
             enableBulkActions={true}
           />
-          <Typography.Title level={4}>Supporting Documents</Typography.Title>
           <DocumentTable
+            header={<Typography.Title level={4}>Supporting Documents</Typography.Title>}
             documents={supporting_documents}
             documentParent="Major Mine Application"
             canArchiveDocuments={false}

--- a/services/minespace-web/src/styles/components/DocumentTableWithExpandedRows.scss
+++ b/services/minespace-web/src/styles/components/DocumentTableWithExpandedRows.scss
@@ -92,3 +92,9 @@
         background-color: $gov-grey;
     }
 }
+
+.document-table-header {
+    .document-table-actions {
+        padding-bottom: 8px;
+    }
+}

--- a/services/minespace-web/src/tests/components/Forms/projects/majorMineApplication/__snapshots__/MajorMineApplicationReviewSubmit.spec.tsx.snap
+++ b/services/minespace-web/src/tests/components/Forms/projects/majorMineApplication/__snapshots__/MajorMineApplicationReviewSubmit.spec.tsx.snap
@@ -603,34 +603,15 @@ exports[`MajorMineApplicationReviewSubmit renders properly as on MajorMineApplic
           </div>
         </div>
       </div>
-      <div>
+      <h4
+        class="ant-typography"
+      >
+        Spatial Components
+      </h4>
+      <div
+        data-testid="spatial-document-table"
+      >
         <div />
-        <div
-          class="ant-row ant-row-space-between ant-row-bottom document-table-header"
-        >
-          <div
-            class="ant-col"
-          >
-            <h4
-              class="ant-typography"
-            >
-              Spatial Components
-            </h4>
-          </div>
-          <div
-            class="ant-col document-table-actions"
-          >
-            <button
-              class="ant-btn ant-btn-primary"
-              disabled=""
-              type="button"
-            >
-              <div>
-                Download
-              </div>
-            </button>
-          </div>
-        </div>
         <div
           class="ant-table-wrapper  core-table"
         >
@@ -652,41 +633,13 @@ exports[`MajorMineApplicationReviewSubmit renders properly as on MajorMineApplic
                     <table
                       style="table-layout: auto;"
                     >
-                      <colgroup>
-                        <col
-                          class="ant-table-selection-col"
-                        />
-                      </colgroup>
+                      <colgroup />
                       <thead
                         class="ant-table-thead"
                       >
                         <tr>
                           <th
-                            class="ant-table-cell ant-table-selection-column"
-                          >
-                            <div
-                              class="ant-table-selection"
-                            >
-                              <label
-                                class="ant-checkbox-wrapper"
-                              >
-                                <span
-                                  class="ant-checkbox"
-                                >
-                                  <input
-                                    aria-label="Select all"
-                                    class="ant-checkbox-input"
-                                    type="checkbox"
-                                  />
-                                  <span
-                                    class="ant-checkbox-inner"
-                                  />
-                                </span>
-                              </label>
-                            </div>
-                          </th>
-                          <th
-                            aria-label=""
+                            aria-label="File Name"
                             class="ant-table-cell ant-table-column-has-sorters"
                             tabindex="0"
                           >
@@ -696,11 +649,7 @@ exports[`MajorMineApplicationReviewSubmit renders properly as on MajorMineApplic
                               <span
                                 class="ant-table-column-title"
                               >
-                                <span
-                                  style="margin-left: 38px;"
-                                >
-                                  File Name
-                                </span>
+                                File Name
                               </span>
                               <span
                                 class="ant-table-column-sorter ant-table-column-sorter-full"
@@ -751,69 +700,8 @@ exports[`MajorMineApplicationReviewSubmit renders properly as on MajorMineApplic
                             </div>
                           </th>
                           <th
-                            aria-label="File Type"
+                            aria-label="Last Modified"
                             class="ant-table-cell ant-table-column-has-sorters"
-                            tabindex="0"
-                          >
-                            <div
-                              class="ant-table-column-sorters"
-                            >
-                              <span
-                                class="ant-table-column-title"
-                              >
-                                File Type
-                              </span>
-                              <span
-                                class="ant-table-column-sorter ant-table-column-sorter-full"
-                              >
-                                <span
-                                  class="ant-table-column-sorter-inner"
-                                >
-                                  <span
-                                    aria-label="caret-up"
-                                    class="anticon anticon-caret-up ant-table-column-sorter-up"
-                                    role="presentation"
-                                  >
-                                    <svg
-                                      aria-hidden="true"
-                                      data-icon="caret-up"
-                                      fill="currentColor"
-                                      focusable="false"
-                                      height="1em"
-                                      viewBox="0 0 1024 1024"
-                                      width="1em"
-                                    >
-                                      <path
-                                        d="M858.9 689L530.5 308.2c-9.4-10.9-27.5-10.9-37 0L165.1 689c-12.2 14.2-1.2 35 18.5 35h656.8c19.7 0 30.7-20.8 18.5-35z"
-                                      />
-                                    </svg>
-                                  </span>
-                                  <span
-                                    aria-label="caret-down"
-                                    class="anticon anticon-caret-down ant-table-column-sorter-down"
-                                    role="presentation"
-                                  >
-                                    <svg
-                                      aria-hidden="true"
-                                      data-icon="caret-down"
-                                      fill="currentColor"
-                                      focusable="false"
-                                      height="1em"
-                                      viewBox="0 0 1024 1024"
-                                      width="1em"
-                                    >
-                                      <path
-                                        d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
-                                      />
-                                    </svg>
-                                  </span>
-                                </span>
-                              </span>
-                            </div>
-                          </th>
-                          <th
-                            aria-sort="descending"
-                            class="ant-table-cell ant-table-column-sort ant-table-column-has-sorters"
                             tabindex="0"
                           >
                             <div
@@ -851,7 +739,7 @@ exports[`MajorMineApplicationReviewSubmit renders properly as on MajorMineApplic
                                   </span>
                                   <span
                                     aria-label="caret-down"
-                                    class="anticon anticon-caret-down ant-table-column-sorter-down active"
+                                    class="anticon anticon-caret-down ant-table-column-sorter-down"
                                     role="presentation"
                                   >
                                     <svg
@@ -944,27 +832,8 @@ exports[`MajorMineApplicationReviewSubmit renders properly as on MajorMineApplic
                       >
                         <tr
                           class="ant-table-row ant-table-row-level-0 table-row-align-middle no-sub-table-expandable-rows fade-in"
-                          data-row-key="0f21c334-1d01-4289-b7ee-a7a5fd8b9a32"
+                          data-row-key="1"
                         >
-                          <td
-                            class="ant-table-cell ant-table-selection-column"
-                          >
-                            <label
-                              class="ant-checkbox-wrapper"
-                            >
-                              <span
-                                class="ant-checkbox"
-                              >
-                                <input
-                                  class="ant-checkbox-input"
-                                  type="checkbox"
-                                />
-                                <span
-                                  class="ant-checkbox-inner"
-                                />
-                              </span>
-                            </label>
-                          </td>
                           <td
                             class="ant-table-cell ant-table-cell-with-append"
                           >
@@ -972,361 +841,72 @@ exports[`MajorMineApplicationReviewSubmit renders properly as on MajorMineApplic
                               class="ant-table-row-indent indent-level-0"
                               style="padding-left: 0px;"
                             />
+                            <a
+                              class="expand-row-icon"
+                              role="link"
+                              style="cursor: pointer;"
+                              tabindex="0"
+                            >
+                              <span
+                                aria-label="plus-square"
+                                class="anticon anticon-plus-square icon-lg--lightgrey"
+                                role="img"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class=""
+                                  data-icon="plus-square"
+                                  fill="currentColor"
+                                  focusable="false"
+                                  height="1em"
+                                  viewBox="64 64 896 896"
+                                  width="1em"
+                                >
+                                  <path
+                                    d="M880 112H144c-17.7 0-32 14.3-32 32v736c0 17.7 14.3 32 32 32h736c17.7 0 32-14.3 32-32V144c0-17.7-14.3-32-32-32zM704 536c0 4.4-3.6 8-8 8H544v152c0 4.4-3.6 8-8 8h-48c-4.4 0-8-3.6-8-8V544H328c-4.4 0-8-3.6-8-8v-48c0-4.4 3.6-8 8-8h152V328c0-4.4 3.6-8 8-8h48c4.4 0 8 3.6 8 8v152h152c4.4 0 8 3.6 8 8v48z"
+                                  />
+                                </svg>
+                              </span>
+                            </a>
                             <div
-                              class="inline-flex flex-between file-name-container"
-                              style="margin-left: 38px;"
+                              class="inline-flex flex-between tag-column-container parent"
                               title="File Name"
                             >
-                              <a>
-                                shape.dbf
-                              </a>
-                              <span
-                                class="file-history-container"
-                              />
-                            </div>
-                          </td>
-                          <td
-                            class="ant-table-cell"
-                          >
-                            <div
-                              class="file_type-column"
-                              title="File Type"
-                            >
-                              .dbf
-                            </div>
-                          </td>
-                          <td
-                            class="ant-table-cell ant-table-column-sort"
-                          >
-                            <div
-                              title="Last Modified"
-                            >
-                              Jul 19 2024
-                            </div>
-                          </td>
-                          <td
-                            class="ant-table-cell"
-                          >
-                            <div
-                              class="create_user-column"
-                              title="Created By"
-                            >
-                              test@bceid
-                            </div>
-                          </td>
-                          <td
-                            class="ant-table-cell actions-column ant-table-cell-fix-right ant-table-cell-fix-right-first"
-                            style="position: sticky; right: 0px;"
-                          >
-                            <div>
-                              <button
-                                class="ant-btn ant-btn-text ant-dropdown-trigger actions-dropdown-button"
-                                data-cy="menu-actions-button"
-                                type="button"
+                              <div
+                                class="tag-text-parent"
                               >
-                                <span>
-                                  Actions
-                                </span>
+                                shape
+                              </div>
+                              <div
+                                class="file-history-container"
+                              >
                                 <span
-                                  alt="Menu"
-                                  aria-label="caret-down"
-                                  class="anticon anticon-caret-down"
-                                  role="img"
+                                  class="ant-tag table-tag table-tag--primary"
                                 >
                                   <svg
                                     aria-hidden="true"
-                                    class=""
-                                    data-icon="caret-down"
-                                    fill="currentColor"
+                                    class="svg-inline--fa fa-files "
+                                    data-icon="files"
+                                    data-prefix="fal"
                                     focusable="false"
-                                    height="1em"
-                                    viewBox="0 0 1024 1024"
-                                    width="1em"
+                                    role="img"
+                                    viewBox="0 0 448 512"
+                                    xmlns="http://www.w3.org/2000/svg"
                                   >
                                     <path
-                                      d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
+                                      d="M160 384c-17.7 0-32-14.3-32-32V64c0-17.7 14.3-32 32-32H304v80c0 17.7 14.3 32 32 32h80c0 .3 0 .5 0 .8V352c0 17.7-14.3 32-32 32H160zM336 57.5L390 112H336V57.5zM160 0C124.7 0 96 28.7 96 64V352c0 35.3 28.7 64 64 64H384c35.3 0 64-28.7 64-64V144.8c0-12.7-5-24.8-13.9-33.8l-96-96.8C329.1 5.1 316.8 0 304 0H160zM32 112c0-8.8-7.2-16-16-16s-16 7.2-16 16V384c0 70.7 57.3 128 128 128H336c8.8 0 16-7.2 16-16s-7.2-16-16-16H128c-53 0-96-43-96-96V112z"
+                                      fill="currentColor"
                                     />
                                   </svg>
+                                  <span>
+                                    4
+                                  </span>
                                 </span>
-                              </button>
-                            </div>
-                          </td>
-                        </tr>
-                        <tr
-                          class="ant-table-row ant-table-row-level-0 table-row-align-middle no-sub-table-expandable-rows fade-in"
-                          data-row-key="92be7cea-e25a-4fa3-9f82-2536c1a786ff"
-                        >
-                          <td
-                            class="ant-table-cell ant-table-selection-column"
-                          >
-                            <label
-                              class="ant-checkbox-wrapper"
-                            >
-                              <span
-                                class="ant-checkbox"
-                              >
-                                <input
-                                  class="ant-checkbox-input"
-                                  type="checkbox"
-                                />
-                                <span
-                                  class="ant-checkbox-inner"
-                                />
-                              </span>
-                            </label>
-                          </td>
-                          <td
-                            class="ant-table-cell ant-table-cell-with-append"
-                          >
-                            <span
-                              class="ant-table-row-indent indent-level-0"
-                              style="padding-left: 0px;"
-                            />
-                            <div
-                              class="inline-flex flex-between file-name-container"
-                              style="margin-left: 38px;"
-                              title="File Name"
-                            >
-                              <a>
-                                shape.prj
-                              </a>
-                              <span
-                                class="file-history-container"
-                              />
+                              </div>
                             </div>
                           </td>
                           <td
                             class="ant-table-cell"
-                          >
-                            <div
-                              class="file_type-column"
-                              title="File Type"
-                            >
-                              .prj
-                            </div>
-                          </td>
-                          <td
-                            class="ant-table-cell ant-table-column-sort"
-                          >
-                            <div
-                              title="Last Modified"
-                            >
-                              Jul 19 2024
-                            </div>
-                          </td>
-                          <td
-                            class="ant-table-cell"
-                          >
-                            <div
-                              class="create_user-column"
-                              title="Created By"
-                            >
-                              test@bceid
-                            </div>
-                          </td>
-                          <td
-                            class="ant-table-cell actions-column ant-table-cell-fix-right ant-table-cell-fix-right-first"
-                            style="position: sticky; right: 0px;"
-                          >
-                            <div>
-                              <button
-                                class="ant-btn ant-btn-text ant-dropdown-trigger actions-dropdown-button"
-                                data-cy="menu-actions-button"
-                                type="button"
-                              >
-                                <span>
-                                  Actions
-                                </span>
-                                <span
-                                  alt="Menu"
-                                  aria-label="caret-down"
-                                  class="anticon anticon-caret-down"
-                                  role="img"
-                                >
-                                  <svg
-                                    aria-hidden="true"
-                                    class=""
-                                    data-icon="caret-down"
-                                    fill="currentColor"
-                                    focusable="false"
-                                    height="1em"
-                                    viewBox="0 0 1024 1024"
-                                    width="1em"
-                                  >
-                                    <path
-                                      d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
-                                    />
-                                  </svg>
-                                </span>
-                              </button>
-                            </div>
-                          </td>
-                        </tr>
-                        <tr
-                          class="ant-table-row ant-table-row-level-0 table-row-align-middle no-sub-table-expandable-rows fade-in"
-                          data-row-key="f5809a0e-e052-4b0e-b37d-eb7976a9e7d7"
-                        >
-                          <td
-                            class="ant-table-cell ant-table-selection-column"
-                          >
-                            <label
-                              class="ant-checkbox-wrapper"
-                            >
-                              <span
-                                class="ant-checkbox"
-                              >
-                                <input
-                                  class="ant-checkbox-input"
-                                  type="checkbox"
-                                />
-                                <span
-                                  class="ant-checkbox-inner"
-                                />
-                              </span>
-                            </label>
-                          </td>
-                          <td
-                            class="ant-table-cell ant-table-cell-with-append"
-                          >
-                            <span
-                              class="ant-table-row-indent indent-level-0"
-                              style="padding-left: 0px;"
-                            />
-                            <div
-                              class="inline-flex flex-between file-name-container"
-                              style="margin-left: 38px;"
-                              title="File Name"
-                            >
-                              <a>
-                                shape.shp
-                              </a>
-                              <span
-                                class="file-history-container"
-                              />
-                            </div>
-                          </td>
-                          <td
-                            class="ant-table-cell"
-                          >
-                            <div
-                              class="file_type-column"
-                              title="File Type"
-                            >
-                              .shp
-                            </div>
-                          </td>
-                          <td
-                            class="ant-table-cell ant-table-column-sort"
-                          >
-                            <div
-                              title="Last Modified"
-                            >
-                              Jul 19 2024
-                            </div>
-                          </td>
-                          <td
-                            class="ant-table-cell"
-                          >
-                            <div
-                              class="create_user-column"
-                              title="Created By"
-                            >
-                              test@bceid
-                            </div>
-                          </td>
-                          <td
-                            class="ant-table-cell actions-column ant-table-cell-fix-right ant-table-cell-fix-right-first"
-                            style="position: sticky; right: 0px;"
-                          >
-                            <div>
-                              <button
-                                class="ant-btn ant-btn-text ant-dropdown-trigger actions-dropdown-button"
-                                data-cy="menu-actions-button"
-                                type="button"
-                              >
-                                <span>
-                                  Actions
-                                </span>
-                                <span
-                                  alt="Menu"
-                                  aria-label="caret-down"
-                                  class="anticon anticon-caret-down"
-                                  role="img"
-                                >
-                                  <svg
-                                    aria-hidden="true"
-                                    class=""
-                                    data-icon="caret-down"
-                                    fill="currentColor"
-                                    focusable="false"
-                                    height="1em"
-                                    viewBox="0 0 1024 1024"
-                                    width="1em"
-                                  >
-                                    <path
-                                      d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
-                                    />
-                                  </svg>
-                                </span>
-                              </button>
-                            </div>
-                          </td>
-                        </tr>
-                        <tr
-                          class="ant-table-row ant-table-row-level-0 table-row-align-middle no-sub-table-expandable-rows fade-in"
-                          data-row-key="f93ba7a4-0236-4110-93a8-d60d8b99adf8"
-                        >
-                          <td
-                            class="ant-table-cell ant-table-selection-column"
-                          >
-                            <label
-                              class="ant-checkbox-wrapper"
-                            >
-                              <span
-                                class="ant-checkbox"
-                              >
-                                <input
-                                  class="ant-checkbox-input"
-                                  type="checkbox"
-                                />
-                                <span
-                                  class="ant-checkbox-inner"
-                                />
-                              </span>
-                            </label>
-                          </td>
-                          <td
-                            class="ant-table-cell ant-table-cell-with-append"
-                          >
-                            <span
-                              class="ant-table-row-indent indent-level-0"
-                              style="padding-left: 0px;"
-                            />
-                            <div
-                              class="inline-flex flex-between file-name-container"
-                              style="margin-left: 38px;"
-                              title="File Name"
-                            >
-                              <a>
-                                shape.shx
-                              </a>
-                              <span
-                                class="file-history-container"
-                              />
-                            </div>
-                          </td>
-                          <td
-                            class="ant-table-cell"
-                          >
-                            <div
-                              class="file_type-column"
-                              title="File Type"
-                            >
-                              .shx
-                            </div>
-                          </td>
-                          <td
-                            class="ant-table-cell ant-table-column-sort"
                           >
                             <div
                               title="Last Modified"
@@ -1387,25 +967,6 @@ exports[`MajorMineApplicationReviewSubmit renders properly as on MajorMineApplic
                           data-row-key="951f3658-3f28-4b7b-a402-a5c7f5a092f3"
                         >
                           <td
-                            class="ant-table-cell ant-table-selection-column"
-                          >
-                            <label
-                              class="ant-checkbox-wrapper"
-                            >
-                              <span
-                                class="ant-checkbox"
-                              >
-                                <input
-                                  class="ant-checkbox-input"
-                                  type="checkbox"
-                                />
-                                <span
-                                  class="ant-checkbox-inner"
-                                />
-                              </span>
-                            </label>
-                          </td>
-                          <td
                             class="ant-table-cell ant-table-cell-with-append"
                           >
                             <span
@@ -1413,30 +974,18 @@ exports[`MajorMineApplicationReviewSubmit renders properly as on MajorMineApplic
                               style="padding-left: 0px;"
                             />
                             <div
-                              class="inline-flex flex-between file-name-container"
-                              style="margin-left: 38px;"
+                              class="inline-flex flex-between tag-column-container child"
                               title="File Name"
                             >
-                              <a>
+                              <div
+                                class="tag-text-child"
+                              >
                                 testfile.kml
-                              </a>
-                              <span
-                                class="file-history-container"
-                              />
+                              </div>
                             </div>
                           </td>
                           <td
                             class="ant-table-cell"
-                          >
-                            <div
-                              class="file_type-column"
-                              title="File Type"
-                            >
-                              .kml
-                            </div>
-                          </td>
-                          <td
-                            class="ant-table-cell ant-table-column-sort"
                           >
                             <div
                               title="Last Modified"
@@ -3111,34 +2660,15 @@ exports[`MajorMineApplicationReviewSubmit renders properly as on ProjectPage 1`]
           </div>
         </div>
       </div>
-      <div>
+      <h4
+        class="ant-typography"
+      >
+        Spatial Components
+      </h4>
+      <div
+        data-testid="spatial-document-table"
+      >
         <div />
-        <div
-          class="ant-row ant-row-space-between ant-row-bottom document-table-header"
-        >
-          <div
-            class="ant-col"
-          >
-            <h4
-              class="ant-typography"
-            >
-              Spatial Components
-            </h4>
-          </div>
-          <div
-            class="ant-col document-table-actions"
-          >
-            <button
-              class="ant-btn ant-btn-primary"
-              disabled=""
-              type="button"
-            >
-              <div>
-                Download
-              </div>
-            </button>
-          </div>
-        </div>
         <div
           class="ant-table-wrapper  core-table"
         >
@@ -3160,41 +2690,13 @@ exports[`MajorMineApplicationReviewSubmit renders properly as on ProjectPage 1`]
                     <table
                       style="table-layout: auto;"
                     >
-                      <colgroup>
-                        <col
-                          class="ant-table-selection-col"
-                        />
-                      </colgroup>
+                      <colgroup />
                       <thead
                         class="ant-table-thead"
                       >
                         <tr>
                           <th
-                            class="ant-table-cell ant-table-selection-column"
-                          >
-                            <div
-                              class="ant-table-selection"
-                            >
-                              <label
-                                class="ant-checkbox-wrapper"
-                              >
-                                <span
-                                  class="ant-checkbox"
-                                >
-                                  <input
-                                    aria-label="Select all"
-                                    class="ant-checkbox-input"
-                                    type="checkbox"
-                                  />
-                                  <span
-                                    class="ant-checkbox-inner"
-                                  />
-                                </span>
-                              </label>
-                            </div>
-                          </th>
-                          <th
-                            aria-label=""
+                            aria-label="File Name"
                             class="ant-table-cell ant-table-column-has-sorters"
                             tabindex="0"
                           >
@@ -3204,11 +2706,7 @@ exports[`MajorMineApplicationReviewSubmit renders properly as on ProjectPage 1`]
                               <span
                                 class="ant-table-column-title"
                               >
-                                <span
-                                  style="margin-left: 38px;"
-                                >
-                                  File Name
-                                </span>
+                                File Name
                               </span>
                               <span
                                 class="ant-table-column-sorter ant-table-column-sorter-full"
@@ -3259,69 +2757,8 @@ exports[`MajorMineApplicationReviewSubmit renders properly as on ProjectPage 1`]
                             </div>
                           </th>
                           <th
-                            aria-label="File Type"
+                            aria-label="Last Modified"
                             class="ant-table-cell ant-table-column-has-sorters"
-                            tabindex="0"
-                          >
-                            <div
-                              class="ant-table-column-sorters"
-                            >
-                              <span
-                                class="ant-table-column-title"
-                              >
-                                File Type
-                              </span>
-                              <span
-                                class="ant-table-column-sorter ant-table-column-sorter-full"
-                              >
-                                <span
-                                  class="ant-table-column-sorter-inner"
-                                >
-                                  <span
-                                    aria-label="caret-up"
-                                    class="anticon anticon-caret-up ant-table-column-sorter-up"
-                                    role="presentation"
-                                  >
-                                    <svg
-                                      aria-hidden="true"
-                                      data-icon="caret-up"
-                                      fill="currentColor"
-                                      focusable="false"
-                                      height="1em"
-                                      viewBox="0 0 1024 1024"
-                                      width="1em"
-                                    >
-                                      <path
-                                        d="M858.9 689L530.5 308.2c-9.4-10.9-27.5-10.9-37 0L165.1 689c-12.2 14.2-1.2 35 18.5 35h656.8c19.7 0 30.7-20.8 18.5-35z"
-                                      />
-                                    </svg>
-                                  </span>
-                                  <span
-                                    aria-label="caret-down"
-                                    class="anticon anticon-caret-down ant-table-column-sorter-down"
-                                    role="presentation"
-                                  >
-                                    <svg
-                                      aria-hidden="true"
-                                      data-icon="caret-down"
-                                      fill="currentColor"
-                                      focusable="false"
-                                      height="1em"
-                                      viewBox="0 0 1024 1024"
-                                      width="1em"
-                                    >
-                                      <path
-                                        d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
-                                      />
-                                    </svg>
-                                  </span>
-                                </span>
-                              </span>
-                            </div>
-                          </th>
-                          <th
-                            aria-sort="descending"
-                            class="ant-table-cell ant-table-column-sort ant-table-column-has-sorters"
                             tabindex="0"
                           >
                             <div
@@ -3359,7 +2796,7 @@ exports[`MajorMineApplicationReviewSubmit renders properly as on ProjectPage 1`]
                                   </span>
                                   <span
                                     aria-label="caret-down"
-                                    class="anticon anticon-caret-down ant-table-column-sorter-down active"
+                                    class="anticon anticon-caret-down ant-table-column-sorter-down"
                                     role="presentation"
                                   >
                                     <svg
@@ -3452,27 +2889,8 @@ exports[`MajorMineApplicationReviewSubmit renders properly as on ProjectPage 1`]
                       >
                         <tr
                           class="ant-table-row ant-table-row-level-0 table-row-align-middle no-sub-table-expandable-rows fade-in"
-                          data-row-key="0f21c334-1d01-4289-b7ee-a7a5fd8b9a32"
+                          data-row-key="1"
                         >
-                          <td
-                            class="ant-table-cell ant-table-selection-column"
-                          >
-                            <label
-                              class="ant-checkbox-wrapper"
-                            >
-                              <span
-                                class="ant-checkbox"
-                              >
-                                <input
-                                  class="ant-checkbox-input"
-                                  type="checkbox"
-                                />
-                                <span
-                                  class="ant-checkbox-inner"
-                                />
-                              </span>
-                            </label>
-                          </td>
                           <td
                             class="ant-table-cell ant-table-cell-with-append"
                           >
@@ -3480,361 +2898,72 @@ exports[`MajorMineApplicationReviewSubmit renders properly as on ProjectPage 1`]
                               class="ant-table-row-indent indent-level-0"
                               style="padding-left: 0px;"
                             />
+                            <a
+                              class="expand-row-icon"
+                              role="link"
+                              style="cursor: pointer;"
+                              tabindex="0"
+                            >
+                              <span
+                                aria-label="plus-square"
+                                class="anticon anticon-plus-square icon-lg--lightgrey"
+                                role="img"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class=""
+                                  data-icon="plus-square"
+                                  fill="currentColor"
+                                  focusable="false"
+                                  height="1em"
+                                  viewBox="64 64 896 896"
+                                  width="1em"
+                                >
+                                  <path
+                                    d="M880 112H144c-17.7 0-32 14.3-32 32v736c0 17.7 14.3 32 32 32h736c17.7 0 32-14.3 32-32V144c0-17.7-14.3-32-32-32zM704 536c0 4.4-3.6 8-8 8H544v152c0 4.4-3.6 8-8 8h-48c-4.4 0-8-3.6-8-8V544H328c-4.4 0-8-3.6-8-8v-48c0-4.4 3.6-8 8-8h152V328c0-4.4 3.6-8 8-8h48c4.4 0 8 3.6 8 8v152h152c4.4 0 8 3.6 8 8v48z"
+                                  />
+                                </svg>
+                              </span>
+                            </a>
                             <div
-                              class="inline-flex flex-between file-name-container"
-                              style="margin-left: 38px;"
+                              class="inline-flex flex-between tag-column-container parent"
                               title="File Name"
                             >
-                              <a>
-                                shape.dbf
-                              </a>
-                              <span
-                                class="file-history-container"
-                              />
-                            </div>
-                          </td>
-                          <td
-                            class="ant-table-cell"
-                          >
-                            <div
-                              class="file_type-column"
-                              title="File Type"
-                            >
-                              .dbf
-                            </div>
-                          </td>
-                          <td
-                            class="ant-table-cell ant-table-column-sort"
-                          >
-                            <div
-                              title="Last Modified"
-                            >
-                              Jul 19 2024
-                            </div>
-                          </td>
-                          <td
-                            class="ant-table-cell"
-                          >
-                            <div
-                              class="create_user-column"
-                              title="Created By"
-                            >
-                              test@bceid
-                            </div>
-                          </td>
-                          <td
-                            class="ant-table-cell actions-column ant-table-cell-fix-right ant-table-cell-fix-right-first"
-                            style="position: sticky; right: 0px;"
-                          >
-                            <div>
-                              <button
-                                class="ant-btn ant-btn-text ant-dropdown-trigger actions-dropdown-button"
-                                data-cy="menu-actions-button"
-                                type="button"
+                              <div
+                                class="tag-text-parent"
                               >
-                                <span>
-                                  Actions
-                                </span>
+                                shape
+                              </div>
+                              <div
+                                class="file-history-container"
+                              >
                                 <span
-                                  alt="Menu"
-                                  aria-label="caret-down"
-                                  class="anticon anticon-caret-down"
-                                  role="img"
+                                  class="ant-tag table-tag table-tag--primary"
                                 >
                                   <svg
                                     aria-hidden="true"
-                                    class=""
-                                    data-icon="caret-down"
-                                    fill="currentColor"
+                                    class="svg-inline--fa fa-files "
+                                    data-icon="files"
+                                    data-prefix="fal"
                                     focusable="false"
-                                    height="1em"
-                                    viewBox="0 0 1024 1024"
-                                    width="1em"
+                                    role="img"
+                                    viewBox="0 0 448 512"
+                                    xmlns="http://www.w3.org/2000/svg"
                                   >
                                     <path
-                                      d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
+                                      d="M160 384c-17.7 0-32-14.3-32-32V64c0-17.7 14.3-32 32-32H304v80c0 17.7 14.3 32 32 32h80c0 .3 0 .5 0 .8V352c0 17.7-14.3 32-32 32H160zM336 57.5L390 112H336V57.5zM160 0C124.7 0 96 28.7 96 64V352c0 35.3 28.7 64 64 64H384c35.3 0 64-28.7 64-64V144.8c0-12.7-5-24.8-13.9-33.8l-96-96.8C329.1 5.1 316.8 0 304 0H160zM32 112c0-8.8-7.2-16-16-16s-16 7.2-16 16V384c0 70.7 57.3 128 128 128H336c8.8 0 16-7.2 16-16s-7.2-16-16-16H128c-53 0-96-43-96-96V112z"
+                                      fill="currentColor"
                                     />
                                   </svg>
+                                  <span>
+                                    4
+                                  </span>
                                 </span>
-                              </button>
-                            </div>
-                          </td>
-                        </tr>
-                        <tr
-                          class="ant-table-row ant-table-row-level-0 table-row-align-middle no-sub-table-expandable-rows fade-in"
-                          data-row-key="92be7cea-e25a-4fa3-9f82-2536c1a786ff"
-                        >
-                          <td
-                            class="ant-table-cell ant-table-selection-column"
-                          >
-                            <label
-                              class="ant-checkbox-wrapper"
-                            >
-                              <span
-                                class="ant-checkbox"
-                              >
-                                <input
-                                  class="ant-checkbox-input"
-                                  type="checkbox"
-                                />
-                                <span
-                                  class="ant-checkbox-inner"
-                                />
-                              </span>
-                            </label>
-                          </td>
-                          <td
-                            class="ant-table-cell ant-table-cell-with-append"
-                          >
-                            <span
-                              class="ant-table-row-indent indent-level-0"
-                              style="padding-left: 0px;"
-                            />
-                            <div
-                              class="inline-flex flex-between file-name-container"
-                              style="margin-left: 38px;"
-                              title="File Name"
-                            >
-                              <a>
-                                shape.prj
-                              </a>
-                              <span
-                                class="file-history-container"
-                              />
+                              </div>
                             </div>
                           </td>
                           <td
                             class="ant-table-cell"
-                          >
-                            <div
-                              class="file_type-column"
-                              title="File Type"
-                            >
-                              .prj
-                            </div>
-                          </td>
-                          <td
-                            class="ant-table-cell ant-table-column-sort"
-                          >
-                            <div
-                              title="Last Modified"
-                            >
-                              Jul 19 2024
-                            </div>
-                          </td>
-                          <td
-                            class="ant-table-cell"
-                          >
-                            <div
-                              class="create_user-column"
-                              title="Created By"
-                            >
-                              test@bceid
-                            </div>
-                          </td>
-                          <td
-                            class="ant-table-cell actions-column ant-table-cell-fix-right ant-table-cell-fix-right-first"
-                            style="position: sticky; right: 0px;"
-                          >
-                            <div>
-                              <button
-                                class="ant-btn ant-btn-text ant-dropdown-trigger actions-dropdown-button"
-                                data-cy="menu-actions-button"
-                                type="button"
-                              >
-                                <span>
-                                  Actions
-                                </span>
-                                <span
-                                  alt="Menu"
-                                  aria-label="caret-down"
-                                  class="anticon anticon-caret-down"
-                                  role="img"
-                                >
-                                  <svg
-                                    aria-hidden="true"
-                                    class=""
-                                    data-icon="caret-down"
-                                    fill="currentColor"
-                                    focusable="false"
-                                    height="1em"
-                                    viewBox="0 0 1024 1024"
-                                    width="1em"
-                                  >
-                                    <path
-                                      d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
-                                    />
-                                  </svg>
-                                </span>
-                              </button>
-                            </div>
-                          </td>
-                        </tr>
-                        <tr
-                          class="ant-table-row ant-table-row-level-0 table-row-align-middle no-sub-table-expandable-rows fade-in"
-                          data-row-key="f5809a0e-e052-4b0e-b37d-eb7976a9e7d7"
-                        >
-                          <td
-                            class="ant-table-cell ant-table-selection-column"
-                          >
-                            <label
-                              class="ant-checkbox-wrapper"
-                            >
-                              <span
-                                class="ant-checkbox"
-                              >
-                                <input
-                                  class="ant-checkbox-input"
-                                  type="checkbox"
-                                />
-                                <span
-                                  class="ant-checkbox-inner"
-                                />
-                              </span>
-                            </label>
-                          </td>
-                          <td
-                            class="ant-table-cell ant-table-cell-with-append"
-                          >
-                            <span
-                              class="ant-table-row-indent indent-level-0"
-                              style="padding-left: 0px;"
-                            />
-                            <div
-                              class="inline-flex flex-between file-name-container"
-                              style="margin-left: 38px;"
-                              title="File Name"
-                            >
-                              <a>
-                                shape.shp
-                              </a>
-                              <span
-                                class="file-history-container"
-                              />
-                            </div>
-                          </td>
-                          <td
-                            class="ant-table-cell"
-                          >
-                            <div
-                              class="file_type-column"
-                              title="File Type"
-                            >
-                              .shp
-                            </div>
-                          </td>
-                          <td
-                            class="ant-table-cell ant-table-column-sort"
-                          >
-                            <div
-                              title="Last Modified"
-                            >
-                              Jul 19 2024
-                            </div>
-                          </td>
-                          <td
-                            class="ant-table-cell"
-                          >
-                            <div
-                              class="create_user-column"
-                              title="Created By"
-                            >
-                              test@bceid
-                            </div>
-                          </td>
-                          <td
-                            class="ant-table-cell actions-column ant-table-cell-fix-right ant-table-cell-fix-right-first"
-                            style="position: sticky; right: 0px;"
-                          >
-                            <div>
-                              <button
-                                class="ant-btn ant-btn-text ant-dropdown-trigger actions-dropdown-button"
-                                data-cy="menu-actions-button"
-                                type="button"
-                              >
-                                <span>
-                                  Actions
-                                </span>
-                                <span
-                                  alt="Menu"
-                                  aria-label="caret-down"
-                                  class="anticon anticon-caret-down"
-                                  role="img"
-                                >
-                                  <svg
-                                    aria-hidden="true"
-                                    class=""
-                                    data-icon="caret-down"
-                                    fill="currentColor"
-                                    focusable="false"
-                                    height="1em"
-                                    viewBox="0 0 1024 1024"
-                                    width="1em"
-                                  >
-                                    <path
-                                      d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
-                                    />
-                                  </svg>
-                                </span>
-                              </button>
-                            </div>
-                          </td>
-                        </tr>
-                        <tr
-                          class="ant-table-row ant-table-row-level-0 table-row-align-middle no-sub-table-expandable-rows fade-in"
-                          data-row-key="f93ba7a4-0236-4110-93a8-d60d8b99adf8"
-                        >
-                          <td
-                            class="ant-table-cell ant-table-selection-column"
-                          >
-                            <label
-                              class="ant-checkbox-wrapper"
-                            >
-                              <span
-                                class="ant-checkbox"
-                              >
-                                <input
-                                  class="ant-checkbox-input"
-                                  type="checkbox"
-                                />
-                                <span
-                                  class="ant-checkbox-inner"
-                                />
-                              </span>
-                            </label>
-                          </td>
-                          <td
-                            class="ant-table-cell ant-table-cell-with-append"
-                          >
-                            <span
-                              class="ant-table-row-indent indent-level-0"
-                              style="padding-left: 0px;"
-                            />
-                            <div
-                              class="inline-flex flex-between file-name-container"
-                              style="margin-left: 38px;"
-                              title="File Name"
-                            >
-                              <a>
-                                shape.shx
-                              </a>
-                              <span
-                                class="file-history-container"
-                              />
-                            </div>
-                          </td>
-                          <td
-                            class="ant-table-cell"
-                          >
-                            <div
-                              class="file_type-column"
-                              title="File Type"
-                            >
-                              .shx
-                            </div>
-                          </td>
-                          <td
-                            class="ant-table-cell ant-table-column-sort"
                           >
                             <div
                               title="Last Modified"
@@ -3895,25 +3024,6 @@ exports[`MajorMineApplicationReviewSubmit renders properly as on ProjectPage 1`]
                           data-row-key="951f3658-3f28-4b7b-a402-a5c7f5a092f3"
                         >
                           <td
-                            class="ant-table-cell ant-table-selection-column"
-                          >
-                            <label
-                              class="ant-checkbox-wrapper"
-                            >
-                              <span
-                                class="ant-checkbox"
-                              >
-                                <input
-                                  class="ant-checkbox-input"
-                                  type="checkbox"
-                                />
-                                <span
-                                  class="ant-checkbox-inner"
-                                />
-                              </span>
-                            </label>
-                          </td>
-                          <td
                             class="ant-table-cell ant-table-cell-with-append"
                           >
                             <span
@@ -3921,30 +3031,18 @@ exports[`MajorMineApplicationReviewSubmit renders properly as on ProjectPage 1`]
                               style="padding-left: 0px;"
                             />
                             <div
-                              class="inline-flex flex-between file-name-container"
-                              style="margin-left: 38px;"
+                              class="inline-flex flex-between tag-column-container child"
                               title="File Name"
                             >
-                              <a>
+                              <div
+                                class="tag-text-child"
+                              >
                                 testfile.kml
-                              </a>
-                              <span
-                                class="file-history-container"
-                              />
+                              </div>
                             </div>
                           </td>
                           <td
                             class="ant-table-cell"
-                          >
-                            <div
-                              class="file_type-column"
-                              title="File Type"
-                            >
-                              .kml
-                            </div>
-                          </td>
-                          <td
-                            class="ant-table-cell ant-table-column-sort"
                           >
                             <div
                               title="Last Modified"

--- a/services/minespace-web/src/tests/components/Forms/projects/majorMineApplication/__snapshots__/MajorMineApplicationReviewSubmit.spec.tsx.snap
+++ b/services/minespace-web/src/tests/components/Forms/projects/majorMineApplication/__snapshots__/MajorMineApplicationReviewSubmit.spec.tsx.snap
@@ -145,45 +145,33 @@ exports[`MajorMineApplicationReviewSubmit renders properly as on MajorMineApplic
       >
         Application Files
       </h3>
-      <h4
-        class="ant-typography"
-      >
-        Primary Document
-      </h4>
       <div>
         <div />
         <div
-          style="float: right;"
+          class="ant-row ant-row-space-between ant-row-bottom document-table-header"
         >
-          <button
-            class="ant-btn ant-btn-primary ant-dropdown-trigger actions-dropdown-button"
-            disabled=""
-            type="button"
+          <div
+            class="ant-col"
           >
-            <span>
-              Action
-            </span>
-            <span
-              aria-label="down"
-              class="anticon anticon-down"
-              role="img"
+            <h4
+              class="ant-typography"
             >
-              <svg
-                aria-hidden="true"
-                class=""
-                data-icon="down"
-                fill="currentColor"
-                focusable="false"
-                height="1em"
-                viewBox="64 64 896 896"
-                width="1em"
-              >
-                <path
-                  d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
-                />
-              </svg>
-            </span>
-          </button>
+              Primary Document
+            </h4>
+          </div>
+          <div
+            class="ant-col document-table-actions"
+          >
+            <button
+              class="ant-btn ant-btn-primary"
+              disabled=""
+              type="button"
+            >
+              <div>
+                Download
+              </div>
+            </button>
+          </div>
         </div>
         <div
           class="ant-table-wrapper  core-table"
@@ -615,45 +603,33 @@ exports[`MajorMineApplicationReviewSubmit renders properly as on MajorMineApplic
           </div>
         </div>
       </div>
-      <h4
-        class="ant-typography"
-      >
-        Spatial Components
-      </h4>
       <div>
         <div />
         <div
-          style="float: right;"
+          class="ant-row ant-row-space-between ant-row-bottom document-table-header"
         >
-          <button
-            class="ant-btn ant-btn-primary ant-dropdown-trigger actions-dropdown-button"
-            disabled=""
-            type="button"
+          <div
+            class="ant-col"
           >
-            <span>
-              Action
-            </span>
-            <span
-              aria-label="down"
-              class="anticon anticon-down"
-              role="img"
+            <h4
+              class="ant-typography"
             >
-              <svg
-                aria-hidden="true"
-                class=""
-                data-icon="down"
-                fill="currentColor"
-                focusable="false"
-                height="1em"
-                viewBox="64 64 896 896"
-                width="1em"
-              >
-                <path
-                  d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
-                />
-              </svg>
-            </span>
-          </button>
+              Spatial Components
+            </h4>
+          </div>
+          <div
+            class="ant-col document-table-actions"
+          >
+            <button
+              class="ant-btn ant-btn-primary"
+              disabled=""
+              type="button"
+            >
+              <div>
+                Download
+              </div>
+            </button>
+          </div>
         </div>
         <div
           class="ant-table-wrapper  core-table"
@@ -1525,45 +1501,33 @@ exports[`MajorMineApplicationReviewSubmit renders properly as on MajorMineApplic
           </div>
         </div>
       </div>
-      <h4
-        class="ant-typography"
-      >
-        Supporting Documents
-      </h4>
       <div>
         <div />
         <div
-          style="float: right;"
+          class="ant-row ant-row-space-between ant-row-bottom document-table-header"
         >
-          <button
-            class="ant-btn ant-btn-primary ant-dropdown-trigger actions-dropdown-button"
-            disabled=""
-            type="button"
+          <div
+            class="ant-col"
           >
-            <span>
-              Action
-            </span>
-            <span
-              aria-label="down"
-              class="anticon anticon-down"
-              role="img"
+            <h4
+              class="ant-typography"
             >
-              <svg
-                aria-hidden="true"
-                class=""
-                data-icon="down"
-                fill="currentColor"
-                focusable="false"
-                height="1em"
-                viewBox="64 64 896 896"
-                width="1em"
-              >
-                <path
-                  d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
-                />
-              </svg>
-            </span>
-          </button>
+              Supporting Documents
+            </h4>
+          </div>
+          <div
+            class="ant-col document-table-actions"
+          >
+            <button
+              class="ant-btn ant-btn-primary"
+              disabled=""
+              type="button"
+            >
+              <div>
+                Download
+              </div>
+            </button>
+          </div>
         </div>
         <div
           class="ant-table-wrapper  core-table"
@@ -2689,45 +2653,33 @@ exports[`MajorMineApplicationReviewSubmit renders properly as on ProjectPage 1`]
       >
         Application Files
       </h3>
-      <h4
-        class="ant-typography"
-      >
-        Primary Document
-      </h4>
       <div>
         <div />
         <div
-          style="float: right;"
+          class="ant-row ant-row-space-between ant-row-bottom document-table-header"
         >
-          <button
-            class="ant-btn ant-btn-primary ant-dropdown-trigger actions-dropdown-button"
-            disabled=""
-            type="button"
+          <div
+            class="ant-col"
           >
-            <span>
-              Action
-            </span>
-            <span
-              aria-label="down"
-              class="anticon anticon-down"
-              role="img"
+            <h4
+              class="ant-typography"
             >
-              <svg
-                aria-hidden="true"
-                class=""
-                data-icon="down"
-                fill="currentColor"
-                focusable="false"
-                height="1em"
-                viewBox="64 64 896 896"
-                width="1em"
-              >
-                <path
-                  d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
-                />
-              </svg>
-            </span>
-          </button>
+              Primary Document
+            </h4>
+          </div>
+          <div
+            class="ant-col document-table-actions"
+          >
+            <button
+              class="ant-btn ant-btn-primary"
+              disabled=""
+              type="button"
+            >
+              <div>
+                Download
+              </div>
+            </button>
+          </div>
         </div>
         <div
           class="ant-table-wrapper  core-table"
@@ -3159,45 +3111,33 @@ exports[`MajorMineApplicationReviewSubmit renders properly as on ProjectPage 1`]
           </div>
         </div>
       </div>
-      <h4
-        class="ant-typography"
-      >
-        Spatial Components
-      </h4>
       <div>
         <div />
         <div
-          style="float: right;"
+          class="ant-row ant-row-space-between ant-row-bottom document-table-header"
         >
-          <button
-            class="ant-btn ant-btn-primary ant-dropdown-trigger actions-dropdown-button"
-            disabled=""
-            type="button"
+          <div
+            class="ant-col"
           >
-            <span>
-              Action
-            </span>
-            <span
-              aria-label="down"
-              class="anticon anticon-down"
-              role="img"
+            <h4
+              class="ant-typography"
             >
-              <svg
-                aria-hidden="true"
-                class=""
-                data-icon="down"
-                fill="currentColor"
-                focusable="false"
-                height="1em"
-                viewBox="64 64 896 896"
-                width="1em"
-              >
-                <path
-                  d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
-                />
-              </svg>
-            </span>
-          </button>
+              Spatial Components
+            </h4>
+          </div>
+          <div
+            class="ant-col document-table-actions"
+          >
+            <button
+              class="ant-btn ant-btn-primary"
+              disabled=""
+              type="button"
+            >
+              <div>
+                Download
+              </div>
+            </button>
+          </div>
         </div>
         <div
           class="ant-table-wrapper  core-table"
@@ -4069,45 +4009,33 @@ exports[`MajorMineApplicationReviewSubmit renders properly as on ProjectPage 1`]
           </div>
         </div>
       </div>
-      <h4
-        class="ant-typography"
-      >
-        Supporting Documents
-      </h4>
       <div>
         <div />
         <div
-          style="float: right;"
+          class="ant-row ant-row-space-between ant-row-bottom document-table-header"
         >
-          <button
-            class="ant-btn ant-btn-primary ant-dropdown-trigger actions-dropdown-button"
-            disabled=""
-            type="button"
+          <div
+            class="ant-col"
           >
-            <span>
-              Action
-            </span>
-            <span
-              aria-label="down"
-              class="anticon anticon-down"
-              role="img"
+            <h4
+              class="ant-typography"
             >
-              <svg
-                aria-hidden="true"
-                class=""
-                data-icon="down"
-                fill="currentColor"
-                focusable="false"
-                height="1em"
-                viewBox="64 64 896 896"
-                width="1em"
-              >
-                <path
-                  d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
-                />
-              </svg>
-            </span>
-          </button>
+              Supporting Documents
+            </h4>
+          </div>
+          <div
+            class="ant-col document-table-actions"
+          >
+            <button
+              class="ant-btn ant-btn-primary"
+              disabled=""
+              type="button"
+            >
+              <div>
+                Download
+              </div>
+            </button>
+          </div>
         </div>
         <div
           class="ant-table-wrapper  core-table"


### PR DESCRIPTION
## Objective 
- don't allow replace on spatial table
- lock down actions on the form according to status instead of assuming they can't navigate to it
- removed some unused imports
- made a couple little tweaks to the document table...
   - I thought it would show Download instead of Actions so I added another condition to the logic to make it so
   - in order to put the header in a row with the Actions/Download button, passed it as a param
   - and then added spacing between the button and the table (on MS only. I seem to recall it already has spacing on CORE)

[MDS-6304](https://bcmines.atlassian.net/browse/MDS-6304)

_Why are you making this change? Provide a short explanation and/or screenshots_
![image](https://github.com/user-attachments/assets/a0992603-051e-4050-aac4-50110aecb7ef)
