### PR TITLE
[MDS-6362] Updated now review post action to also receive object rather than tuples for documents

### DIFF
--- a/services/core-api/app/api/now_applications/resources/now_application_review_resource.py
+++ b/services/core-api/app/api/now_applications/resources/now_application_review_resource.py
@@ -56,13 +56,13 @@ class NOWApplicationReviewListResource(Resource, UserMixin):
         for doc in new_documents:
             new_mine_doc = MineDocument(
                 mine_guid=now_application.mine_guid,
-                document_manager_guid=doc[0],
-                document_name=doc[1])
+                document_manager_guid=doc.get('document_manager_guid'),
+                document_name=doc.get('document_name'))
             current_app.logger.info('[MDS-5629][%s] - new_mine_doc created' \
                                     '\nmine_guid: %s' \
                                     '\ndocument_manager_guid: %s' \
                                     '\ndocument_name: %s',
-                                    self.__class__.__name__, now_application.mine_guid, doc[0], doc[1])
+                                    self.__class__.__name__, now_application.mine_guid, doc.get('document_manager_guid'), doc.get('document_name'))
             new_now_mine_doc = NOWApplicationDocumentXref(
                 mine_document=new_mine_doc,
                 now_application_document_type_code=data['now_application_document_type_code'],


### PR DESCRIPTION
Missed updating the post method to match the new payload sent by the now review modal documents.  Fixed that here.

## Objective 

[MDS-6362](https://bcmines.atlassian.net/browse/MDS-6362)


