### PR TITLE
[CHORE] Provide types for react-redux hooks

### DIFF
--- a/services/common/src/redux/actionCreators/incidentActionCreator.ts
+++ b/services/common/src/redux/actionCreators/incidentActionCreator.ts
@@ -8,12 +8,16 @@ import * as incidentActions from "../actions/incidentActions";
 import * as API from "@mds/common/constants/API";
 import { createRequestHeader } from "../utils/RequestHeaders";
 import CustomAxios from "../customAxios";
+import { IMineIncident } from "@mds/common/interfaces";
+import { AppThunk } from "@mds/common/interfaces/appThunk.type";
+import { AxiosResponse } from "axios";
+
 
 export const createMineIncident = (
   mine_guid,
   payload,
   message = "Successfully created incident."
-) => (dispatch) => {
+): AppThunk<Promise<AxiosResponse<IMineIncident>>> => (dispatch): Promise<AxiosResponse<IMineIncident>> => {
   dispatch(request(NetworkReducerTypes.CREATE_MINE_INCIDENT));
   dispatch(showLoading("modal"));
   return CustomAxios()

--- a/services/common/src/redux/rootState.ts
+++ b/services/common/src/redux/rootState.ts
@@ -1,9 +1,10 @@
 import { sharedReducer } from "@mds/common/redux/reducers/rootReducerShared";
-import { configureStore } from "@reduxjs/toolkit";
+import { configureStore, Dispatch } from "@reduxjs/toolkit";
 import { loadingBarReducer } from "react-redux-loading-bar";
 
 import type { TypedUseSelectorHook } from 'react-redux'
 import { useDispatch, useSelector, useStore } from 'react-redux'
+import type { FormAction } from 'redux-form';
 
 export const getStore = (preloadedState = {}) =>
   configureStore({
@@ -17,10 +18,14 @@ export const getStore = (preloadedState = {}) =>
 
 export const store = getStore();
 
-// Provide typed versions for global redux functions
+/**
+ * Provide typed versions for global redux functions
+**/
+
 type RootState = ReturnType<typeof store.getState>;
 
-export type AppDispatch = typeof store.dispatch;
+// Infer the `RootState` and `AppDispatch` types from the store itself + make sure redux-form actions are captured as well.
+export type AppDispatch = typeof store.dispatch & Dispatch<FormAction>;
 export type AppStore = typeof store;
 
 // Use throughout your app instead of plain `useDispatch` and `useSelector`

--- a/services/common/src/redux/rootState.ts
+++ b/services/common/src/redux/rootState.ts
@@ -2,6 +2,9 @@ import { sharedReducer } from "@mds/common/redux/reducers/rootReducerShared";
 import { configureStore } from "@reduxjs/toolkit";
 import { loadingBarReducer } from "react-redux-loading-bar";
 
+import type { TypedUseSelectorHook } from 'react-redux'
+import { useDispatch, useSelector, useStore } from 'react-redux'
+
 export const getStore = (preloadedState = {}) =>
   configureStore({
     reducer: {
@@ -14,6 +17,16 @@ export const getStore = (preloadedState = {}) =>
 
 export const store = getStore();
 
+// Provide typed versions for global redux functions
 type RootState = ReturnType<typeof store.getState>;
+
+export type AppDispatch = typeof store.dispatch;
+export type AppStore = typeof store;
+
+// Use throughout your app instead of plain `useDispatch` and `useSelector`
+export const useAppDispatch: () => AppDispatch = useDispatch;
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;
+export const useAppStore: () => AppStore = useStore;
+
 
 export { RootState };

--- a/services/common/src/redux/rootState.ts
+++ b/services/common/src/redux/rootState.ts
@@ -1,5 +1,5 @@
 import { sharedReducer } from "@mds/common/redux/reducers/rootReducerShared";
-import { configureStore, Dispatch } from "@reduxjs/toolkit";
+import { configureStore, Dispatch, UnknownAction } from "@reduxjs/toolkit";
 import { loadingBarReducer } from "react-redux-loading-bar";
 
 import type { TypedUseSelectorHook } from 'react-redux'
@@ -24,8 +24,10 @@ export const store = getStore();
 
 type RootState = ReturnType<typeof store.getState>;
 
-// Infer the `RootState` and `AppDispatch` types from the store itself + make sure redux-form actions are captured as well.
-export type AppDispatch = typeof store.dispatch & Dispatch<FormAction>;
+type AppAction = UnknownAction | FormAction;
+
+// Infer the `RootState` and `AppDispatch` types from the store itself + make sure redux-form acti are captured as well.
+export type AppDispatch = typeof store.dispatch & Dispatch<AppAction>;
 export type AppStore = typeof store;
 
 // Use throughout your app instead of plain `useDispatch` and `useSelector`

--- a/services/core-web/src/components/mine/Incidents/MineIncident.tsx
+++ b/services/core-web/src/components/mine/Incidents/MineIncident.tsx
@@ -11,12 +11,12 @@ import {
   fetchMineIncident,
   updateMineIncident,
 } from "@mds/common/redux/actionCreators/incidentActionCreator";
-import { clearMineIncident } from "@mds/common/redux/actions/incidentActions";
 import * as Strings from "@mds/common/constants/strings";
 import * as FORM from "@/constants/forms";
 import IncidentForm from "@/components/Forms/incidents/IncidentForm";
 import ScrollSideMenu from "@mds/common/components/common/ScrollSideMenu";
 import * as routes from "@/constants/routes";
+import { useAppDispatch } from "@mds/common/redux/rootState";
 
 interface IParams {
   mineGuid?: string;
@@ -25,7 +25,7 @@ interface IParams {
 }
 
 export const MineIncident = (props) => {
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
 
   const { history } = props;
   const params = useParams<IParams>();


### PR DESCRIPTION
## Objective 

[CHORE](https://bcmines.atlassian.net/browse/MDS-CHORE)

This PR adds typed versions of common react-redux hooks as per https://react-redux.js.org/using-react-redux/usage-with-typescript.

Using those hooks will have the types defined in your action creators propagate or if those are untyped, will be `any`
redux-form actions is supported in addition to our actions

Before:

![image](https://github.com/user-attachments/assets/2e4c2ef5-24db-4428-b05b-18c918e12a7d)
![image](https://github.com/user-attachments/assets/fab59698-637b-4200-a9c9-159be07618e7)
![image](https://github.com/user-attachments/assets/445f12d3-e4b0-42ab-9b6e-242b9d02627e)


After:
![image](https://github.com/user-attachments/assets/82272498-d294-4af0-9710-47e6c0ff05ea)
![image](https://github.com/user-attachments/assets/5134169b-a1d7-462a-9803-e05a1338ef0e)
![image](https://github.com/user-attachments/assets/7b224295-82a4-45ce-a37a-5a006f569d3a)

