### PR TITLE
[MDS-6027] Edit Permit Condition Category

### DIFF
--- a/services/common/src/components/forms/BaseInput.tsx
+++ b/services/common/src/components/forms/BaseInput.tsx
@@ -1,5 +1,5 @@
 import { EMPTY_FIELD } from "@mds/common/constants";
-import { Typography } from "antd";
+import { Form, Typography } from "antd";
 import React, { FC, ReactNode } from "react";
 import { WrappedFieldProps, WrappedFieldMetaProps, WrappedFieldInputProps } from "redux-form";
 
@@ -76,6 +76,7 @@ export interface BaseInputProps extends WrappedFieldProps {
   showOptional?: boolean;
   showNA?: boolean;
   autoFocus?: boolean;
+  className?: string;
 }
 
 interface BaseViewInputProps {
@@ -131,3 +132,40 @@ export const getFormItemLabel = (
     </div>
   );
 };
+
+interface WrappedInputProps extends BaseInputProps {
+  children: ReactNode;
+  getValueProps?: () => any;
+}
+
+export const WrappedInput: FC<WrappedInputProps> = ({
+  id,
+  label = "",
+  labelSubtitle,
+  meta,
+  input,
+  required,
+  showOptional,
+  children,
+  getValueProps,
+  className
+}) => {
+  return (
+    <Form.Item
+      className={className}
+      name={input.name}
+      label={getFormItemLabel(label, required, labelSubtitle, showOptional)}
+      required={required}
+      validateStatus={
+        meta.touched ? (meta.error && "error") || (meta.warning && "warning") : ""
+      }
+      help={
+        (meta.touched) &&
+        ((meta.error && <span>{meta.error}</span>) ||
+          (meta.warning && <span>{meta.warning}</span>))
+      }
+      id={id}
+      getValueProps={getValueProps}
+    >{children}</Form.Item>
+  );
+}

--- a/services/common/src/components/forms/RenderGroupedSelect.tsx
+++ b/services/common/src/components/forms/RenderGroupedSelect.tsx
@@ -1,67 +1,52 @@
-import React from "react";
-import PropTypes from "prop-types";
-import { Select, Form } from "antd";
+import React, { FC } from "react";
+import { Select } from "antd";
+import { BaseInputProps, WrappedInput } from "./BaseInput";
+import { IGroupedDropdownList } from "@mds/common/interfaces";
 
 /**
- * @constant RenderGroupedSelect - Ant Design `Select` component for redux-form - used for data sets that require grouping.
+ * @component RenderGroupedSelect - Ant Design `Select` component for redux-form - used for data sets that require grouping.
  * There is a bug when the data sets are large enough to cause the dropdown to scroll, and the field is in a modal.
  * In the case where the modal cannot scroll, it is better to pass in the prop doNotPinDropdown.  It allows the
  * dropdown to render properly
  */
 
-const propTypes = {
-  id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
-  input: PropTypes.objectOf(PropTypes.any).isRequired,
-  placeholder: PropTypes.string,
-  label: PropTypes.string,
-  meta: PropTypes.any, //CustomPropTypes.formMeta,
-  data: PropTypes.any, //CustomPropTypes.groupOptions,
-  disabled: PropTypes.bool,
-  onSelect: PropTypes.func,
-  usedOptions: PropTypes.arrayOf(PropTypes.objectOf(PropTypes.any)),
-};
 
-const defaultProps = {
-  placeholder: "",
-  label: "",
-  data: [],
-  disabled: false,
-  meta: {},
-  onSelect: () => {},
-  usedOptions: [],
-};
+interface GroupedSelectProps extends BaseInputProps {
+  data: IGroupedDropdownList[];
+  allowClear?: boolean;
+  onSelect?: (value, option) => void;
+}
 
