### PR TITLE
[MDS-6409] Cannot add a report requirement to NoW permits

### DIFF
--- a/services/core-web/src/components/mine/Permit/PermitConditionForm.tsx
+++ b/services/core-web/src/components/mine/Permit/PermitConditionForm.tsx
@@ -28,7 +28,7 @@ import { deleteConfirmWrapper } from "@mds/common/components/common/ActionMenu";
 import { formatPermitConditionStep, parsePermitConditionStep } from "@mds/common/utils/helpers";
 import { FORM } from "@mds/common/constants/forms";
 import RenderGroupedSelect from "@mds/common/components/forms/RenderGroupedSelect";
-import { usePermitConditions } from "./PermitConditionsContext";
+import { PermitConditionsProvider, usePermitConditions } from "./PermitConditionsContext";
 
 
 interface PermitConditionFormProps {
@@ -64,7 +64,8 @@ const PermitConditionForm: FC<PermitConditionFormProps> = ({
     const dispatch = useAppDispatch();
     const { id: mineGuid, permitGuid } = useParams<{ id: string; permitGuid: string }>();
     const [isEditMode, setIsEditMode] = useState<boolean>(false);
-    const { currentAmendment, loading, setLoading } = usePermitConditions();
+    const permitConditionsValue = usePermitConditions();
+    const { currentAmendment, loading, setLoading } = permitConditionsValue;
     // the form fails to re-initialize when the category is changed, so concatenating it forces it to make a new one
     const formName = `${FORM.EDIT_PERMIT_CONDITION}_${condition.permit_condition_id}_${condition.condition_category_code}`;
 
@@ -142,7 +143,7 @@ const PermitConditionForm: FC<PermitConditionFormProps> = ({
                     mineGuid,
                     currentAmendment
                 },
-                content: ReportPermitRequirementForm,
+                content: (props) => <PermitConditionsProvider value={permitConditionsValue}> <ReportPermitRequirementForm {...props} /> </PermitConditionsProvider>,
             })
         );
     };


### PR DESCRIPTION
## Objective 
- modal was missing the provider
- gave it the provider

[MDS-6409](https://bcmines.atlassian.net/browse/MDS-6409)

_Why are you making this change? Provide a short explanation and/or screenshots_
