### PR TITLE
[MDS-6203] - Add ZAP scan workflow for Permit Service

### DIFF
--- a/.github/workflows/zap-scan-permit-service.yaml
+++ b/.github/workflows/zap-scan-permit-service.yaml
@@ -1,0 +1,26 @@
+name: Permit Service - ZAP Scan
+
+on:
+  schedule:
+    - cron: "0 8 * * *"  # Runs at 08:00 UTC (Midnight PST)
+  workflow_dispatch:
+
+jobs:
+  zap_scan:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: ZAP API Full Scan
+        uses: zaproxy/action-full-scan@v0.12.0
+        with:
+          target: "https://mds-permits-test.apps.silver.devops.gov.bc.ca/"
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload ZAP Report
+        uses: actions/upload-artifact@v4
+        with:
+          name: zap-report
+          path: report_html.html


### PR DESCRIPTION
Introduce a scheduled GitHub Actions workflow to run ZAP API full scans on the Permit Service.

## Objective 

[MDS-6203](https://bcmines.atlassian.net/browse/MDS-6203)
