### PR TITLE
[MDS-6265] Project Summary: Change from Change Requested -> Under Review on final submit only

### DIFF
--- a/services/common/src/components/forms/SteppedForm.tsx
+++ b/services/common/src/components/forms/SteppedForm.tsx
@@ -12,7 +12,7 @@ interface SteppedFormProps extends Omit<FormWrapperProps, "onSubmit"> {
   children: Array<ReactElement<StepProps>>;
   handleTabChange: (newTab: string) => void | Promise<void>;
   handleSaveDraft?: (formValues) => Promise<void>;
-  handleSaveData?: (values, newActiveTab?: string) => Promise<void>;
+  handleSaveData?: (values, newActiveTab?: string, currentTab?: string) => Promise<void>;
   handleCancel?: () => void | Promise<void>;
   transformPayload?: (values: any) => any;
   activeTab: string;
@@ -108,7 +108,7 @@ const SteppedForm: FC<SteppedFormProps> = ({
     setIsSubmitting(true);
     try {
       if (handleSaveData && (await saveCheck())) {
-        await handleSaveData(getValues(formValues), tab);
+        await handleSaveData(getValues(formValues), tab, `${tabs[tabIndex]}`);
       }
       if (errors.length > 0) return;
       setTabIndex(indexOf(tabs, tab));

--- a/services/common/src/components/projectSummary/ProjectSummaryForm.tsx
+++ b/services/common/src/components/projectSummary/ProjectSummaryForm.tsx
@@ -29,7 +29,7 @@ import { areAuthFieldsDisabled, areDocumentFieldsDisabled, areFieldsDisabled, is
 interface ProjectSummaryFormProps {
   initialValues: IProjectSummary;
   handleTabChange: (newTab: string) => void;
-  handleSaveData: (formValues, newActiveTab?) => Promise<void>;
+  handleSaveData: (formValues, newActiveTab?, currentTab?) => Promise<void>;
   activeTab: string;
   isEditMode?: boolean;
 }

--- a/services/minespace-web/src/components/pages/Project/ProjectSummaryPage.tsx
+++ b/services/minespace-web/src/components/pages/Project/ProjectSummaryPage.tsx
@@ -183,14 +183,20 @@ export const ProjectSummaryPage = () => {
     history.push(url);
   };
 
-  const handleSaveData = async (formValues, newActiveTab?: string) => {
+  const handleSaveData = async (formValues, newActiveTab?: string, currentTab?: string) => {
     let message = newActiveTab
       ? "Successfully updated the project description."
       : "Successfully submitted a project description to the Province of British Columbia.";
     let status_code = projectSummary.status_code;
     let is_historic = projectSummary.is_historic;
 
-    if (status_code === "CHR" && formValues.confirmation_of_submission) {
+    if (
+      status_code === "CHR" &&
+      formValues.confirmation_of_submission &&
+      currentTab === "declaration"
+    ) {
+      // If a proponent re-submits the declaration, when changes are made to the project description,
+      // change it back to under review.
       status_code = "UNR";
     } else if ((!status_code || !isEditMode) && status_code !== "UNR") {
       status_code = "DFT";


### PR DESCRIPTION
## Objective 

[MDS-6265](https://bcmines.atlassian.net/browse/MDS-6265)

Updated the Project Summary submission logic to change the status of the application from Change Requested to Under Review only when the declaration is re-submitted, not on updates on the other tabs.