### PR TITLE
[MDS-6396] Allow all Core users to view permit conditions page

### DIFF
--- a/services/core-api/app/api/mines/permits/permit_conditions/resources/permit_amendment_condition_category_user_resource.py
+++ b/services/core-api/app/api/mines/permits/permit_conditions/resources/permit_amendment_condition_category_user_resource.py
@@ -4,7 +4,7 @@ from werkzeug.exceptions import BadRequest, NotFound, Unauthorized
 from app.api.mines.permits.permit_conditions.models import PermitConditionCategory
 from app.api.mines.permits.permit_conditions.models.permit_condition_review_assignment import PermitConditionReviewAssignment
 from app.api.mines.permits.permit_amendment.models.permit_amendment import PermitAmendment
-from app.api.mines.response_models import PERMIT_CONDITION_CATEGORY_MODEL, PERMIT_CONDITION_REVIEW_ASSIGNMENT_MODEL
+from app.api.mines.response_models import PERMIT_CONDITION_REVIEW_ASSIGNMENT_MODEL
 from app.api.users.models.user import User
 from app.api.utils.access_decorators import requires_role_edit_standard_permit_conditions, \
     requires_role_view_all, EDIT_STANDARD_PERMIT_CONDITIONS
@@ -16,7 +16,7 @@ class AssignUserToPermitConditionCategory(Resource):
     @api.doc(
             description="Get a list of review assignments",
             params={'permit_amendment_id': "The permit amendment for the reviewer assignment"})
-    @requires_role_edit_standard_permit_conditions
+    @requires_role_view_all
     @api.marshal_with(PERMIT_CONDITION_REVIEW_ASSIGNMENT_MODEL, envelope='records', code=200)
     def get(self):
         parser = reqparse.RequestParser()

--- a/services/core-web/src/components/mine/Permit/MinePermitTable.tsx
+++ b/services/core-web/src/components/mine/Permit/MinePermitTable.tsx
@@ -187,20 +187,7 @@ export const MinePermitTable: React.FC<MinePermitTableProps> = ({
     mineGuid,
   });
 
