### PR TITLE
[MDS-6319] Fix for incorrect data in esup draft letters

### DIFF
--- a/services/core-web/src/components/mine/ExplosivesPermit/ExplosivesPermit.tsx
+++ b/services/core-web/src/components/mine/ExplosivesPermit/ExplosivesPermit.tsx
@@ -91,7 +91,11 @@ export const ExplosivesPermit: FC<ExplosivesPermitProps> = ({
     const payload = {
       explosives_permit_guid: record.explosives_permit_guid,
       ...(record.explosives_permit_amendment_id && { explosives_permit_amendment_id: record.explosives_permit_amendment_id }),
-      template_data: values,
+      template_data: {
+        ...values,
+        mine_manager_mine_party_appt_id: record.mine_manager_mine_party_appt_id,
+        permittee_mine_party_appt_id: record.permittee_mine_party_appt_id
+      },
     };
     return props.generateExplosivesPermitDocument(
       documentTypeCode,


### PR DESCRIPTION
## Objective 

[MDS-6319](https://bcmines.atlassian.net/browse/MDS-6319)

-ESUP draft enclosed letter would not display the mine manager and permittee information selected by user in the form. This PR adds logic to do so.
