### PR TITLE
[MDS-6347] Fix to add report bug and other css issues

### DIFF
--- a/services/core-web/src/components/mine/Permit/PermitConditionForm.tsx
+++ b/services/core-web/src/components/mine/Permit/PermitConditionForm.tsx
@@ -185,7 +185,7 @@ const PermitConditionForm: FC<PermitConditionFormProps> = ({
             <Row
                 wrap={false}
                 align="top"
-                className={`condition-content ${!editingConditionGuid ? "editable" : ""}`}
+                className={`condition-content ${!editingConditionGuid ? "editable" : ""} ${!condition.parent_permit_condition_id ? "top-level-condition" : ""}`}
             >
                 <Col className="step-column" style={{ flexShrink: 0 }}>
                     <Field
@@ -238,8 +238,9 @@ const PermitConditionForm: FC<PermitConditionFormProps> = ({
                                     type="default"
                                     icon={<FontAwesomeIcon icon={faClipboard} />}
                                     onClick={(e) => handleOpenAddReportModal(e, condition)}
+                                    disabled={condition?.mineReportPermitRequirement !== undefined}
                                 >
-                                    Add Report Requirement
+                                    {condition?.mineReportPermitRequirement ? "Report Added" : "Add Report Requirement"}
                                 </Button>
                             </Col>
                             <Col>

--- a/services/core-web/src/components/mine/Permit/PermitConditionForm.tsx
+++ b/services/core-web/src/components/mine/Permit/PermitConditionForm.tsx
@@ -185,7 +185,7 @@ const PermitConditionForm: FC<PermitConditionFormProps> = ({
             <Row
                 wrap={false}
                 align="top"
-                className={`condition-content ${!editingConditionGuid ? "editable" : ""} ${!condition.parent_permit_condition_id ? "top-level-condition" : ""}`}
+                className={`condition-content ${!editingConditionGuid ? "editable" : ""}${!condition.parent_permit_condition_id ? " top-level-condition" : ""}`}
             >
                 <Col className="step-column" style={{ flexShrink: 0 }}>
                     <Field

--- a/services/core-web/src/components/mine/Permit/PermitConditionLayer.tsx
+++ b/services/core-web/src/components/mine/Permit/PermitConditionLayer.tsx
@@ -156,7 +156,7 @@ const PermitConditionLayer: FC<PermitConditionLayerProps> = ({
       {level == 0 && isFeatureEnabled(Feature.MODIFY_PERMIT_CONDITIONS) && (
         <div>
           {(!condition?.parent_permit_condition_id && requirements.length > 0) && (
-            <div className="report-collapse-container ">
+            <div className="report-collapse-container">
               <Title level={4} className="primary-colour">
                 Report Requirements
               </Title>

--- a/services/core-web/src/components/mine/Permit/PermitConditionReviewAssignment.tsx
+++ b/services/core-web/src/components/mine/Permit/PermitConditionReviewAssignment.tsx
@@ -51,8 +51,10 @@ const PermitConditionReviewAssignment: FC<PermitConditionReviewAssignmentProps> 
     userHasRole(state, USER_ROLES.role_edit_template_conditions)
   );
 
+  const isUserAssigned = user?.sub === category?.assigned_review_user?.sub;
+
   const userCanUnassignReviewer =
-    user?.sub === category?.assigned_review_user?.sub || userCanAssignReviewers;
+    isUserAssigned || userCanAssignReviewers;
 
   const formName = `${FORM.PERMIT_CONDITION_REVIEW_ASSIGNMENT}-${category.condition_category_code}`;
 
@@ -96,7 +98,9 @@ const PermitConditionReviewAssignment: FC<PermitConditionReviewAssignmentProps> 
         condition_category_code: category.condition_category_code,
       }}
     >
-      <Row align="top" justify="start" gutter={16}>
+      <Row align="top" justify="start" gutter={16}
+        className={`${isUserAssigned ? "" : "condition-category-reviewer-row"}`}
+      >
         <Col>
           <Typography.Paragraph>Assigned Reviewer</Typography.Paragraph>
         </Col>

--- a/services/core-web/src/components/mine/Permit/__snapshots__/PermitConditionForm.spec.tsx.snap
+++ b/services/core-web/src/components/mine/Permit/__snapshots__/PermitConditionForm.spec.tsx.snap
@@ -7,7 +7,7 @@ exports[`PermitConditionForm renders properly in edit mode 1`] = `
     id="EDIT_PERMIT_CONDITION_1639_HSC"
   >
     <div
-      class="ant-row ant-row-no-wrap ant-row-top condition-content editable"
+      class="ant-row ant-row-no-wrap ant-row-top condition-content editable top-level-condition"
     >
       <div
         class="ant-col step-column"

--- a/services/core-web/src/components/mine/Permit/__snapshots__/PermitConditions.spec.tsx.snap
+++ b/services/core-web/src/components/mine/Permit/__snapshots__/PermitConditions.spec.tsx.snap
@@ -1609,7 +1609,7 @@ exports[`PermitConditions renders properly 1`] = `
                                             id="EDIT_PERMIT_CONDITION_1641_ELC"
                                           >
                                             <div
-                                              class="ant-row ant-row-no-wrap ant-row-top condition-content editable "
+                                              class="ant-row ant-row-no-wrap ant-row-top condition-content editable"
                                             >
                                               <div
                                                 class="ant-col step-column"
@@ -1654,7 +1654,7 @@ exports[`PermitConditions renders properly 1`] = `
                                                   id="EDIT_PERMIT_CONDITION_1644_ELC"
                                                 >
                                                   <div
-                                                    class="ant-row ant-row-no-wrap ant-row-top condition-content editable "
+                                                    class="ant-row ant-row-no-wrap ant-row-top condition-content editable"
                                                   >
                                                     <div
                                                       class="ant-col step-column"
@@ -1705,7 +1705,7 @@ exports[`PermitConditions renders properly 1`] = `
                                             id="EDIT_PERMIT_CONDITION_12507_ELC"
                                           >
                                             <div
-                                              class="ant-row ant-row-no-wrap ant-row-top condition-content editable "
+                                              class="ant-row ant-row-no-wrap ant-row-top condition-content editable"
                                             >
                                               <div
                                                 class="ant-col step-column"
@@ -1750,7 +1750,7 @@ exports[`PermitConditions renders properly 1`] = `
                                                   id="EDIT_PERMIT_CONDITION_12509_ELC"
                                                 >
                                                   <div
-                                                    class="ant-row ant-row-no-wrap ant-row-top condition-content editable "
+                                                    class="ant-row ant-row-no-wrap ant-row-top condition-content editable"
                                                   >
                                                     <div
                                                       class="ant-col step-column"
@@ -1795,7 +1795,7 @@ exports[`PermitConditions renders properly 1`] = `
                                                         id="EDIT_PERMIT_CONDITION_12510_ELC"
                                                       >
                                                         <div
-                                                          class="ant-row ant-row-no-wrap ant-row-top condition-content editable "
+                                                          class="ant-row ant-row-no-wrap ant-row-top condition-content editable"
                                                         >
                                                           <div
                                                             class="ant-col step-column"
@@ -1843,7 +1843,7 @@ exports[`PermitConditions renders properly 1`] = `
                                                         id="EDIT_PERMIT_CONDITION_12511_ELC"
                                                       >
                                                         <div
-                                                          class="ant-row ant-row-no-wrap ant-row-top condition-content editable "
+                                                          class="ant-row ant-row-no-wrap ant-row-top condition-content editable"
                                                         >
                                                           <div
                                                             class="ant-col step-column"
@@ -1891,7 +1891,7 @@ exports[`PermitConditions renders properly 1`] = `
                                                         id="EDIT_PERMIT_CONDITION_12512_ELC"
                                                       >
                                                         <div
-                                                          class="ant-row ant-row-no-wrap ant-row-top condition-content editable "
+                                                          class="ant-row ant-row-no-wrap ant-row-top condition-content editable"
                                                         >
                                                           <div
                                                             class="ant-col step-column"
@@ -1936,7 +1936,7 @@ exports[`PermitConditions renders properly 1`] = `
                                                               id="EDIT_PERMIT_CONDITION_12513_ELC"
                                                             >
                                                               <div
-                                                                class="ant-row ant-row-no-wrap ant-row-top condition-content editable "
+                                                                class="ant-row ant-row-no-wrap ant-row-top condition-content editable"
                                                               >
                                                                 <div
                                                                   class="ant-col step-column"
@@ -2093,7 +2093,7 @@ exports[`PermitConditions renders properly 1`] = `
                                             id="EDIT_PERMIT_CONDITION_12515_ELC"
                                           >
                                             <div
-                                              class="ant-row ant-row-no-wrap ant-row-top condition-content editable "
+                                              class="ant-row ant-row-no-wrap ant-row-top condition-content editable"
                                             >
                                               <div
                                                 class="ant-col step-column"

--- a/services/core-web/src/components/mine/Permit/__snapshots__/PermitConditions.spec.tsx.snap
+++ b/services/core-web/src/components/mine/Permit/__snapshots__/PermitConditions.spec.tsx.snap
@@ -1016,7 +1016,7 @@ exports[`PermitConditions renders properly 1`] = `
                                       id="EDIT_PERMIT_CONDITION_1639_HSC"
                                     >
                                       <div
-                                        class="ant-row ant-row-no-wrap ant-row-top condition-content editable"
+                                        class="ant-row ant-row-no-wrap ant-row-top condition-content editable top-level-condition"
                                       >
                                         <div
                                           class="ant-col step-column"
@@ -1152,7 +1152,7 @@ exports[`PermitConditions renders properly 1`] = `
                                   id="PERMIT_CONDITION_REVIEW_ASSIGNMENT-RCC"
                                 >
                                   <div
-                                    class="ant-row ant-row-start ant-row-top"
+                                    class="ant-row ant-row-start ant-row-top condition-category-reviewer-row"
                                     style="margin-left: -8px; margin-right: -8px;"
                                   >
                                     <div
@@ -1305,7 +1305,7 @@ exports[`PermitConditions renders properly 1`] = `
                                       id="EDIT_PERMIT_CONDITION_1646_RCC"
                                     >
                                       <div
-                                        class="ant-row ant-row-no-wrap ant-row-top condition-content editable"
+                                        class="ant-row ant-row-no-wrap ant-row-top condition-content editable top-level-condition"
                                       >
                                         <div
                                           class="ant-col step-column"
@@ -1411,7 +1411,7 @@ exports[`PermitConditions renders properly 1`] = `
                                   id="PERMIT_CONDITION_REVIEW_ASSIGNMENT-ELC"
                                 >
                                   <div
-                                    class="ant-row ant-row-start ant-row-top"
+                                    class="ant-row ant-row-start ant-row-top condition-category-reviewer-row"
                                     style="margin-left: -8px; margin-right: -8px;"
                                   >
                                     <div
@@ -1564,7 +1564,7 @@ exports[`PermitConditions renders properly 1`] = `
                                       id="EDIT_PERMIT_CONDITION_1650_ELC"
                                     >
                                       <div
-                                        class="ant-row ant-row-no-wrap ant-row-top condition-content editable"
+                                        class="ant-row ant-row-no-wrap ant-row-top condition-content editable top-level-condition"
                                       >
                                         <div
                                           class="ant-col step-column"
@@ -1609,7 +1609,7 @@ exports[`PermitConditions renders properly 1`] = `
                                             id="EDIT_PERMIT_CONDITION_1641_ELC"
                                           >
                                             <div
-                                              class="ant-row ant-row-no-wrap ant-row-top condition-content editable"
+                                              class="ant-row ant-row-no-wrap ant-row-top condition-content editable "
                                             >
                                               <div
                                                 class="ant-col step-column"
@@ -1654,7 +1654,7 @@ exports[`PermitConditions renders properly 1`] = `
                                                   id="EDIT_PERMIT_CONDITION_1644_ELC"
                                                 >
                                                   <div
-                                                    class="ant-row ant-row-no-wrap ant-row-top condition-content editable"
+                                                    class="ant-row ant-row-no-wrap ant-row-top condition-content editable "
                                                   >
                                                     <div
                                                       class="ant-col step-column"
@@ -1705,7 +1705,7 @@ exports[`PermitConditions renders properly 1`] = `
                                             id="EDIT_PERMIT_CONDITION_12507_ELC"
                                           >
                                             <div
-                                              class="ant-row ant-row-no-wrap ant-row-top condition-content editable"
+                                              class="ant-row ant-row-no-wrap ant-row-top condition-content editable "
                                             >
                                               <div
                                                 class="ant-col step-column"
@@ -1750,7 +1750,7 @@ exports[`PermitConditions renders properly 1`] = `
                                                   id="EDIT_PERMIT_CONDITION_12509_ELC"
                                                 >
                                                   <div
-                                                    class="ant-row ant-row-no-wrap ant-row-top condition-content editable"
+                                                    class="ant-row ant-row-no-wrap ant-row-top condition-content editable "
                                                   >
                                                     <div
                                                       class="ant-col step-column"
@@ -1795,7 +1795,7 @@ exports[`PermitConditions renders properly 1`] = `
                                                         id="EDIT_PERMIT_CONDITION_12510_ELC"
                                                       >
                                                         <div
-                                                          class="ant-row ant-row-no-wrap ant-row-top condition-content editable"
+                                                          class="ant-row ant-row-no-wrap ant-row-top condition-content editable "
                                                         >
                                                           <div
                                                             class="ant-col step-column"
@@ -1843,7 +1843,7 @@ exports[`PermitConditions renders properly 1`] = `
                                                         id="EDIT_PERMIT_CONDITION_12511_ELC"
                                                       >
                                                         <div
-                                                          class="ant-row ant-row-no-wrap ant-row-top condition-content editable"
+                                                          class="ant-row ant-row-no-wrap ant-row-top condition-content editable "
                                                         >
                                                           <div
                                                             class="ant-col step-column"
@@ -1891,7 +1891,7 @@ exports[`PermitConditions renders properly 1`] = `
                                                         id="EDIT_PERMIT_CONDITION_12512_ELC"
                                                       >
                                                         <div
-                                                          class="ant-row ant-row-no-wrap ant-row-top condition-content editable"
+                                                          class="ant-row ant-row-no-wrap ant-row-top condition-content editable "
                                                         >
                                                           <div
                                                             class="ant-col step-column"
@@ -1936,7 +1936,7 @@ exports[`PermitConditions renders properly 1`] = `
                                                               id="EDIT_PERMIT_CONDITION_12513_ELC"
                                                             >
                                                               <div
-                                                                class="ant-row ant-row-no-wrap ant-row-top condition-content editable"
+                                                                class="ant-row ant-row-no-wrap ant-row-top condition-content editable "
                                                               >
                                                                 <div
                                                                   class="ant-col step-column"
@@ -2048,7 +2048,7 @@ exports[`PermitConditions renders properly 1`] = `
                                       id="EDIT_PERMIT_CONDITION_12514_ELC"
                                     >
                                       <div
-                                        class="ant-row ant-row-no-wrap ant-row-top condition-content editable"
+                                        class="ant-row ant-row-no-wrap ant-row-top condition-content editable top-level-condition"
                                       >
                                         <div
                                           class="ant-col step-column"
@@ -2093,7 +2093,7 @@ exports[`PermitConditions renders properly 1`] = `
                                             id="EDIT_PERMIT_CONDITION_12515_ELC"
                                           >
                                             <div
-                                              class="ant-row ant-row-no-wrap ant-row-top condition-content editable"
+                                              class="ant-row ant-row-no-wrap ant-row-top condition-content editable "
                                             >
                                               <div
                                                 class="ant-col step-column"

--- a/services/core-web/src/styles/components/PermitConditions.scss
+++ b/services/core-web/src/styles/components/PermitConditions.scss
@@ -34,7 +34,6 @@ div.condition-layer {
     border: 1px solid $transparent-dark-grey;
     border-radius: 4px;
     padding: 16px;
-    font-weight: 700;
 
     p.condition-layer--0 {
       font-weight: 600;
@@ -55,17 +54,27 @@ div.condition-layer {
   }
 }
 
+.top-level-condition {
+  font-weight: 600;
+}
+
 .condition-edit-buttons {
   padding: 0 8px;
 }
 
 .report-collapse-container {
   width: 100%;
-  margin-bottom: 15px;
+  margin-bottom: 16px;
+  margin-top: 16px;
 }
 
 .report-collapse-container>div {
   border: 1px solid #d9d9d9;
+}
+
+.report-collapse-container>h4 {
+  font-size: 1rem;
+  margin-bottom: 16px;
 }
 
 .report-collapse {
@@ -124,4 +133,8 @@ div.condition-layer {
   &--incomplete {
     @extend .bg-color-warning;
   }
+}
+
+.condition-category-reviewer-row {
+  margin-top: 10px;
 }


### PR DESCRIPTION
## Objective 

[MDS-6347](https://bcmines.atlassian.net/browse/MDS-6347)

- Disable add report button for a condition when condition already has a report
- Adjusted spacing around conditions and reports section. Also adjusted font weight for some report fields
