### PR TITLE
[MDS-6346] Fix unable to add custom category

### DIFF
--- a/services/common/src/components/common/ScrollSideMenu.tsx
+++ b/services/common/src/components/common/ScrollSideMenu.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect } from "react";
+import React, { FC, ReactNode, useEffect } from "react";
 import { useParams, useHistory, useLocation } from "react-router-dom";
 import { Anchor } from "antd";
 import { ISideMenuOption } from "../../interfaces/common/sideMenuOption.interface";
@@ -14,12 +14,14 @@ export interface ScrollSideMenuProps {
   tabSection?: string;
   offsetTop?: number;
   view?: "default" | "steps" | "anchor";
+  extraItems?: ReactNode;
 }
 
 export const ScrollSideMenu: FC<ScrollSideMenuProps> = ({
   tabSection = "",
   offsetTop = 180,
   view = "anchor",
+  extraItems,
   ...props
 }) => {
   const history = useHistory();
@@ -101,6 +103,7 @@ export const ScrollSideMenu: FC<ScrollSideMenuProps> = ({
             />
           );
         })}
+        {extraItems ?? ''}
       </Anchor>
     </div>
   );

--- a/services/common/src/components/common/ScrollSidePageWrapper.tsx
+++ b/services/common/src/components/common/ScrollSidePageWrapper.tsx
@@ -88,9 +88,7 @@ const ScrollSidePageWrapper: FC<ScrollSidePageWrapperProps> = ({
           style={{ top: menuTopOffset }}
         >
           {/* the 24 matches the margin/padding on the menu/content. Looks nicer */}
-          <ScrollSideMenu offsetTop={topOffset + contentPaddingY} {...menuProps} view={view} />
-
-          {extraItems ?? ''}
+          <ScrollSideMenu offsetTop={topOffset + contentPaddingY} {...menuProps} view={view} extraItems={extraItems} />
         </div>
       )}
       <div className={contentClass} style={{ top: contentTopOffset }}>

--- a/services/common/src/components/common/ScrollSidePageWrapper.tsx
+++ b/services/common/src/components/common/ScrollSidePageWrapper.tsx
@@ -88,7 +88,7 @@ const ScrollSidePageWrapper: FC<ScrollSidePageWrapperProps> = ({
           style={{ top: menuTopOffset }}
         >
           {/* the 24 matches the margin/padding on the menu/content. Looks nicer */}
-          <ScrollSideMenu offsetTop={topOffset + contentPaddingY} {...menuProps} view={view} extraItems={extraItems} />
+          <ScrollSideMenu offsetTop={topOffset + contentPaddingY*2} {...menuProps} view={view} extraItems={extraItems} />
         </div>
       )}
       <div className={contentClass} style={{ top: contentTopOffset }}>

--- a/services/common/src/components/projects/__snapshots__/ProjectDocumentsTab.spec.tsx.snap
+++ b/services/common/src/components/projects/__snapshots__/ProjectDocumentsTab.spec.tsx.snap
@@ -12,7 +12,7 @@ exports[`ProjectDocumentsTab renders properly 1`] = `
       <div>
         <div
           class="ant-anchor-wrapper"
-          style="max-height: calc(100vh - 278px);"
+          style="max-height: calc(100vh - 304px);"
         >
           <div
             class="ant-anchor ant-anchor-fixed"
@@ -239,10 +239,10 @@ exports[`ProjectDocumentsTab renders properly 1`] = `
                 </div>
               </a>
             </div>
+            
           </div>
         </div>
       </div>
-      
     </div>
     <div
       class="side-menu--content"

