### PR TITLE
[MDS-6334] Fix condition category bad request

### DIFF
--- a/services/core-api/app/api/mines/permits/permit_conditions/models/permit_conditions.py
+++ b/services/core-api/app/api/mines/permits/permit_conditions/models/permit_conditions.py
@@ -16,7 +16,7 @@ class PermitConditions(SoftDeleteMixin, AuditMixin, Base):
     class _ModelSchema(Base._ModelSchema):
         permit_condition_id = fields.Integer(dump_only=True)
         permit_condition_guid = fields.UUID(dump_only=True)
-        condition_category_code = fields.String(dump_only=True)
+        condition_category_code = fields.String(dump_only=False)
         condition_type_code = FieldTemplate(
             field=fields.String, one_of="PermitConditionType"
         )

--- a/services/core-api/app/api/mines/permits/permit_conditions/models/permit_conditions.py
+++ b/services/core-api/app/api/mines/permits/permit_conditions/models/permit_conditions.py
@@ -16,9 +16,7 @@ class PermitConditions(SoftDeleteMixin, AuditMixin, Base):
     class _ModelSchema(Base._ModelSchema):
         permit_condition_id = fields.Integer(dump_only=True)
         permit_condition_guid = fields.UUID(dump_only=True)
-        condition_category_code = FieldTemplate(
-            field=fields.String, one_of="PermitConditionCategory"
-        )
+        condition_category_code = fields.String(dump_only=True)
         condition_type_code = FieldTemplate(
             field=fields.String, one_of="PermitConditionType"
         )

--- a/services/core-api/app/api/mines/permits/permit_conditions/resources/permit_conditions_resource.py
+++ b/services/core-api/app/api/mines/permits/permit_conditions/resources/permit_conditions_resource.py
@@ -11,6 +11,7 @@ from app.api.mines.permits.permit_amendment.models.permit_amendment import Permi
 from app.api.utils.access_decorators import MINESPACE_PROPONENT, VIEW_ALL, requires_role_edit_permit, requires_any_of
 from app.api.utils.resources_mixins import UserMixin
 from app.api.mines.permits.permit.models.permit import Permit
+from app.api.mines.permits.permit_conditions.models.permit_condition_category import PermitConditionCategory
 from app.api.mines.mine.models.mine import Mine
 from app.api.utils.include.user_info import User
 
@@ -31,6 +32,9 @@ class PermitConditionsListResource(Resource, UserMixin):
 
         try:
             permit_condition = PermitConditions._schema().load(request.json['permit_condition'])
+
+            if not PermitConditionCategory.find_by_permit_condition_category_code(permit_condition.condition_category_code):
+                raise BadRequest('condition_category_code is invalid')
 
             if permit_condition.top_level_parent_permit_condition_id is not None:
                 top_condition = PermitConditions.find_by_permit_condition_id(permit_condition.top_level_parent_permit_condition_id)
@@ -88,6 +92,8 @@ class PermitConditionsResource(Resource, UserMixin):
         old_display_order = old_condition.display_order
         old_category_code = old_condition.condition_category_code
         new_category_code = request_data.get("condition_category_code", None)
+        if not PermitConditionCategory.find_by_permit_condition_category_code(new_category_code):
+            raise BadRequest('condition_category_code is invalid')
         changed_category = old_category_code != new_category_code
         new_status_code = request_data.get("permit_condition_status_code",None)
         changed_status = old_condition.permit_condition_status_code != new_status_code


### PR DESCRIPTION
## Objective 

[MDS-6334](https://bcmines.atlassian.net/browse/MDS-6334)

Small PR to fix a bug where newly extracted permit conditions were unable to be updated. This was caused by the validation checking the static data instead of live data for the conditon_category_code, likely a remnant from the original implementation which only included 5 standard categories and not custom/unique categories per extraction.

I have removed the validation from the marshalling and instead added checks on the create and update PermitConditions endpoints. There may be other endpoints that also need this validation but I'm not sure which.

![image](https://github.com/user-attachments/assets/3c3d5af6-4f86-4d93-97ff-3c94b81f9874)



