### PR TITLE
[MDS-6386] Update postgres github actions

### DIFF
--- a/.github/workflows/postgres.build.dev.yaml
+++ b/.github/workflows/postgres.build.dev.yaml
@@ -1,4 +1,4 @@
-name: Postgres Image Build
+name: Postgres Image Build DEV
 
 on:
   workflow_dispatch:
@@ -11,7 +11,7 @@ on:
 
 env:
   INITIAL_TAG: latest
-  TAG: 13
+  TAG: dev
   NAME: postgres
   CONTEXT: services/postgres/
 

--- a/.github/workflows/postgres.build.dev.yaml
+++ b/.github/workflows/postgres.build.dev.yaml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   build-postgres:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/postgres.deploy.prod.yaml
+++ b/.github/workflows/postgres.deploy.prod.yaml
@@ -1,0 +1,29 @@
+name: Postgres - Promote PROD
+
+on:
+  workflow_dispatch:
+
+env:
+  ORIG_TAG: test
+  PROMOTE_TAG: prod
+  IMAGE: postgres
+
+jobs:
+  promote-image:
+    name: promote-image
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Install oc
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: "4.7"
+
+      - name: oc login
+        run: |
+          oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
+
+      - name: Promote from test to prod
+        run: |
+          oc -n ${{secrets.NS_TOOLS}} tag \
+          ${{ secrets.NS_TOOLS }}/${{ env.IMAGE }}:${{ env.ORIG_TAG }} \
+          ${{ secrets.NS_TOOLS }}/${{ env.IMAGE }}:${{ env.PROMOTE_TAG }}

--- a/.github/workflows/postgres.deploy.prod.yaml
+++ b/.github/workflows/postgres.deploy.prod.yaml
@@ -11,7 +11,7 @@ env:
 jobs:
   promote-image:
     name: promote-image
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Install oc
         uses: redhat-actions/openshift-tools-installer@v1

--- a/.github/workflows/postgres.deploy.test.yaml
+++ b/.github/workflows/postgres.deploy.test.yaml
@@ -11,7 +11,7 @@ env:
 jobs:
   promote-image:
     name: promote-image
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Install oc
         uses: redhat-actions/openshift-tools-installer@v1

--- a/.github/workflows/postgres.deploy.test.yaml
+++ b/.github/workflows/postgres.deploy.test.yaml
@@ -1,0 +1,29 @@
+name: Postgres - Promote Test
+
+on:
+  workflow_dispatch:
+
+env:
+  ORIG_TAG: dev
+  PROMOTE_TAG: test
+  IMAGE: postgres
+
+jobs:
+  promote-image:
+    name: promote-image
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Install oc
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: "4.7"
+
+      - name: oc login
+        run: |
+          oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
+
+      - name: Promote from dev to test
+        run: |
+          oc -n ${{secrets.NS_TOOLS}} tag \
+          ${{ secrets.NS_TOOLS }}/${{ env.IMAGE }}:${{ env.ORIG_TAG }} \
+          ${{ secrets.NS_TOOLS }}/${{ env.IMAGE }}:${{ env.PROMOTE_TAG }}


### PR DESCRIPTION
## Objective 

[MDS-](https://bcmines.atlassian.net/browse/MDS-6386)

Before continuing the work on update postgres we need to ensure that dev, test and productions are all using different image tags so that we can do a gradual roll out. This is the first step, tagging the images separately. Next I need to update the deployment configs in the tenant gitops repo to point to these tags.

Currently there is no deployment step in these actions, the images are created and pushed to openshift but the stateful set is not redeployed. Thoughts?