-  // EDIT_PERMITS required for *every* item- enforced at menu-level
-  const actions: ITableAction[] = [
-    isFeatureEnabled(Feature.DIGITIZED_PERMITS) && {
-      key: "view",
-      label: "View",
-      clickFunction: (_, record) =>
-        history.push(
-          VIEW_MINE_PERMIT.dynamicRoute(
-            id,
-            record.permit.permit_guid ?? record.permit.permit_amendment_guid
-          )
-        ),
-      icon: <EyeOutlined />,
-    },
+  const editPermitActions = !userCanEditPermits ? [] : [
     {
       key: "amalgamate-amend",
       label: "Add Permit Amendment",
@@ -288,7 +275,23 @@ export const MinePermitTable: React.FC<MinePermitTableProps> = ({
           cancelText: "Cancel",
         });
       },
+    }
+  ];
+
+  const actions: ITableAction[] = [
+    isFeatureEnabled(Feature.DIGITIZED_PERMITS) && {
+      key: "view",
+      label: "View",
+      clickFunction: (_, record) =>
+        history.push(
+          VIEW_MINE_PERMIT.dynamicRoute(
+            id,
+            record.permit.permit_guid ?? record.permit.permit_amendment_guid
+          )
+        ),
+      icon: <EyeOutlined />,
     },
+    ...editPermitActions
   ].filter(Boolean);
 
   const recordActionsFilter = (record, actionItems) => {
@@ -310,7 +313,7 @@ export const MinePermitTable: React.FC<MinePermitTableProps> = ({
     renderTextColumn("permittee", "Permittee"),
     renderTextColumn("firstIssued", "First Issued"),
     renderTextColumn("lastAmended", "Last Amended"),
-    userCanEditPermits && actionsMenu,
+    actionsMenu,
   ].filter(Boolean);
 
   const handleNavigateToPermitConditions = (record) => {

--- a/services/core-web/src/components/mine/Permit/PermitConditions.tsx
+++ b/services/core-web/src/components/mine/Permit/PermitConditions.tsx
@@ -481,8 +481,7 @@ const PermitConditions: FC<PermitConditionProps> = ({
                         icon={<FileOutlined />}
                         loading={showLoading}
                         onClick={toggleViewPdf}
-                      >
-                        Open Permit in Document Viewer
+                      >{viewPdf ? "Close" : "Open Permit in"} Document Viewer
                       </CoreButton>
                     </Col>
                   </Row>

--- a/services/core-web/src/tests/components/mine/Permit/__snapshots__/MinePermitInfo.spec.tsx.snap
+++ b/services/core-web/src/tests/components/mine/Permit/__snapshots__/MinePermitInfo.spec.tsx.snap
@@ -152,7 +152,7 @@ exports[`MinePermitInfo renders properly 1`] = `
                   class="ant-spin-container"
                 >
                   <div
-                    class="ant-table"
+                    class="ant-table ant-table-has-fix-right"
                   >
                     <div
                       class="ant-table-container"
@@ -200,6 +200,10 @@ exports[`MinePermitInfo renders properly 1`] = `
                               >
                                 Last Amended
                               </th>
+                              <th
+                                class="ant-table-cell actions-column ant-table-cell-fix-right ant-table-cell-fix-right-first"
+                                style="position: sticky; right: 0px;"
+                              />
                             </tr>
                           </thead>
                           <tbody
@@ -290,6 +294,43 @@ exports[`MinePermitInfo renders properly 1`] = `
                                   Apr 01 2020
                                 </div>
                               </td>
+                              <td
+                                class="ant-table-cell actions-column ant-table-cell-fix-right ant-table-cell-fix-right-first"
+                                style="position: sticky; right: 0px;"
+                              >
+                                <div>
+                                  <button
+                                    class="ant-btn ant-btn-text ant-dropdown-trigger actions-dropdown-button"
+                                    data-cy="menu-actions-button"
+                                    type="button"
+                                  >
+                                    <span>
+                                      Actions
+                                    </span>
+                                    <span
+                                      alt="Menu"
+                                      aria-label="caret-down"
+                                      class="anticon anticon-caret-down"
+                                      role="img"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        class=""
+                                        data-icon="caret-down"
+                                        fill="currentColor"
+                                        focusable="false"
+                                        height="1em"
+                                        viewBox="0 0 1024 1024"
+                                        width="1em"
+                                      >
+                                        <path
+                                          d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </button>
+                                </div>
+                              </td>
                             </tr>
                             <tr
                               class="ant-table-row ant-table-row-level-0 fade-in"
@@ -374,6 +415,43 @@ exports[`MinePermitInfo renders properly 1`] = `
                                   title="Last Amended"
                                 >
                                   Mar 07 2024
+                                </div>
+                              </td>
+                              <td
+                                class="ant-table-cell actions-column ant-table-cell-fix-right ant-table-cell-fix-right-first"
+                                style="position: sticky; right: 0px;"
+                              >
+                                <div>
+                                  <button
+                                    class="ant-btn ant-btn-text ant-dropdown-trigger actions-dropdown-button"
+                                    data-cy="menu-actions-button"
+                                    type="button"
+                                  >
+                                    <span>
+                                      Actions
+                                    </span>
+                                    <span
+                                      alt="Menu"
+                                      aria-label="caret-down"
+                                      class="anticon anticon-caret-down"
+                                      role="img"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        class=""
+                                        data-icon="caret-down"
+                                        fill="currentColor"
+                                        focusable="false"
+                                        height="1em"
+                                        viewBox="0 0 1024 1024"
+                                        width="1em"
+                                      >
+                                        <path
+                                          d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </button>
                                 </div>
                               </td>
                             </tr>

--- a/services/core-web/src/tests/components/mine/Permit/__snapshots__/MinePermitTable.spec.tsx.snap
+++ b/services/core-web/src/tests/components/mine/Permit/__snapshots__/MinePermitTable.spec.tsx.snap
@@ -13,7 +13,7 @@ exports[`MinePermitTable renders properly 1`] = `
         class="ant-spin-container"
       >
         <div
-          class="ant-table"
+          class="ant-table ant-table-has-fix-right"
         >
           <div
             class="ant-table-container"
@@ -61,6 +61,10 @@ exports[`MinePermitTable renders properly 1`] = `
                     >
                       Last Amended
                     </th>
+                    <th
+                      class="ant-table-cell actions-column ant-table-cell-fix-right ant-table-cell-fix-right-first"
+                      style="position: sticky; right: 0px;"
+                    />
                   </tr>
                 </thead>
                 <tbody
@@ -151,6 +155,43 @@ exports[`MinePermitTable renders properly 1`] = `
                         Apr 01 2020
                       </div>
                     </td>
+                    <td
+                      class="ant-table-cell actions-column ant-table-cell-fix-right ant-table-cell-fix-right-first"
+                      style="position: sticky; right: 0px;"
+                    >
+                      <div>
+                        <button
+                          class="ant-btn ant-btn-text ant-dropdown-trigger actions-dropdown-button"
+                          data-cy="menu-actions-button"
+                          type="button"
+                        >
+                          <span>
+                            Actions
+                          </span>
+                          <span
+                            alt="Menu"
+                            aria-label="caret-down"
+                            class="anticon anticon-caret-down"
+                            role="img"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class=""
+                              data-icon="caret-down"
+                              fill="currentColor"
+                              focusable="false"
+                              height="1em"
+                              viewBox="0 0 1024 1024"
+                              width="1em"
+                            >
+                              <path
+                                d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
+                              />
+                            </svg>
+                          </span>
+                        </button>
+                      </div>
+                    </td>
                   </tr>
                   <tr
                     class="ant-table-row ant-table-row-level-0 fade-in"
@@ -235,6 +276,43 @@ exports[`MinePermitTable renders properly 1`] = `
                         title="Last Amended"
                       >
                         Mar 07 2024
+                      </div>
+                    </td>
+                    <td
+                      class="ant-table-cell actions-column ant-table-cell-fix-right ant-table-cell-fix-right-first"
+                      style="position: sticky; right: 0px;"
+                    >
+                      <div>
+                        <button
+                          class="ant-btn ant-btn-text ant-dropdown-trigger actions-dropdown-button"
+                          data-cy="menu-actions-button"
+                          type="button"
+                        >
+                          <span>
+                            Actions
+                          </span>
+                          <span
+                            alt="Menu"
+                            aria-label="caret-down"
+                            class="anticon anticon-caret-down"
+                            role="img"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class=""
+                              data-icon="caret-down"
+                              fill="currentColor"
+                              focusable="false"
+                              height="1em"
+                              viewBox="0 0 1024 1024"
+                              width="1em"
+                            >
+                              <path
+                                d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
+                              />
+                            </svg>
+                          </span>
+                        </button>
                       </div>
                     </td>
                   </tr>


### PR DESCRIPTION
## Objective 
- technically they could view the page before, they just didn't have a link to it from the table
- was clicking around and noticed the document viewing button did a toggle but didn't toggle the button text so I changed that

[MDS-6396](https://bcmines.atlassian.net/browse/MDS-6396)

_Why are you making this change? Provide a short explanation and/or screenshots_
