### PR TITLE
[MDS-6374] Change addressing duplicate report on extraction

### DIFF
--- a/services/common/src/utils/helpers.ts
+++ b/services/common/src/utils/helpers.ts
@@ -104,7 +104,7 @@ export const getConditionsWithRequirements = (conditions: IPermitCondition[], re
     }
 
     if (condition?.sub_conditions?.length > 0) {
-      result = result.concat(getConditionsWithRequirements(condition.sub_conditions));
+      result = result.concat(getConditionsWithRequirements(condition.sub_conditions, requirements));
     }
   });
 

--- a/services/common/src/utils/helpers.ts
+++ b/services/common/src/utils/helpers.ts
@@ -97,8 +97,9 @@ export const getConditionsWithRequirements = (conditions: IPermitCondition[], re
 
   conditions.forEach((condition) => {
     if (requirements && condition?.permit_condition_id) {
-      const req = requirementsByCondition[condition.permit_condition_id];
-      result = [...result, ...(req || [])];
+      const reqs = requirementsByCondition[condition.permit_condition_id];
+      const conditionWithRequirement = reqs?.map(req => ({ ...condition, mineReportPermitRequirement: req }));
+      result = [...result, ...(conditionWithRequirement || [])];
     } else if (condition?.mineReportPermitRequirement) {
       result.push(condition);
     }

--- a/services/core-api/app/api/mines/permits/permit_extraction/create_permit_conditions.py
+++ b/services/core-api/app/api/mines/permits/permit_extraction/create_permit_conditions.py
@@ -15,6 +15,9 @@ from .models.permit_condition_result import (
 )
 from .permit_condition_category_creator import PermitConditionCategoryCreator
 from .permit_condition_creator import PermitConditionCreator
+from app.api.mines.reports.models.mine_report_permit_requirement import (
+    MineReportPermitRequirement,
+)
 
 
 def create_permit_conditions_from_task(task: PermitExtractionTask):
@@ -49,9 +52,10 @@ def create_permit_conditions_from_task(task: PermitExtractionTask):
                     condition=condition,
                 )
                 comparisons = comparisons + created_comparisons
-                created_cond.append(main_cond)
                 if title_cond:
                     created_cond.append(title_cond)
+                
+                created_cond.append(main_cond)
         
         comparison_by_id = {}
 
@@ -60,7 +64,19 @@ def create_permit_conditions_from_task(task: PermitExtractionTask):
 
         for condition in created_cond:
             comparison = comparison_by_id.get(condition.permit_condition_id)
-            report_requirement = create_or_copy_permit_condition_report_requirements(task, condition, comparison)
+            parent_mine_report = MineReportPermitRequirement.find_by_permit_condition_id(condition.parent_permit_condition_id)
+            is_duplicate_of_parent_report = False
+            report_requirement = None
+
+            if parent_mine_report:
+                meta = condition.meta or {}
+                questions = meta.get("questions", [])
+                condition_report_name = next((q for q in questions if (q and q["question_key"] == "report_name")), None)
+                if condition_report_name:
+                    is_duplicate_of_parent_report = parent_mine_report.report_name == condition_report_name['answer']
+            
+            if not is_duplicate_of_parent_report:
+                report_requirement = create_or_copy_permit_condition_report_requirements(task, condition, comparison)
             if report_requirement:
                 db.session.add(report_requirement)
 

--- a/services/core-api/app/api/mines/reports/models/mine_report_permit_requirement.py
+++ b/services/core-api/app/api/mines/reports/models/mine_report_permit_requirement.py
@@ -51,6 +51,13 @@ class MineReportPermitRequirement(SoftDeleteMixin, Base, AuditMixin):
             return cls.query.filter_by(mine_report_permit_requirement_id=_id, deleted_ind=False).first()
         except ValueError:
             return None
+        
+    @classmethod
+    def find_by_permit_condition_id(cls, _id) -> "MineReportPermitRequirement":
+        try:
+            return cls.query.filter_by(permit_condition_id=_id, deleted_ind=False).first()
+        except ValueError:
+            return None
 
     @classmethod
     def find_by_report_name(cls, _report_name) -> "MineReportPermitRequirement":

--- a/services/core-api/app/api/mines/reports/models/mine_report_permit_requirement.py
+++ b/services/core-api/app/api/mines/reports/models/mine_report_permit_requirement.py
@@ -46,23 +46,23 @@ class MineReportPermitRequirement(SoftDeleteMixin, Base, AuditMixin):
         return '<MineReportPermitRequirement %r>' % self.mine_report_permit_requirement_id
 
     @classmethod
-    def find_by_mine_report_permit_requirement_id(cls, _id) -> "MineReportPermitRequirement":
+    def find_by_mine_report_permit_requirement_id(cls, id) -> "MineReportPermitRequirement":
         try:
-            return cls.query.filter_by(mine_report_permit_requirement_id=_id, deleted_ind=False).first()
+            return cls.query.filter_by(mine_report_permit_requirement_id=id, deleted_ind=False).first()
         except ValueError:
             return None
         
     @classmethod
-    def find_by_permit_condition_id(cls, _id) -> "MineReportPermitRequirement":
+    def find_by_permit_condition_id(cls, id) -> "MineReportPermitRequirement":
         try:
-            return cls.query.filter_by(permit_condition_id=_id, deleted_ind=False).first()
+            return cls.query.filter_by(permit_condition_id=id, deleted_ind=False).first()
         except ValueError:
             return None
 
     @classmethod
-    def find_by_report_name(cls, _report_name) -> "MineReportPermitRequirement":
+    def find_by_report_name(cls, report_name) -> "MineReportPermitRequirement":
         try:
-            return cls.query.filter_by(report_name=_report_name).all()
+            return cls.query.filter_by(report_name=report_name).all()
         except ValueError:
             return None
 

--- a/services/core-web/src/components/Forms/reports/ReportPermitRequirementForm.tsx
+++ b/services/core-web/src/components/Forms/reports/ReportPermitRequirementForm.tsx
@@ -154,7 +154,7 @@ export const ReportPermitRequirementForm: FC<ReportPermitRequirementProps> = ({
                   Regulatory Authority
                 </Typography.Paragraph>
                 <Typography.Paragraph>
-                  {mineReportPermitRequirement.cim_or_cpo
+                  {mineReportPermitRequirement?.cim_or_cpo
                     ? REPORT_REGULATORY_AUTHORITY_CODES_HASH[mineReportPermitRequirement.cim_or_cpo]
                     : "Not Specified"}
                 </Typography.Paragraph>
@@ -183,7 +183,7 @@ export const ReportPermitRequirementForm: FC<ReportPermitRequirementProps> = ({
                   Ministry Recipient
                 </Typography.Paragraph>
                 <Typography.Paragraph>
-                  {mineReportPermitRequirement.ministry_recipient?.map(
+                  {mineReportPermitRequirement?.ministry_recipient?.map(
                     (dest, index) =>
                       `${REPORT_MINISTRY_RECIPIENT_HASH[dest]}${index < mineReportPermitRequirement.ministry_recipient.length - 1 ? ", " : ""} `
                   ) ?? "None Specified"}

--- a/services/core-web/src/components/mine/Permit/ComparePermitConditionHistoryModal.tsx
+++ b/services/core-web/src/components/mine/Permit/ComparePermitConditionHistoryModal.tsx
@@ -31,7 +31,7 @@ const ComparePermitConditionHistoryModal: FC<ComparePermitConditionHistoryModalP
         getMineReportPermitRequirementsByAmendment(props.permitGuid, props.previousAmendment?.permit_amendment_guid)
     );
 
-    const oldReports = getConditionsWithRequirements([props.currentAmendmentCondition], previousMineReportPermitRequirements);
+    const oldReports = getConditionsWithRequirements([props.previousAmendmentCondition], previousMineReportPermitRequirements);
     const newReports = getConditionsWithRequirements([props.currentAmendmentCondition], newMineReportPermitRequirements);
 
     return (

--- a/services/core-web/src/components/mine/Permit/PermitConditionReportRequirements.tsx
+++ b/services/core-web/src/components/mine/Permit/PermitConditionReportRequirements.tsx
@@ -23,31 +23,41 @@ const PermitConditionReportRequirements: FC<PermitConditionReportRequirementsPro
 
     return (
         <Collapse expandIconPosition="end">
-            {conditionsWithRequirements.map((cond: IPermitCondition, index) => (
-                <Collapse.Panel
-                    key={cond.permit_condition_id}
-                    header={
-                        <Typography.Text strong>
-                            Report #{index + 1}
-                            {cond.mineReportPermitRequirement?.report_name
-                                ? ` - ${cond.mineReportPermitRequirement.report_name}`
-                                : ""}
-                        </Typography.Text>
-                    }
-                    className="report-collapse"
-                >
-                    <ReportPermitRequirementForm
-                        modalView={false}
-                        condition={cond}
-                        permitGuid={permitGuid}
-                        mineReportPermitRequirement={cond.mineReportPermitRequirement}
-                        canEditPermitConditions={canEditPermitConditions}
-                        refreshData={refreshData}
-                        currentAmendment={currentAmendment}
-                        mineGuid={mineGuid}
-                    />
-                </Collapse.Panel>
-            ))}
+            {conditionsWithRequirements.map((cond, index) => {
+                let reportName = null;
+                if (cond.mineReportPermitRequirement?.report_name) {
+                    reportName = cond.mineReportPermitRequirement?.report_name;
+                } else if (cond["report_name"]) {
+                    reportName = cond["report_name"];
+                }
+
+                return (
+                    <Collapse.Panel
+                        key={cond.permit_condition_id}
+                        header={
+                            <Typography.Text strong>
+                                Report #{index + 1}
+                                {reportName
+                                    ? ` - ${reportName}`
+                                    : ""}
+                            </Typography.Text>
+                        }
+                        className="report-collapse"
+                    >
+                        <ReportPermitRequirementForm
+                            modalView={false}
+                            condition={cond}
+                            permitGuid={permitGuid}
+                            mineReportPermitRequirement={cond.mineReportPermitRequirement}
+                            canEditPermitConditions={canEditPermitConditions}
+                            refreshData={refreshData}
+                            currentAmendment={currentAmendment}
+                            mineGuid={mineGuid}
+                        />
+                    </Collapse.Panel>
+                )
+            }
+            )}
         </Collapse>
     );
 };

--- a/services/core-web/src/components/mine/Permit/PermitConditionReportRequirements.tsx
+++ b/services/core-web/src/components/mine/Permit/PermitConditionReportRequirements.tsx
@@ -23,22 +23,15 @@ const PermitConditionReportRequirements: FC<PermitConditionReportRequirementsPro
 
     return (
         <Collapse expandIconPosition="end">
-            {conditionsWithRequirements.map((cond, index) => {
-                let reportName = null;
-                if (cond.mineReportPermitRequirement?.report_name) {
-                    reportName = cond.mineReportPermitRequirement?.report_name;
-                } else if (cond["report_name"]) {
-                    reportName = cond["report_name"];
-                }
-
+            {conditionsWithRequirements.map((cond: IPermitCondition, index) => {
                 return (
                     <Collapse.Panel
                         key={cond.permit_condition_id}
                         header={
                             <Typography.Text strong>
                                 Report #{index + 1}
-                                {reportName
-                                    ? ` - ${reportName}`
+                                {cond.mineReportPermitRequirement?.report_name
+                                    ? ` - ${cond.mineReportPermitRequirement.report_name}`
                                     : ""}
                             </Typography.Text>
                         }


### PR DESCRIPTION
## Objective 

[MDS-6374](https://bcmines.atlassian.net/browse/MDS-6374)

- Change to check report name to address duplicate report on permit extraction
- Change to address blank page showing when clicking a report
- Change to address report name sometimes not showing up
- I noticed when doing a permit amalgamation using the same document as the original permit extraction sometimes the previous report doesn't show in the comparison modal. Included a change for this.

![image](https://github.com/user-attachments/assets/84fb1e76-1958-4374-9d4d-afcf03377abb)
