### PR TITLE
[MDS-6395] Remove Skeleton from Permit Conditions

### DIFF
--- a/services/common/src/components/forms/RenderCancelButton.tsx
+++ b/services/common/src/components/forms/RenderCancelButton.tsx
@@ -32,6 +32,8 @@ interface RenderCancelButtonProps {
   cancelFunction?: () => void | Promise<void>;
   cancelModalProps?: ModalFuncProps;
   iconButton?: boolean;
+  disabled?: boolean;
+  loading?: boolean;
 }
 
 /**
@@ -48,7 +50,9 @@ const RenderCancelButton: FC<RenderCancelButtonProps> = ({
   buttonProps = { type: "default" },
   cancelFunction,
   cancelModalProps,
-  iconButton = false
+  iconButton = false,
+  disabled = false,
+  loading = false,
 }) => {
   const dispatch = useDispatch();
   const { formName, isModal, isEditMode } = useContext(FormContext);
@@ -72,7 +76,7 @@ const RenderCancelButton: FC<RenderCancelButtonProps> = ({
   const className = `${buttonProps?.className ?? ""} form-btn`;
 
   return (
-    <CoreButton aria-label="Cancel" {...buttonProps} className={className} type={buttonType} onClick={() => buttonCancelFunction()}>
+    <CoreButton aria-label="Cancel" loading={loading} disabled={disabled} {...buttonProps} className={className} type={buttonType} onClick={() => buttonCancelFunction()}>
       {!iconButton && buttonLabel}
     </CoreButton>
   );

--- a/services/common/src/components/forms/RenderSubmitButton.tsx
+++ b/services/common/src/components/forms/RenderSubmitButton.tsx
@@ -27,6 +27,7 @@ const RenderSubmitButton: FC<RenderSubmitButtonProps> = ({
   const submitting = useSelector(isSubmitting(formName));
   const isFormDirty = useSelector(isDirty(formName));
   const disabled = props.disabled || submitting || (!isFormDirty && disableOnClean);
+  const loading = props.loading || (submitting && !iconButton);
   const className = `${buttonProps?.className ?? ""} form-btn`;
 
   return (
@@ -35,7 +36,7 @@ const RenderSubmitButton: FC<RenderSubmitButtonProps> = ({
         <Button
           type="primary"
           disabled={disabled}
-          loading={submitting || props.loading}
+          loading={loading}
           htmlType="submit"
           icon={icon}
           aria-label="Submit"

--- a/services/core-web/src/components/Forms/reports/ReportPermitRequirementForm.tsx
+++ b/services/core-web/src/components/Forms/reports/ReportPermitRequirementForm.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from "react";
+import React, { FC, useEffect } from "react";
 import { Field } from "@mds/common/components/forms/form";
 import { Button, Col, Row, Typography } from "antd";
 import { useAppDispatch } from "@mds/common/redux/rootState";
@@ -56,6 +56,12 @@ export const ReportPermitRequirementForm: FC<ReportPermitRequirementProps> = ({
   const { loading } = usePermitConditions();
   const dispatch = useAppDispatch();
   const [isEditMode, setIsEditMode] = React.useState(modalView && canEditPermitConditions);
+
+  useEffect(() => {
+    if (!canEditPermitConditions) {
+      setIsEditMode(false);
+    }
+  }, [canEditPermitConditions]);
 
   const handleDeleteReportRequirement = async ({ mine_report_permit_requirement_id }) => {
     deleteConfirmWrapper("Report Requirement", async () => {

--- a/services/core-web/src/components/Forms/reports/ReportPermitRequirementForm.tsx
+++ b/services/core-web/src/components/Forms/reports/ReportPermitRequirementForm.tsx
@@ -1,7 +1,7 @@
-import React, { FC, useEffect } from "react";
+import React, { FC } from "react";
 import { Field } from "@mds/common/components/forms/form";
 import { Button, Col, Row, Typography } from "antd";
-import { useDispatch } from "react-redux";
+import { useAppDispatch } from "@mds/common/redux/rootState";
 import {
   IMineReport,
   IMineReportPermitRequirement,
@@ -27,6 +27,8 @@ import {
   updateMineReportPermitRequirement,
 } from "@mds/common/redux/slices/mineReportPermitRequirementSlice";
 import { deleteConfirmWrapper } from "@mds/common/components/common/ActionMenu";
+import { usePermitConditions } from "@/components/mine/Permit/PermitConditionsContext";
+
 
 interface ReportPermitRequirementProps {
   onSubmit?: (values: Partial<IMineReport>) => void | Promise<void>;
@@ -51,18 +53,12 @@ export const ReportPermitRequirementForm: FC<ReportPermitRequirementProps> = ({
   currentAmendment,
   mineGuid,
 }) => {
-  const dispatch = useDispatch();
-  const [isEditMode, setIsEditMode] = React.useState(modalView);
-
-  useEffect(() => {
-    if (!canEditPermitConditions) {
-      setIsEditMode(false);
-    }
-  }, [canEditPermitConditions]);
+  const { loading } = usePermitConditions();
+  const dispatch = useAppDispatch();
+  const [isEditMode, setIsEditMode] = React.useState(modalView && canEditPermitConditions);
 
   const handleDeleteReportRequirement = async ({ mine_report_permit_requirement_id }) => {
     deleteConfirmWrapper("Report Requirement", async () => {
-      // @ts-ignore
       await dispatch(deleteMineReportPermitRequirement({ mineGuid, mine_report_permit_requirement_id })).then(async () => {
         await refreshData();
         setIsEditMode(false);
@@ -71,7 +67,6 @@ export const ReportPermitRequirementForm: FC<ReportPermitRequirementProps> = ({
   };
 
   const handleEditReportRequirement = async (values) => {
-    // @ts-ignore
     await dispatch(updateMineReportPermitRequirement({ mineGuid, values })).then(async () => {
       await refreshData();
       setIsEditMode(false);
@@ -121,6 +116,7 @@ export const ReportPermitRequirementForm: FC<ReportPermitRequirementProps> = ({
               label="Report Type"
               validate={[maxLength(255)]}
               component={RenderField}
+              disabled={loading}
             />
           </Col>
           <Col span={12}>
@@ -136,6 +132,7 @@ export const ReportPermitRequirementForm: FC<ReportPermitRequirementProps> = ({
                   label: key,
                 };
               })}
+              disabled={loading}
             />
           </Col>
           <Col md={12} sm={24}>
@@ -145,6 +142,7 @@ export const ReportPermitRequirementForm: FC<ReportPermitRequirementProps> = ({
               placeholder="Select date"
               formatViewDate
               component={RenderDate}
+              disabled={loading}
             />
           </Col>
           <Col md={12} sm={24}>
@@ -173,6 +171,7 @@ export const ReportPermitRequirementForm: FC<ReportPermitRequirementProps> = ({
                 isVertical
                 validate={[requiredRadioButton]}
                 component={RenderRadioButtons}
+                disabled={loading}
               />
             )}
           </Col>
@@ -201,6 +200,7 @@ export const ReportPermitRequirementForm: FC<ReportPermitRequirementProps> = ({
                     label: REPORT_MINISTRY_RECIPIENT_HASH[key],
                   };
                 })}
+                disabled={loading}
               />
             )}
           </Col>
@@ -208,6 +208,7 @@ export const ReportPermitRequirementForm: FC<ReportPermitRequirementProps> = ({
         <Row justify={isEditMode && mineReportPermitRequirement ? "space-between" : "end"}>
           {(isEditMode && mineReportPermitRequirement) && (
             <LinkButton
+              disabled={loading}
               className="report-delete-button"
               onClick={() => handleDeleteReportRequirement(mineReportPermitRequirement)}
             >
@@ -218,14 +219,16 @@ export const ReportPermitRequirementForm: FC<ReportPermitRequirementProps> = ({
           {isEditMode ? (
             <div>
               <RenderCancelButton
+                loading={loading}
                 cancelFunction={!modalView ? () => setIsEditMode(false) : undefined}
               />
-              <Button type="primary" htmlType="submit">
+              <Button type="primary" htmlType="submit" loading={loading}>
                 {mineReportPermitRequirement ? "Update" : "Add"} Report
               </Button>
             </div>
           ) : (canEditPermitConditions &&
             <Button
+              loading={loading}
               type="primary"
               onClick={(event) => {
                 event.preventDefault();

--- a/services/core-web/src/components/mine/Permit/PermitConditionCategory.spec.tsx
+++ b/services/core-web/src/components/mine/Permit/PermitConditionCategory.spec.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { render, fireEvent, screen } from "@testing-library/react";
 import { ReduxWrapper } from "@mds/common/tests/utils/ReduxWrapper";
 import { EditPermitConditionCategoryInline } from "./PermitConditionCategory";
+import { PermitConditionsProvider } from "./PermitConditionsContext";
 
 const mockCategory = {
   condition_category_code: "TEST-CAT",
@@ -22,13 +23,25 @@ const mockProps = {
   moveDown: jest.fn()
 };
 
+const providerParams = {
+  mineGuid: "mineGuid",
+  permitGuid: "permitGuid",
+  latestAmendment: null,
+  previousAmendment: null,
+  currentAmendment: null,
+  loading: false,
+  setLoading: jest.fn(),
+};
+
 const initialState = {};
 
 describe("PermitConditionCategory", () => {
   it("renders category title with count in view mode", () => {
     render(
       <ReduxWrapper initialState={initialState}>
-        <EditPermitConditionCategoryInline {...mockProps} />
+        <PermitConditionsProvider value={providerParams}>
+          <EditPermitConditionCategoryInline {...mockProps} />
+        </PermitConditionsProvider>
       </ReduxWrapper>
     );
 
@@ -38,7 +51,9 @@ describe("PermitConditionCategory", () => {
   it("switches to edit mode on click", () => {
     render(
       <ReduxWrapper initialState={initialState}>
-        <EditPermitConditionCategoryInline {...mockProps} />
+        <PermitConditionsProvider value={providerParams}>
+          <EditPermitConditionCategoryInline {...mockProps} />
+        </PermitConditionsProvider>
       </ReduxWrapper>
     );
 
@@ -49,7 +64,9 @@ describe("PermitConditionCategory", () => {
   it("calls moveUp when up arrow clicked", () => {
     render(
       <ReduxWrapper initialState={initialState}>
-        <EditPermitConditionCategoryInline {...mockProps} />
+        <PermitConditionsProvider value={providerParams}>
+          <EditPermitConditionCategoryInline {...mockProps} />
+        </PermitConditionsProvider>
       </ReduxWrapper>
     );
 
@@ -63,7 +80,9 @@ describe("PermitConditionCategory", () => {
   it("calls moveDown when down arrow clicked", () => {
     render(
       <ReduxWrapper initialState={initialState}>
-        <EditPermitConditionCategoryInline {...mockProps} />
+        <PermitConditionsProvider value={providerParams}>
+          <EditPermitConditionCategoryInline {...mockProps} />
+        </PermitConditionsProvider>
       </ReduxWrapper>
     );
 
@@ -77,7 +96,9 @@ describe("PermitConditionCategory", () => {
   it("disables delete button when condition count > 0", () => {
     render(
       <ReduxWrapper initialState={initialState}>
-        <EditPermitConditionCategoryInline {...mockProps} conditionCount={1} />
+        <PermitConditionsProvider value={providerParams}>
+          <EditPermitConditionCategoryInline {...mockProps} conditionCount={1} />
+        </PermitConditionsProvider>
       </ReduxWrapper>
     );
 
@@ -90,7 +111,9 @@ describe("PermitConditionCategory", () => {
   it("enables delete button when condition count = 0", () => {
     render(
       <ReduxWrapper initialState={initialState}>
-        <EditPermitConditionCategoryInline {...mockProps} conditionCount={0} />
+        <PermitConditionsProvider value={providerParams}>
+          <EditPermitConditionCategoryInline {...mockProps} conditionCount={0} />
+        </PermitConditionsProvider>
       </ReduxWrapper>
     );
 
@@ -110,7 +133,9 @@ describe("PermitConditionCategory", () => {
   it("submits form with updated values", async () => {
     render(
       <ReduxWrapper initialState={initialState}>
-        <EditPermitConditionCategoryInline {...mockProps} />
+        <PermitConditionsProvider value={providerParams}>
+          <EditPermitConditionCategoryInline {...mockProps} />
+        </PermitConditionsProvider>
       </ReduxWrapper>
     );
 

--- a/services/core-web/src/components/mine/Permit/PermitConditionCategory.tsx
+++ b/services/core-web/src/components/mine/Permit/PermitConditionCategory.tsx
@@ -12,6 +12,7 @@ import PermitConditionCategorySelector from "./PermitConditionCategorySelector";
 import { required } from "@mds/common/redux/utils/Validate";
 import { useDispatch } from "react-redux";
 import { formatPermitConditionStep } from "@mds/common/utils/helpers";
+import { usePermitConditions } from "./PermitConditionsContext";
 
 export interface IPermitConditionCategoryProps {
   canEdit: boolean;
@@ -28,6 +29,7 @@ export interface IPermitConditionCategoryProps {
 export const EditPermitConditionCategoryInline: FC<IPermitConditionCategoryProps> = ({ category, ...props }) => {
   const [isEditMode, setIsEditMode] = useState(false);
   const { condition_category_code } = category;
+  const { loading } = usePermitConditions();
 
   const dispatch = useDispatch();
   const formName = `${FORM.INLINE_EDIT_PERMIT_CONDITION_CATEGORY}}-${condition_category_code}`;
@@ -73,13 +75,21 @@ export const EditPermitConditionCategoryInline: FC<IPermitConditionCategoryProps
     <FormWrapper scrollOnToggleEdit={false} name={formName} onSubmit={handleSubmit} initialValues={category} isEditMode={isEditMode}>
       <Row style={{ gap: '0.5em' }}>
         <Col flex-shrink="1" style={{ maxWidth: '40px' }}>
-          <Field name="step" component={RenderField} required={true} validate={[required]} style={{ marginRight: 0, }} />
+          <Field
+            name="step"
+            component={RenderField}
+            required={true}
+            validate={[required]}
+            style={{ marginRight: 0, }}
+            disabled={loading}
+          />
         </Col>
         <Col>
           <PermitConditionCategorySelector showLabel={false} />
         </Col>
         <Col flex="auto" style={{ display: 'flex', gap: '0.5em' }}>
           <Button
+            disabled={loading}
             className="icon-button-container"
             style={{ marginRight: 0 }}
             onClick={cancel}
@@ -87,7 +97,11 @@ export const EditPermitConditionCategoryInline: FC<IPermitConditionCategoryProps
             icon={<FontAwesomeIcon icon={faXmark} />}
           />
 
-          <RenderSubmitButton buttonText="" buttonProps={{ "aria-label": "Confirm", className: "icon-button-container", style: { marginRight: 0, marginLeft: 0 }, icon: <FontAwesomeIcon icon={faCheck} /> }} />
+          <RenderSubmitButton
+            disabled={loading}
+            icon={<FontAwesomeIcon icon={faCheck} />}
+            buttonProps={{ "aria-label": "Confirm", className: "fa-icon-container", style: { marginRight: 0, marginLeft: 0 } }}
+          />
 
           <Popconfirm
             disabled={props.conditionCount > 0}
@@ -103,6 +117,7 @@ export const EditPermitConditionCategoryInline: FC<IPermitConditionCategoryProps
             cancelText="No"
           >
             <Button
+              loading={loading}
               disabled={props.conditionCount > 0}
               danger={true}
               icon={<FontAwesomeIcon icon={faTrash} />}
@@ -110,7 +125,7 @@ export const EditPermitConditionCategoryInline: FC<IPermitConditionCategoryProps
           </Popconfirm>
 
           <Button
-            disabled={props.currentPosition <= 0}
+            disabled={props.currentPosition <= 0 || loading}
             onClick={(event) => {
               event.stopPropagation();
               props.moveUp(category);
@@ -121,7 +136,7 @@ export const EditPermitConditionCategoryInline: FC<IPermitConditionCategoryProps
           />
           <Button
             style={{ marginLeft: 0 }}
-            disabled={props.currentPosition >= props.categoryCount - 1}
+            disabled={props.currentPosition >= props.categoryCount - 1 || loading}
             aria-label="Move Category Down"
             onClick={(event) => {
               event.stopPropagation();

--- a/services/core-web/src/components/mine/Permit/PermitConditionForm.spec.tsx
+++ b/services/core-web/src/components/mine/Permit/PermitConditionForm.spec.tsx
@@ -37,6 +37,8 @@ describe("PermitConditionForm", () => {
         latestAmendment: MOCK.PERMITS[0].permit_amendments[0],
         previousAmendment: MOCK.PERMITS[0].permit_amendments[1],
         currentAmendment: MOCK.PERMITS[0].permit_amendments[0],
+        loading: false,
+        setLoading: jest.fn()
     };
 
     it("renders properly in edit mode", async () => {

--- a/services/core-web/src/components/mine/Permit/PermitConditionForm.tsx
+++ b/services/core-web/src/components/mine/Permit/PermitConditionForm.tsx
@@ -64,7 +64,7 @@ const PermitConditionForm: FC<PermitConditionFormProps> = ({
     const dispatch = useAppDispatch();
     const { id: mineGuid, permitGuid } = useParams<{ id: string; permitGuid: string }>();
     const [isEditMode, setIsEditMode] = useState<boolean>(false);
-    const { currentAmendment, loading } = usePermitConditions();
+    const { currentAmendment, loading, setLoading } = usePermitConditions();
     // the form fails to re-initialize when the category is changed, so concatenating it forces it to make a new one
     const formName = `${FORM.EDIT_PERMIT_CONDITION}_${condition.permit_condition_id}_${condition.condition_category_code}`;
 
@@ -89,6 +89,7 @@ const PermitConditionForm: FC<PermitConditionFormProps> = ({
     }, [canEditPermitConditions]);
 
     const handleSubmit = async (values) => {
+        setLoading(true);
         const payload = values.step
             ? {
                 ...values,
@@ -99,8 +100,9 @@ const PermitConditionForm: FC<PermitConditionFormProps> = ({
         // @ts-ignore
         if (resp?.type !== ERROR) {
             cancelEdit();
-            return refreshData();
+            refreshData();
         }
+        setLoading(false);
     };
     const handleCancel = () => {
         cancelEdit();

--- a/services/core-web/src/components/mine/Permit/PermitConditionForm.tsx
+++ b/services/core-web/src/components/mine/Permit/PermitConditionForm.tsx
@@ -1,5 +1,5 @@
 import React, { FC, useEffect, useState } from "react";
-import { useDispatch } from "react-redux";
+import { useAppDispatch } from "@mds/common/redux/rootState";
 import { useParams } from "react-router-dom";
 import { change, Field, reset } from "@mds/common/components/forms/form";
 import { Row, Col, Button, Typography } from "antd";
@@ -61,10 +61,10 @@ const PermitConditionForm: FC<PermitConditionFormProps> = ({
     isAddingListItem,
     categoryOptions
 }) => {
-    const dispatch = useDispatch();
+    const dispatch = useAppDispatch();
     const { id: mineGuid, permitGuid } = useParams<{ id: string; permitGuid: string }>();
     const [isEditMode, setIsEditMode] = useState<boolean>(false);
-    const { currentAmendment } = usePermitConditions();
+    const { currentAmendment, loading } = usePermitConditions();
     // the form fails to re-initialize when the category is changed, so concatenating it forces it to make a new one
     const formName = `${FORM.EDIT_PERMIT_CONDITION}_${condition.permit_condition_id}_${condition.condition_category_code}`;
 
@@ -145,7 +145,9 @@ const PermitConditionForm: FC<PermitConditionFormProps> = ({
         );
     };
 
-    const editableProps = !editingConditionGuid && canEditPermitConditions ?
+    const editingEnabled = !editingConditionGuid && canEditPermitConditions && !loading;
+
+    const editableProps = editingEnabled ?
         {
             onClick: startEdit,
             title: "Edit Condition",
@@ -168,7 +170,7 @@ const PermitConditionForm: FC<PermitConditionFormProps> = ({
             (<Row
                 wrap={false}
                 align="top"
-                className={`condition-content ${!editingConditionGuid ? "editable" : ""}`}
+                className={`condition-content ${editingEnabled ? "editable" : ""}`}
             >
                 <Col className="step-column" style={{ flexShrink: 0 }}>
                     <Typography.Paragraph className="view-item-value">{formatPermitConditionStep(condition.step)}</Typography.Paragraph>
@@ -194,6 +196,7 @@ const PermitConditionForm: FC<PermitConditionFormProps> = ({
                 {(isEditMode && isExtracted && categoryOptions) && <Row>
                     <Col span={24}>
                         <Field
+                            disabled={loading}
                             showOptional={false}
                             label="Condition Category:"
                             component={RenderGroupedSelect}
@@ -216,7 +219,7 @@ const PermitConditionForm: FC<PermitConditionFormProps> = ({
                             name="step"
                             component={RenderField}
                             showNA={false}
-                            disabled={isAddingListItem}
+                            disabled={isAddingListItem || loading}
                             onChange={handleBackSpace}
                         />
                     </Col>
@@ -226,7 +229,7 @@ const PermitConditionForm: FC<PermitConditionFormProps> = ({
                         <Field
                             name="condition"
                             component={RenderAutoSizeField}
-                            disabled={isAddingListItem}
+                            disabled={isAddingListItem || loading}
                         />
                     </Col>
                 </Row>
@@ -238,6 +241,7 @@ const PermitConditionForm: FC<PermitConditionFormProps> = ({
                             >
                                 {isExtracted && <Col>
                                     <Button
+                                        loading={loading}
                                         className="fa-icon-container btn-sm-padding"
                                         type="default"
                                         icon={<FontAwesomeIcon icon={faPlus} />}
@@ -256,6 +260,7 @@ const PermitConditionForm: FC<PermitConditionFormProps> = ({
                                 </Col> */}
                                 <Col>
                                     <Button