-const RenderGroupedSelect = (props) => (
-  <Form.Item
-    label={props.label}
-    validateStatus={
-      props.meta.touched ? (props.meta.error && "error") || (props.meta.warning && "warning") : ""
-    }
-    help={
-      props.meta.touched &&
-      ((props.meta.error && <span>{props.meta.error}</span>) ||
-        (props.meta.warning && <span>{props.meta.warning}</span>))
-    }
-  >
+
+const RenderGroupedSelect: FC<GroupedSelectProps> = (props) => {
+  const {
+    placeholder = "",
+    id,
+    input,
+    data = [],
+    onSelect = () => { },
+    allowClear = true,
+    disabled = false,
+  } = props;
+  return <WrappedInput {...props}>
     <Select
       virtual={false}
-      disabled={props.disabled}
+      disabled={disabled}
       dropdownMatchSelectWidth
       showSearch
-      placeholder={props.placeholder}
+      placeholder={placeholder}
       optionFilterProp="children"
-      id={props.id}
-      defaultValue={props.input.value}
-      value={props.input.value ? props.input.value : undefined}
-      onChange={props.input.onChange}
-      onSelect={props.onSelect}
+      id={id}
+      value={input.value ? input.value : undefined}
+      onChange={input.onChange}
+      onSelect={onSelect}
+      allowClear={allowClear}
     >
-      {props.data.map((group) => (
+      {data.map((group) => (
         <Select.OptGroup label={group.groupName} key={group.groupName}>
           {group.opt.map((opt) => (
             <Select.Option
-              disabled={props.usedOptions && props.usedOptions.includes(opt.value)}
-              key={opt.value}
+              key={opt.value.toString()}
               value={opt.value}
             >
               {opt.label}
@@ -70,10 +55,7 @@ const RenderGroupedSelect = (props) => (
         </Select.OptGroup>
       ))}
     </Select>
-  </Form.Item>
-);
-
-RenderGroupedSelect.propTypes = propTypes;
-RenderGroupedSelect.defaultProps = defaultProps;
+  </WrappedInput>
+};
 
 export default RenderGroupedSelect;

--- a/services/core-web/src/components/mine/Permit/PermitConditionForm.tsx
+++ b/services/core-web/src/components/mine/Permit/PermitConditionForm.tsx
@@ -1,7 +1,7 @@
 import React, { FC, useState } from "react";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router-dom";
-import { change, Field, reset } from "redux-form";
+import { change, Field, getFormValues, reset } from "redux-form";
 import { Row, Col, Button } from "antd";
 import {
     faArrowDown,
@@ -13,6 +13,7 @@ import {
     faXmark,
 } from "@fortawesome/pro-regular-svg-icons";
 import { FORM, IPermitCondition } from "@mds/common";
+import { IGroupedDropdownList } from "@mds/common/interfaces/common/option.interface";
 import { ERROR } from "@mds/common/constants/actionTypes";
 import FormWrapper from "@mds/common/components/forms/FormWrapper";
 import RenderAutoSizeField from "@mds/common/components/forms/RenderAutoSizeField";
@@ -26,6 +27,7 @@ import { createMineReportPermitRequirement } from "@mds/common/redux/slices/mine
 import RenderField from "@mds/common/components/forms/RenderField";
 import { deleteConfirmWrapper } from "@mds/common/components/common/ActionMenu";
 import { formatPermitConditionStep, parsePermitConditionStep } from "@mds/common/utils/helpers";
+import RenderGroupedSelect from "@mds/common/components/forms/RenderGroupedSelect";
 
 
 interface PermitConditionFormProps {
@@ -40,6 +42,7 @@ interface PermitConditionFormProps {
     refreshData: () => Promise<void>;
     setIsAddingListItem: (isAdding: boolean) => void;
     isAddingListItem: boolean;
+    categoryOptions?: IGroupedDropdownList[];
 }
 const PermitConditionForm: FC<PermitConditionFormProps> = ({
     permitAmendmentGuid,
@@ -52,12 +55,15 @@ const PermitConditionForm: FC<PermitConditionFormProps> = ({
     moveDown,
     refreshData,
     setIsAddingListItem,
-    isAddingListItem
+    isAddingListItem,
+    categoryOptions
 }) => {
     const dispatch = useDispatch();
     const { id: mineGuid, permitGuid } = useParams<{ id: string; permitGuid: string }>();
     const [isEditMode, setIsEditMode] = useState<boolean>(false);
-    const formName = `${FORM.EDIT_PERMIT_CONDITION}_${condition.permit_condition_id}`;
+    // the form fails to re-initialize when the category is changed, so concatenating it forces it to make a new one
+    const formName = `${FORM.EDIT_PERMIT_CONDITION}_${condition.permit_condition_id}_${condition.condition_category_code}`;
+    const formValues = useSelector(getFormValues(formName)) as IPermitCondition;
 
     const startEdit = () => {
         onEdit();
@@ -81,8 +87,8 @@ const PermitConditionForm: FC<PermitConditionFormProps> = ({
         const resp = await dispatch(updatePermitCondition(values.permit_condition_guid, permitAmendmentGuid, payload));
         // @ts-ignore
         if (resp?.type !== ERROR) {
-            refreshData();
             cancelEdit();
+            return refreshData();
         }
     };
     const handleCancel = () => {
@@ -153,8 +159,22 @@ const PermitConditionForm: FC<PermitConditionFormProps> = ({
                 enableReinitialize: true
             }}
         >
+            {(isEditMode && categoryOptions) && <Row>
+                <Col span={24}>
+                    <Field
+                        showOptional={false}
+                        label="Condition Category:"
+                        component={RenderGroupedSelect}
+                        name="condition_category_code"
+                        data={categoryOptions}
+                        allowClear={false}
+                        className="horizontal-form-item"
+                    />
+                </Col>
+            </Row>}
             <Row
                 wrap={false}
+                align="top"
                 className={`condition-content ${!editingConditionGuid ? "editable" : ""}`}
             >
                 <Col className="step-column" style={{ flexShrink: 0 }}>

--- a/services/core-web/src/components/mine/Permit/PermitConditionForm.tsx
+++ b/services/core-web/src/components/mine/Permit/PermitConditionForm.tsx
@@ -1,7 +1,7 @@
 import React, { FC, useState } from "react";
-import { useDispatch, useSelector } from "react-redux";
+import { useDispatch } from "react-redux";
 import { useParams } from "react-router-dom";
-import { change, Field, getFormValues, reset } from "redux-form";
+import { change, Field, reset } from "redux-form";
 import { Row, Col, Button } from "antd";
 import {
     faArrowDown,
@@ -63,7 +63,6 @@ const PermitConditionForm: FC<PermitConditionFormProps> = ({
     const [isEditMode, setIsEditMode] = useState<boolean>(false);
     // the form fails to re-initialize when the category is changed, so concatenating it forces it to make a new one
     const formName = `${FORM.EDIT_PERMIT_CONDITION}_${condition.permit_condition_id}_${condition.condition_category_code}`;
-    const formValues = useSelector(getFormValues(formName)) as IPermitCondition;
 
     const startEdit = () => {
         onEdit();

--- a/services/core-web/src/components/mine/Permit/PermitConditionLayer.tsx
+++ b/services/core-web/src/components/mine/Permit/PermitConditionLayer.tsx
@@ -2,6 +2,7 @@ import React, { FC, useEffect, useState } from "react";
 import { IPermitCondition } from "@mds/common/interfaces/permits/permitCondition.interface";
 import PermitConditionForm from "./PermitConditionForm";
 import SubConditionForm from "./SubConditionForm";
+import { IGroupedDropdownList } from "@mds/common/interfaces/common/option.interface";
 
 interface PermitConditionLayerProps {
   condition: IPermitCondition;
@@ -17,6 +18,7 @@ interface PermitConditionLayerProps {
   permitAmendmentGuid: string;
   refreshData: () => Promise<void>;
   conditionSelected?: (condition: IPermitCondition) => void;
+  categoryOptions?: IGroupedDropdownList[];
 }
 
 const PermitConditionLayer: FC<PermitConditionLayerProps> = ({
@@ -33,6 +35,7 @@ const PermitConditionLayer: FC<PermitConditionLayerProps> = ({
   conditionCount,
   permitAmendmentGuid,
   refreshData,
+  categoryOptions
 }) => {
   const editingCondition = editingConditionGuid === condition.permit_condition_guid;
   const [isAddingListItem, setIsAddingListItem] = useState<boolean>(false);
@@ -97,6 +100,7 @@ const PermitConditionLayer: FC<PermitConditionLayerProps> = ({
           refreshData={refreshData}
           setIsAddingListItem={setIsAddingListItem}
           isAddingListItem={isAddingListItem}
+          categoryOptions={categoryOptions}
         />
         {condition?.sub_conditions?.map((subCondition, idx) => {
           return (

--- a/services/core-web/src/components/mine/Permit/PermitConditions.tsx
+++ b/services/core-web/src/components/mine/Permit/PermitConditions.tsx
@@ -53,6 +53,7 @@ import { getIsFetching } from "@mds/common/redux/reducers/networkReducer";
 import { NetworkReducerTypes } from "@mds/common/constants/networkReducerTypes";
 import PermitConditionReviewAssignment from "@/components/mine/Permit/PermitConditionReviewAssignment";
 import { getUser } from "@mds/common/redux/slices/userSlice";
+import { createDropDownList } from "@common/utils/helpers";
 
 const { Title } = Typography;
 
@@ -200,6 +201,26 @@ const PermitConditions: FC<PermitConditionProps> = ({
     featureUrlRoute: VIEW_MINE_PERMIT.hashRoute,
     featureUrlRouteArguments: [mineGuid, permitGuid, "conditions"],
   };
+
+  const customCategories = createDropDownList(
+    latestAmendment?.condition_categories ?? [],
+    "description",
+    "condition_category_code"
+  );
+
+  const standardCategories = createDropDownList(
+    condWithoutConditionsText,
+    "description",
+    "condition_category_code"
+  );
+
+  const dropdownCategories = [{
+    groupName: "Custom Categories",
+    opt: customCategories
+  }, {
+    groupName: "Standard Categories",
+    opt: standardCategories
+  }]
 
   const topOffset = 99 + 49; // header + tab nav
 
@@ -458,6 +479,7 @@ const PermitConditions: FC<PermitConditionProps> = ({
                                 editingConditionGuid={editingConditionGuid ?? addingToCategoryCode}
                                 refreshData={refreshData}
                                 conditionSelected={setSelectedCondition}
+                                categoryOptions={dropdownCategories}
                               />
                             </Col>
                           ))}
@@ -468,9 +490,8 @@ const PermitConditions: FC<PermitConditionProps> = ({
                                 permitAmendmentGuid={latestAmendment.permit_amendment_guid}
                                 handleCancel={() => setAddingToCategoryCode(null)}
                                 onSubmit={handleAddCondition}
-                              />
-                            </Col>
-                          )}
+                                categoryOptions={dropdownCategories}
+                              /></Col>)}
                           {conditionsWithRequirements?.length > 0 && (
                             <div className="report-collapse-container ">
                               <Title level={4} className="primary-colour">

--- a/services/core-web/src/components/mine/Permit/SubConditionForm.spec.tsx
+++ b/services/core-web/src/components/mine/Permit/SubConditionForm.spec.tsx
@@ -3,12 +3,33 @@ import { render } from "@testing-library/react";
 import { ReduxWrapper } from "@mds/common/tests/utils/ReduxWrapper";
 import * as MOCK from "@mds/common/tests/mocks/dataMocks";
 import SubConditionForm from "./SubConditionForm";
+import { createDropDownList } from "@mds/common/redux/utils/helpers";
 
 const condition = MOCK.PERMITS[0].permit_amendments[0].conditions[0];
+const conditionCategories = MOCK.PERMITS[0].permit_amendments[0].condition_categories;
 const conditionCategory = {
-    ...MOCK.PERMITS[0].permit_amendments[0].condition_categories[0],
+    ...conditionCategories[0],
     conditions: [condition]
 }
+const standardCategories = MOCK.BULK_STATIC_CONTENT_RESPONSE.permitConditionCategoryOptions;
+const dropdownOptions = [
+    {
+        groupName: "Custom Categories",
+        opt: createDropDownList(
+            conditionCategories,
+            "description",
+            "condition_category_code"
+        )
+    },
+    {
+        groupName: "Standard Categories",
+        opt: createDropDownList(
+            standardCategories,
+            "description",
+            "condition_category_code"
+        )
+    }
+]
 const initialState = {}
 
 describe("SubConditionForm", () => {
@@ -32,6 +53,7 @@ describe("SubConditionForm", () => {
                 conditionCategory={conditionCategory}
                 handleCancel={jest.fn()}
                 onSubmit={jest.fn()}
+                categoryOptions={dropdownOptions}
             />
         </ReduxWrapper>);
 

--- a/services/core-web/src/components/mine/Permit/SubConditionForm.tsx
+++ b/services/core-web/src/components/mine/Permit/SubConditionForm.tsx
@@ -5,7 +5,7 @@ import {
     faCheck,
     faXmark,
 } from "@fortawesome/pro-regular-svg-icons";
-import { FORM, IPermitCondition, IPermitConditionCategory } from "@mds/common";
+import { FORM, IGroupedDropdownList, IPermitCondition, IPermitConditionCategory } from "@mds/common";
 import { ERROR } from "@mds/common/constants/actionTypes";
 import FormWrapper from "@mds/common/components/forms/FormWrapper";
 import RenderAutoSizeField from "@mds/common/components/forms/RenderAutoSizeField";
@@ -14,6 +14,7 @@ import RenderSubmitButton from "@mds/common/components/forms/RenderSubmitButton"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useDispatch } from "react-redux";
 import { createPermitCondition } from "@mds/common/redux/actionCreators/permitActionCreator";
+import RenderGroupedSelect from "@mds/common/components/forms/RenderGroupedSelect";
 
 interface SubConditionFormProps {
     level?: number;
@@ -22,9 +23,10 @@ interface SubConditionFormProps {
     handleCancel: () => void;
     onSubmit: () => Promise<void>;
     permitAmendmentGuid: string;
+    categoryOptions?: IGroupedDropdownList[];
 };
 
-const SubConditionForm: FC<SubConditionFormProps> = ({ level = 1, parentCondition, conditionCategory, permitAmendmentGuid, handleCancel, onSubmit }) => {
+const SubConditionForm: FC<SubConditionFormProps> = ({ level = 1, parentCondition, conditionCategory, permitAmendmentGuid, categoryOptions, handleCancel, onSubmit }) => {
     const dispatch = useDispatch();
 
     const handleSubmit = async (values) => {
@@ -74,6 +76,19 @@ const SubConditionForm: FC<SubConditionFormProps> = ({ level = 1, parentConditio
             scrollOnToggleEdit={false}
         >
             <div className={`condition-layer condition-layer--${level} condition-${emptyCondition.condition_type_code} fade-in`}>
+                {categoryOptions && <Row>
+                    <Col span={24}>
+                        <Field
+                            showOptional={false}
+                            label="Condition Category:"
+                            component={RenderGroupedSelect}
+                            name="condition_category_code"
+                            data={categoryOptions}
+                            allowClear={false}
+                            className="horizontal-form-item"
+                        />
+                    </Col>
+                </Row>}
                 <Row wrap={false} >
                     <Col span={24}>
                         <Field

--- a/services/core-web/src/components/mine/Permit/__snapshots__/PermitConditionForm.spec.tsx.snap
+++ b/services/core-web/src/components/mine/Permit/__snapshots__/PermitConditionForm.spec.tsx.snap
@@ -3,11 +3,11 @@
 exports[`PermitConditionForm renders properly in edit mode 1`] = `
 <div>
   <form
-    class="ant-form ant-form-vertical common-form common-form-EDIT_PERMIT_CONDITION_1639 form-edit"
-    id="EDIT_PERMIT_CONDITION_1639"
+    class="ant-form ant-form-vertical common-form common-form-EDIT_PERMIT_CONDITION_1639_HSC form-edit"
+    id="EDIT_PERMIT_CONDITION_1639_HSC"
   >
     <div
-      class="ant-row ant-row-no-wrap condition-content editable"
+      class="ant-row ant-row-no-wrap ant-row-top condition-content editable"
     >
       <div
         class="ant-col step-column"
@@ -42,7 +42,7 @@ exports[`PermitConditionForm renders properly in edit mode 1`] = `
               >
                 <div
                   class="ant-form-item-explain ant-form-item-explain-connected"
-                  id="EDIT_PERMIT_CONDITION_1639_step_help"
+                  id="EDIT_PERMIT_CONDITION_1639_HSC_step_help"
                   role="alert"
                 >
                   <div
@@ -88,7 +88,7 @@ exports[`PermitConditionForm renders properly in edit mode 1`] = `
               >
                 <div
                   class="ant-form-item-explain ant-form-item-explain-connected"
-                  id="EDIT_PERMIT_CONDITION_1639_condition_help"
+                  id="EDIT_PERMIT_CONDITION_1639_HSC_condition_help"
                   role="alert"
                 >
                   <div

--- a/services/core-web/src/components/mine/Permit/__snapshots__/PermitConditions.spec.tsx.snap
+++ b/services/core-web/src/components/mine/Permit/__snapshots__/PermitConditions.spec.tsx.snap
@@ -934,11 +934,11 @@ exports[`PermitConditions renders properly 1`] = `
                                     class="condition-collapsed"
                                   >
                                     <form
-                                      class="ant-form ant-form-vertical common-form common-form-EDIT_PERMIT_CONDITION_1639 form-view"
-                                      id="EDIT_PERMIT_CONDITION_1639"
+                                      class="ant-form ant-form-vertical common-form common-form-EDIT_PERMIT_CONDITION_1639_HSC form-view"
+                                      id="EDIT_PERMIT_CONDITION_1639_HSC"
                                     >
                                       <div
-                                        class="ant-row ant-row-no-wrap condition-content editable"
+                                        class="ant-row ant-row-no-wrap ant-row-top condition-content editable"
                                       >
                                         <div
                                           class="ant-col step-column"
@@ -1161,11 +1161,11 @@ exports[`PermitConditions renders properly 1`] = `
                                     class="condition-collapsed"
                                   >
                                     <form
-                                      class="ant-form ant-form-vertical common-form common-form-EDIT_PERMIT_CONDITION_1646 form-view"
-                                      id="EDIT_PERMIT_CONDITION_1646"
+                                      class="ant-form ant-form-vertical common-form common-form-EDIT_PERMIT_CONDITION_1646_RCC form-view"
+                                      id="EDIT_PERMIT_CONDITION_1646_RCC"
                                     >
                                       <div
-                                        class="ant-row ant-row-no-wrap condition-content editable"
+                                        class="ant-row ant-row-no-wrap ant-row-top condition-content editable"
                                       >
                                         <div
                                           class="ant-col step-column"
@@ -1390,11 +1390,11 @@ exports[`PermitConditions renders properly 1`] = `
                                     class="condition-collapsed"
                                   >
                                     <form
-                                      class="ant-form ant-form-vertical common-form common-form-EDIT_PERMIT_CONDITION_1650 form-view"
-                                      id="EDIT_PERMIT_CONDITION_1650"
+                                      class="ant-form ant-form-vertical common-form common-form-EDIT_PERMIT_CONDITION_1650_ELC form-view"
+                                      id="EDIT_PERMIT_CONDITION_1650_ELC"
                                     >
                                       <div
-                                        class="ant-row ant-row-no-wrap condition-content editable"
+                                        class="ant-row ant-row-no-wrap ant-row-top condition-content editable"
                                       >
                                         <div
                                           class="ant-col step-column"
@@ -1437,11 +1437,11 @@ exports[`PermitConditions renders properly 1`] = `
                                           class="condition-collapsed"
                                         >
                                           <form
-                                            class="ant-form ant-form-vertical common-form common-form-EDIT_PERMIT_CONDITION_1641 form-view"
-                                            id="EDIT_PERMIT_CONDITION_1641"
+                                            class="ant-form ant-form-vertical common-form common-form-EDIT_PERMIT_CONDITION_1641_ELC form-view"
+                                            id="EDIT_PERMIT_CONDITION_1641_ELC"
                                           >
                                             <div
-                                              class="ant-row ant-row-no-wrap condition-content editable"
+                                              class="ant-row ant-row-no-wrap ant-row-top condition-content editable"
                                             >
                                               <div
                                                 class="ant-col step-column"
@@ -1484,11 +1484,11 @@ exports[`PermitConditions renders properly 1`] = `
                                                 class="condition-collapsed"
                                               >
                                                 <form
-                                                  class="ant-form ant-form-vertical common-form common-form-EDIT_PERMIT_CONDITION_1644 form-view"
-                                                  id="EDIT_PERMIT_CONDITION_1644"
+                                                  class="ant-form ant-form-vertical common-form common-form-EDIT_PERMIT_CONDITION_1644_ELC form-view"
+                                                  id="EDIT_PERMIT_CONDITION_1644_ELC"
                                                 >
                                                   <div
-                                                    class="ant-row ant-row-no-wrap condition-content editable"
+                                                    class="ant-row ant-row-no-wrap ant-row-top condition-content editable"
                                                   >
                                                     <div
                                                       class="ant-col step-column"
@@ -1537,11 +1537,11 @@ exports[`PermitConditions renders properly 1`] = `
                                           class="condition-collapsed"
                                         >
                                           <form
-                                            class="ant-form ant-form-vertical common-form common-form-EDIT_PERMIT_CONDITION_12507 form-view"
-                                            id="EDIT_PERMIT_CONDITION_12507"
+                                            class="ant-form ant-form-vertical common-form common-form-EDIT_PERMIT_CONDITION_12507_ELC form-view"
+                                            id="EDIT_PERMIT_CONDITION_12507_ELC"
                                           >
                                             <div
-                                              class="ant-row ant-row-no-wrap condition-content editable"
+                                              class="ant-row ant-row-no-wrap ant-row-top condition-content editable"
                                             >
                                               <div
                                                 class="ant-col step-column"
@@ -1584,11 +1584,11 @@ exports[`PermitConditions renders properly 1`] = `
                                                 class="condition-collapsed"
                                               >
                                                 <form
-                                                  class="ant-form ant-form-vertical common-form common-form-EDIT_PERMIT_CONDITION_12509 form-view"
-                                                  id="EDIT_PERMIT_CONDITION_12509"
+                                                  class="ant-form ant-form-vertical common-form common-form-EDIT_PERMIT_CONDITION_12509_ELC form-view"
+                                                  id="EDIT_PERMIT_CONDITION_12509_ELC"
                                                 >
                                                   <div
-                                                    class="ant-row ant-row-no-wrap condition-content editable"
+                                                    class="ant-row ant-row-no-wrap ant-row-top condition-content editable"
                                                   >
                                                     <div
                                                       class="ant-col step-column"
@@ -1631,11 +1631,11 @@ exports[`PermitConditions renders properly 1`] = `
                                                       class="condition-collapsed"
                                                     >
                                                       <form
-                                                        class="ant-form ant-form-vertical common-form common-form-EDIT_PERMIT_CONDITION_12510 form-view"
-                                                        id="EDIT_PERMIT_CONDITION_12510"
+                                                        class="ant-form ant-form-vertical common-form common-form-EDIT_PERMIT_CONDITION_12510_ELC form-view"
+                                                        id="EDIT_PERMIT_CONDITION_12510_ELC"
                                                       >
                                                         <div
-                                                          class="ant-row ant-row-no-wrap condition-content editable"
+                                                          class="ant-row ant-row-no-wrap ant-row-top condition-content editable"
                                                         >
                                                           <div
                                                             class="ant-col step-column"
@@ -1681,11 +1681,11 @@ exports[`PermitConditions renders properly 1`] = `
                                                       class="condition-collapsed"
                                                     >
                                                       <form
-                                                        class="ant-form ant-form-vertical common-form common-form-EDIT_PERMIT_CONDITION_12511 form-view"
-                                                        id="EDIT_PERMIT_CONDITION_12511"
+                                                        class="ant-form ant-form-vertical common-form common-form-EDIT_PERMIT_CONDITION_12511_ELC form-view"
+                                                        id="EDIT_PERMIT_CONDITION_12511_ELC"
                                                       >
                                                         <div
-                                                          class="ant-row ant-row-no-wrap condition-content editable"
+                                                          class="ant-row ant-row-no-wrap ant-row-top condition-content editable"
                                                         >
                                                           <div
                                                             class="ant-col step-column"
@@ -1731,11 +1731,11 @@ exports[`PermitConditions renders properly 1`] = `
                                                       class="condition-collapsed"
                                                     >
                                                       <form
-                                                        class="ant-form ant-form-vertical common-form common-form-EDIT_PERMIT_CONDITION_12512 form-view"
-                                                        id="EDIT_PERMIT_CONDITION_12512"
+                                                        class="ant-form ant-form-vertical common-form common-form-EDIT_PERMIT_CONDITION_12512_ELC form-view"
+                                                        id="EDIT_PERMIT_CONDITION_12512_ELC"
                                                       >
                                                         <div
-                                                          class="ant-row ant-row-no-wrap condition-content editable"
+                                                          class="ant-row ant-row-no-wrap ant-row-top condition-content editable"
                                                         >
                                                           <div
                                                             class="ant-col step-column"
@@ -1778,11 +1778,11 @@ exports[`PermitConditions renders properly 1`] = `
                                                             class="condition-collapsed"
                                                           >
                                                             <form
-                                                              class="ant-form ant-form-vertical common-form common-form-EDIT_PERMIT_CONDITION_12513 form-view"
-                                                              id="EDIT_PERMIT_CONDITION_12513"
+                                                              class="ant-form ant-form-vertical common-form common-form-EDIT_PERMIT_CONDITION_12513_ELC form-view"
+                                                              id="EDIT_PERMIT_CONDITION_12513_ELC"
                                                             >
                                                               <div
-                                                                class="ant-row ant-row-no-wrap condition-content editable"
+                                                                class="ant-row ant-row-no-wrap ant-row-top condition-content editable"
                                                               >
                                                                 <div
                                                                   class="ant-col step-column"
@@ -1843,11 +1843,11 @@ exports[`PermitConditions renders properly 1`] = `
                                     class="condition-collapsed"
                                   >
                                     <form
-                                      class="ant-form ant-form-vertical common-form common-form-EDIT_PERMIT_CONDITION_12514 form-view"
-                                      id="EDIT_PERMIT_CONDITION_12514"
+                                      class="ant-form ant-form-vertical common-form common-form-EDIT_PERMIT_CONDITION_12514_ELC form-view"
+                                      id="EDIT_PERMIT_CONDITION_12514_ELC"
                                     >
                                       <div
-                                        class="ant-row ant-row-no-wrap condition-content editable"
+                                        class="ant-row ant-row-no-wrap ant-row-top condition-content editable"
                                       >
                                         <div
                                           class="ant-col step-column"
@@ -1890,11 +1890,11 @@ exports[`PermitConditions renders properly 1`] = `
                                           class="condition-collapsed"
                                         >
                                           <form
-                                            class="ant-form ant-form-vertical common-form common-form-EDIT_PERMIT_CONDITION_12515 form-view"
-                                            id="EDIT_PERMIT_CONDITION_12515"
+                                            class="ant-form ant-form-vertical common-form common-form-EDIT_PERMIT_CONDITION_12515_ELC form-view"
+                                            id="EDIT_PERMIT_CONDITION_12515_ELC"
                                           >
                                             <div
-                                              class="ant-row ant-row-no-wrap condition-content editable"
+                                              class="ant-row ant-row-no-wrap ant-row-top condition-content editable"
                                             >
                                               <div
                                                 class="ant-col step-column"

--- a/services/core-web/src/styles/components/Forms.scss
+++ b/services/core-web/src/styles/components/Forms.scss
@@ -95,6 +95,19 @@
   }
 }
 
+.horizontal-form-item {
+  .ant-form-item-row {
+    flex-direction: row;
+    flex-wrap: nowrap;
+    align-items: baseline;
+
+    .ant-form-item-label {
+      flex-shrink: 0;
+      padding-right: 6px;
+    }
+  }
+}
+
 .common-form.form-view {
   .ant-form-item-required::before {
     display: none !important;

--- a/services/core-web/src/styles/components/PermitConditions.scss
+++ b/services/core-web/src/styles/components/PermitConditions.scss
@@ -77,3 +77,9 @@ div.condition-layer {
   justify-content: space-between;
   align-items: center;
 }
+
+.horizontal-form-item {
+  .ant-select {
+    max-width: 350px;
+  }
+}


### PR DESCRIPTION
## Objective 
- I was tired of doing boilerplate for input components and inconsistently propagating changes to things like the label so I made a wrapper (when updating RenderGroupedSelect)
- I thought it was super confusing for conditions to sometimes appear in the middle of a section because the display order didn't change so I made it go to the bottom instead.
- it was weirdly difficult to get the form to not show "N/A" for all fields when the category changed after saving, so did the hacky change with the form name (the other approach that technically worked was dispatching initialize when formValues was undefined but a. that was even more hacky and b. it still flashed "N/A" for a bit)

[MDS-6027](https://bcmines.atlassian.net/browse/MDS-6027)

