### PR TITLE
[FIX] Don't scroll to top on permit conditions page

### DIFF
--- a/services/core-web/src/components/Forms/permits/conditions/ConditionForm.js
+++ b/services/core-web/src/components/Forms/permits/conditions/ConditionForm.js
@@ -32,6 +32,7 @@ export const ConditionForm = (props) => {
       <Col span={formSpan}>
         <FormWrapper
           name={FORM.CONDITION_SECTION}
+          scrollOnToggleEdit={false}
           reduxFormConfig={{
             onSubmitSuccess: resetForm(FORM.CONDITION_SECTION),
           }}

--- a/services/core-web/src/tests/components/Forms/permits/conditions/__snapshots__/ConditionForm.spec.js.snap
+++ b/services/core-web/src/tests/components/Forms/permits/conditions/__snapshots__/ConditionForm.spec.js.snap
@@ -24,6 +24,7 @@ exports[`ConditionForm renders properly 1`] = `
           "onSubmitSuccess": [Function],
         }
       }
+      scrollOnToggleEdit={false}
     >
       <Field
         component={[Function]}


### PR DESCRIPTION
## Objective 
we don't want to scroll to the top here

_Why are you making this change? Provide a short explanation and/or screenshots_
