### PR TITLE
[MDS-6291] Update development postgres instances

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ updatedb:
 		echo "+\n++ Backup volume 'mds_postgres_data_bkp' already exists"; \
 	else \
 		echo "+\n++ Creating a backup volume"; \
-		docker volume create --name mds_postgres_data_bkp; \
+		docker volume create --name mds_postgres_data_bkp --label com.docker.compose.project=mds --label com.docker.compose.volume=postgres_data_bkp; \
 		docker run --rm -it -v mds_postgres_data:/from -v mds_postgres_data_bkp:/to alpine ash -c 'cd /from ; cp -av . /to'; \
 	fi
 	@echo "+\n++ Backup complete, wiping mds_postgres_data volume"

--- a/Makefile
+++ b/Makefile
@@ -125,6 +125,8 @@ updatedb:
 	@docker run --rm -v mds_postgres_data:/tmp alpine sh -c "rm -rf /tmp/*"
 	@echo "+\n++ Updating postgres and copying result to the mds_postgres_data volume"
 	@docker compose $(DC_FILE) up postgres_update
+	@echo "+\n++ Copying conf files"
+	@docker run --rm -v ./services/postgres/:/tmp -v mds_postgres_data:/data alpine sh -c "cp -v /tmp/postgresql.conf /data/postgresql.conf && cp -v /tmp/pg_hba.conf /data/pg_hba.conf"
 	@echo "+\n++ Deleting old postgres image & update image"
 	@docker compose $(DC_FILE) rm -f -v -s postgres postgres_update
 	@docker rmi -f mds-postgres

--- a/Makefile
+++ b/Makefile
@@ -125,8 +125,8 @@ updatedb:
 	@docker run --rm -v mds_postgres_data:/tmp alpine sh -c "rm -rf /tmp/*"
 	@echo "+\n++ Updating postgres and copying result to the mds_postgres_data volume"
 	@docker compose $(DC_FILE) up postgres_update
-	@echo "+\n++ Copying conf files"
-	@docker run --rm -v ./services/postgres/:/tmp -v mds_postgres_data:/data alpine sh -c "cp -v /tmp/postgresql.conf /data/postgresql.conf && cp -v /tmp/pg_hba.conf /data/pg_hba.conf"
+#	@echo "+\n++ Copying conf files"
+#@docker run --rm -v ./services/postgres/:/tmp -v mds_postgres_data:/data alpine sh -c "cp -v /tmp/postgresql.conf /data/postgresql.conf && cp -v /tmp/pg_hba.conf /data/pg_hba.conf"
 	@echo "+\n++ Deleting old postgres image & update image"
 	@docker compose $(DC_FILE) rm -f -v -s postgres postgres_update
 	@docker rmi -f mds-postgres

--- a/Makefile
+++ b/Makefile
@@ -125,8 +125,6 @@ updatedb:
 	@docker run --rm -v mds_postgres_data:/tmp alpine sh -c "rm -rf /tmp/*"
 	@echo "+\n++ Updating postgres and copying result to the mds_postgres_data volume"
 	@docker compose $(DC_FILE) up postgres_update
-#	@echo "+\n++ Copying conf files"
-#@docker run --rm -v ./services/postgres/:/tmp -v mds_postgres_data:/data alpine sh -c "cp -v /tmp/postgresql.conf /data/postgresql.conf && cp -v /tmp/pg_hba.conf /data/pg_hba.conf"
 	@echo "+\n++ Deleting old postgres image & update image"
 	@docker compose $(DC_FILE) rm -f -v -s postgres postgres_update
 	@docker rmi -f mds-postgres

--- a/docker-compose.M1.yaml
+++ b/docker-compose.M1.yaml
@@ -70,6 +70,7 @@ services:
       interval: 5s
       timeout: 5s
       retries: 5
+    stop_grace_period: 30s
 
   postgres_update:
     platform: linux/amd64

--- a/docker-compose.M1.yaml
+++ b/docker-compose.M1.yaml
@@ -64,6 +64,8 @@ services:
     ports:
       - "5432:5432"
     volumes:
+      - ./services/postgres/postgresql.conf:/var/lib/postgresql/data/postgresql.conf
+      - ./services/postgres/pg_hba.conf:/var/lib/postgresql/data/pg_hba.conf
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
       test: [ "CMD", "pg_isready" ]

--- a/docker-compose.M1.yaml
+++ b/docker-compose.M1.yaml
@@ -56,7 +56,7 @@ services:
     user: postgres
     build:
       context: services/postgres
-      dockerfile: Dockerfile_new
+      dockerfile: Dockerfile
     environment:
       - POSTGRES_USER=mds
       - POSTGRES_PASSWORD=test
@@ -346,4 +346,3 @@ volumes:
   core_api_logs: {}
   core_web_logs: {}
   document_manager_logs: {}
-  

--- a/docker-compose.M1.yaml
+++ b/docker-compose.M1.yaml
@@ -83,7 +83,7 @@ services:
     - POSTGRES_PASSWORD=test
     - POSTGRES_INITDB_ARGS=-U mds
     volumes:
-    - mds_postgres_data_bkp:/var/lib/postgresql/13/data
+    - postgres_data_bkp:/var/lib/postgresql/13/data
     - postgres_data:/var/lib/postgresql/16/data
 
   ####################### Flyway Migration Definition #######################
@@ -341,8 +341,7 @@ networks:
 ####################### Volumes Definition #######################
 volumes:
   postgres_data: {}
-  mds_postgres_data_bkp: 
-    external: true
+  postgres_data_bkp: {}
   core_api_logs: {}
   core_web_logs: {}
   document_manager_logs: {}

--- a/docker-compose.M1.yaml
+++ b/docker-compose.M1.yaml
@@ -56,7 +56,7 @@ services:
     user: postgres
     build:
       context: services/postgres
-      dockerfile: Dockerfile
+      dockerfile: Dockerfile_new
     environment:
       - POSTGRES_USER=mds
       - POSTGRES_PASSWORD=test
@@ -70,6 +70,21 @@ services:
       interval: 5s
       timeout: 5s
       retries: 5
+
+  postgres_update:
+    platform: linux/amd64
+    container_name: mds_postgres_update
+    user: postgres
+    build:
+      context: services/postgres
+      dockerfile: Dockerfile_update
+    environment:
+    - PGUSER=mds
+    - POSTGRES_PASSWORD=test
+    - POSTGRES_INITDB_ARGS=-U mds
+    volumes:
+    - mds_postgres_data_bkp:/var/lib/postgresql/13/data
+    - postgres_data:/var/lib/postgresql/16/data
 
   ####################### Flyway Migration Definition #######################
   flyway:
@@ -326,6 +341,9 @@ networks:
 ####################### Volumes Definition #######################
 volumes:
   postgres_data: {}
+  mds_postgres_data_bkp: 
+    external: true
   core_api_logs: {}
   core_web_logs: {}
   document_manager_logs: {}
+  

--- a/docker-compose.M1.yaml
+++ b/docker-compose.M1.yaml
@@ -64,9 +64,11 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - ./services/postgres/postgresql.conf:/var/lib/postgresql/data/postgresql.conf
-      - ./services/postgres/pg_hba.conf:/var/lib/postgresql/data/pg_hba.conf
+      - ./services/postgres/postgresql.conf:/config/postgresql.conf
+      - ./services/postgres/pg_hba.conf:/config/pg_hba.conf
       - postgres_data:/var/lib/postgresql/data
+    command:
+      postgres -c 'config_file=/config/postgresql.conf' -c 'hba_file=/config/pg_hba.conf'
     healthcheck:
       test: [ "CMD", "pg_isready" ]
       interval: 5s

--- a/docker-compose.ci.yaml
+++ b/docker-compose.ci.yaml
@@ -63,6 +63,7 @@ services:
       interval: 5s
       timeout: 5s
       retries: 10
+    stop_grace_period: 30s
 
   ####################### Flyway Migration Definition #######################
   flyway:

