### PR TITLE
[MDS-6370] Take out unused pages on TSF form

### DIFF
--- a/services/common/src/components/tailings/TailingsSummaryPage.tsx
+++ b/services/common/src/components/tailings/TailingsSummaryPage.tsx
@@ -69,7 +69,7 @@ export const TailingsSummaryPage: FC = () => {
     const [uploadedFiles, setUploadedFiles] = useState([]);
     const canEditTSF = !isCore || coreCanEditTsf;
 
-    const isUserActionEdit = userAction === "edit";
+    const isUserActionEdit = canEditTSF && userAction === "edit";
 
     const handleFetchData = async (forceReload = false) => {
         setIsReloading(true);
@@ -229,10 +229,11 @@ export const TailingsSummaryPage: FC = () => {
                 <SteppedForm
                     initialValues={initialValues}
                     name={formName}
+                    isEditMode={isUserActionEdit}
                     handleSaveData={handleSaveData}
                     handleTabChange={handleTabChange}
                     activeTab={tab}
-                    sectionChangeText={canEditTSF && isUserActionEdit ? undefined : "Continue"}
+                    sectionChangeText={isUserActionEdit ? undefined : "Continue"}
                     reduxFormConfig={{
                         touchOnBlur: true,
                         touchOnChange: false,
@@ -267,12 +268,6 @@ export const TailingsSummaryPage: FC = () => {
                     </Step>
                     <Step key="associated-dams" disabled={!hasCreatedTSF}>
                         <AssociatedDams canEditTSF={canEditTSF} isEditMode={isUserActionEdit} />
-                    </Step>
-                    <Step key="reports" disabled={!hasCreatedTSF}>
-                        <div />
-                    </Step>
-                    <Step key="summary" disabled={!hasCreatedTSF}>
-                        <div />
                     </Step>
                 </SteppedForm>
             </div>


### PR DESCRIPTION
## Objective 
- snuck in a little "use the view mode of stepped form when we're in view mode"
   - it didn't exist when this was originally made
   - but using it prevents validation errors from breaking the navigation when you're not even editing 

[MDS-6370](https://bcmines.atlassian.net/browse/MDS-6370)

_Why are you making this change? Provide a short explanation and/or screenshots_
![image](https://github.com/user-attachments/assets/9d22798b-1de2-44c9-81f5-787ea2e32187)