--- a/services/common/src/redux/actionCreators/permitActionCreator.spec.js
+++ b/services/common/src/redux/actionCreators/permitActionCreator.spec.js
@@ -738,7 +738,7 @@ describe("`createPermitCondition` action creator", () => {
         expect(requestSpy).toHaveBeenCalledWith("CREATE_PERMIT_CONDITION_CATEGORY");
         expect(successSpy).toHaveBeenCalledTimes(1);
         expect(successSpy).toHaveBeenCalledWith("CREATE_PERMIT_CONDITION_CATEGORY");
-        expect(dispatch).toHaveBeenCalledTimes(5);
+        expect(dispatch).toHaveBeenCalledTimes(6);
       });
     });
 
@@ -839,7 +839,7 @@ describe("`createPermitCondition` action creator", () => {
         expect(requestSpy).toHaveBeenCalledWith("DELETE_PERMIT_CONDITION_CATEGORY");
         expect(successSpy).toHaveBeenCalledTimes(1);
         expect(successSpy).toHaveBeenCalledWith("DELETE_PERMIT_CONDITION_CATEGORY");
-        expect(dispatch).toHaveBeenCalledTimes(5);
+        expect(dispatch).toHaveBeenCalledTimes(6);
       });
     });
 

--- a/services/common/src/redux/actionCreators/permitActionCreator.ts
+++ b/services/common/src/redux/actionCreators/permitActionCreator.ts
@@ -250,6 +250,7 @@ export const createPermitAmendmentConditionCategory = (
 
         dispatch(success(NetworkReducerTypes.CREATE_PERMIT_CONDITION_CATEGORY));
         dispatch(fetchPermitAmendmentConditionCategories(mineGuid, permitGuid, permitAmdendmentGuid));
+        dispatch(fetchPermits(mineGuid));
         return response.data;
       })
       .catch(() => dispatch(error(NetworkReducerTypes.CREATE_PERMIT_CONDITION_CATEGORY)))
@@ -309,6 +310,7 @@ export const deletePermitAmendmentConditionCategory = (
 
         dispatch(success(NetworkReducerTypes.DELETE_PERMIT_CONDITION_CATEGORY));
         dispatch(fetchPermitAmendmentConditionCategories(mineGuid, permitGuid, permitAmdendmentGuid));
+        dispatch(fetchPermits(mineGuid));
         return response.data;
       })
       .catch(() => dispatch(error(NetworkReducerTypes.DELETE_PERMIT_CONDITION_CATEGORY)))