--- a/docker-compose.ci.yaml
+++ b/docker-compose.ci.yaml
@@ -57,6 +57,8 @@ services:
     ports:
       - "5432:5432"
     volumes:
+      - ./services/postgres/postgresql.conf:/var/lib/postgresql/data/postgresql.conf
+      - ./services/postgres/pg_hba.conf:/var/lib/postgresql/data/pg_hba.conf
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
       test: [ "CMD", "pg_isready" ]

--- a/docker-compose.ci.yaml
+++ b/docker-compose.ci.yaml
@@ -57,8 +57,6 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - ./services/postgres/postgresql.conf:/var/lib/postgresql/data/postgresql.conf
-      - ./services/postgres/pg_hba.conf:/var/lib/postgresql/data/pg_hba.conf
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
       test: [ "CMD", "pg_isready" ]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -69,6 +69,20 @@ services:
       interval: 5s
       timeout: 5s
       retries: 5
+  
+  postgres_update:
+    container_name: mds_postgres_update
+    user: postgres
+    build:
+      context: services/postgres
+      dockerfile: Dockerfile_update
+    environment:
+    - PGUSER=mds
+    - POSTGRES_PASSWORD=test
+    - POSTGRES_INITDB_ARGS=-U mds
+    volumes:
+    - mds_postgres_data_bkp:/var/lib/postgresql/13/data
+    - postgres_data:/var/lib/postgresql/16/data
 
   ####################### Flyway Migration Definition #######################
   flyway:
@@ -332,6 +346,8 @@ networks:
 ####################### Volumes Definition #######################
 volumes:
   postgres_data: {}
+  mds_postgres_data_bkp: 
+    external: true
   core_api_logs: {}
   core_web_logs: {}
   document_manager_logs: {}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -63,6 +63,8 @@ services:
     ports:
       - "5432:5432"
     volumes:
+      - ./services/postgres/postgresql.conf:/var/lib/postgresql/data/postgresql.conf
+      - ./services/postgres/pg_hba.conf:/var/lib/postgresql/data/pg_hba.conf
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
       test: [ "CMD", "pg_isready" ]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -81,7 +81,7 @@ services:
     - POSTGRES_PASSWORD=test
     - POSTGRES_INITDB_ARGS=-U mds
     volumes:
-    - mds_postgres_data_bkp:/var/lib/postgresql/13/data
+    - postgres_data_bkp:/var/lib/postgresql/13/data
     - postgres_data:/var/lib/postgresql/16/data
 
   ####################### Flyway Migration Definition #######################
@@ -346,8 +346,7 @@ networks:
 ####################### Volumes Definition #######################
 volumes:
   postgres_data: {}
-  mds_postgres_data_bkp: 
-    external: true
+  postgres_data_bkp: {}
   core_api_logs: {}
   core_web_logs: {}
   document_manager_logs: {}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -63,9 +63,11 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - ./services/postgres/postgresql.conf:/var/lib/postgresql/data/postgresql.conf
-      - ./services/postgres/pg_hba.conf:/var/lib/postgresql/data/pg_hba.conf
+      - ./services/postgres/postgresql.conf:/config/postgresql.conf
+      - ./services/postgres/pg_hba.conf:/config/pg_hba.conf
       - postgres_data:/var/lib/postgresql/data
+    command:
+      postgres -c 'config_file=/config/postgresql.conf' -c 'hba_file=/config/pg_hba.conf'
     healthcheck:
       test: [ "CMD", "pg_isready" ]
       interval: 5s

--- a/migrations/Dockerfile.flyway.ci
+++ b/migrations/Dockerfile.flyway.ci
@@ -1,4 +1,4 @@
-FROM flyway/flyway:7.14-alpine
+FROM flyway/flyway:11.1-alpine
 ENV FLYWAY_HOME=/flyway
 
 USER 0
