### PR TITLE
[FIX] Ask to confirm delete permit conditions before doing it

### DIFF
--- a/services/common/src/components/common/ActionMenu.tsx
+++ b/services/common/src/components/common/ActionMenu.tsx
@@ -4,9 +4,10 @@ import CaretDownOutlined from "@ant-design/icons/CaretDownOutlined";
 import DownOutlined from "@ant-design/icons/DownOutlined";
 import { ITableAction } from "@mds/common/components/common/CoreTableCommonColumns";
 
-export const deleteConfirmWrapper = (recordDescription: string, onOk: () => void) => {
+export const deleteConfirmWrapper = (recordDescription: string, onOk: () => void, plural = false) => {
   const title = `Confirm Deletion`;
-  const content = `Are you sure you want to delete this ${recordDescription}?`;
+  const article = plural ? "these" : "this"
+  const content = `Are you sure you want to delete ${article} ${recordDescription}?`;
   const modalContent = {
     title,
     content,

--- a/services/common/src/tests/mocks/dataMocks.tsx
+++ b/services/common/src/tests/mocks/dataMocks.tsx
@@ -1817,7 +1817,6 @@ export const PERMITS: IPermit[] = [
               permit_condition_id: 1639,
               due_date_period_months: 12,
               initial_due_date: "2024-01-01",
-              condition_category_code: "HSC"
             }
           },
           {

--- a/services/core-web/src/components/mine/Permit/ViewPermit.tsx
+++ b/services/core-web/src/components/mine/Permit/ViewPermit.tsx
@@ -18,7 +18,7 @@ import { useFeatureFlag } from "@mds/common/providers/featureFlags/useFeatureFla
 import { Feature } from "@mds/common/utils/featureFlag";
 import { PresetStatusColorType } from "antd/es/_util/colors";
 import { Badge } from "antd";
-import { ActionMenuButton } from "@mds/common/components/common/ActionMenu";
+import { ActionMenuButton, deleteConfirmWrapper } from "@mds/common/components/common/ActionMenu";
 import {
   getPermitExtractionByGuid,
   initiatePermitExtraction,
@@ -234,11 +234,12 @@ const ViewPermit: FC = () => {
   };
 
   const handleDeleteConditions = async () => {
-    await dispatch(
-      deletePermitConditions({ permit_amendment_id: latestAmendment?.permit_amendment_id })
-    );
-
-    dispatch(fetchPermits(id));
+    deleteConfirmWrapper("permit conditions", async () => {
+      await dispatch(
+        deletePermitConditions({ permit_amendment_id: latestAmendment?.permit_amendment_id })
+      );
+      dispatch(fetchPermits(id));
+    }, true);
   };
 
   const headerActions = [


### PR DESCRIPTION
## Objective 
- it's surprising when it just deletes the conditions
- so confirm first
- also I was getting _one_ type error in one of the compiles there so I made it go away

_Why are you making this change? Provide a short explanation and/or screenshots_
![image](https://github.com/user-attachments/assets/043a485a-0da6-417c-a6a1-813ff522e1df)
