### PR TITLE
[MDS-6012] Adjust comment editor max character limit to 500

### DIFF
--- a/migrations/sql/V2025.01.07.12.01__alter_incident_and_report_comment_character_limit.sql
+++ b/migrations/sql/V2025.01.07.12.01__alter_incident_and_report_comment_character_limit.sql
@@ -1,0 +1,3 @@
+ALTER TABLE mine_incident_note ALTER COLUMN content TYPE character varying(500);
+
+ALTER TABLE mine_report_comment ALTER COLUMN report_comment TYPE character varying(500);

--- a/services/common/src/components/comments/CommentEditor.tsx
+++ b/services/common/src/components/comments/CommentEditor.tsx
@@ -12,7 +12,7 @@ interface CommentEditorProps {
 export const CommentEditor: FC<CommentEditorProps> = ({
   onSubmit,
   addCommentPermission,
-  maxLength = 300,
+  maxLength = 500,
 }) => {
   const [submitting, setSubmitting] = React.useState(false);
   const [comment, setComment] = React.useState("");

--- a/services/common/src/components/projectSummary/ProjectManagement.tsx
+++ b/services/common/src/components/projectSummary/ProjectManagement.tsx
@@ -150,7 +150,6 @@ export const ProjectManagement: FC = () => {
                   renderEditor={true}
                   onSubmit={submitComment}
                   loading={false}
-                  maxLength={500}
                   comments={ministryComments?.map((comment: IProjectSummaryMinistryComment) => ({
                     key: comment.project_summary_ministry_comment_guid,
                     author: comment.update_user,

--- a/services/core-web/src/tests/components/common/comments/__snapshots__/CommentEditor.spec.tsx.snap
+++ b/services/core-web/src/tests/components/common/comments/__snapshots__/CommentEditor.spec.tsx.snap
@@ -20,7 +20,7 @@ exports[`Comment renders properly 1`] = `
             >
               <div
                 class="ant-input-textarea ant-input-textarea-show-count ant-input-textarea-in-form-item"
-                data-count="0 / 300"
+                data-count="0 / 500"
               >
                 <textarea
                   class="ant-input"


### PR DESCRIPTION
## Objective 

[MDS-6012](https://bcmines.atlassian.net/browse/MDS-6012)

- A User mentioned today that they would prefer the character limit for the comments to be at 500 instead of 300. This PR just makes that character limit change.

![Screenshot (551)](https://github.com/user-attachments/assets/c377a55e-b9f5-4410-9827-2c4ded03e66e)
 