@@ -10,7 +10,7 @@ COPY sql-prod/* /flyway/sql-prod/
 COPY scripts/* /flyway/scripts/
 
 
-ENV FLYWAY_VERSION=5.2.4
+ENV FLYWAY_VERSION=11.1
 
 # Copy over the SQL files and scripts
 COPY sql/* $FLYWAY_HOME/sql/

--- a/migrations/Dockerfile.flyway.dev
+++ b/migrations/Dockerfile.flyway.dev
@@ -1,4 +1,4 @@
-FROM flyway/flyway:7.14-alpine
+FROM flyway/flyway:11.1-alpine
 
 USER root
 

--- a/migrations/sql/V2021.06.03__add_serial_to_equipmentid_in_now_submissions.sql
+++ b/migrations/sql/V2021.06.03__add_serial_to_equipmentid_in_now_submissions.sql
@@ -9,7 +9,7 @@ BEGIN
             INTO start_with;
     EXECUTE 'CREATE SEQUENCE ' || sequence_name ||
             ' START WITH ' || start_with ||
-            'INCREMENT BY 1 NO MINVALUE NO MAXVALUE CACHE 1';
+            ' INCREMENT BY 1 NO MINVALUE NO MAXVALUE CACHE 1';
            
     EXECUTE 'ALTER TABLE ' || sequence_name || ' OWNER TO mds';
    

--- a/services/postgres/Dockerfile
+++ b/services/postgres/Dockerfile
@@ -70,13 +70,8 @@ RUN rm -rf /pgexts/oraclelibs/*.zip /pgexts/${ORACLE_FDW_VERSION}.tar.gz /tmp/or
 # Init Scripts
 
 COPY init.sql /docker-entrypoint-initdb.d/init.sql
-COPY postgresql.conf      /tmp/postgresql.conf
-COPY pg_hba.conf      /tmp/pg_hba.conf
 
 RUN mkdir -p /pg_log
 RUN chown -R postgres:postgres /pg_log
-
-COPY updateConfig.sh      /docker-entrypoint-initdb.d/_updateConfig.sh
-RUN chmod +x /docker-entrypoint-initdb.d/_updateConfig.sh
 
 WORKDIR /docker-entrypoint-initdb.d

--- a/services/postgres/Dockerfile
+++ b/services/postgres/Dockerfile
@@ -1,12 +1,12 @@
-FROM postgis/postgis:13-3.4
+FROM postgis/postgis:16-3.5
 
 # The Git ref (branch/tag) specifying the version of oracle-fdw to use
 # This is referencing a specific revision (master as of 2021.06.01)
 # because there is not a tagged version that works with the 
 # Oracle 21.x client libraries yet
 
-ARG ORACLE_FDW_VERSION=3035e4453404a143b8154d7b77c6db793fad0e06
-ARG oracle_fdw_version=2_1_0
+ARG ORACLE_FDW_VERSION=ORACLE_FDW_2_6_0
+ARG oracle_fdw_version=2_6_0
 ARG instantclient_version=21_6
 
 # =================================== # 
@@ -30,7 +30,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     unzip \
     wget \ 
     ca-certificates \ 
-    postgresql-server-dev-13 \ 
+    postgresql-server-dev-16 \ 
     libaio1 \
     libaio-dev
 
@@ -55,7 +55,7 @@ ENV LD_LIBRARY_PATH /pgexts/oraclelibs/instantclient_${instantclient_version}
 # =================================== # 
 
 RUN cd /pgexts && \
-    wget -nv https://github.com/laurenz/oracle_fdw/archive/${ORACLE_FDW_VERSION}.tar.gz && \
+    wget -nv https://github.com/laurenz/oracle_fdw/archive/refs/tags/${ORACLE_FDW_VERSION}.tar.gz && \
     tar -xzf ${ORACLE_FDW_VERSION}.tar.gz && \
     cd oracle_fdw-${ORACLE_FDW_VERSION} && \
     make && \
@@ -71,7 +71,13 @@ RUN rm -rf /pgexts/oraclelibs/*.zip /pgexts/${ORACLE_FDW_VERSION}.tar.gz /tmp/or
 
 COPY init.sql /docker-entrypoint-initdb.d/init.sql
 COPY postgresql.conf      /tmp/postgresql.conf
-COPY updateConfig.sh      /docker-entrypoint-initdb.d/_updateConfig.sh
+COPY pg_hba.conf      /tmp/pg_hba.conf
 
-# Set the working directory to container entrypoint
-WORKDIR /docker-entrypoint-initdb.d
+RUN mkdir -p /pg_log
+RUN chown -R postgres:postgres /pg_log
+
+COPY updateConfig.sh      /docker-entrypoint-initdb.d/_updateConfig.sh
+RUN chmod +x /docker-entrypoint-initdb.d/_updateConfig.sh
+ENTRYPOINT ["sh", "-c", "/docker-entrypoint-initdb.d/_updateConfig.sh && docker-entrypoint.sh postgres"]
+
+CMD ["postgres"]

--- a/services/postgres/Dockerfile
+++ b/services/postgres/Dockerfile
@@ -78,6 +78,5 @@ RUN chown -R postgres:postgres /pg_log
 
 COPY updateConfig.sh      /docker-entrypoint-initdb.d/_updateConfig.sh
 RUN chmod +x /docker-entrypoint-initdb.d/_updateConfig.sh
-ENTRYPOINT ["sh", "-c", "/docker-entrypoint-initdb.d/_updateConfig.sh && docker-entrypoint.sh postgres"]
 
-CMD ["postgres"]
+WORKDIR /docker-entrypoint-initdb.d

--- a/services/postgres/Dockerfile_update
+++ b/services/postgres/Dockerfile_update
@@ -1,0 +1,30 @@
+FROM postgis/postgis:16-3.4
+
+RUN sed -i 's/$/ 13/' /etc/apt/sources.list.d/pgdg.list
+
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+    postgresql-13 \
+    postgresql-13-postgis-3 \
+    ; \
+    rm -rf /var/lib/apt/lists/*
+
+ENV PGBINOLD /usr/lib/postgresql/13/bin
+ENV PGBINNEW /usr/lib/postgresql/16/bin
+
+ENV PGDATAOLD /var/lib/postgresql/13/data
+ENV PGDATANEW /var/lib/postgresql/16/data
+
+RUN set -eux; \
+    mkdir -p "$PGDATAOLD" "$PGDATANEW"; \
+    chown -R postgres:postgres /var/lib/postgresql
+
+WORKDIR /var/lib/postgresql
+
+COPY docker-upgrade.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/docker-upgrade.sh
+
+ENTRYPOINT ["/usr/local/bin/docker-upgrade.sh"]
+
+CMD ["pg_upgrade"]

--- a/services/postgres/docker-upgrade.sh
+++ b/services/postgres/docker-upgrade.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -e
+
+if [ "$#" -eq 0 -o "${1:0:1}" = '-' ]; then
+	set -- pg_upgrade "$@"
+fi
+
+if [ "$1" = 'pg_upgrade' -a "$(id -u)" = '0' ]; then
+	mkdir -p "$PGDATAOLD" "$PGDATANEW"
+	chmod 700 "$PGDATAOLD" "$PGDATANEW"
+	chown postgres .
+	chown -R postgres "$PGDATAOLD" "$PGDATANEW"
+	exec gosu postgres "$BASH_SOURCE" "$@"
+fi
+
+if [ "$1" = 'pg_upgrade' ]; then
+	if [ ! -s "$PGDATANEW/PG_VERSION" ]; then
+		PGDATA="$PGDATANEW" eval "initdb $POSTGRES_INITDB_ARGS"
+	fi
+fi
+
+exec "$@"

--- a/services/postgres/pg_hba.conf
+++ b/services/postgres/pg_hba.conf
@@ -12,4 +12,4 @@ local   replication     all                                     trust
 host    replication     all             127.0.0.1/32            trust
 host    replication     all             ::1/128                 trust
 
-host all all all scram-sha-256
+host all all all md5

--- a/services/postgres/pg_hba.conf
+++ b/services/postgres/pg_hba.conf
@@ -4,8 +4,6 @@
 local   all             all                                     trust
 # IPv4 local connections:
 host    all             all             127.0.0.1/32            trust
-host    all             mds             172.20.0.0/24           password
-host    all             mds             172.17.0.0/24           password
 # IPv6 local connections:
 host    all             all             ::1/128                 trust
 # Allow replication connections from localhost, by a user with the
@@ -13,3 +11,5 @@ host    all             all             ::1/128                 trust
 local   replication     all                                     trust
 host    replication     all             127.0.0.1/32            trust
 host    replication     all             ::1/128                 trust
+
+host all all all scram-sha-256

--- a/services/postgres/pg_hba.conf
+++ b/services/postgres/pg_hba.conf
@@ -1,0 +1,15 @@
+# TYPE  DATABASE        USER            ADDRESS                 METHOD
+
+# "local" is for Unix domain socket connections only
+local   all             all                                     trust
+# IPv4 local connections:
+host    all             all             127.0.0.1/32            trust
+host    all             mds             172.20.0.0/24           password
+host    all             mds             172.17.0.0/24           password
+# IPv6 local connections:
+host    all             all             ::1/128                 trust
+# Allow replication connections from localhost, by a user with the
+# replication privilege.
+local   replication     all                                     trust
+host    replication     all             127.0.0.1/32            trust
+host    replication     all             ::1/128                 trust

--- a/services/postgres/postgresql.conf
+++ b/services/postgres/postgresql.conf
@@ -24,11 +24,13 @@
 # "postgres -c log_connections=on".  Some parameters can be changed at run time
 # with the "SET" SQL command.
 #
-# Memory units:  kB = kilobytes        Time units:  ms  = milliseconds
+# Memory units:  B  = bytes            Time units:  us  = microseconds
+#                kB = kilobytes                     ms  = milliseconds
 #                MB = megabytes                     s   = seconds
 #                GB = gigabytes                     min = minutes
 #                TB = terabytes                     h   = hours
 #                                                   d   = days
+
 
 #------------------------------------------------------------------------------
 # FILE LOCATIONS
@@ -38,15 +40,16 @@
 # option or PGDATA environment variable, represented here as ConfigDir.
 
 #data_directory = 'ConfigDir'		# use data in another directory
-# (change requires restart)
+					# (change requires restart)
 #hba_file = 'ConfigDir/pg_hba.conf'	# host-based authentication file
-# (change requires restart)
+					# (change requires restart)
 #ident_file = 'ConfigDir/pg_ident.conf'	# ident configuration file
-# (change requires restart)
+					# (change requires restart)
 
 # If external_pid_file is not explicitly set, no extra PID file is written.
 #external_pid_file = ''			# write an extra PID file
-# (change requires restart)
+					# (change requires restart)
+
 
 #------------------------------------------------------------------------------
 # CONNECTIONS AND AUTHENTICATION
@@ -55,43 +58,50 @@
 # - Connection Settings -
 
 listen_addresses = '*'
-# comma-separated list of addresses;
-# defaults to 'localhost'; use '*' for all
-# (change requires restart)
+					# comma-separated list of addresses;
+					# defaults to 'localhost'; use '*' for all
+					# (change requires restart)
 #port = 5432				# (change requires restart)
-max_connections = 100 # (change requires restart)
+max_connections = 100			# (change requires restart)
+#reserved_connections = 0		# (change requires restart)
 #superuser_reserved_connections = 3	# (change requires restart)
-#unix_socket_directories = '/var/run/postgresql'	# comma-separated list of directories
-# (change requires restart)
+#unix_socket_directories = '/var/run/postgresql' # comma-separated list of directories
+					# (change requires restart)
 #unix_socket_group = ''			# (change requires restart)
 #unix_socket_permissions = 0777		# begin with 0 to use octal notation
-# (change requires restart)
+					# (change requires restart)
 #bonjour = off				# advertise server via Bonjour
-# (change requires restart)
+					# (change requires restart)
 #bonjour_name = ''			# defaults to the computer name
-# (change requires restart)
+					# (change requires restart)
 
 # - TCP settings -
 # see "man tcp" for details
 
 #tcp_keepalives_idle = 0		# TCP_KEEPIDLE, in seconds;
-# 0 selects the system default
+					# 0 selects the system default
 #tcp_keepalives_interval = 0		# TCP_KEEPINTVL, in seconds;
-# 0 selects the system default
+					# 0 selects the system default
 #tcp_keepalives_count = 0		# TCP_KEEPCNT;
-# 0 selects the system default
+					# 0 selects the system default
 #tcp_user_timeout = 0			# TCP_USER_TIMEOUT, in milliseconds;
-# 0 selects the system default
+					# 0 selects the system default
+
+#client_connection_check_interval = 0	# time between checks for client
+					# disconnection while running queries;
+					# 0 for never
 
 # - Authentication -
 
 #authentication_timeout = 1min		# 1s-600s
-#password_encryption = md5		# md5 or scram-sha-256
+#password_encryption = scram-sha-256	# scram-sha-256 or md5
+#scram_iterations = 4096
 #db_user_namespace = off
 
 # GSSAPI using Kerberos
-#krb_server_keyfile = ''
+#krb_server_keyfile = 'FILE:${sysconfdir}/krb5.keytab'
 #krb_caseins_users = off
+#gss_accept_delegation = off
 
 # - SSL -
 
@@ -99,6 +109,7 @@ max_connections = 100 # (change requires restart)
 #ssl_ca_file = ''
 #ssl_cert_file = 'server.crt'
 #ssl_crl_file = ''
+#ssl_crl_dir = ''
 #ssl_key_file = 'server.key'
 #ssl_ciphers = 'HIGH:MEDIUM:+3DES:!aNULL' # allowed SSL ciphers
 #ssl_prefer_server_ciphers = on
@@ -109,56 +120,63 @@ max_connections = 100 # (change requires restart)
 #ssl_passphrase_command = ''
 #ssl_passphrase_command_supports_reload = off
 
+
 #------------------------------------------------------------------------------
 # RESOURCE USAGE (except WAL)
 #------------------------------------------------------------------------------
 
 # - Memory -
 
-shared_buffers = 128MB # min 128kB
-# (change requires restart)
+shared_buffers = 128MB			# min 128kB
+					# (change requires restart)
 #huge_pages = try			# on, off, or try
-# (change requires restart)
+					# (change requires restart)
+#huge_page_size = 0			# zero for system default
+					# (change requires restart)
 #temp_buffers = 8MB			# min 800kB
 #max_prepared_transactions = 0		# zero disables the feature
-# (change requires restart)
+					# (change requires restart)
 # Caution: it is not advisable to set max_prepared_transactions nonzero unless
 # you actively intend to use prepared transactions.
 #work_mem = 4MB				# min 64kB
-#hash_mem_multiplier = 1.0		# 1-1000.0 multiplier on hash table work_mem
+#hash_mem_multiplier = 2.0		# 1-1000.0 multiplier on hash table work_mem
 #maintenance_work_mem = 64MB		# min 1MB
 #autovacuum_work_mem = -1		# min 1MB, or -1 to use maintenance_work_mem
 #logical_decoding_work_mem = 64MB	# min 64kB
 #max_stack_depth = 2MB			# min 100kB
 #shared_memory_type = mmap		# the default is the first option
-# supported by the operating system:
-#   mmap
-#   sysv
-#   windows
-# (change requires restart)
-dynamic_shared_memory_type = posix # the default is the first option
-# supported by the operating system:
-#   posix
-#   sysv
-#   windows
-#   mmap
-# (change requires restart)
+					# supported by the operating system:
+					#   mmap
+					#   sysv
+					#   windows
+					# (change requires restart)
+dynamic_shared_memory_type = posix	# the default is usually the first option
+					# supported by the operating system:
+					#   posix
+					#   sysv
+					#   windows
+					#   mmap
+					# (change requires restart)
+#min_dynamic_shared_memory = 0MB	# (change requires restart)
+#vacuum_buffer_usage_limit = 256kB	# size of vacuum and analyze buffer access strategy ring;
+					# 0 to disable vacuum buffer access strategy;
+					# range 128kB to 16GB
 
 # - Disk -
 
 #temp_file_limit = -1			# limits per-process temp file space
-# in kilobytes, or -1 for no limit
+					# in kilobytes, or -1 for no limit
 
 # - Kernel Resources -
 
 #max_files_per_process = 1000		# min 64
-# (change requires restart)
+					# (change requires restart)
 
 # - Cost-Based Vacuum Delay -
 
 #vacuum_cost_delay = 0			# 0-100 milliseconds (0 disables)
 #vacuum_cost_page_hit = 1		# 0-10000 credits
-#vacuum_cost_page_miss = 10		# 0-10000 credits
+#vacuum_cost_page_miss = 2		# 0-10000 credits
 #vacuum_cost_page_dirty = 20		# 0-10000 credits
 #vacuum_cost_limit = 200		# 1-10000 credits
 
@@ -171,17 +189,18 @@ dynamic_shared_memory_type = posix # the default is the first option
 
 # - Asynchronous Behavior -
 
+#backend_flush_after = 0		# measured in pages, 0 disables
 #effective_io_concurrency = 1		# 1-1000; 0 disables prefetching
 #maintenance_io_concurrency = 10	# 1-1000; 0 disables prefetching
 #max_worker_processes = 8		# (change requires restart)
-#max_parallel_maintenance_workers = 2	# taken from max_parallel_workers
-#max_parallel_workers_per_gather = 2	# taken from max_parallel_workers
+#max_parallel_workers_per_gather = 2	# limited by max_parallel_workers
+#max_parallel_maintenance_workers = 2	# limited by max_parallel_workers
+#max_parallel_workers = 8		# number of max_worker_processes that
+					# can be used in parallel operations
 #parallel_leader_participation = on
-#max_parallel_workers = 8		# maximum number of max_worker_processes that
-# can be used in parallel operations
 #old_snapshot_threshold = -1		# 1min-60d; -1 disables; 0 is immediate
-# (change requires restart)
-#backend_flush_after = 0		# measured in pages, 0 disables
+					# (change requires restart)
+
 
 #------------------------------------------------------------------------------
 # WRITE-AHEAD LOG
@@ -190,27 +209,28 @@ dynamic_shared_memory_type = posix # the default is the first option
 # - Settings -
 
 #wal_level = replica			# minimal, replica, or logical
-# (change requires restart)
+					# (change requires restart)
 #fsync = on				# flush data to disk for crash safety
-# (turning this off can cause
-# unrecoverable data corruption)
+					# (turning this off can cause
+					# unrecoverable data corruption)
 #synchronous_commit = on		# synchronization level;
-# off, local, remote_write, remote_apply, or on
+					# off, local, remote_write, remote_apply, or on
 #wal_sync_method = fsync		# the default is the first option
-# supported by the operating system:
-#   open_datasync
-#   fdatasync (default on Linux)
-#   fsync
-#   fsync_writethrough
-#   open_sync
+					# supported by the operating system:
+					#   open_datasync
+					#   fdatasync (default on Linux and FreeBSD)
+					#   fsync
+					#   fsync_writethrough
+					#   open_sync
 #full_page_writes = on			# recover from partial page writes
-#wal_compression = off			# enable compression of full-page writes
 #wal_log_hints = off			# also do full page writes of non-critical updates
-# (change requires restart)
+					# (change requires restart)
+#wal_compression = off			# enables compression of full-page writes;
+					# off, pglz, lz4, zstd, or on
 #wal_init_zero = on			# zero-fill new WAL files
 #wal_recycle = on			# recycle WAL files
 #wal_buffers = -1			# min 32kB, -1 sets based on shared_buffers
-# (change requires restart)
+					# (change requires restart)
 #wal_writer_delay = 200ms		# 1-10000 milliseconds
 #wal_writer_flush_after = 1MB		# measured in pages, 0 disables
 #wal_skip_threshold = 2MB
@@ -221,32 +241,40 @@ dynamic_shared_memory_type = posix # the default is the first option
 # - Checkpoints -
 
 #checkpoint_timeout = 5min		# range 30s-1d
-max_wal_size = 1GB
-min_wal_size = 80MB
-#checkpoint_completion_target = 0.5	# checkpoint target duration, 0.0 - 1.0
+#checkpoint_completion_target = 0.9	# checkpoint target duration, 0.0 - 1.0
 #checkpoint_flush_after = 256kB		# measured in pages, 0 disables
 #checkpoint_warning = 30s		# 0 disables
+max_wal_size = 1GB
+min_wal_size = 80MB
+
+# - Prefetching during recovery -
+
+#recovery_prefetch = try		# prefetch pages referenced in the WAL?
+#wal_decode_buffer_size = 512kB		# lookahead window used for prefetching
+					# (change requires restart)
 
 # - Archiving -
 
 #archive_mode = off		# enables archiving; off, on, or always
-# (change requires restart)
-#archive_command = ''		# command to use to archive a logfile segment
-# placeholders: %p = path of file to archive
-#               %f = file name only
-# e.g. 'test ! -f /mnt/server/archivedir/%f && cp %p /mnt/server/archivedir/%f'
-#archive_timeout = 0		# force a logfile segment switch after this
-# number of seconds; 0 disables
+				# (change requires restart)
+#archive_library = ''		# library to use to archive a WAL file
+				# (empty string indicates archive_command should
+				# be used)
+#archive_command = ''		# command to use to archive a WAL file
+				# placeholders: %p = path of file to archive
+				#               %f = file name only
+				# e.g. 'test ! -f /mnt/server/archivedir/%f && cp %p /mnt/server/archivedir/%f'
+#archive_timeout = 0		# force a WAL file switch after this
+				# number of seconds; 0 disables
 
 # - Archive Recovery -
 
 # These are only used in recovery mode.
 
-#restore_command = ''		# command to use to restore an archived logfile segment
-# placeholders: %p = path of file to restore
-#               %f = file name only
-# e.g. 'cp /mnt/server/archivedir/%f %p'
-# (change requires restart)
+#restore_command = ''		# command to use to restore an archived WAL file
+				# placeholders: %p = path of file to restore
+				#               %f = file name only
+				# e.g. 'cp /mnt/server/archivedir/%f %p'
 #archive_cleanup_command = ''	# command to execute at every restartpoint
 #recovery_end_command = ''	# command to execute at completion of recovery
 
@@ -255,24 +283,25 @@ min_wal_size = 80MB
 # Set these only when performing a targeted recovery.
 
 #recovery_target = ''		# 'immediate' to end recovery as soon as a
-# consistent state is reached
-# (change requires restart)
+                                # consistent state is reached
+				# (change requires restart)
 #recovery_target_name = ''	# the named restore point to which recovery will proceed
-# (change requires restart)
+				# (change requires restart)
 #recovery_target_time = ''	# the time stamp up to which recovery will proceed
-# (change requires restart)
+				# (change requires restart)
 #recovery_target_xid = ''	# the transaction ID up to which recovery will proceed
-# (change requires restart)
+				# (change requires restart)
 #recovery_target_lsn = ''	# the WAL LSN up to which recovery will proceed
-# (change requires restart)
+				# (change requires restart)
 #recovery_target_inclusive = on # Specifies whether to stop:
-# just after the specified recovery target (on)
-# just before the recovery target (off)
-# (change requires restart)
+				# just after the specified recovery target (on)
+				# just before the recovery target (off)
+				# (change requires restart)
 #recovery_target_timeline = 'latest'	# 'current', 'latest', or timeline ID
-# (change requires restart)
+				# (change requires restart)
 #recovery_target_action = 'pause'	# 'pause', 'promote', 'shutdown'
-# (change requires restart)
+				# (change requires restart)
+
 
 #------------------------------------------------------------------------------
 # REPLICATION
@@ -280,55 +309,52 @@ min_wal_size = 80MB
 
 # - Sending Servers -
 
-# Set these on the master and on any standby that will send replication data.
+# Set these on the primary and on any standby that will send replication data.
 
 #max_wal_senders = 10		# max number of walsender processes
-# (change requires restart)
+				# (change requires restart)
+#max_replication_slots = 10	# max number of replication slots
+				# (change requires restart)
 #wal_keep_size = 0		# in megabytes; 0 disables
 #max_slot_wal_keep_size = -1	# in megabytes; -1 disables
 #wal_sender_timeout = 60s	# in milliseconds; 0 disables
-
-#max_replication_slots = 10	# max number of replication slots
-# (change requires restart)
 #track_commit_timestamp = off	# collect timestamp of transaction commit
-# (change requires restart)
+				# (change requires restart)
 
-# - Master Server -
+# - Primary Server -
 
 # These settings are ignored on a standby server.
 
 #synchronous_standby_names = ''	# standby servers that provide sync rep
-# method to choose sync standbys, number of sync standbys,
-# and comma-separated list of application_name
-# from standby(s); '*' = all
-#vacuum_defer_cleanup_age = 0	# number of xacts by which cleanup is delayed
+				# method to choose sync standbys, number of sync standbys,
+				# and comma-separated list of application_name
+				# from standby(s); '*' = all
 
 # - Standby Servers -
 
-# These settings are ignored on a master server.
+# These settings are ignored on a primary server.
 
 #primary_conninfo = ''			# connection string to sending server
 #primary_slot_name = ''			# replication slot on sending server
-#promote_trigger_file = ''		# file name whose presence ends recovery
 #hot_standby = on			# "off" disallows queries during recovery
-# (change requires restart)
+					# (change requires restart)
 #max_standby_archive_delay = 30s	# max delay before canceling queries
-# when reading WAL from archive;
-# -1 allows indefinite delay
+					# when reading WAL from archive;
+					# -1 allows indefinite delay
 #max_standby_streaming_delay = 30s	# max delay before canceling queries
-# when reading streaming WAL;
-# -1 allows indefinite delay
+					# when reading streaming WAL;
+					# -1 allows indefinite delay
 #wal_receiver_create_temp_slot = off	# create temp slot if primary_slot_name
-# is not set
+					# is not set
 #wal_receiver_status_interval = 10s	# send replies at least this often
-# 0 disables
+					# 0 disables
 #hot_standby_feedback = off		# send info from standby to prevent
-# query conflicts
+					# query conflicts
 #wal_receiver_timeout = 60s		# time that receiver waits for
-# communication from master
-# in milliseconds; 0 disables
+					# communication from primary
+					# in milliseconds; 0 disables
 #wal_retrieve_retry_interval = 5s	# time to wait before retrying to
-# retrieve WAL after a failed attempt
+					# retrieve WAL after a failed attempt
 #recovery_min_apply_delay = 0		# minimum delay for applying changes during recovery
 
 # - Subscribers -
@@ -336,8 +362,10 @@ min_wal_size = 80MB
 # These settings are ignored on a publisher.
 
 #max_logical_replication_workers = 4	# taken from max_worker_processes
-# (change requires restart)
+					# (change requires restart)
 #max_sync_workers_per_subscription = 2	# taken from max_logical_replication_workers
+#max_parallel_apply_workers_per_subscription = 2	# taken from max_logical_replication_workers
+
 
 #------------------------------------------------------------------------------
 # QUERY TUNING
@@ -345,23 +373,27 @@ min_wal_size = 80MB
 
 # - Planner Method Configuration -
 
+#enable_async_append = on
 #enable_bitmapscan = on
+#enable_gathermerge = on
 #enable_hashagg = on
 #enable_hashjoin = on
+#enable_incremental_sort = on
 #enable_indexscan = on
 #enable_indexonlyscan = on
 #enable_material = on
+#enable_memoize = on
 #enable_mergejoin = on
 #enable_nestloop = on
 #enable_parallel_append = on
-#enable_seqscan = on
-#enable_sort = on
-#enable_incremental_sort = on
-#enable_tidscan = on
-#enable_partitionwise_join = off
-#enable_partitionwise_aggregate = off
 #enable_parallel_hash = on
 #enable_partition_pruning = on
+#enable_partitionwise_join = off
+#enable_partitionwise_aggregate = off
+#enable_presorted_aggregate = on
+#enable_seqscan = on
+#enable_sort = on
+#enable_tidscan = on
 
 # - Planner Cost Constants -
 
@@ -370,21 +402,20 @@ min_wal_size = 80MB
 #cpu_tuple_cost = 0.01			# same scale as above
 #cpu_index_tuple_cost = 0.005		# same scale as above
 #cpu_operator_cost = 0.0025		# same scale as above
-#parallel_tuple_cost = 0.1		# same scale as above
 #parallel_setup_cost = 1000.0	# same scale as above
-
-#jit_above_cost = 100000		# perform JIT compilation if available
-# and query more expensive than this;
-# -1 disables
-#jit_inline_above_cost = 500000		# inline small functions if query is
-# more expensive than this; -1 disables
-#jit_optimize_above_cost = 500000	# use expensive JIT optimizations if
-# query is more expensive than this;
-# -1 disables
-
+#parallel_tuple_cost = 0.1		# same scale as above
 #min_parallel_table_scan_size = 8MB
 #min_parallel_index_scan_size = 512kB
-effective_cache_size = 4GB
+#effective_cache_size = 4GB
+
+#jit_above_cost = 100000		# perform JIT compilation if available
+					# and query more expensive than this;
+					# -1 disables
+#jit_inline_above_cost = 500000		# inline small functions if query is
+					# more expensive than this; -1 disables
+#jit_optimize_above_cost = 500000	# use expensive JIT optimizations if
+					# query is more expensive than this;
+					# -1 disables
 
 # - Genetic Query Optimizer -
 
@@ -402,12 +433,13 @@ effective_cache_size = 4GB
 #constraint_exclusion = partition	# on, off, or partition
 #cursor_tuple_fraction = 0.1		# range 0.0-1.0
 #from_collapse_limit = 8
-#join_collapse_limit = 8		# 1 disables collapsing of explicit
-# JOIN clauses
-#force_parallel_mode = off
 #jit = on				# allow JIT compilation
+#join_collapse_limit = 8		# 1 disables collapsing of explicit
+					# JOIN clauses
 #plan_cache_mode = auto			# auto, force_generic_plan or
-# force_custom_plan
+					# force_custom_plan
+#recursive_worktable_factor = 10.0	# range 0.001-1000000
+
 
 #------------------------------------------------------------------------------
 # REPORTING AND LOGGING
@@ -415,37 +447,38 @@ effective_cache_size = 4GB
 
 # - Where to Log -
 
-log_destination = 'stderr' # Valid values are combinations of
-# stderr, csvlog, syslog, and eventlog,
-# depending on platform.  csvlog
-# requires logging_collector to be on.
+log_destination = 'stderr'		# Valid values are combinations of
+					# stderr, csvlog, jsonlog, syslog, and
+					# eventlog, depending on platform.
+					# csvlog and jsonlog require
+					# logging_collector to be on.
 
 # This is used when logging to stderr:
-logging_collector = on # Enable capturing of stderr and csvlog
-# into log files. Required to be on for
-# csvlogs.
-# (change requires restart)
+logging_collector = on		# Enable capturing of stderr, jsonlog,
+					# and csvlog into log files. Required
+					# to be on for csvlogs and jsonlogs.
+					# (change requires restart)
 
 # These are only used if logging_collector is on:
-log_directory = '/pg_log' # directory where log files are written,
-# can be absolute or relative to PGDATA
-log_filename = 'postgresql-%a.log' # log file name pattern,
-# can include strftime() escapes
+log_directory = '/pg_log'			# directory where log files are written,
+					# can be absolute or relative to PGDATA
+log_filename = 'postgresql-%a.log'	# log file name pattern,
+					# can include strftime() escapes
 #log_file_mode = 0600			# creation mode for log files,
-# begin with 0 to use octal notation
-log_truncate_on_rotation = on # If on, an existing log file with the
-# same name as the new log file will be
-# truncated rather than appended to.
-# But such truncation only occurs on
-# time-driven rotation, not on restarts
-# or size-driven rotation.  Default is
-# off, meaning append to existing files
-# in all cases.
-log_rotation_age = '1d' # Automatic rotation of logfiles will
-# happen after that time.  0 disables.
-log_rotation_size = 0 # Automatic rotation of logfiles will
-# happen after that much log output.
-# 0 disables.
+					# begin with 0 to use octal notation
+log_rotation_age = 1d			# Automatic rotation of logfiles will
+					# happen after that time.  0 disables.
+log_rotation_size = 0		# Automatic rotation of logfiles will
+					# happen after that much log output.
+					# 0 disables.
+log_truncate_on_rotation = on		# If on, an existing log file with the
+					# same name as the new log file will be
+					# truncated rather than appended to.
+					# But such truncation only occurs on
+					# time-driven rotation, not on restarts
+					# or size-driven rotation.  Default is
+					# off, meaning append to existing files
+					# in all cases.
 
 # These are relevant when logging to syslog:
 #syslog_facility = 'LOCAL0'
@@ -453,58 +486,64 @@ log_rotation_size = 0 # Automatic rotation of logfiles will
 #syslog_sequence_numbers = on
 #syslog_split_messages = on
 
-# This is only relevant when logging to eventlog (win32):
+# This is only relevant when logging to eventlog (Windows):
 # (change requires restart)
 #event_source = 'PostgreSQL'
 
 # - When to Log -
 
 #log_min_messages = warning		# values in order of decreasing detail:
-#   debug5
-#   debug4
-#   debug3
-#   debug2
-#   debug1
-#   info
-#   notice
-#   warning
-#   error
-#   log
-#   fatal
-#   panic
+					#   debug5
+					#   debug4
+					#   debug3
+					#   debug2
+					#   debug1
+					#   info
+					#   notice
+					#   warning
+					#   error
+					#   log
+					#   fatal
+					#   panic
 
 #log_min_error_statement = error	# values in order of decreasing detail:
-#   debug5
-#   debug4
-#   debug3
-#   debug2
-#   debug1
-#   info
-#   notice
-#   warning
-#   error
-#   log
-#   fatal
-#   panic (effectively off)
+					#   debug5
+					#   debug4
+					#   debug3
+					#   debug2
+					#   debug1
+					#   info
+					#   notice
+					#   warning
+					#   error
+					#   log
+					#   fatal
+					#   panic (effectively off)
 
 #log_min_duration_statement = -1	# -1 is disabled, 0 logs all statements
-# and their durations, > 0 logs only
-# statements running at least this number
-# of milliseconds
+					# and their durations, > 0 logs only
+					# statements running at least this number
+					# of milliseconds
 
 #log_min_duration_sample = -1		# -1 is disabled, 0 logs a sample of statements
-# and their durations, > 0 logs only a sample of
-# statements running at least this number
-# of milliseconds;
-# sample fraction is determined by log_statement_sample_rate
+					# and their durations, > 0 logs only a sample of
+					# statements running at least this number
+					# of milliseconds;
+					# sample fraction is determined by log_statement_sample_rate
 
 #log_statement_sample_rate = 1.0	# fraction of logged statements exceeding
-# log_min_duration_sample to be logged;
-# 1.0 logs all such statements, 0.0 never logs
+					# log_min_duration_sample to be logged;
+					# 1.0 logs all such statements, 0.0 never logs
+
 
 #log_transaction_sample_rate = 0.0	# fraction of transactions whose statements
-# are logged regardless of their duration; 1.0 logs all
-# statements from all transactions, 0.0 never logs
+					# are logged regardless of their duration; 1.0 logs all
+					# statements from all transactions, 0.0 never logs
+
+#log_startup_progress_interval = 10s	# Time between progress updates for
+					# long-running startup operations.
+					# 0 disables the feature, > 0 indicates
+					# the interval in milliseconds.
 
 # - What to Log -
 
@@ -512,114 +551,120 @@ log_rotation_size = 0 # Automatic rotation of logfiles will
 #debug_print_rewritten = off
 #debug_print_plan = off
 #debug_pretty_print = on
-#log_checkpoints = off
+#log_autovacuum_min_duration = 10min	# log autovacuum activity;
+					# -1 disables, 0 logs all actions and
+					# their durations, > 0 logs only
+					# actions running at least this number
+					# of milliseconds.
+#log_checkpoints = on
+log_connections = true
+#log_disconnections = off
+#log_duration = off
 #log_error_verbosity = default		# terse, default, or verbose messages
 #log_hostname = off
-
-log_line_prefix = '%t %u'
-#log_line_prefix = '%m [%p] '		# special values:
-#   %a = application name
-#   %u = user name
-#   %d = database name
-#   %r = remote host and port
-#   %h = remote host
-#   %b = backend type
-#   %p = process ID
-#   %t = timestamp without milliseconds
-#   %m = timestamp with milliseconds
-#   %n = timestamp with milliseconds (as a Unix epoch)
-#   %i = command tag
-#   %e = SQL state
-#   %c = session ID
-#   %l = session line number
-#   %s = session start timestamp
-#   %v = virtual transaction ID
-#   %x = transaction ID (0 if none)
-#   %q = stop here in non-session
-#        processes
-#   %% = '%'
-# e.g. '<%u%%%d> '
+log_line_prefix = '%t %u '		# special values:
+					#   %a = application name
+					#   %u = user name
+					#   %d = database name
+					#   %r = remote host and port
+					#   %h = remote host
+					#   %b = backend type
+					#   %p = process ID
+					#   %P = process ID of parallel group leader
+					#   %t = timestamp without milliseconds
+					#   %m = timestamp with milliseconds
+					#   %n = timestamp with milliseconds (as a Unix epoch)
+					#   %Q = query ID (0 if none or not computed)
+					#   %i = command tag
+					#   %e = SQL state
+					#   %c = session ID
+					#   %l = session line number
+					#   %s = session start timestamp
+					#   %v = virtual transaction ID
+					#   %x = transaction ID (0 if none)
+					#   %q = stop here in non-session
+					#        processes
+					#   %% = '%'
+					# e.g. '<%u%%%d> '
 #log_lock_waits = off			# log lock waits >= deadlock_timeout
+#log_recovery_conflict_waits = off	# log standby recovery conflict waits
+					# >= deadlock_timeout
 #log_parameter_max_length = -1		# when logging statements, limit logged
-# bind-parameter values to N bytes;
-# -1 means print in full, 0 disables
+					# bind-parameter values to N bytes;
+					# -1 means print in full, 0 disables
 #log_parameter_max_length_on_error = 0	# when logging an error, limit logged
-# bind-parameter values to N bytes;
-# -1 means print in full, 0 disables
-#log_statement = 'none'			# none, ddl, mod, all
-log_statement = 'mod'
-log_connections = 1
-log_disconnections = 0
-log_duration = 0
+					# bind-parameter values to N bytes;
+					# -1 means print in full, 0 disables
+log_statement = 'mod'			# none, ddl, mod, all
 #log_replication_commands = off
 #log_temp_files = -1			# log temporary files equal or larger
-# than the specified size in kilobytes;
-# -1 disables, 0 logs all temp files
+					# than the specified size in kilobytes;
+					# -1 disables, 0 logs all temp files
 log_timezone = 'Etc/UTC'
 
-#------------------------------------------------------------------------------
-# PROCESS TITLE
-#------------------------------------------------------------------------------
+# - Process Title -
 
 #cluster_name = ''			# added to process titles if nonempty
-# (change requires restart)
+					# (change requires restart)
 #update_process_title = on
+
 
 #------------------------------------------------------------------------------
 # STATISTICS
 #------------------------------------------------------------------------------
 
-# - Query and Index Statistics Collector -
+# - Cumulative Query and Index Statistics -
 
 #track_activities = on
+#track_activity_query_size = 1024	# (change requires restart)
 #track_counts = on
 #track_io_timing = off
+#track_wal_io_timing = off
 #track_functions = none			# none, pl, all
-#track_activity_query_size = 1024	# (change requires restart)
-#stats_temp_directory = 'pg_stat_tmp'
+#stats_fetch_consistency = cache	# cache, none, snapshot
+
 
 # - Monitoring -
 
+#compute_query_id = auto
+#log_statement_stats = off
 #log_parser_stats = off
 #log_planner_stats = off
 #log_executor_stats = off
-#log_statement_stats = off
+
 
 #------------------------------------------------------------------------------
 # AUTOVACUUM
 #------------------------------------------------------------------------------
 
-autovacuum = on # Enable autovacuum subprocess?  'on'
-# requires track_counts to also be on.
-log_autovacuum_min_duration = 20000 # -1 disables, 0 logs all actions and # 20 seconds = 20000 ms
-# their durations, > 0 logs only
-# actions running at least this number
-# of milliseconds.
-autovacuum_max_workers = 3 # max number of autovacuum subprocesses
-# (change requires restart)
+#autovacuum = on			# Enable autovacuum subprocess?  'on'
+					# requires track_counts to also be on.
+#autovacuum_max_workers = 3		# max number of autovacuum subprocesses
+					# (change requires restart)
 #autovacuum_naptime = 1min		# time between autovacuum runs
 #autovacuum_vacuum_threshold = 50	# min number of row updates before
-# vacuum
+					# vacuum
 #autovacuum_vacuum_insert_threshold = 1000	# min number of row inserts
-# before vacuum; -1 disables insert
-# vacuums
+					# before vacuum; -1 disables insert
+					# vacuums
 #autovacuum_analyze_threshold = 50	# min number of row updates before
-# analyze
+					# analyze
 #autovacuum_vacuum_scale_factor = 0.2	# fraction of table size before vacuum
 #autovacuum_vacuum_insert_scale_factor = 0.2	# fraction of inserts over table
-# size before insert vacuum
+					# size before insert vacuum
 #autovacuum_analyze_scale_factor = 0.1	# fraction of table size before analyze
 #autovacuum_freeze_max_age = 200000000	# maximum XID age before forced vacuum
-# (change requires restart)
+					# (change requires restart)
 #autovacuum_multixact_freeze_max_age = 400000000	# maximum multixact age
-# before forced vacuum
-# (change requires restart)
+					# before forced vacuum
+					# (change requires restart)
 #autovacuum_vacuum_cost_delay = 2ms	# default vacuum cost delay for
-# autovacuum, in milliseconds;
-# -1 means use vacuum_cost_delay
+					# autovacuum, in milliseconds;
+					# -1 means use vacuum_cost_delay
 #autovacuum_vacuum_cost_limit = -1	# default vacuum cost limit for
-# autovacuum, -1 means use
-# vacuum_cost_limit
+					# autovacuum, -1 means use
+					# vacuum_cost_limit
+
 
 #------------------------------------------------------------------------------
 # CLIENT CONNECTION DEFAULTS
@@ -628,21 +673,22 @@ autovacuum_max_workers = 3 # max number of autovacuum subprocesses
 # - Statement Behavior -
 
 #client_min_messages = notice		# values in order of decreasing detail:
-#   debug5
-#   debug4
-#   debug3
-#   debug2
-#   debug1
-#   log
-#   notice
-#   warning
-#   error
+					#   debug5
+					#   debug4
+					#   debug3
+					#   debug2
+					#   debug1
+					#   log
+					#   notice
+					#   warning
+					#   error
 #search_path = '"$user", public'	# schema names
 #row_security = on
-#default_tablespace = ''		# a tablespace name, '' uses the default
-#temp_tablespaces = ''			# a list of tablespace names, '' uses
-# only default tablespace
 #default_table_access_method = 'heap'
+#default_tablespace = ''		# a tablespace name, '' uses the default
+#default_toast_compression = 'pglz'	# 'pglz' or 'lz4'
+#temp_tablespaces = ''			# a list of tablespace names, '' uses
+					# only default tablespace
 #check_function_bodies = on
 #default_transaction_isolation = 'read committed'
 #default_transaction_read_only = off
@@ -651,18 +697,18 @@ autovacuum_max_workers = 3 # max number of autovacuum subprocesses
 #statement_timeout = 0			# in milliseconds, 0 is disabled
 #lock_timeout = 0			# in milliseconds, 0 is disabled
 #idle_in_transaction_session_timeout = 0	# in milliseconds, 0 is disabled
-#vacuum_freeze_min_age = 50000000
+#idle_session_timeout = 0		# in milliseconds, 0 is disabled
 #vacuum_freeze_table_age = 150000000
-#vacuum_multixact_freeze_min_age = 5000000
+#vacuum_freeze_min_age = 50000000
+#vacuum_failsafe_age = 1600000000
 #vacuum_multixact_freeze_table_age = 150000000
-#vacuum_cleanup_index_scale_factor = 0.1	# fraction of total number of tuples
-# before index cleanup, 0 always performs
-# index cleanup
+#vacuum_multixact_freeze_min_age = 5000000
+#vacuum_multixact_failsafe_age = 1600000000
 #bytea_output = 'hex'			# hex, escape
 #xmlbinary = 'base64'
 #xmloption = 'content'
-#gin_fuzzy_search_limit = 0
 #gin_pending_list_limit = 4MB
+#createrole_self_grant = ''		# set and/or inherit
 
 # - Locale and Formatting -
 
@@ -670,39 +716,44 @@ datestyle = 'iso, mdy'
 #intervalstyle = 'postgres'
 timezone = 'Etc/UTC'
 #timezone_abbreviations = 'Default'     # Select the set of available time zone
-# abbreviations.  Currently, there are
-#   Default
-#   Australia (historical usage)
-#   India
-# You can create your own file in
-# share/timezonesets/.
+					# abbreviations.  Currently, there are
+					#   Default
+					#   Australia (historical usage)
+					#   India
+					# You can create your own file in
+					# share/timezonesets/.
 #extra_float_digits = 1			# min -15, max 3; any value >0 actually
-# selects precise output mode
+					# selects precise output mode
 #client_encoding = sql_ascii		# actually, defaults to database
-# encoding
+					# encoding
 
 # These settings are initialized by initdb, but they can be changed.
-lc_messages = 'en_US.utf8' # locale for system error message
-# strings
-lc_monetary = 'en_US.utf8' # locale for monetary formatting
-lc_numeric = 'en_US.utf8'  # locale for number formatting
-lc_time = 'en_US.utf8'     # locale for time formatting
+lc_messages = 'en_US.utf8'		# locale for system error message
+					# strings
+lc_monetary = 'en_US.utf8'		# locale for monetary formatting
+lc_numeric = 'en_US.utf8'		# locale for number formatting
+lc_time = 'en_US.utf8'			# locale for time formatting
+
+#icu_validation_level = warning		# report ICU locale validation
+					# errors at the given level
 
 # default configuration for text search
 default_text_search_config = 'pg_catalog.english'
 
 # - Shared Library Preloading -
 
-#shared_preload_libraries = ''	# (change requires restart)
 #local_preload_libraries = ''
 #session_preload_libraries = ''
+#shared_preload_libraries = ''	# (change requires restart)
 #jit_provider = 'llvmjit'		# JIT library to use
 
 # - Other Defaults -
 
 #dynamic_library_path = '$libdir'
 #extension_destdir = ''			# prepend path when loading extensions
-# and shared objects (added by Debian)
+					# and shared objects (added by Debian)
+#gin_fuzzy_search_limit = 0
+
 
 #------------------------------------------------------------------------------
 # LOCK MANAGEMENT
@@ -710,13 +761,14 @@ default_text_search_config = 'pg_catalog.english'
 
 #deadlock_timeout = 1s
 #max_locks_per_transaction = 64		# min 10
-# (change requires restart)
+					# (change requires restart)
 #max_pred_locks_per_transaction = 64	# min 10
-# (change requires restart)
+					# (change requires restart)
 #max_pred_locks_per_relation = -2	# negative values mean
-# (max_pred_locks_per_transaction
-#  / -max_pred_locks_per_relation) - 1
+					# (max_pred_locks_per_transaction
+					#  / -max_pred_locks_per_relation) - 1
 #max_pred_locks_per_page = 2            # min 0
+
 
 #------------------------------------------------------------------------------
 # VERSION AND PLATFORM COMPATIBILITY
@@ -728,7 +780,6 @@ default_text_search_config = 'pg_catalog.english'
 #backslash_quote = safe_encoding	# on, off, or safe_encoding
 #escape_string_warning = on
 #lo_compat_privileges = off
-#operator_precedence_warning = off
 #quote_all_identifiers = off
 #standard_conforming_strings = on
 #synchronize_seqscans = on
@@ -737,6 +788,7 @@ default_text_search_config = 'pg_catalog.english'
 
 #transform_null_equals = off
 
+
 #------------------------------------------------------------------------------
 # ERROR HANDLING
 #------------------------------------------------------------------------------
@@ -744,8 +796,10 @@ default_text_search_config = 'pg_catalog.english'
 #exit_on_error = off			# terminate session on any error?
 #restart_after_crash = on		# reinitialize after backend crash?
 #data_sync_retry = off			# retry or panic on failure to fsync
-# data?
-# (change requires restart)
+					# data?
+					# (change requires restart)
+#recovery_init_sync_method = fsync	# fsync, syncfs (Linux 5.8+)
+
 
 #------------------------------------------------------------------------------
 # CONFIG FILE INCLUDES
@@ -756,9 +810,10 @@ default_text_search_config = 'pg_catalog.english'
 # assignments, so they can usefully be given more than once.
 
 #include_dir = '...'			# include files ending in '.conf' from
-# a directory, e.g., 'conf.d'
+					# a directory, e.g., 'conf.d'
 #include_if_exists = '...'		# include file only if it exists
 #include = '...'			# include file
+
 
 #------------------------------------------------------------------------------
 # CUSTOMIZED OPTIONS

--- a/services/postgres/updateConfig.sh
+++ b/services/postgres/updateConfig.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 
-cat /tmp/postgresql.conf >/var/lib/postgresql/data/pgdata/postgresql.conf
+cat /tmp/postgresql.conf >/var/lib/postgresql/data/postgresql.conf
+cat /tmp/pg_hba.conf >/var/lib/postgresql/data/pg_hba.conf

--- a/services/postgres/updateConfig.sh
+++ b/services/postgres/updateConfig.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-
-cat /tmp/postgresql.conf >/var/lib/postgresql/data/postgresql.conf
-cat /tmp/pg_hba.conf >/var/lib/postgresql/data/pg_hba.conf


### PR DESCRIPTION
## Objective 

[MDS-6291](https://bcmines.atlassian.net/browse/MDS-6291)

Aim: Update development setups to run Postgresql version 16. (17 is too new for crunchyDB)
- Updated postgres dockerfile to postgis 16-3.5 and FDW client
- Added new postgres_update container to both the M1 and standard(untested!) docker-compose files. (Not the ci one at this time)
- Added make updatedb command to automate the process of backing up, updating and re-creating postgres db.
- Had to change how the postgresql.conf and ph_hba.conf were being applied to the container as they are on a volume and initdb only runs if there is no existing postgresql install (Which there is after an upgrade!)
- Fixed a migration, which means the checksum will need to be updated if you want to run a flyway verify. `update public.flyway_schema_history set checksum = '-702230991' where version = '2021.06.03'`

To run locally:
- Pull this branch
- Run `make updatedb`. This will stop the running container, make a volume backup, delete the old image, perform the update and build the new postgres image.

@simensma-fresh Can you please review my changes and be my test dummy before anyone else tries to run this locally 