--- a/services/core-web/src/components/mine/Permit/PermitConditionCategoryEditModal.tsx
+++ b/services/core-web/src/components/mine/Permit/PermitConditionCategoryEditModal.tsx
@@ -16,7 +16,7 @@ interface PermitConditionCategoryEditModalProps {
 
 const PermitConditionCategoryEditModal: FC<PermitConditionCategoryEditModalProps> = ({ handleSubmit }) => {
   return (
-    <FormWrapper name={FORM.ADD_PERMIT_CONDITION_CATEGORY} isModal onSubmit={handleSubmit}>
+    <FormWrapper name={FORM.ADD_PERMIT_CONDITION_CATEGORY} isModal onSubmit={handleSubmit} scrollOnToggleEdit={false}>
       <Row gutter={6}>
         <Col span={24}>
           <Form.Item>

--- a/services/core-web/src/components/mine/Permit/PermitConditions.tsx
+++ b/services/core-web/src/components/mine/Permit/PermitConditions.tsx
@@ -420,7 +420,7 @@ const PermitConditions: FC<PermitConditionProps> = ({
   const AddConditionModalContent = (
     <Typography.Paragraph
       className="no_link_styling grey"
-      style={{ fontSize: "14px", textAlign: "center" }}
+      style={{ fontSize: "14px", textAlign: "center", margin: "20px" }}
     >
       {showLoading ? (
         <Skeleton active paragraph={{ rows: 1 }} />

--- a/services/core-web/src/components/mine/Permit/__snapshots__/PermitConditions.spec.tsx.snap
+++ b/services/core-web/src/components/mine/Permit/__snapshots__/PermitConditions.spec.tsx.snap
@@ -431,7 +431,7 @@ exports[`PermitConditions renders properly 1`] = `
                       <div>
                         <div
                           class="ant-anchor-wrapper"
-                          style="max-height: calc(100vh - 280px);"
+                          style="max-height: calc(100vh - 306px);"
                         >
                           <div
                             class="ant-anchor ant-anchor-fixed"
@@ -660,19 +660,19 @@ exports[`PermitConditions renders properly 1`] = `
                                 </div>
                               </a>
                             </div>
+                            <div
+                              class="ant-typography no_link_styling grey"
+                              style="font-size: 14px; text-align: center; margin: 20px;"
+                            >
+                              <a
+                                class="ant-typography fade-in"
+                                title="Add Condition Category"
+                              >
+                                + Add Condition Category
+                              </a>
+                            </div>
                           </div>
                         </div>
-                      </div>
-                      <div
-                        class="ant-typography no_link_styling grey"
-                        style="font-size: 14px; text-align: center;"
-                      >
-                        <a
-                          class="ant-typography fade-in"
-                          title="Add Condition Category"
-                        >
-                          + Add Condition Category
-                        </a>
                       </div>
                     </div>
                     <div

--- a/services/core-web/src/tests/components/Forms/reports/__snapshots__/ReportPage-prr.spec.tsx.snap
+++ b/services/core-web/src/tests/components/Forms/reports/__snapshots__/ReportPage-prr.spec.tsx.snap
@@ -84,7 +84,7 @@ exports[`ReportPage renders view mode properly 1`] = `
     <div>
       <div
         class="ant-anchor-wrapper"
-        style="max-height: calc(100vh - 226px);"
+        style="max-height: calc(100vh - 250px);"
       >
         <div
           class="ant-anchor ant-anchor-fixed"
@@ -211,10 +211,10 @@ exports[`ReportPage renders view mode properly 1`] = `
               </div>
             </a>
           </div>
+          
         </div>
       </div>
     </div>
-    
   </div>
   <div
     class="side-menu--content"

--- a/services/core-web/src/tests/components/Forms/reports/__snapshots__/ReportPage.spec.tsx.snap
+++ b/services/core-web/src/tests/components/Forms/reports/__snapshots__/ReportPage.spec.tsx.snap
@@ -86,7 +86,7 @@ exports[`ReportPage renders view mode properly 1`] = `
     <div>
       <div
         class="ant-anchor-wrapper"
-        style="max-height: calc(100vh - 226px);"
+        style="max-height: calc(100vh - 250px);"
       >
         <div
           class="ant-anchor ant-anchor-fixed"
@@ -213,10 +213,10 @@ exports[`ReportPage renders view mode properly 1`] = `
               </div>
             </a>
           </div>
+          
         </div>
       </div>
     </div>
-    
   </div>
   <div
     class="side-menu--content"


### PR DESCRIPTION
## Objective 

[MDS-6346](https://bcmines.atlassian.net/browse/MDS-6346)

Fixes:
- On small screens/permits withs lots of permit conditions the '+ Add Condition Category' button disappears off the screen. Fixed by moving the extraItems into the Anchor element which has the scroll overflow.
- When opening the Add Condition Category modal the page would scroll to the top losing your position on the page. Fixed by setting scrollOnToggleEdit to false.
- Adding a new Condition Category was not causing a state update/ page re-render. I'm assuming this worked at some point and has broken since moving to custom categories. Added an additonal dispatch on create & delete.

![image](https://github.com/user-attachments/assets/97bbd671-50e1-4de6-8021-b520d027693c)

Other bugs discovered:
- On a small screen when scrolled all the way down the sidebar will bottom out and go over the footer. This is due to the sidebar being fixed and how Antd handles the overflow. The fix for this is to replace the sidebar--fixed class with a new sidebar--sticky class. However this breaks countless rules including Z-indexes and would require the page layout to be fixed so that the content and sidebar sit nicely next to each other. (I tried and put this in the too hard basket)