+                                        loading={loading}
                                         className="fa-icon-container btn-sm-padding"
                                         type="default"
                                         icon={<FontAwesomeIcon icon={faClipboard} />}
@@ -267,6 +272,7 @@ const PermitConditionForm: FC<PermitConditionFormProps> = ({
                                 </Col>
                                 <Col>
                                     <RenderCancelButton
+                                        disabled={loading}
                                         cancelFunction={handleCancel}
                                         buttonProps={{
                                             type: "primary",
@@ -278,6 +284,7 @@ const PermitConditionForm: FC<PermitConditionFormProps> = ({
                                 </Col>
                                 <Col>
                                     <RenderSubmitButton
+                                        disabled={loading}
                                         buttonProps={{
                                             icon: <FontAwesomeIcon icon={faCheck} />,
                                         }}
@@ -290,6 +297,7 @@ const PermitConditionForm: FC<PermitConditionFormProps> = ({
                             <Row gutter={8} align="middle" className="condition-edit-buttons">
                                 <Col>
                                     <Button
+                                        disabled={loading}
                                         className="fa-icon-container"
                                         aria-label="Delete Condition"
                                         type="default"
@@ -302,7 +310,7 @@ const PermitConditionForm: FC<PermitConditionFormProps> = ({
                                         className="fa-icon-container"
                                         aria-label="Move Condition Up"
                                         type="default"
-                                        disabled={!moveUp}
+                                        disabled={!moveUp || loading}
                                         icon={<FontAwesomeIcon icon={faArrowUp} />}
                                         onClick={() => moveUp(condition)}
                                     />
@@ -312,7 +320,7 @@ const PermitConditionForm: FC<PermitConditionFormProps> = ({
                                         className="fa-icon-container"
                                         aria-label="Move Condition Down"
                                         type="default"
-                                        disabled={!moveDown}
+                                        disabled={!moveDown || loading}
                                         icon={<FontAwesomeIcon icon={faArrowDown} />}
                                         onClick={() => moveDown(condition)}
                                     />

--- a/services/core-web/src/components/mine/Permit/PermitConditionLayer.tsx
+++ b/services/core-web/src/components/mine/Permit/PermitConditionLayer.tsx
@@ -12,6 +12,7 @@ import { getConditionsWithRequirements } from "@mds/common/utils/helpers";
 const { Title } = Typography;
 import { IPermitAmendment } from "@mds/common/interfaces";
 import PermitConditionReportRequirements from "./PermitConditionReportRequirements";
+import { usePermitConditions } from "./PermitConditionsContext";
 
 interface PermitConditionLayerProps {
   isExtracted: boolean;
@@ -54,12 +55,14 @@ const PermitConditionLayer: FC<PermitConditionLayerProps> = ({
   permitGuid,
   mineGuid,
 }) => {
+  const { loading } = usePermitConditions();
   const editingCondition = editingConditionGuid === condition.permit_condition_guid;
   const [isAddingListItem, setIsAddingListItem] = useState<boolean>(false);
   const [expandClass, setExpandClass] = useState(
     isExpanded ? "condition-expanded" : "condition-collapsed"
   );
-  const className = `condition-layer condition-layer--${level} condition-${condition.condition_type_code} fade-in`;
+  const loadClassName = level === 0 && loading ? " condition-layer--loading" : "";
+  const className = `condition-layer condition-layer--${level}${loadClassName} condition-${condition.condition_type_code} fade-in`;
   const { isFeatureEnabled } = useFeatureFlag();
 
   const handleSetParentExpand = () => {

--- a/services/core-web/src/components/mine/Permit/PermitConditionReviewAssignment.tsx
+++ b/services/core-web/src/components/mine/Permit/PermitConditionReviewAssignment.tsx
@@ -28,12 +28,13 @@ interface PermitConditionReviewAssignmentProps {
 const PermitConditionReviewAssignment: FC<PermitConditionReviewAssignmentProps> = ({
   category,
 }) => {
-  const { currentAmendment } = usePermitConditions();
+  const { currentAmendment, loading } = usePermitConditions();
   const { permit_amendment_id } = currentAmendment;
   const reviewAssignment = useSelector(getCategoryReviewAssignment(permit_amendment_id, category.condition_category_code));
   const isUserAssigned = useSelector(isUserAssignedToReviewCategory(permit_amendment_id, category.condition_category_code));
-  const isLoaded = useSelector(getPermitReviewAssignmentsIsLoaded(permit_amendment_id));
+  const assignmentsLoaded = useSelector(getPermitReviewAssignmentsIsLoaded(permit_amendment_id));
   const reviewer = reviewAssignment?.assigned_review_user;
+  const isLoaded = !loading && assignmentsLoaded;
 
   const dispatch = useDispatch();
   const initialValues = { value: reviewer?.sub ?? "", label: reviewer?.display_name ?? "" }

--- a/services/core-web/src/components/mine/Permit/PermitConditionStatus.tsx
+++ b/services/core-web/src/components/mine/Permit/PermitConditionStatus.tsx
@@ -7,8 +7,7 @@ import CoreButton from "@mds/common/components/common/CoreButton";
 import { IPermitCondition } from "@mds/common/interfaces/permits";
 import { PERMIT_CONDITION_STATUS_CODE } from "@mds/common/constants/enums";
 import { getConditionsWithRequirements } from "@mds/common/utils/helpers";
-
-import { useDispatch } from "react-redux";
+import { useAppDispatch } from "@mds/common/redux/rootState";
 import { updatePermitCondition } from "@mds/common/redux/actionCreators/permitActionCreator";
 import { openModal } from "@mds/common/redux/actions/modalActions";
 import ComparePermitConditionHistoryModal from "./ComparePermitConditionHistoryModal";
@@ -32,7 +31,7 @@ export const PermitConditionStatus: FC<PermitConditionStatusProps> = ({
   refreshData,
 }) => {
 
-  const { mineGuid, permitGuid, latestAmendment, previousAmendment, currentAmendment } = usePermitConditions();
+  const { mineGuid, permitGuid, latestAmendment, previousAmendment, currentAmendment, loading, setLoading } = usePermitConditions();
 
   const [isSubmitting, setIsSubmitting] = useState(false);
 
@@ -65,18 +64,16 @@ export const PermitConditionStatus: FC<PermitConditionStatusProps> = ({
         },
         width: 2048,
         content: (props) => {
-          const value = { mineGuid, permitGuid, latestAmendment, previousAmendment, currentAmendment };
+          const value = { mineGuid, permitGuid, latestAmendment, previousAmendment, currentAmendment, loading, setLoading };
           return <PermitConditionsProvider value={value} > <ComparePermitConditionHistoryModal {...props} /></PermitConditionsProvider>;
         }
-
       })
     );
-
   }
 
   const requirements = getConditionsWithRequirements([condition]);
 
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
 
   return <Col span={24}>
     <Row justify="space-between">
@@ -97,6 +94,7 @@ export const PermitConditionStatus: FC<PermitConditionStatusProps> = ({
         {
           canEditPermitConditions && condition.permit_condition_status_code !== PERMIT_CONDITION_STATUS_CODE.COM &&
           <CoreButton
+            loading={loading}
             type="primary"
             disabled={isDisabled || isSubmitting}
             onClick={() => handleCompleteReview(condition)}

--- a/services/core-web/src/components/mine/Permit/PermitConditions.tsx
+++ b/services/core-web/src/components/mine/Permit/PermitConditions.tsx
@@ -1,6 +1,6 @@
 import React, { FC, useEffect, useMemo, useState } from "react";
 import { useHistory, useParams } from "react-router-dom";
-import { Alert, Button, Col, Row, Skeleton, Space, Typography } from "antd";
+import { Alert, Button, Col, Row, Space, Typography } from "antd";
 import FileOutlined from "@ant-design/icons/FileOutlined";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
@@ -98,7 +98,7 @@ const PermitConditions: FC<PermitConditionProps> = ({
   const [selectedCondition, setSelectedCondition] = useState<IPermitCondition | null>(null);
   const [editingConditionGuid, setEditingConditionGuid] = useState<string>();
   const [addingToCategoryCode, setAddingToCategoryCode] = useState<string>();
-
+  const [loading, setLoading] = useState(false);
   const mineReportPermitRequirements: IMineReportPermitRequirement[] = useAppSelector(
     getMineReportPermitRequirementsByAmendment(permitGuid, currentAmendment?.permit_amendment_guid)
   );
@@ -107,7 +107,7 @@ const PermitConditions: FC<PermitConditionProps> = ({
   const userReviewAssignments = useAppSelector(getUserReviewAssignmentsByAmendment(currentAmendment.permit_amendment_id));
 
   const permitsLoading = useAppSelector(getIsFetching(NetworkReducerTypes.GET_PERMITS));
-  const showLoading = permitsLoading;
+  const showLoading = permitsLoading || loading;
 
   const permitConditions = currentAmendment?.conditions;
   const permitExtraction = useAppSelector(
@@ -322,6 +322,7 @@ const PermitConditions: FC<PermitConditionProps> = ({
   };
 
   const handleUpdateConditionCategory = (category: IPermitConditionCategory) => {
+    setLoading(true);
     dispatch(
       updatePermitAmendmentConditionCategory(
         mineGuid,
@@ -329,10 +330,11 @@ const PermitConditions: FC<PermitConditionProps> = ({
         currentAmendment.permit_amendment_guid,
         category
       )
-    );
+    ).finally(() => setLoading(false));
   };
 
   const handleDeleteConditionCategory = (category: IPermitConditionCategory) => {
+    setLoading(true);
     dispatch(
       deletePermitAmendmentConditionCategory(
         mineGuid,
@@ -340,7 +342,7 @@ const PermitConditions: FC<PermitConditionProps> = ({
         currentAmendment.permit_amendment_guid,
         category.condition_category_code
       )
-    );
+    ).finally(() => setLoading(false));
   };
 
   const handleMove = (category: IPermitConditionCategory, newOrder: number) => {
@@ -426,13 +428,12 @@ const PermitConditions: FC<PermitConditionProps> = ({
       className="no_link_styling grey"
       style={{ fontSize: "14px", textAlign: "center", margin: "20px" }}
     >
-      {showLoading ? (
-        <Skeleton active paragraph={{ rows: 1 }} />
-      ) : (
-        <Typography.Link onClick={openCreateCategoryModal} className="fade-in" title="Add Condition Category">
-          + Add Condition Category
-        </Typography.Link>
-      )}
+      <CoreButton
+        type="link"
+        loading={showLoading}
+        onClick={openCreateCategoryModal}
+        className="fade-in category-add-btn"
+      >+ Add Condition Category</CoreButton>
     </Typography.Paragraph>
   );
 
@@ -441,7 +442,7 @@ const PermitConditions: FC<PermitConditionProps> = ({
   const hasConditions = latestAmendment?.conditions?.length > 0;
   return (<>
     {hasConditions && <PermitReviewBanner isExtracted={isExtracted} height={bannerHeight} isReviewComplete={isReviewComplete} />}
-    <PermitConditionsProvider value={{ mineGuid, permitGuid, latestAmendment, previousAmendment, currentAmendment }}>
+    <PermitConditionsProvider value={{ mineGuid, permitGuid, latestAmendment, previousAmendment, currentAmendment, loading: showLoading, setLoading }}>
       <Row>
         <Col span={canViewPdfSplitScreen ? 16 : 24}>
           <ScrollSidePageWrapper
@@ -463,7 +464,7 @@ const PermitConditions: FC<PermitConditionProps> = ({
                   <Row gutter={10}>
                     <Col>
                       <CoreButton
-                        disabled={showLoading}
+                        loading={showLoading}
                         type="tertiary"
                         className="fa-icon-container"
                         icon={
@@ -478,7 +479,7 @@ const PermitConditions: FC<PermitConditionProps> = ({
                       <CoreButton
                         type="tertiary"
                         icon={<FileOutlined />}
-                        disabled={showLoading}
+                        loading={showLoading}
                         onClick={toggleViewPdf}
                       >
                         Open Permit in Document Viewer
@@ -489,9 +490,7 @@ const PermitConditions: FC<PermitConditionProps> = ({
                 <Col span={24}>
                   <div className="core-page-content">
                     <Row gutter={[16, 16]}>
-                      {showLoading && <Skeleton active paragraph={{ rows: 10 }} />}
-
-                      {!showLoading && permitConditionCategories.map((category, idx) => {
+                      {permitConditionCategories.map((category, idx) => {
                         return (
                           <React.Fragment key={category.href}>
                             <Col span={24}>
@@ -512,6 +511,7 @@ const PermitConditions: FC<PermitConditionProps> = ({
                                 {canEditPermitConditions(category.condition_category) && isExtracted && (
                                   <CoreButton
                                     type="primary"
+                                    loading={showLoading}
                                     disabled={
                                       Boolean(addingToCategoryCode) || Boolean(editingConditionGuid)
                                     }

--- a/services/core-web/src/components/mine/Permit/PermitConditionsContext.tsx
+++ b/services/core-web/src/components/mine/Permit/PermitConditionsContext.tsx
@@ -7,6 +7,8 @@ interface PermitConditionsContextType {
     latestAmendment: IPermitAmendment;
     previousAmendment: IPermitAmendment;
     currentAmendment: IPermitAmendment;
+    loading: boolean;
+    setLoading: (loading: boolean) => void;
 }
 
 const PermitConditionsContext = React.createContext<PermitConditionsContextType | undefined>(undefined);

--- a/services/core-web/src/components/mine/Permit/SubConditionForm.spec.tsx
+++ b/services/core-web/src/components/mine/Permit/SubConditionForm.spec.tsx
@@ -4,6 +4,7 @@ import { ReduxWrapper } from "@mds/common/tests/utils/ReduxWrapper";
 import * as MOCK from "@mds/common/tests/mocks/dataMocks";
 import SubConditionForm from "./SubConditionForm";
 import { createDropDownList } from "@mds/common/redux/utils/helpers";
+import { PermitConditionsProvider } from "./PermitConditionsContext";
 
 const condition = MOCK.PERMITS[0].permit_amendments[0].conditions[0];
 const conditionCategories = MOCK.PERMITS[0].permit_amendments[0].condition_categories;
@@ -32,29 +33,42 @@ const dropdownOptions = [
 ]
 const initialState = {}
 
+const providerParams = {
+    mineGuid: "mineGuid",
+    permitGuid: "permitGuid",
+    latestAmendment: null,
+    previousAmendment: null,
+    currentAmendment: null,
+    loading: false,
+    setLoading: jest.fn(),
+};
+
 describe("SubConditionForm", () => {
     it("renders properly for adding list item", async () => {
         const { container } = render(<ReduxWrapper initialState={initialState}>
-            <SubConditionForm
-                level={2}
-                permitAmendmentGuid={MOCK.PERMITS[0].permit_amendments[0].permit_amendment_guid}
-                parentCondition={condition}
-                handleCancel={jest.fn()}
-                onSubmit={jest.fn()}
-            />
+            <PermitConditionsProvider value={providerParams}>
+                <SubConditionForm
+                    level={2}
+                    permitAmendmentGuid={MOCK.PERMITS[0].permit_amendments[0].permit_amendment_guid}
+                    parentCondition={condition}
+                    handleCancel={jest.fn()}
+                    onSubmit={jest.fn()}
+                />
+            </PermitConditionsProvider>
         </ReduxWrapper>);
 
         expect(container).toMatchSnapshot()
     });
     it("renders properly for adding to category", () => {
         const { container } = render(<ReduxWrapper initialState={initialState}>
-            <SubConditionForm
-                permitAmendmentGuid={MOCK.PERMITS[0].permit_amendments[0].permit_amendment_guid}
-                conditionCategory={conditionCategory}
-                handleCancel={jest.fn()}
-                onSubmit={jest.fn()}
-                categoryOptions={dropdownOptions}
-            />
+            <PermitConditionsProvider value={providerParams}>
+                <SubConditionForm
+                    permitAmendmentGuid={MOCK.PERMITS[0].permit_amendments[0].permit_amendment_guid}
+                    conditionCategory={conditionCategory}
+                    handleCancel={jest.fn()}
+                    onSubmit={jest.fn()}
+                    categoryOptions={dropdownOptions}
+                /></PermitConditionsProvider>
         </ReduxWrapper>);
 
         const textInput = container.querySelector("textarea");

--- a/services/core-web/src/components/mine/Permit/SubConditionForm.tsx
+++ b/services/core-web/src/components/mine/Permit/SubConditionForm.tsx
@@ -12,10 +12,11 @@ import RenderAutoSizeField from "@mds/common/components/forms/RenderAutoSizeFiel
 import RenderCancelButton from "@mds/common/components/forms/RenderCancelButton";
 import RenderSubmitButton from "@mds/common/components/forms/RenderSubmitButton";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { useDispatch } from "react-redux";
+import { useAppDispatch } from "@mds/common/redux/rootState";
 import { createPermitCondition } from "@mds/common/redux/actionCreators/permitActionCreator";
 import { FORM } from "@mds/common/constants/forms";
 import RenderGroupedSelect from "@mds/common/components/forms/RenderGroupedSelect";
+import { usePermitConditions } from "./PermitConditionsContext";
 
 interface SubConditionFormProps {
     level?: number;
@@ -28,17 +29,19 @@ interface SubConditionFormProps {
 };
 
 const SubConditionForm: FC<SubConditionFormProps> = ({ level = 1, parentCondition, conditionCategory, permitAmendmentGuid, categoryOptions, handleCancel, onSubmit }) => {
-    const dispatch = useDispatch();
-
+    const dispatch = useAppDispatch();
+    const { loading, setLoading } = usePermitConditions();
     const handleSubmit = async (values) => {
+        setLoading(true);
         const resp = await dispatch(createPermitCondition(
             permitAmendmentGuid,
             values
         ));
         // @ts-ignore
         if (resp?.type !== ERROR) {
-            onSubmit();
+            await onSubmit();
         }
+        setLoading(false);
     }
 
     const getConditionTypeCode = () => {
@@ -88,6 +91,7 @@ const SubConditionForm: FC<SubConditionFormProps> = ({ level = 1, parentConditio
                             data={categoryOptions}
                             allowClear={false}
                             className="horizontal-form-item"
+                            disabled={loading}
                         />
                     </Col>
                 </Row>}
@@ -98,6 +102,7 @@ const SubConditionForm: FC<SubConditionFormProps> = ({ level = 1, parentConditio
                             name="condition"
                             component={RenderAutoSizeField}
                             autoFocus
+                            disabled={loading}
                         />
                     </Col>
                 </Row>
@@ -106,6 +111,7 @@ const SubConditionForm: FC<SubConditionFormProps> = ({ level = 1, parentConditio
                 >
                     <Col>
                         <RenderCancelButton
+                            disabled={loading}
                             cancelFunction={handleCancel}
                             buttonProps={{
                                 type: "primary",
@@ -116,6 +122,7 @@ const SubConditionForm: FC<SubConditionFormProps> = ({ level = 1, parentConditio
                     </Col>
                     <Col>
                         <RenderSubmitButton
+                            disabled={loading}
                             buttonProps={{
                                 icon: <FontAwesomeIcon icon={faCheck} />
                             }}

--- a/services/core-web/src/components/mine/Permit/__snapshots__/PermitConditions.spec.tsx.snap
+++ b/services/core-web/src/components/mine/Permit/__snapshots__/PermitConditions.spec.tsx.snap
@@ -664,12 +664,14 @@ exports[`PermitConditions renders properly 1`] = `
                               class="ant-typography no_link_styling grey"
                               style="font-size: 14px; text-align: center; margin: 20px;"
                             >
-                              <a
-                                class="ant-typography fade-in"
-                                title="Add Condition Category"
+                              <button
+                                class="ant-btn ant-btn-link core-btn core-btn-link fade-in category-add-btn"
+                                type="button"
                               >
-                                + Add Condition Category
-                              </a>
+                                <span>
+                                  + Add Condition Category
+                                </span>
+                              </button>
                             </div>
                           </div>
                         </div>
@@ -956,26 +958,34 @@ exports[`PermitConditions renders properly 1`] = `
                                         style="display: inline-block; cursor: not-allowed;"
                                       >
                                         <button
-                                          class="ant-btn ant-btn-default ant-btn-icon-only"
+                                          class="ant-btn ant-btn-default ant-btn-icon-only ant-btn-loading"
                                           disabled=""
                                           style="pointer-events: none;"
                                           type="button"
                                         >
-                                          <svg
-                                            aria-hidden="true"
-                                            class="svg-inline--fa fa-xmark "
-                                            data-icon="xmark"
-                                            data-prefix="fal"
-                                            focusable="false"
-                                            role="img"
-                                            viewBox="0 0 384 512"
-                                            xmlns="http://www.w3.org/2000/svg"
+                                          <span
+                                            class="ant-btn-loading-icon"
                                           >
-                                            <path
-                                              d="M324.5 411.1c6.2 6.2 16.4 6.2 22.6 0s6.2-16.4 0-22.6L214.6 256 347.1 123.5c6.2-6.2 6.2-16.4 0-22.6s-16.4-6.2-22.6 0L192 233.4 59.5 100.9c-6.2-6.2-16.4-6.2-22.6 0s-6.2 16.4 0 22.6L169.4 256 36.9 388.5c-6.2 6.2-6.2 16.4 0 22.6s16.4 6.2 22.6 0L192 278.6 324.5 411.1z"
-                                              fill="currentColor"
-                                            />
-                                          </svg>
+                                            <span
+                                              aria-label="loading"
+                                              class="anticon anticon-loading anticon-spin"
+                                              role="img"
+                                            >
+                                              <svg
+                                                aria-hidden="true"
+                                                data-icon="loading"
+                                                fill="currentColor"
+                                                focusable="false"
+                                                height="1em"
+                                                viewBox="0 0 1024 1024"
+                                                width="1em"
+                                              >
+                                                <path
+                                                  d="M988 548c-19.9 0-36-16.1-36-36 0-59.4-11.6-117-34.6-171.3a440.45 440.45 0 00-94.3-139.9 437.71 437.71 0 00-139.9-94.3C629 83.6 571.4 72 512 72c-19.9 0-36-16.1-36-36s16.1-36 36-36c69.1 0 136.2 13.5 199.3 40.3C772.3 66 827 103 874 150c47 47 83.9 101.8 109.7 162.7 26.7 63.1 40.2 130.2 40.2 199.3.1 19.9-16 36-35.9 36z"
+                                                />
+                                              </svg>
+                                            </span>
+                                          </span>
                                         </button>
                                       </span>
                                     </div>
@@ -1274,7 +1284,7 @@ exports[`PermitConditions renders properly 1`] = `
                                     class="condition-collapsed"
                                   >
                                     <div
-                                      class="ant-row ant-row-no-wrap ant-row-top condition-content editable"
+                                      class="ant-row ant-row-no-wrap ant-row-top condition-content "
                                     >
                                       <div
                                         class="ant-col step-column"
@@ -1525,7 +1535,7 @@ exports[`PermitConditions renders properly 1`] = `
                                     class="condition-collapsed"
                                   >
                                     <div
-                                      class="ant-row ant-row-no-wrap ant-row-top condition-content editable"
+                                      class="ant-row ant-row-no-wrap ant-row-top condition-content "
                                     >
                                       <div
                                         class="ant-col step-column"
@@ -1555,7 +1565,7 @@ exports[`PermitConditions renders properly 1`] = `
                                           class="condition-collapsed"
                                         >
                                           <div
-                                            class="ant-row ant-row-no-wrap ant-row-top condition-content editable"
+                                            class="ant-row ant-row-no-wrap ant-row-top condition-content "
                                           >
                                             <div
                                               class="ant-col step-column"
@@ -1585,7 +1595,7 @@ exports[`PermitConditions renders properly 1`] = `
                                                 class="condition-collapsed"
                                               >
                                                 <div
-                                                  class="ant-row ant-row-no-wrap ant-row-top condition-content editable"
+                                                  class="ant-row ant-row-no-wrap ant-row-top condition-content "
                                                 >
                                                   <div
                                                     class="ant-col step-column"
@@ -1621,7 +1631,7 @@ exports[`PermitConditions renders properly 1`] = `
                                           class="condition-collapsed"
                                         >
                                           <div
-                                            class="ant-row ant-row-no-wrap ant-row-top condition-content editable"
+                                            class="ant-row ant-row-no-wrap ant-row-top condition-content "
                                           >
                                             <div
                                               class="ant-col step-column"
@@ -1651,7 +1661,7 @@ exports[`PermitConditions renders properly 1`] = `
                                                 class="condition-collapsed"
                                               >
                                                 <div
-                                                  class="ant-row ant-row-no-wrap ant-row-top condition-content editable"
+                                                  class="ant-row ant-row-no-wrap ant-row-top condition-content "
                                                 >
                                                   <div
                                                     class="ant-col step-column"
@@ -1681,7 +1691,7 @@ exports[`PermitConditions renders properly 1`] = `
                                                       class="condition-collapsed"
                                                     >
                                                       <div
-                                                        class="ant-row ant-row-no-wrap ant-row-top condition-content editable"
+                                                        class="ant-row ant-row-no-wrap ant-row-top condition-content "
                                                       >
                                                         <div
                                                           class="ant-col step-column"
@@ -1714,7 +1724,7 @@ exports[`PermitConditions renders properly 1`] = `
                                                       class="condition-collapsed"
                                                     >
                                                       <div
-                                                        class="ant-row ant-row-no-wrap ant-row-top condition-content editable"
+                                                        class="ant-row ant-row-no-wrap ant-row-top condition-content "
                                                       >
                                                         <div
                                                           class="ant-col step-column"
@@ -1747,7 +1757,7 @@ exports[`PermitConditions renders properly 1`] = `
                                                       class="condition-collapsed"
                                                     >
                                                       <div
-                                                        class="ant-row ant-row-no-wrap ant-row-top condition-content editable"
+                                                        class="ant-row ant-row-no-wrap ant-row-top condition-content "
                                                       >
                                                         <div
                                                           class="ant-col step-column"
@@ -1777,7 +1787,7 @@ exports[`PermitConditions renders properly 1`] = `
                                                             class="condition-collapsed"
                                                           >
                                                             <div
-                                                              class="ant-row ant-row-no-wrap ant-row-top condition-content editable"
+                                                              class="ant-row ant-row-no-wrap ant-row-top condition-content "
                                                             >
                                                               <div
                                                                 class="ant-col step-column"
@@ -1879,7 +1889,7 @@ exports[`PermitConditions renders properly 1`] = `
                                     class="condition-collapsed"
                                   >
                                     <div
-                                      class="ant-row ant-row-no-wrap ant-row-top condition-content editable"
+                                      class="ant-row ant-row-no-wrap ant-row-top condition-content "
                                     >
                                       <div
                                         class="ant-col step-column"
@@ -1909,7 +1919,7 @@ exports[`PermitConditions renders properly 1`] = `
                                           class="condition-collapsed"
                                         >
                                           <div
-                                            class="ant-row ant-row-no-wrap ant-row-top condition-content editable"
+                                            class="ant-row ant-row-no-wrap ant-row-top condition-content "
                                           >
                                             <div
                                               class="ant-col step-column"

--- a/services/core-web/src/components/mine/Permit/__snapshots__/PermitConditions.spec.tsx.snap
+++ b/services/core-web/src/components/mine/Permit/__snapshots__/PermitConditions.spec.tsx.snap
@@ -958,34 +958,26 @@ exports[`PermitConditions renders properly 1`] = `
                                         style="display: inline-block; cursor: not-allowed;"
                                       >
                                         <button
-                                          class="ant-btn ant-btn-default ant-btn-icon-only ant-btn-loading"
+                                          class="ant-btn ant-btn-default ant-btn-icon-only"
                                           disabled=""
                                           style="pointer-events: none;"
                                           type="button"
                                         >
-                                          <span
-                                            class="ant-btn-loading-icon"
+                                          <svg
+                                            aria-hidden="true"
+                                            class="svg-inline--fa fa-xmark "
+                                            data-icon="xmark"
+                                            data-prefix="fal"
+                                            focusable="false"
+                                            role="img"
+                                            viewBox="0 0 384 512"
+                                            xmlns="http://www.w3.org/2000/svg"
                                           >
-                                            <span
-                                              aria-label="loading"
-                                              class="anticon anticon-loading anticon-spin"
-                                              role="img"
-                                            >
-                                              <svg
-                                                aria-hidden="true"
-                                                data-icon="loading"
-                                                fill="currentColor"
-                                                focusable="false"
-                                                height="1em"
-                                                viewBox="0 0 1024 1024"
-                                                width="1em"
-                                              >
-                                                <path
-                                                  d="M988 548c-19.9 0-36-16.1-36-36 0-59.4-11.6-117-34.6-171.3a440.45 440.45 0 00-94.3-139.9 437.71 437.71 0 00-139.9-94.3C629 83.6 571.4 72 512 72c-19.9 0-36-16.1-36-36s16.1-36 36-36c69.1 0 136.2 13.5 199.3 40.3C772.3 66 827 103 874 150c47 47 83.9 101.8 109.7 162.7 26.7 63.1 40.2 130.2 40.2 199.3.1 19.9-16 36-35.9 36z"
-                                                />
-                                              </svg>
-                                            </span>
-                                          </span>
+                                            <path
+                                              d="M324.5 411.1c6.2 6.2 16.4 6.2 22.6 0s6.2-16.4 0-22.6L214.6 256 347.1 123.5c6.2-6.2 6.2-16.4 0-22.6s-16.4-6.2-22.6 0L192 233.4 59.5 100.9c-6.2-6.2-16.4-6.2-22.6 0s-6.2 16.4 0 22.6L169.4 256 36.9 388.5c-6.2 6.2-6.2 16.4 0 22.6s16.4 6.2 22.6 0L192 278.6 324.5 411.1z"
+                                              fill="currentColor"
+                                            />
+                                          </svg>
                                         </button>
                                       </span>
                                     </div>

--- a/services/core-web/src/styles/components/PermitConditions.scss
+++ b/services/core-web/src/styles/components/PermitConditions.scss
@@ -30,6 +30,10 @@ div.condition-layer {
     cursor: initial;
   }
 
+  &--loading {
+    opacity: 0.8;
+  }
+
   &--0 {
     border: 1px solid $transparent-dark-grey;
     border-radius: 4px;
@@ -137,6 +141,15 @@ div.condition-layer {
 
 .condition-category-reviewer-row {
   margin-top: 10px;
+}
+
+.category-add-btn {
+  border: none;
+  font-weight: 400;
+
+  &:focus {
+    color: inherit;
+  }
 }
 
 

--- a/services/core-web/src/tests/components/Forms/reports/ReportPermitRequirementForm.spec.tsx
+++ b/services/core-web/src/tests/components/Forms/reports/ReportPermitRequirementForm.spec.tsx
@@ -7,6 +7,7 @@ import { USER_ROLES } from "@mds/common/constants/environment";
 import { SystemFlagEnum } from "@mds/common/constants/enums";
 import { ReportPermitRequirementForm } from "@/components/Forms/reports/ReportPermitRequirementForm";
 import { complianceReportReducerType, reportParamsGetAll } from "@mds/common/redux/slices/complianceReportsSlice";
+import { PermitConditionsProvider } from "@/components/mine/Permit/PermitConditionsContext";
 
 const initialState = {
   [STATIC_CONTENT]: {
@@ -35,19 +36,31 @@ const initialState = {
   },
 };
 
+const providerParams = {
+  mineGuid: "mineGuid",
+  permitGuid: "permitGuid",
+  latestAmendment: null,
+  previousAmendment: null,
+  currentAmendment: null,
+  loading: false,
+  setLoading: jest.fn(),
+};
+
 describe("RequestReportForm", () => {
   it("renders form properly", () => {
     const { container } = render(
       <ReduxWrapper initialState={initialState}>
-        <ReportPermitRequirementForm
-          permitGuid={MOCK.PERMITS[0].permit_guid}
-          onSubmit={() => { }}
-          canEditPermitConditions={true}
-          refreshData={jest.fn()}
-          currentAmendment={MOCK.PERMITS[0].permit_amendments[0]}
-          mineGuid={MOCK.PERMITS[0].mine_guid}
-          condition={MOCK.PERMITS[0].permit_amendments[0].conditions[0]}
-        />
+        <PermitConditionsProvider value={providerParams}>
+          <ReportPermitRequirementForm
+            permitGuid={MOCK.PERMITS[0].permit_guid}
+            onSubmit={() => { }}
+            canEditPermitConditions={true}
+            refreshData={jest.fn()}
+            currentAmendment={MOCK.PERMITS[0].permit_amendments[0]}
+            mineGuid={MOCK.PERMITS[0].mine_guid}
+            condition={MOCK.PERMITS[0].permit_amendments[0].conditions[0]}
+          />
+        </PermitConditionsProvider>
       </ReduxWrapper>
     );
 

--- a/services/core-web/src/tests/components/mine/Permit/PermitConditionReportRequirements.spec.tsx
+++ b/services/core-web/src/tests/components/mine/Permit/PermitConditionReportRequirements.spec.tsx
@@ -16,6 +16,8 @@ const params = {
     currentAmendment: MOCK.PERMITS[0].permit_amendments[0],
     latestAmendment: MOCK.PERMITS[0].permit_amendments[0],
     previousAmendment: MOCK.PERMITS[0].permit_amendments[0],
+    loading: false,
+    setLoading: jest.fn()
 };
 
 describe("PermitConditionReportRequirements", () => {


### PR DESCRIPTION
## Objective 
- for a smoother user experience
- there's a lot of subforms and stuff, so added loading/setLoading to the context provider instead of props passing
- snuck in some useDispatch --> useAppDispatch
- Just a note that on the icon buttons with no text- using "loading" doesn't fit in the button, so it renders a spinner _below_ the button (ew) so I used disabled for those buttons, although I generally prefer loading > disabled

[MDS-6395](https://bcmines.atlassian.net/browse/MDS-6395)
![conditions-loading](https://github.com/user-attachments/assets/683e5b0a-6ad1-4ac2-b9a1-e10ff49e2e6c)
