### PR TITLE
[FIX] Inefficient selectors

### DIFF
--- a/services/common/src/redux/selectors/staticContentSelectors.ts
+++ b/services/common/src/redux/selectors/staticContentSelectors.ts
@@ -333,10 +333,8 @@ export const getHSRCMComplianceCodesHash = createSelector([getCurrentComplianceC
     .filter(({ article_act_code }) => article_act_code === "HSRCM")
     .reduce((map, code) => {
       const composedValue = formatComplianceCodeValueOrLabel(code, true);
-      return {
-        [code.compliance_article_id]: composedValue,
-        ...map,
-      };
+        map[code.compliance_article_id] = composedValue;
+        return map;
     }, {})
 );
 

--- a/services/common/src/redux/utils/helpers.ts
+++ b/services/common/src/redux/utils/helpers.ts
@@ -75,8 +75,12 @@ export const createDropDownList = (
 };
 
 // Function to create a hash given an array of values and labels
-export const createLabelHash = (arr) =>
-  arr.reduce((map, { value, label }) => ({ [value]: label, ...map }), {});
+export const createLabelHash = (arr) => {
+  return arr.reduce((map, { value, label }) => {
+    map[value] = label;
+    return map;
+  }, {});
+};
 
 export const formatTractionDate = (dateString: string) => {
   const year = dateString.slice(0, 4);


### PR DESCRIPTION
## Objective 

I noticed locally that certain pages were slow to load (Variances, Incidents). This isn't as noticeable on test and production due to the far lower amount of data and not running in dev mode. The cause turned out to be a couple of selectors used in mapStateToProps that were very slow due to an underlying functions use of the spread operator (...) in a reduce statement.

Generally in React we always aim to avoid mutating the state, which is one of the reasons the spread operator is so great - it creates a new object. However in this case when we are operating over a large number of elements in a list (1000+) this leads to issues and potentially even O(n2) time complexity. Directly mutating the object is linear and therefore far quicker for large datasets.

See:
https://prateeksurana.me/blog/why-using-object-spread-with-reduce-bad-idea/
https://stackoverflow.com/questions/44683789/using-spread-notation-in-array-reduce
https://typeofnan.dev/beware-the-reduce-spread-operator-combination/

Before:
![image](https://github.com/user-attachments/assets/5d1b2801-11bf-4ead-99c0-e4fc44460fae)
After:
![image](https://github.com/user-attachments/assets/c239847a-4133-422e-8baa-ed1cf6676b9c)

