### PR TITLE
[MDS-6369] Report definition bugs (+[MDS-6388])

### DIFF
--- a/services/core-api/app/api/mines/reports/models/mine_report_definition.py
+++ b/services/core-api/app/api/mines/reports/models/mine_report_definition.py
@@ -201,9 +201,11 @@ class MineReportDefinition(Base, AuditMixin):
 
         if compliance_sort or compliance_filter:
             query = query.join(MineReportDefinitionComplianceArticleXref,
-                               MineReportDefinitionComplianceArticleXref.mine_report_definition_id == MineReportDefinition.mine_report_definition_id)
+                               MineReportDefinitionComplianceArticleXref.mine_report_definition_id == MineReportDefinition.mine_report_definition_id,
+                               isouter=True)
             query = query.join(ComplianceArticle,
-                               ComplianceArticle.compliance_article_id == MineReportDefinitionComplianceArticleXref.compliance_article_id)
+                               ComplianceArticle.compliance_article_id == MineReportDefinitionComplianceArticleXref.compliance_article_id,
+                               isouter=True)
 
         query = cls._apply_sort(query, sort_field, sort_dir)
         query = cls._apply_filters(query, regulatory_authority, is_prr_only, active_ind, section)

--- a/services/core-api/tests/reports/resource/test_mine_reports_resource.py
+++ b/services/core-api/tests/reports/resource/test_mine_reports_resource.py
@@ -66,7 +66,7 @@ def test_get_code_required_reports_for_mine(test_client, db_session, auth_header
     for report in get_data['records']:
         received_date = datetime.strptime(report['received_date'], '%Y-%m-%d')
 
-        assert (start_date <= received_date.date())
+        assert (start_date.date() <= received_date.date())
         assert (received_date.date() <= end_date)
 
 

--- a/services/core-web/src/components/admin/complianceCodes/AddReportDefinitionForm.tsx
+++ b/services/core-web/src/components/admin/complianceCodes/AddReportDefinitionForm.tsx
@@ -10,7 +10,7 @@ import { useAppSelector } from "@mds/common/redux/rootState";
 import { getMineReportDueDateTypes } from "@mds/common/redux/slices/complianceReportsSlice";
 import RenderCancelButton from "@mds/common/components/forms/RenderCancelButton";
 import RenderSubmitButton from "@mds/common/components/forms/RenderSubmitButton";
-import { required, requiredRadioButton } from "@mds/common/redux/utils/Validate";
+import { maxLength, required, requiredRadioButton } from "@mds/common/redux/utils/Validate";
 import { Field } from "@mds/common/components/forms/form";
 
 const { Title, Paragraph } = Typography;
@@ -36,15 +36,16 @@ const AddReportDefinitionForm = ({ handleSubmit, isModal = false }) => {
         component={RenderField}
         name="report_name"
         label="Report Name"
-        validate={[required]}
+        validate={[required, maxLength(100)]}
       />
       <Field
         required
         component={RenderAutoSizeField}
         name="description"
         label="Description"
+        maximumCharacter={300}
         placeholder="Describe the report's definition / purpose for the mine proponent"
-        validate={[required]}
+        validate={[required, maxLength(300)]}
       />
       <Row gutter={16}>
         <Col span={12}>

--- a/services/core-web/src/components/admin/complianceCodes/AddReportDefinitionForm.tsx
+++ b/services/core-web/src/components/admin/complianceCodes/AddReportDefinitionForm.tsx
@@ -26,11 +26,7 @@ const AddReportDefinitionForm = ({ handleSubmit, isModal = false }) => {
 
   return (
     <FormWrapper name={ADD_REPORT_DEFINITION} onSubmit={handleSubmit} isModal={isModal}>
-      <Title level={3}>Create Report</Title>
-      <Title level={4}>Report Details</Title>
-      <Paragraph strong className="margin-small--bottom">
-        Report Name
-      </Paragraph>
+      <Title level={3}>Report Details</Title>
       <Field
         required
         component={RenderField}

--- a/services/core-web/src/components/admin/complianceCodes/AddReportDefinitionForm.tsx
+++ b/services/core-web/src/components/admin/complianceCodes/AddReportDefinitionForm.tsx
@@ -15,7 +15,7 @@ import { Field } from "@mds/common/components/forms/form";
 
 const { Title, Paragraph } = Typography;
 
-const AddReportDefinitionForm = ({ handleSubmit }) => {
+const AddReportDefinitionForm = ({ handleSubmit, isModal = false }) => {
   const mineReportDueDateTypes = useAppSelector(getMineReportDueDateTypes);
 
   const dueDatePeriodMonthsOptions = [
@@ -25,7 +25,7 @@ const AddReportDefinitionForm = ({ handleSubmit }) => {
   ];
 
   return (
-    <FormWrapper name={ADD_REPORT_DEFINITION} onSubmit={handleSubmit}>
+    <FormWrapper name={ADD_REPORT_DEFINITION} onSubmit={handleSubmit} isModal={isModal}>
       <Title level={3}>Create Report</Title>
       <Title level={4}>Report Details</Title>
       <Paragraph strong className="margin-small--bottom">

--- a/services/core-web/src/components/admin/complianceCodes/ComplianceCodeViewEditForm.spec.tsx
+++ b/services/core-web/src/components/admin/complianceCodes/ComplianceCodeViewEditForm.spec.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import { ReduxWrapper } from "@/tests/utils/ReduxWrapper";
+import ComplianceCodeViewEditForm from "./ComplianceCodeViewEditForm";
+import { COMPLIANCE_CODES } from "@/tests/mocks/dataMocks";
+import { complianceCodeReducerType } from "@mds/common/redux/slices/complianceCodesSlice";
+
+const initialState = {
+    [complianceCodeReducerType]: {
+        complianceCodeMap: {}
+    }
+};
+
+describe("ComplianceCodeViewEditForm", () => {
+    it("renders properly", async () => {
+        const { container } = render(
+            <ReduxWrapper initialState={initialState}>
+                <ComplianceCodeViewEditForm initialValues={null} isEditMode onSave={jest.fn()} />
+                <ComplianceCodeViewEditForm initialValues={COMPLIANCE_CODES[0]} isEditMode={false} onSave={jest.fn()} />
+            </ReduxWrapper>
+        );
+        expect(container).toMatchSnapshot()
+    });
+})

--- a/services/core-web/src/components/admin/complianceCodes/ComplianceCodeViewEditForm.tsx
+++ b/services/core-web/src/components/admin/complianceCodes/ComplianceCodeViewEditForm.tsx
@@ -1,5 +1,4 @@
 import React, { FC, useEffect, useState } from "react";
-import { useSelector, useDispatch } from "react-redux";
 import { getFormValues, change, touch } from "@mds/common/components/forms/form";
 import { Row, Button, Steps } from "antd";
 import * as FORM from "@/constants/forms";
@@ -17,6 +16,7 @@ import { ReportEditForm } from "./ReportEditForm";
 import CoreButton from "@mds/common/components/common/CoreButton";
 import { IComplianceArticle } from "@mds/common/interfaces";
 import { REPORT_REGULATORY_AUTHORITY_CODES } from "@mds/common/constants/enums";
+import { useAppDispatch, useAppSelector } from "@mds/common/redux/rootState";
 
 const ComplianceCodeViewEditForm: FC<{
   initialValues: IComplianceArticle;
@@ -24,10 +24,10 @@ const ComplianceCodeViewEditForm: FC<{
   onSave: (values: IComplianceArticle) => void | Promise<void>;
 }> = ({ initialValues = {}, isEditMode = true, onSave = null }) => {
   const [currentStep, setCurrentStep] = useState(0);
-  const dispatch = useDispatch();
-  const complianceCodes = useSelector(getActiveComplianceCodesList);
-  const formValues = useSelector(getFormValues(FORM.ADD_COMPLIANCE_CODE)) ?? {};
-  const { section, sub_section, paragraph, sub_paragraph } = formValues;
+  const dispatch = useAppDispatch();
+  const complianceCodes = useAppSelector(getActiveComplianceCodesList);
+  const formValues = useAppSelector(getFormValues(FORM.ADD_COMPLIANCE_CODE)) as IComplianceArticle;
+  const { section, sub_section, paragraph, sub_paragraph } = formValues ?? {};
 
   const generateArticleNumber = () => {
     const articleNumber = [section, sub_section, paragraph, sub_paragraph]
@@ -59,7 +59,7 @@ const ComplianceCodeViewEditForm: FC<{
     {
       title: "Report Details",
       content: (
-        <ReportEditForm complianceCodes={complianceCodes} isEditMode={isEditMode}></ReportEditForm>
+        <ReportEditForm isEditMode={isEditMode}></ReportEditForm>
       ),
     },
   ];
@@ -91,42 +91,39 @@ const ComplianceCodeViewEditForm: FC<{
         isEditMode={isEditMode}
         isModal={true}
       >
-        <Row>
-          <Steps current={currentStep}>
-            {steps.map((step) => (
-              <Steps.Step key={step.title} title={step.title} />
-            ))}
-          </Steps>
+        <Steps current={currentStep}>
+          {steps.map((step) => (
+            <Steps.Step key={step.title} title={step.title} />
+          ))}
+        </Steps>
+        {steps[currentStep].content}
+        <Row style={{ width: "100%" }} justify="end">
+          <RenderCancelButton />
+          {currentStep > 0 && (
+            <CoreButton
+              className="full-mobile"
+              type="filled-tertiary"
+              onClick={previous}
+              disabled={false}
+            >
+              Back
+            </CoreButton>
+          )}
 
-          <Row style={{ marginTop: "16px", width: "100%" }}>{steps[currentStep].content}</Row>
-          <Row style={{ width: "100%" }} justify="end">
-            <RenderCancelButton />
-            {currentStep > 0 && (
-              <CoreButton
-                className="full-mobile"
-                type="filled-tertiary"
-                onClick={previous}
-                disabled={false}
-              >
-                Back
-              </CoreButton>
-            )}
-
-            {isEditMode ? (
-              <RenderSubmitButton
-                buttonText={currentStep === steps.length - 1 ? "Save Code" : "Continue"}
-              />
-            ) : (
-              ""
-            )}
-            {!isEditMode && currentStep < steps.length - 1 ? (
-              <Button type="primary" onClick={next}>
-                Continue
-              </Button>
-            ) : (
-              ""
-            )}
-          </Row>
+          {isEditMode ? (
+            <RenderSubmitButton
+              buttonText={currentStep === steps.length - 1 ? "Save Code" : "Continue"}
+            />
+          ) : (
+            ""
+          )}
+          {!isEditMode && currentStep < steps.length - 1 ? (
+            <Button type="primary" onClick={next}>
+              Continue
+            </Button>
+          ) : (
+            ""
+          )}
         </Row>
       </FormWrapper>
     </div>

--- a/services/core-web/src/components/admin/complianceCodes/ComplianceReportManagement.spec.tsx
+++ b/services/core-web/src/components/admin/complianceCodes/ComplianceReportManagement.spec.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { render, waitFor } from "@testing-library/react";
-import * as MOCK from "@mds/common/tests/mocks/dataMocks";
 import { ReduxWrapper } from "@/tests/utils/ReduxWrapper";
 import {
     complianceReportReducerType,

--- a/services/core-web/src/components/admin/complianceCodes/__snapshots__/ComplianceCodeViewEditForm.spec.tsx.snap
+++ b/services/core-web/src/components/admin/complianceCodes/__snapshots__/ComplianceCodeViewEditForm.spec.tsx.snap
@@ -1,0 +1,1443 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ComplianceCodeViewEditForm renders properly 1`] = `
+<div>
+  <div>
+    <form
+      class="ant-form ant-form-vertical common-form common-form-ADD_COMPLIANCE_CODE form-edit"
+      id="ADD_COMPLIANCE_CODE"
+    >
+      <div
+        class="ant-steps ant-steps-horizontal ant-steps-label-horizontal"
+      >
+        <div
+          class="ant-steps-item ant-steps-item-process ant-steps-item-active"
+        >
+          <div
+            class="ant-steps-item-container"
+          >
+            <div
+              class="ant-steps-item-tail"
+            />
+            <div
+              class="ant-steps-item-icon"
+            >
+              <span
+                class="ant-steps-icon"
+              >
+                1
+              </span>
+            </div>
+            <div
+              class="ant-steps-item-content"
+            >
+              <div
+                class="ant-steps-item-title"
+              >
+                HSRC Details
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="ant-steps-item ant-steps-item-wait"
+        >
+          <div
+            class="ant-steps-item-container"
+          >
+            <div
+              class="ant-steps-item-tail"
+            />
+            <div
+              class="ant-steps-item-icon"
+            >
+              <span
+                class="ant-steps-icon"
+              >
+                2
+              </span>
+            </div>
+            <div
+              class="ant-steps-item-content"
+            >
+              <div
+                class="ant-steps-item-title"
+              >
+                Report Details
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="ant-row form-row-margin"
+        style="margin: -8px -8px -8px -8px;"
+      >
+        <div
+          class="ant-col ant-col-24"
+          style="padding: 8px 8px 8px 8px;"
+        >
+          <span
+            class="ant-typography"
+          >
+            <strong>
+              HSRC Details
+            </strong>
+          </span>
+        </div>
+        <div
+          class="ant-col ant-col-sm-10 ant-col-md-5"
+          style="padding: 8px 8px 8px 8px;"
+        >
+          <div
+            class="ant-form-item ant-form-item-with-help"
+          >
+            <div
+              class="ant-row ant-form-item-row"
+            >
+              <div
+                class="ant-col ant-form-item-label"
+              >
+                <label
+                  class="ant-form-item-required"
+                  for="ADD_COMPLIANCE_CODE_section"
+                  title=""
+                >
+                  <div
+                    style="width: 100%;"
+                  >
+                    Section
+                  </div>
+                </label>
+              </div>
+              <div
+                class="ant-col ant-form-item-control"
+              >
+                <div
+                  class="ant-form-item-control-input"
+                >
+                  <div
+                    class="ant-form-item-control-input-content"
+                  >
+                    <input
+                      aria-label="section"
+                      class="ant-input"
+                      name="section"
+                      type="text"
+                      value=""
+                    />
+                  </div>
+                </div>
+                <div
+                  style="display: flex; flex-wrap: nowrap;"
+                >
+                  <div
+                    class="ant-form-item-explain ant-form-item-explain-connected"
+                    id="ADD_COMPLIANCE_CODE_section_help"
+                    role="alert"
+                  >
+                    <div
+                      class=""
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="ant-col ant-col-sm-12 ant-col-md-6"
+          style="padding: 8px 8px 8px 8px;"
+        >
+          <div
+            class="ant-form-item ant-form-item-with-help"
+          >
+            <div
+              class="ant-row ant-form-item-row"
+            >
+              <div
+                class="ant-col ant-form-item-label"
+              >
+                <label
+                  class=""
+                  for="ADD_COMPLIANCE_CODE_sub_section"
+                  title=""
+                >
+                  <div>
+                    Subsection
+                     
+                    <span
+                      class="form-item-optional"
+                    >
+                       (optional)
+                    </span>
+                  </div>
+                </label>
+              </div>
+              <div
+                class="ant-col ant-form-item-control"
+              >
+                <div
+                  class="ant-form-item-control-input"
+                >
+                  <div
+                    class="ant-form-item-control-input-content"
+                  >
+                    <input
+                      aria-label="sub_section"
+                      class="ant-input"
+                      name="sub_section"
+                      type="text"
+                      value=""
+                    />
+                  </div>
+                </div>
+                <div
+                  style="display: flex; flex-wrap: nowrap;"
+                >
+                  <div
+                    class="ant-form-item-explain ant-form-item-explain-connected"
+                    id="ADD_COMPLIANCE_CODE_sub_section_help"
+                    role="alert"
+                  >
+                    <div
+                      class=""
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="ant-col ant-col-sm-12 ant-col-md-6"
+          style="padding: 8px 8px 8px 8px;"
+        >
+          <div
+            class="ant-form-item ant-form-item-with-help"
+          >
+            <div
+              class="ant-row ant-form-item-row"
+            >
+              <div
+                class="ant-col ant-form-item-label"
+              >
+                <label
+                  class=""
+                  for="ADD_COMPLIANCE_CODE_paragraph"
+                  title=""
+                >
+                  <div>
+                    Paragraph
+                     
+                    <span
+                      class="form-item-optional"
+                    >
+                       (optional)
+                    </span>
+                  </div>
+                </label>
+              </div>
+              <div
+                class="ant-col ant-form-item-control"
+              >
+                <div
+                  class="ant-form-item-control-input"
+                >
+                  <div
+                    class="ant-form-item-control-input-content"
+                  >
+                    <input
+                      aria-label="paragraph"
+                      class="ant-input"
+                      name="paragraph"
+                      type="text"
+                      value=""
+                    />
+                  </div>
+                </div>
+                <div
+                  style="display: flex; flex-wrap: nowrap;"
+                >
+                  <div
+                    class="ant-form-item-explain ant-form-item-explain-connected"
+                    id="ADD_COMPLIANCE_CODE_paragraph_help"
+                    role="alert"
+                  >
+                    <div
+                      class=""
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="ant-col ant-col-sm-14 ant-col-md-7"
+          style="padding: 8px 8px 8px 8px;"
+        >
+          <div
+            class="ant-form-item ant-form-item-with-help"
+          >
+            <div
+              class="ant-row ant-form-item-row"
+            >
+              <div
+                class="ant-col ant-form-item-label"
+              >
+                <label
+                  class=""
+                  for="ADD_COMPLIANCE_CODE_sub_paragraph"
+                  title=""
+                >
+                  <div>
+                    Subparagraph
+                     
+                    <span
+                      class="form-item-optional"
+                    >
+                       (optional)
+                    </span>
+                  </div>
+                </label>
+              </div>
+              <div
+                class="ant-col ant-form-item-control"
+              >
+                <div
+                  class="ant-form-item-control-input"
+                >
+                  <div
+                    class="ant-form-item-control-input-content"
+                  >
+                    <input
+                      aria-label="sub_paragraph"
+                      class="ant-input"
+                      name="sub_paragraph"
+                      type="text"
+                      value=""
+                    />
+                  </div>
+                </div>
+                <div
+                  style="display: flex; flex-wrap: nowrap;"
+                >
+                  <div
+                    class="ant-form-item-explain ant-form-item-explain-connected"
+                    id="ADD_COMPLIANCE_CODE_sub_paragraph_help"
+                    role="alert"
+                  >
+                    <div
+                      class=""
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="ant-row form-row-margin"
+        style="margin: -8px -8px -8px -8px;"
+      >
+        <div
+          class="ant-col ant-col-24 hide-required-indicator"
+          style="padding: 8px 8px 8px 8px;"
+        >
+          <div
+            class="ant-form-item ant-form-item-with-help"
+          >
+            <div
+              class="ant-row ant-form-item-row"
+            >
+              <div
+                class="ant-col ant-form-item-label"
+              >
+                <label
+                  class=""
+                  for="ADD_COMPLIANCE_CODE_articleNumber"
+                  title=""
+                >
+                  <div>
+                    Section Displayed
+                     
+                    <span
+                      class="form-item-optional"
+                    >
+                       (optional)
+                    </span>
+                  </div>
+                </label>
+              </div>
+              <div
+                class="ant-col ant-form-item-control"
+              >
+                <div
+                  class="ant-form-item-control-input"
+                >
+                  <div
+                    class="ant-form-item-control-input-content"
+                  >
+                    <input
+                      aria-label="articleNumber"
+                      class="ant-input ant-input-disabled"
+                      disabled=""
+                      id="articleNumber"
+                      name="articleNumber"
+                      type="text"
+                      value=""
+                    />
+                  </div>
+                </div>
+                <div
+                  style="display: flex; flex-wrap: nowrap;"
+                >
+                  <div
+                    class="ant-form-item-explain ant-form-item-explain-connected"
+                    id="ADD_COMPLIANCE_CODE_articleNumber_help"
+                    role="alert"
+                  >
+                    <div
+                      class=""
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="ant-row form-row-margin"
+        style="margin: -8px -8px -8px -8px;"
+      >
+        <div
+          class="ant-col ant-col-12"
+          style="padding: 8px 8px 8px 8px;"
+        >
+          <div
+            class="ant-form-item ant-form-item-with-help"
+          >
+            <div
+              class="ant-row ant-form-item-row"
+            >
+              <div
+                class="ant-col ant-form-item-label"
+              >
+                <label
+                  class="ant-form-item-required"
+                  for="ADD_COMPLIANCE_CODE_effective_date"
+                  title=""
+                >
+                  <div
+                    style="width: 100%;"
+                  >
+                    Date Active
+                  </div>
+                </label>
+              </div>
+              <div
+                class="ant-col ant-form-item-control"
+              >
+                <div
+                  class="ant-form-item-control-input"
+                >
+                  <div
+                    class="ant-form-item-control-input-content"
+                  >
+                    <div
+                      class="ant-picker"
+                    >
+                      <div
+                        class="ant-picker-input"
+                      >
+                        <input
+                          aria-required="true"
+                          autocomplete="off"
+                          id="ADD_COMPLIANCE_CODE_effective_date"
+                          name="effective_date"
+                          placeholder="Select date"
+                          readonly=""
+                          size="12"
+                          title=""
+                          value=""
+                        />
+                        <span
+                          class="ant-picker-suffix"
+                        >
+                          <span
+                            aria-label="calendar"
+                            class="anticon anticon-calendar"
+                            role="img"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              data-icon="calendar"
+                              fill="currentColor"
+                              focusable="false"
+                              height="1em"
+                              viewBox="64 64 896 896"
+                              width="1em"
+                            >
+                              <path
+                                d="M880 184H712v-64c0-4.4-3.6-8-8-8h-56c-4.4 0-8 3.6-8 8v64H384v-64c0-4.4-3.6-8-8-8h-56c-4.4 0-8 3.6-8 8v64H144c-17.7 0-32 14.3-32 32v664c0 17.7 14.3 32 32 32h736c17.7 0 32-14.3 32-32V216c0-17.7-14.3-32-32-32zm-40 656H184V460h656v380zM184 392V256h128v48c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8v-48h256v48c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8v-48h128v136H184z"
+                              />
+                            </svg>
+                          </span>
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  style="display: flex; flex-wrap: nowrap;"
+                >
+                  <div
+                    class="ant-form-item-explain ant-form-item-explain-connected"
+                    id="ADD_COMPLIANCE_CODE_effective_date_help"
+                    role="alert"
+                  >
+                    <div
+                      class=""
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="ant-col ant-col-12"
+          style="padding: 8px 8px 8px 8px;"
+        >
+          <div
+            class="ant-form-item ant-form-item-with-help"
+          >
+            <div
+              class="ant-row ant-form-item-row"
+            >
+              <div
+                class="ant-col ant-form-item-label"
+              >
+                <label
+                  class=""
+                  for="ADD_COMPLIANCE_CODE_expiry_date"
+                  title=""
+                >
+                  <div>
+                    Date Expire
+                     
+                    <span
+                      class="form-item-optional"
+                    >
+                       (optional)
+                    </span>
+                  </div>
+                </label>
+              </div>
+              <div
+                class="ant-col ant-form-item-control"
+              >
+                <div
+                  class="ant-form-item-control-input"
+                >
+                  <div
+                    class="ant-form-item-control-input-content"
+                  >
+                    <div
+                      class="ant-picker"
+                    >
+                      <div
+                        class="ant-picker-input"
+                      >
+                        <input
+                          autocomplete="off"
+                          id="ADD_COMPLIANCE_CODE_expiry_date"
+                          name="expiry_date"
+                          placeholder="Select date"
+                          readonly=""
+                          size="12"
+                          title=""
+                          value=""
+                        />
+                        <span
+                          class="ant-picker-suffix"
+                        >
+                          <span
+                            aria-label="calendar"
+                            class="anticon anticon-calendar"
+                            role="img"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              data-icon="calendar"
+                              fill="currentColor"
+                              focusable="false"
+                              height="1em"
+                              viewBox="64 64 896 896"
+                              width="1em"
+                            >
+                              <path
+                                d="M880 184H712v-64c0-4.4-3.6-8-8-8h-56c-4.4 0-8 3.6-8 8v64H384v-64c0-4.4-3.6-8-8-8h-56c-4.4 0-8 3.6-8 8v64H144c-17.7 0-32 14.3-32 32v664c0 17.7 14.3 32 32 32h736c17.7 0 32-14.3 32-32V216c0-17.7-14.3-32-32-32zm-40 656H184V460h656v380zM184 392V256h128v48c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8v-48h256v48c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8v-48h128v136H184z"
+                              />
+                            </svg>
+                          </span>
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  style="display: flex; flex-wrap: nowrap;"
+                >
+                  <div
+                    class="ant-form-item-explain ant-form-item-explain-connected"
+                    id="ADD_COMPLIANCE_CODE_expiry_date_help"
+                    role="alert"
+                  >
+                    <div
+                      class=""
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="ant-row"
+        style="margin: -8px -8px -8px -8px;"
+      >
+        <div
+          class="ant-col ant-col-24"
+          style="padding: 8px 8px 8px 8px;"
+        >
+          <div
+            class="ant-form-item ant-form-item-with-help"
+          >
+            <div
+              class="ant-row ant-form-item-row"
+            >
+              <div
+                class="ant-col ant-form-item-label"
+              >
+                <label
+                  class="ant-form-item-required"
+                  for="ADD_COMPLIANCE_CODE_description"
+                  title=""
+                >
+                  <div
+                    style="width: 100%;"
+                  >
+                    Description
+                  </div>
+                </label>
+              </div>
+              <div
+                class="ant-col ant-form-item-control"
+              >
+                <div
+                  class="ant-form-item-control-input"
+                >
+                  <div
+                    class="ant-form-item-control-input-content"
+                  >
+                    <input
+                      aria-label="description"
+                      class="ant-input"
+                      name="description"
+                      type="text"
+                      value=""
+                    />
+                  </div>
+                </div>
+                <div
+                  style="display: flex; flex-wrap: nowrap;"
+                >
+                  <div
+                    class="ant-form-item-explain ant-form-item-explain-connected"
+                    id="ADD_COMPLIANCE_CODE_description_help"
+                    role="alert"
+                  >
+                    <div
+                      class=""
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="ant-col ant-col-24"
+          style="padding: 8px 8px 8px 8px;"
+        >
+          <div
+            class="ant-form-item ant-form-item-with-help"
+          >
+            <div
+              class="ant-row ant-form-item-row"
+            >
+              <div
+                class="ant-col ant-form-item-label"
+              >
+                <label
+                  class="ant-form-item-required"
+                  for="ADD_COMPLIANCE_CODE_long_description"
+                  title=""
+                >
+                  <div
+                    style="width: 100%;"
+                  >
+                    Long Description
+                  </div>
+                </label>
+              </div>
+              <div
+                class="ant-col ant-form-item-control"
+              >
+                <div
+                  class="ant-form-item-control-input"
+                >
+                  <div
+                    class="ant-form-item-control-input-content"
+                  >
+                    <textarea
+                      class="ant-input"
+                      name="long_description"
+                      style="height: 0px; resize: none; min-height: -12px;"
+                    />
+                    <div
+                      class="ant-row ant-row-space-between form-item-help long_description-form-help"
+                    >
+                      <span>
+                        Maximum 3000 characters
+                      </span>
+                      <span
+                        class="flex-end"
+                      >
+                        3000 / 3000
+                      </span>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  style="display: flex; flex-wrap: nowrap;"
+                >
+                  <div
+                    class="ant-form-item-explain ant-form-item-explain-connected"
+                    id="ADD_COMPLIANCE_CODE_long_description_help"
+                    role="alert"
+                  >
+                    <div
+                      class=""
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="ant-col ant-col-24"
+          style="padding: 8px 8px 8px 8px;"
+        >
+          <span
+            class="ant-typography"
+          >
+            <strong>
+              Regulatory Authority
+            </strong>
+          </span>
+        </div>
+        <div
+          class="ant-col ant-col-24"
+          style="padding: 8px 8px 8px 8px;"
+        >
+          <div
+            class="ant-form-item ant-form-item-with-help"
+          >
+            <div
+              class="ant-row ant-form-item-row"
+            >
+              <div
+                class="ant-col ant-form-item-label"
+              >
+                <label
+                  class="ant-form-item-required"
+                  for="ADD_COMPLIANCE_CODE_cim_or_cpo"
+                  title=""
+                >
+                  <div
+                    style="width: 100%;"
+                  >
+                    Who is the report for?
+                  </div>
+                </label>
+              </div>
+              <div
+                class="ant-col ant-form-item-control"
+              >
+                <div
+                  class="ant-form-item-control-input"
+                >
+                  <div
+                    class="ant-form-item-control-input-content"
+                  >
+                    <div
+                      class="ant-radio-group ant-radio-group-solid vertical-radio-group"
+                    >
+                      <label
+                        class="ant-radio-wrapper ant-radio-wrapper-in-form-item"
+                      >
+                        <span
+                          class="ant-radio"
+                        >
+                          <input
+                            class="ant-radio-input"
+                            name="cim_or_cpo"
+                            type="radio"
+                            value="CPO"
+                          />
+                          <span
+                            class="ant-radio-inner"
+                          />
+                        </span>
+                        <span>
+                          Chief Permitting Officer
+                        </span>
+                      </label>
+                      <label
+                        class="ant-radio-wrapper ant-radio-wrapper-in-form-item"
+                      >
+                        <span
+                          class="ant-radio"
+                        >
+                          <input
+                            class="ant-radio-input"
+                            name="cim_or_cpo"
+                            type="radio"
+                            value="CIM"
+                          />
+                          <span
+                            class="ant-radio-inner"
+                          />
+                        </span>
+                        <span>
+                          Chief Inspector of Mines
+                        </span>
+                      </label>
+                      <label
+                        class="ant-radio-wrapper ant-radio-wrapper-in-form-item"
+                      >
+                        <span
+                          class="ant-radio"
+                        >
+                          <input
+                            class="ant-radio-input"
+                            name="cim_or_cpo"
+                            type="radio"
+                            value="Both"
+                          />
+                          <span
+                            class="ant-radio-inner"
+                          />
+                        </span>
+                        <span>
+                          Both
+                        </span>
+                      </label>
+                      <label
+                        class="ant-radio-wrapper ant-radio-wrapper-in-form-item"
+                      >
+                        <span
+                          class="ant-radio"
+                        >
+                          <input
+                            class="ant-radio-input"
+                            name="cim_or_cpo"
+                            type="radio"
+                            value="Not specified"
+                          />
+                          <span
+                            class="ant-radio-inner"
+                          />
+                        </span>
+                        <span>
+                          Not specified
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  style="display: flex; flex-wrap: nowrap;"
+                >
+                  <div
+                    class="ant-form-item-explain ant-form-item-explain-connected"
+                    id="ADD_COMPLIANCE_CODE_cim_or_cpo_help"
+                    role="alert"
+                  >
+                    <div
+                      class=""
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="ant-col ant-col-24"
+          style="padding: 8px 8px 8px 8px;"
+        >
+          <div
+            class="ant-form-item ant-form-item-with-help"
+          >
+            <div
+              class="ant-row ant-form-item-row"
+            >
+              <div
+                class="ant-col ant-form-item-label"
+              >
+                <label
+                  class=""
+                  for="ADD_COMPLIANCE_CODE_help_reference_link"
+                  title=""
+                >
+                  <div>
+                    Resource Information Link
+                     
+                    <span
+                      class="form-item-optional"
+                    >
+                       (optional)
+                    </span>
+                  </div>
+                </label>
+              </div>
+              <div
+                class="ant-col ant-form-item-control"
+              >
+                <div
+                  class="ant-form-item-control-input"
+                >
+                  <div
+                    class="ant-form-item-control-input-content"
+                  >
+                    <input
+                      aria-label="help_reference_link"
+                      class="ant-input"
+                      name="help_reference_link"
+                      type="text"
+                      value=""
+                    />
+                  </div>
+                </div>
+                <div
+                  style="display: flex; flex-wrap: nowrap;"
+                >
+                  <div
+                    class="ant-form-item-explain ant-form-item-explain-connected"
+                    id="ADD_COMPLIANCE_CODE_help_reference_link_help"
+                    role="alert"
+                  >
+                    <div
+                      class=""
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="ant-row ant-row-end"
+        style="width: 100%;"
+      >
+        <button
+          aria-label="Cancel"
+          class="ant-btn ant-btn-default core-btn core-btn-default  form-btn"
+          type="button"
+        >
+          <span>
+            Cancel
+          </span>
+        </button>
+        <button
+          aria-label="Submit"
+          class="ant-btn ant-btn-primary  form-btn"
+          disabled=""
+          type="submit"
+        >
+          <span>
+            Continue
+          </span>
+        </button>
+        
+      </div>
+    </form>
+  </div>
+  <div>
+    <form
+      class="ant-form ant-form-vertical common-form common-form-ADD_COMPLIANCE_CODE form-view"
+      id="ADD_COMPLIANCE_CODE"
+    >
+      <div
+        class="ant-steps ant-steps-horizontal ant-steps-label-horizontal"
+      >
+        <div
+          class="ant-steps-item ant-steps-item-process ant-steps-item-active"
+        >
+          <div
+            class="ant-steps-item-container"
+          >
+            <div
+              class="ant-steps-item-tail"
+            />
+            <div
+              class="ant-steps-item-icon"
+            >
+              <span
+                class="ant-steps-icon"
+              >
+                1
+              </span>
+            </div>
+            <div
+              class="ant-steps-item-content"
+            >
+              <div
+                class="ant-steps-item-title"
+              >
+                HSRC Details
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="ant-steps-item ant-steps-item-wait"
+        >
+          <div
+            class="ant-steps-item-container"
+          >
+            <div
+              class="ant-steps-item-tail"
+            />
+            <div
+              class="ant-steps-item-icon"
+            >
+              <span
+                class="ant-steps-icon"
+              >
+                2
+              </span>
+            </div>
+            <div
+              class="ant-steps-item-content"
+            >
+              <div
+                class="ant-steps-item-title"
+              >
+                Report Details
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="ant-row form-row-margin"
+        style="margin: -8px -8px -8px -8px;"
+      >
+        <div
+          class="ant-col ant-col-24"
+          style="padding: 8px 8px 8px 8px;"
+        >
+          <span
+            class="ant-typography"
+          >
+            <strong>
+              HSRC Details
+            </strong>
+          </span>
+        </div>
+        <div
+          class="ant-col ant-col-sm-10 ant-col-md-5"
+          style="padding: 8px 8px 8px 8px;"
+        >
+          <div
+            class="view-item ant-form-item"
+          >
+            <div
+              class="ant-typography view-item-label"
+            >
+              Section
+            </div>
+            <div
+              class="ant-typography view-item-value"
+            >
+              N/A
+            </div>
+          </div>
+        </div>
+        <div
+          class="ant-col ant-col-sm-12 ant-col-md-6"
+          style="padding: 8px 8px 8px 8px;"
+        >
+          <div
+            class="view-item ant-form-item"
+          >
+            <div
+              class="ant-typography view-item-label"
+            >
+              Subsection
+            </div>
+            <div
+              class="ant-typography view-item-value"
+            >
+              N/A
+            </div>
+          </div>
+        </div>
+        <div
+          class="ant-col ant-col-sm-12 ant-col-md-6"
+          style="padding: 8px 8px 8px 8px;"
+        >
+          <div
+            class="view-item ant-form-item"
+          >
+            <div
+              class="ant-typography view-item-label"
+            >
+              Paragraph
+            </div>
+            <div
+              class="ant-typography view-item-value"
+            >
+              N/A
+            </div>
+          </div>
+        </div>
+        <div
+          class="ant-col ant-col-sm-14 ant-col-md-7"
+          style="padding: 8px 8px 8px 8px;"
+        >
+          <div
+            class="view-item ant-form-item"
+          >
+            <div
+              class="ant-typography view-item-label"
+            >
+              Subparagraph
+            </div>
+            <div
+              class="ant-typography view-item-value"
+            >
+              N/A
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="ant-row form-row-margin"
+        style="margin: -8px -8px -8px -8px;"
+      >
+        <div
+          class="ant-col ant-col-24 hide-required-indicator"
+          style="padding: 8px 8px 8px 8px;"
+        >
+          <div
+            class="view-item ant-form-item"
+          >
+            <div
+              class="ant-typography view-item-label"
+            >
+              Section Displayed
+            </div>
+            <div
+              class="ant-typography view-item-value"
+            >
+              N/A
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="ant-row form-row-margin"
+        style="margin: -8px -8px -8px -8px;"
+      >
+        <div
+          class="ant-col ant-col-12"
+          style="padding: 8px 8px 8px 8px;"
+        >
+          <div
+            class="view-item ant-form-item"
+          >
+            <div
+              class="ant-typography view-item-label"
+            >
+              Date Active
+            </div>
+            <div
+              class="ant-typography view-item-value"
+            >
+              N/A
+            </div>
+          </div>
+        </div>
+        <div
+          class="ant-col ant-col-12"
+          style="padding: 8px 8px 8px 8px;"
+        >
+          <div
+            class="view-item ant-form-item"
+          >
+            <div
+              class="ant-typography view-item-label"
+            >
+              Date Expire
+            </div>
+            <div
+              class="ant-typography view-item-value"
+            >
+              N/A
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="ant-row"
+        style="margin: -8px -8px -8px -8px;"
+      >
+        <div
+          class="ant-col ant-col-24"
+          style="padding: 8px 8px 8px 8px;"
+        >
+          <div
+            class="view-item ant-form-item"
+          >
+            <div
+              class="ant-typography view-item-label"
+            >
+              Description
+            </div>
+            <div
+              class="ant-typography view-item-value"
+            >
+              N/A
+            </div>
+          </div>
+        </div>
+        <div
+          class="ant-col ant-col-24"
+          style="padding: 8px 8px 8px 8px;"
+        >
+          <div
+            class="view-item ant-form-item"
+          >
+            <div
+              class="ant-typography view-item-label"
+            >
+              Long Description
+            </div>
+            <div
+              class="ant-typography view-item-value"
+            >
+              N/A
+            </div>
+          </div>
+        </div>
+        <div
+          class="ant-col ant-col-24"
+          style="padding: 8px 8px 8px 8px;"
+        >
+          <span
+            class="ant-typography"
+          >
+            <strong>
+              Regulatory Authority
+            </strong>
+          </span>
+        </div>
+        <div
+          class="ant-col ant-col-24"
+          style="padding: 8px 8px 8px 8px;"
+        >
+          <div
+            class="ant-form-item view-item"
+          >
+            <div
+              class="ant-row ant-form-item-row"
+            >
+              <div
+                class="ant-col ant-form-item-label"
+              >
+                <label
+                  class=""
+                  for="ADD_COMPLIANCE_CODE_cim_or_cpo"
+                  title=""
+                >
+                  <div
+                    class="view-item-label"
+                  >
+                    <div>
+                      Who is the report for?
+                       
+                    </div>
+                  </div>
+                </label>
+              </div>
+              <div
+                class="ant-col ant-form-item-control"
+              >
+                <div
+                  class="ant-form-item-control-input"
+                >
+                  <div
+                    class="ant-form-item-control-input-content"
+                  >
+                    <div
+                      class="ant-radio-group ant-radio-group-solid vertical-radio-group view-item"
+                    >
+                      <label
+                        class="ant-radio-wrapper ant-radio-wrapper-disabled ant-radio-wrapper-in-form-item"
+                      >
+                        <span
+                          class="ant-radio ant-radio-disabled"
+                        >
+                          <input
+                            class="ant-radio-input"
+                            disabled=""
+                            name="cim_or_cpo"
+                            type="radio"
+                            value="CPO"
+                          />
+                          <span
+                            class="ant-radio-inner"
+                          />
+                        </span>
+                        <span>
+                          Chief Permitting Officer
+                        </span>
+                      </label>
+                      <label
+                        class="ant-radio-wrapper ant-radio-wrapper-disabled ant-radio-wrapper-in-form-item"
+                      >
+                        <span
+                          class="ant-radio ant-radio-disabled"
+                        >
+                          <input
+                            class="ant-radio-input"
+                            disabled=""
+                            name="cim_or_cpo"
+                            type="radio"
+                            value="CIM"
+                          />
+                          <span
+                            class="ant-radio-inner"
+                          />
+                        </span>
+                        <span>
+                          Chief Inspector of Mines
+                        </span>
+                      </label>
+                      <label
+                        class="ant-radio-wrapper ant-radio-wrapper-disabled ant-radio-wrapper-in-form-item"
+                      >
+                        <span
+                          class="ant-radio ant-radio-disabled"
+                        >
+                          <input
+                            class="ant-radio-input"
+                            disabled=""
+                            name="cim_or_cpo"
+                            type="radio"
+                            value="Both"
+                          />
+                          <span
+                            class="ant-radio-inner"
+                          />
+                        </span>
+                        <span>
+                          Both
+                        </span>
+                      </label>
+                      <label
+                        class="ant-radio-wrapper ant-radio-wrapper-disabled ant-radio-wrapper-in-form-item"
+                      >
+                        <span
+                          class="ant-radio ant-radio-disabled"
+                        >
+                          <input
+                            class="ant-radio-input"
+                            disabled=""
+                            name="cim_or_cpo"
+                            type="radio"
+                            value="Not specified"
+                          />
+                          <span
+                            class="ant-radio-inner"
+                          />
+                        </span>
+                        <span>
+                          Not specified
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="ant-col ant-col-24"
+          style="padding: 8px 8px 8px 8px;"
+        >
+          <div
+            class="view-item ant-form-item"
+          >
+            <div
+              class="ant-typography view-item-label"
+            >
+              Resource Information Link
+            </div>
+            <div
+              class="ant-typography view-item-value"
+            >
+              N/A
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="ant-row ant-row-end"
+        style="width: 100%;"
+      >
+        <button
+          aria-label="Cancel"
+          class="ant-btn ant-btn-default core-btn core-btn-default  form-btn"
+          type="button"
+        >
+          <span>
+            Close
+          </span>
+        </button>
+        
+        <button
+          class="ant-btn ant-btn-primary"
+          type="button"
+        >
+          <span>
+            Continue
+          </span>
+        </button>
+      </div>
+    </form>
+  </div>
+</div>
+`;

--- a/services/core-web/src/components/common/wrappers/AddPartyComponentWrapper.tsx
+++ b/services/core-web/src/components/common/wrappers/AddPartyComponentWrapper.tsx
@@ -1,5 +1,5 @@
 import React, { FC, useEffect, useState } from "react";
-import { useDispatch, useSelector } from "react-redux";
+import { useSelector } from "react-redux";
 import { Radio, Divider } from "antd";
 import { ArrowLeftOutlined } from "@ant-design/icons";
 import { Carousel } from "react-responsive-carousel";
@@ -13,6 +13,7 @@ import AddQuickPartyForm from "@/components/Forms/parties/AddQuickPartyForm";
 import { getDropdownProvinceOptions } from "@mds/common/redux/selectors/staticContentSelectors";
 import LinkButton from "../buttons/LinkButton";
 import { closeModal } from "@mds/common/redux/actions/modalActions";
+import { useAppDispatch } from "@mds/common/redux/rootState";
 
 const defaultAddPartyFormState = {
   showingAddPartyForm: false,
@@ -31,7 +32,7 @@ const AddPartyComponentWrapper: FC<AddPartyComponentWrapperProps> = ({ childProp
   const [isPerson, setIsPerson] = useState(true);
   const [addingParty, setAddingParty] = useState(false);
 
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
   const addPartyFormState = useSelector(getAddPartyFormState);
   const provinceOptions = useSelector(getDropdownProvinceOptions);
 
@@ -131,7 +132,7 @@ const AddPartyComponentWrapper: FC<AddPartyComponentWrapperProps> = ({ childProp
         <div style={addingParty ? { display: "none" } : {}}>
           {ChildComponent && (
             <div className="fade-in">
-              <ChildComponent closeModal={() => dispatch(closeModal())} {...childProps} />
+              <ChildComponent closeModal={() => dispatch(closeModal())} {...childProps} isModal />
             </div>
           )}
         </div>

--- a/services/core-web/src/tests/components/Forms/reports/__snapshots__/AddReportDefinitionForm.spec.tsx.snap
+++ b/services/core-web/src/tests/components/Forms/reports/__snapshots__/AddReportDefinitionForm.spec.tsx.snap
@@ -8,20 +8,8 @@ exports[`AddReportDefinitionForm renders properly 1`] = `
   <h3
     class="ant-typography"
   >
-    Create Report
-  </h3>
-  <h4
-    class="ant-typography"
-  >
     Report Details
-  </h4>
-  <div
-    class="ant-typography margin-small--bottom"
-  >
-    <strong>
-      Report Name
-    </strong>
-  </div>
+  </h3>
   <div
     class="ant-form-item ant-form-item-with-help"
   >

--- a/services/minespace-web/src/components/common/wrappers/ModalWrapper.tsx
+++ b/services/minespace-web/src/components/common/wrappers/ModalWrapper.tsx
@@ -30,6 +30,7 @@ const ModalWrapper: FC = () => {
           // TODO: this really doesn't belong here, but too many downstream effects to take out
           closeModal={dispatchCloseModal}
           {...childProps}
+          isModal
         />
       )}
     </CommonModalWrapper>


### PR DESCRIPTION
## Objective 
A minor bug bash.
- sorting by "section" excluded all results without a corresponding compliance article. Inspecting the query showed that it was because the emitted SQL was doing `JOIN compliance_article` (an inner join) so adding `isouter` flag fixed the issue. Didn't test this, but would have also affected any filter or sort that resulted in that join
- cancel button on create report definition form wasn't working. Told it was a modal, now it works.
  - I passed this in the modal wrapper with the idea that a form may or may not be in the modal, but the modal wrapper can always tell it so. 
- mine report definition form wanted a character limit- there are limits on the BE for report name & description, so just added FE validation to match (100 for report name, 300 for description)
- fixed the alignment on the compliance code view/edit that has been bothering me

[MDS-6369](https://bcmines.atlassian.net/browse/MDS-6369)
[MDS-6388](https://bcmines.atlassian.net/browse/MDS-6388)

_Why are you making this change? Provide a short explanation and/or screenshots_
Here's the resulting alignment on compliance code view/edit. 
View:
![image](https://github.com/user-attachments/assets/0e07803e-bb0b-40cb-8ab5-f1971c58f5b9)
Edit:
![image](https://github.com/user-attachments/assets/7a22274c-57c5-4137-bde2-aa6abe0ceca2)

