### PR TITLE
[FIX] Update Ubuntu versions for GH actions

### DIFF
--- a/.github/workflows/aws-infra-dev.yaml
+++ b/.github/workflows/aws-infra-dev.yaml
@@ -18,7 +18,7 @@ env:
 jobs:
   infra-dev-plan:
     name: infra-dev-plan
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
 
     steps:
@@ -56,7 +56,7 @@ jobs:
   ## waits for plan and runs apply
   infra-dev-apply:
     name: infra-dev-apply
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: infra-dev-plan
     timeout-minutes: 20
 

--- a/.github/workflows/aws-infra-prod.yaml
+++ b/.github/workflows/aws-infra-prod.yaml
@@ -13,7 +13,7 @@ env:
 jobs:
   infra-prod-plan:
     name: infra-prod-plan
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
 
     steps:
@@ -51,7 +51,7 @@ jobs:
   ## waits for plan and runs apply
   infra-prod-apply:
     name: infra-prod-apply
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: infra-prod-plan
     timeout-minutes: 20
 

--- a/.github/workflows/aws-infra-test.yaml
+++ b/.github/workflows/aws-infra-test.yaml
@@ -18,7 +18,7 @@ env:
 jobs:
   infra-test-plan:
     name: infra-test-plan
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
 
     steps:
@@ -56,7 +56,7 @@ jobs:
   ## waits for plan and runs apply
   infra-test-apply:
     name: infra-test-apply
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: infra-test-plan
     timeout-minutes: 20
 

--- a/.github/workflows/clear_caches.yaml
+++ b/.github/workflows/clear_caches.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   clean-cache:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
       - name: Checkout

--- a/.github/workflows/common-package.unit.yaml
+++ b/.github/workflows/common-package.unit.yaml
@@ -13,7 +13,7 @@ on:
 jobs:
   test-common-package:
     name: test-common-package
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     steps:

--- a/.github/workflows/core-api.build.deploy.dev.yaml
+++ b/.github/workflows/core-api.build.deploy.dev.yaml
@@ -20,7 +20,7 @@ env:
 
 jobs:
   build-backend:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -37,7 +37,7 @@ jobs:
           docker push --all-tags ${{ secrets.CLUSTER_REGISTRY }}/${{ secrets.NS_TOOLS }}/${{ env.NAME }}
 
   build-flyway:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -60,7 +60,7 @@ jobs:
         
 
   trigger-gitops:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     needs: [build-backend, build-flyway]
     steps:
@@ -82,7 +82,7 @@ jobs:
         run: ./gitops/watch-deployment.sh core-api dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGO_CD_CLI_JWT }}
 
   run-if-failed:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: [build-backend, build-flyway, trigger-gitops]
     if: ${{ always() && contains(needs.*.result, 'failure') }}
     steps:

--- a/.github/workflows/core-api.deploy.prod.yaml
+++ b/.github/workflows/core-api.deploy.prod.yaml
@@ -10,7 +10,7 @@ env:
 jobs:
   promote-image-to-prod:
     name: promote-core-api-to-prod
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Install oc
         uses: redhat-actions/openshift-tools-installer@v1
@@ -39,7 +39,7 @@ jobs:
     secrets: inherit
 
   trigger-gitops:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     needs: promote-image-to-prod
     steps:
@@ -61,7 +61,7 @@ jobs:
         run: ./gitops/watch-deployment.sh core-api prod ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGO_CD_CLI_JWT }}
 
   run-if-failed:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: [promote-image-to-prod, trigger-gitops]
     if: ${{ always() && contains(needs.*.result, 'failure') }}
     steps:

--- a/.github/workflows/core-api.deploy.test.yaml
+++ b/.github/workflows/core-api.deploy.test.yaml
@@ -10,7 +10,7 @@ env:
 jobs:
   promote-image-to-test:
     name: promote-core-api-to-test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Install oc
         uses: redhat-actions/openshift-tools-installer@v1
@@ -39,7 +39,7 @@ jobs:
     secrets: inherit
 
   trigger-gitops:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     needs: promote-image-to-test
     steps:
@@ -64,7 +64,7 @@ jobs:
         run: ./gitops/watch-deployment.sh core-api test ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGO_CD_CLI_JWT }}
 
   run-if-failed:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: [promote-image-to-test, trigger-gitops]
     if: ${{ always() && contains(needs.*.result, 'failure') }}
     steps:

--- a/.github/workflows/core-web.build.deploy.dev.yaml
+++ b/.github/workflows/core-web.build.deploy.dev.yaml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   build-frontend:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -38,7 +38,7 @@ jobs:
           docker push --all-tags ${{ secrets.CLUSTER_REGISTRY }}/${{ secrets.NS_TOOLS }}/${{ env.NAME }}
 
   trigger-gitops:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     needs: build-frontend
     steps:
@@ -60,7 +60,7 @@ jobs:
         run: ./gitops/watch-deployment.sh core-web dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGO_CD_CLI_JWT }}
 
   run-if-failed:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: [trigger-gitops]
     if: always() && (needs.trigger-gitops.result == 'failure')
     steps:

--- a/.github/workflows/core-web.cypress.yaml
+++ b/.github/workflows/core-web.cypress.yaml
@@ -12,7 +12,7 @@ on:
 jobs:
   run-cypress:
     name: run-cypress
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
         name: checkout

--- a/.github/workflows/core-web.deploy.prod.yaml
+++ b/.github/workflows/core-web.deploy.prod.yaml
@@ -10,7 +10,7 @@ env:
 jobs:
   promote-image-to-prod:
     name: promote-core-web-to-prod
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Install oc
         uses: redhat-actions/openshift-tools-installer@v1
@@ -28,7 +28,7 @@ jobs:
           ${{ secrets.NS_TOOLS }}/frontend:${{ env.PROMOTE_TAG }}
 
   trigger-gitops:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     needs: promote-image-to-prod
     steps:
@@ -50,7 +50,7 @@ jobs:
         run: ./gitops/watch-deployment.sh core-web prod ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGO_CD_CLI_JWT }}
 
   run-if-failed:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: [trigger-gitops]
     if: always() && (needs.trigger-gitops.result == 'failure')
     steps:

--- a/.github/workflows/core-web.deploy.test.yaml
+++ b/.github/workflows/core-web.deploy.test.yaml
@@ -10,7 +10,7 @@ env:
 jobs:
   promote-image-to-test:
     name: promote-core-web-to-test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Install oc
         uses: redhat-actions/openshift-tools-installer@v1
@@ -28,7 +28,7 @@ jobs:
           ${{ secrets.NS_TOOLS }}/frontend:${{ env.PROMOTE_TAG }}
 
   trigger-gitops:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     needs: promote-image-to-test
     steps:
@@ -55,7 +55,7 @@ jobs:
         run: ./gitops/watch-deployment.sh core-web test ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGO_CD_CLI_JWT }}
 
   run-if-failed:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: [trigger-gitops]
     if: always() && (needs.trigger-gitops.result == 'failure')
     steps:

--- a/.github/workflows/core-web.unit.yaml
+++ b/.github/workflows/core-web.unit.yaml
@@ -16,7 +16,7 @@ on:
 jobs:
   tests-unit-frontend:
     name: tests-unit-frontend
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     steps:

--- a/.github/workflows/discord.bot.build.yaml
+++ b/.github/workflows/discord.bot.build.yaml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/docman.build.deploy.dev.yaml
+++ b/.github/workflows/docman.build.deploy.dev.yaml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   build-docman:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -34,7 +34,7 @@ jobs:
           docker push --all-tags ${{ secrets.CLUSTER_REGISTRY }}/${{ secrets.NS_TOOLS }}/${{ env.NAME }}
 
   trigger-gitops:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     needs: [build-docman]
     steps:
@@ -56,7 +56,7 @@ jobs:
         run: ./gitops/watch-deployment.sh docman dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGO_CD_CLI_JWT }}
 
   run-if-failed:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: [trigger-gitops]
     if: always() && (needs.trigger-gitops.result == 'failure')
     steps:

--- a/.github/workflows/docman.deploy.prod.yaml
+++ b/.github/workflows/docman.deploy.prod.yaml
@@ -11,7 +11,7 @@ env:
 jobs:
   promote-image:
     name: promote-image
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Install oc
         uses: redhat-actions/openshift-tools-installer@v1
@@ -29,7 +29,7 @@ jobs:
           ${{ secrets.NS_TOOLS }}/${{ env.IMAGE }}:${{ env.PROMOTE_TAG }}
 
   trigger-gitops:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     needs: promote-image
     steps:
@@ -51,7 +51,7 @@ jobs:
         run: ./gitops/watch-deployment.sh docman prod ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGO_CD_CLI_JWT }}
 
   run-if-failed:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: [trigger-gitops]
     if: always() && (needs.trigger-gitops.result == 'failure')
     steps:

--- a/.github/workflows/docman.deploy.test.yaml
+++ b/.github/workflows/docman.deploy.test.yaml
@@ -11,7 +11,7 @@ env:
 jobs:
   promote-image:
     name: promote-image
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Install oc
         uses: redhat-actions/openshift-tools-installer@v1
@@ -29,7 +29,7 @@ jobs:
           ${{ secrets.NS_TOOLS }}/${{ env.IMAGE }}:${{ env.PROMOTE_TAG }}
 
   trigger-gitops:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     needs: promote-image
     steps:
@@ -51,7 +51,7 @@ jobs:
         run: ./gitops/watch-deployment.sh docman test ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGO_CD_CLI_JWT }}
 
   run-if-failed:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: [trigger-gitops]
     if: always() && (needs.trigger-gitops.result == 'failure')
     steps:

--- a/.github/workflows/filesystem-provider.build.deploy.dev.yaml
+++ b/.github/workflows/filesystem-provider.build.deploy.dev.yaml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   build-filesystem-provider:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -38,7 +38,7 @@ jobs:
           docker push --all-tags ${{ secrets.CLUSTER_REGISTRY }}/${{ secrets.NS_TOOLS }}/${{ env.NAME }}
 
   trigger-gitops:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     needs: build-filesystem-provider
     steps:
@@ -60,7 +60,7 @@ jobs:
         run: ./gitops/watch-deployment.sh filesystem-provider dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGO_CD_CLI_JWT }}
 
   run-if-failed:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: [trigger-gitops]
     if: always() && (needs.trigger-gitops.result == 'failure')
     steps:

--- a/.github/workflows/filesystem-provider.deploy.prod.yaml
+++ b/.github/workflows/filesystem-provider.deploy.prod.yaml
@@ -11,7 +11,7 @@ env:
 jobs:
   promote-image:
     name: promote-image
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Install oc
         uses: redhat-actions/openshift-tools-installer@v1
@@ -29,7 +29,7 @@ jobs:
           ${{ secrets.NS_TOOLS }}/${{ env.IMAGE }}:${{ env.PROMOTE_TAG }}
 
   trigger-gitops:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     needs: promote-image
     steps:
@@ -51,7 +51,7 @@ jobs:
         run: ./gitops/watch-deployment.sh filesystem-provider prod ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGO_CD_CLI_JWT }}
 
   run-if-failed:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: [trigger-gitops]
     if: always() && (needs.trigger-gitops.result == 'failure')
     steps:

--- a/.github/workflows/filesystem-provider.deploy.test.yaml
+++ b/.github/workflows/filesystem-provider.deploy.test.yaml
@@ -11,7 +11,7 @@ env:
 jobs:
   promote-image:
     name: promote-image
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Install oc
         uses: redhat-actions/openshift-tools-installer@v1
@@ -29,7 +29,7 @@ jobs:
           ${{ secrets.NS_TOOLS }}/${{ env.IMAGE }}:${{ env.PROMOTE_TAG }}
 
   trigger-gitops:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     needs: promote-image
     steps:
@@ -51,7 +51,7 @@ jobs:
         run: ./gitops/watch-deployment.sh filesystem-provider test ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGO_CD_CLI_JWT }}
 
   run-if-failed:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: [trigger-gitops]
     if: always() && (needs.trigger-gitops.result == 'failure')
     steps:

--- a/.github/workflows/minespace.build.deploy.dev.yaml
+++ b/.github/workflows/minespace.build.deploy.dev.yaml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   build-minespace:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -38,7 +38,7 @@ jobs:
           docker push --all-tags ${{ secrets.CLUSTER_REGISTRY }}/${{ secrets.NS_TOOLS }}/${{ env.NAME }}
 
   trigger-gitops:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     needs: [build-minespace]
     steps:
@@ -60,7 +60,7 @@ jobs:
         run: ./gitops/watch-deployment.sh minespace dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGO_CD_CLI_JWT }}
 
   run-if-failed:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: [trigger-gitops]
     if: always() && (needs.trigger-gitops.result == 'failure')
     steps:

--- a/.github/workflows/minespace.cypress.yaml
+++ b/.github/workflows/minespace.cypress.yaml
@@ -12,7 +12,7 @@ on:
 jobs:
   run-cypress-minespace:
     name: run-cypress-minespace
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
         name: checkout

--- a/.github/workflows/minespace.deploy.prod.yaml
+++ b/.github/workflows/minespace.deploy.prod.yaml
@@ -11,7 +11,7 @@ env:
 jobs:
   promote-image:
     name: promote-image
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Install oc
         uses: redhat-actions/openshift-tools-installer@v1
@@ -29,7 +29,7 @@ jobs:
           ${{ secrets.NS_TOOLS }}/${{ env.IMAGE }}:${{ env.PROMOTE_TAG }}
 
   trigger-gitops:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     needs: promote-image
     steps:
@@ -51,7 +51,7 @@ jobs:
         run: ./gitops/watch-deployment.sh minespace prod ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGO_CD_CLI_JWT }}
 
   run-if-failed:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: [trigger-gitops]
     if: always() && (needs.trigger-gitops.result == 'failure')
     steps:

--- a/.github/workflows/minespace.deploy.test.yaml
+++ b/.github/workflows/minespace.deploy.test.yaml
@@ -11,7 +11,7 @@ env:
 jobs:
   promote-image:
     name: promote-image
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Install oc
         uses: redhat-actions/openshift-tools-installer@v1
@@ -29,7 +29,7 @@ jobs:
           ${{ secrets.NS_TOOLS }}/${{ env.IMAGE }}:${{ env.PROMOTE_TAG }}
 
   trigger-gitops:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     needs: promote-image
     steps:
@@ -54,7 +54,7 @@ jobs:
         run: ./gitops/watch-deployment.sh minespace test ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGO_CD_CLI_JWT }}
 
   run-if-failed:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: [trigger-gitops]
     if: always() && (needs.trigger-gitops.result == 'failure')
     steps:

--- a/.github/workflows/minespace.unit.yaml
+++ b/.github/workflows/minespace.unit.yaml
@@ -15,7 +15,7 @@ on:
 jobs:
   tests-unit-minespace:
     name: tests-unit-minespace
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     steps:

--- a/.github/workflows/minespace.unit.yaml
+++ b/.github/workflows/minespace.unit.yaml
@@ -5,6 +5,7 @@ on:
     paths:
       - services/common/**
       - services/minespace-web/**
+  workflow_dispatch:
   push:
     branches:
       - develop

--- a/.github/workflows/nris.build.deploy.dev.yaml
+++ b/.github/workflows/nris.build.deploy.dev.yaml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   build-nris:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -34,7 +34,7 @@ jobs:
           docker push --all-tags ${{ secrets.CLUSTER_REGISTRY }}/${{ secrets.NS_TOOLS }}/${{ env.NAME }}
 
   trigger-gitops:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     needs: [build-nris]
     steps:
@@ -56,7 +56,7 @@ jobs:
         run: ./gitops/watch-deployment.sh nris dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGO_CD_CLI_JWT }}
 
   run-if-failed:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: [trigger-gitops]
     if: always() && (needs.trigger-gitops.result == 'failure')
     steps:

--- a/.github/workflows/nris.deploy.prod.yaml
+++ b/.github/workflows/nris.deploy.prod.yaml
@@ -11,7 +11,7 @@ env:
 jobs:
   promote-image:
     name: promote-image
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Install oc
         uses: redhat-actions/openshift-tools-installer@v1
@@ -29,7 +29,7 @@ jobs:
           ${{ secrets.NS_TOOLS }}/${{ env.IMAGE }}:${{ env.PROMOTE_TAG }}
 
   trigger-gitops:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     needs: promote-image
     steps:
@@ -51,7 +51,7 @@ jobs:
         run: ./gitops/watch-deployment.sh nris prod ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGO_CD_CLI_JWT }}
 
   run-if-failed:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: [trigger-gitops]
     if: always() && (needs.trigger-gitops.result == 'failure')
     steps:

--- a/.github/workflows/nris.deploy.test.yaml
+++ b/.github/workflows/nris.deploy.test.yaml
@@ -11,7 +11,7 @@ env:
 jobs:
   promote-image:
     name: promote-image
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Install oc
         uses: redhat-actions/openshift-tools-installer@v1
@@ -29,7 +29,7 @@ jobs:
           ${{ secrets.NS_TOOLS }}/${{ env.IMAGE }}:${{ env.PROMOTE_TAG }}
 
   trigger-gitops:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     needs: promote-image
     steps:
@@ -51,7 +51,7 @@ jobs:
         run: ./gitops/watch-deployment.sh nris test ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGO_CD_CLI_JWT }}
 
   run-if-failed:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: [trigger-gitops]
     if: always() && (needs.trigger-gitops.result == 'failure')
     steps:

--- a/.github/workflows/permit-service.unit.yaml
+++ b/.github/workflows/permit-service.unit.yaml
@@ -15,7 +15,7 @@ on:
 jobs:
   run-permit-tests:
     name: run-permit-tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3

--- a/.github/workflows/postgres.build.yaml
+++ b/.github/workflows/postgres.build.yaml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   build-postgres:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/schemaspy-rollout.yaml
+++ b/.github/workflows/schemaspy-rollout.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   schemaspy-rollout:
     name: schemaspy-rollout    
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Install oc
         uses: redhat-actions/openshift-tools-installer@v1

--- a/.github/workflows/tests.coverage.yaml
+++ b/.github/workflows/tests.coverage.yaml
@@ -8,7 +8,7 @@ env:
 
 jobs:
   tests-coverage-backend:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3
@@ -63,7 +63,7 @@ jobs:
           retention-days: 1
 
   tests-coverage-frontend:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3
@@ -119,7 +119,7 @@ jobs:
           retention-days: 1
 
   tests-coverage-minespace:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3
@@ -182,7 +182,7 @@ jobs:
       - tests-coverage-backend
       - tests-coverage-frontend
       - tests-coverage-minespace
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check if push event
         if: github.event_name == 'push'

--- a/.github/workflows/tests.integration.yaml
+++ b/.github/workflows/tests.integration.yaml
@@ -17,7 +17,7 @@ on:
 jobs:
   tests-verify-migrations:
     name: tests-verify-migrations
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3
@@ -30,7 +30,7 @@ jobs:
 
   tests-integration-backend:
     name: tests-integration-backend
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3

--- a/.github/workflows/tusd.build.deploy.dev.yaml
+++ b/.github/workflows/tusd.build.deploy.dev.yaml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   build-tusd:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -34,7 +34,7 @@ jobs:
           docker push --all-tags ${{ secrets.CLUSTER_REGISTRY }}/${{ secrets.NS_TOOLS }}/${{ env.NAME }}
 
   trigger-gitops:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     needs: [build-tusd]
     steps:
@@ -56,7 +56,7 @@ jobs:
         run: ./gitops/watch-deployment.sh tusd dev ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGO_CD_CLI_JWT }}
 
   run-if-failed:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: [trigger-gitops]
     if: always() && (needs.trigger-gitops.result == 'failure')
     steps:

--- a/.github/workflows/tusd.deploy.prod.yaml
+++ b/.github/workflows/tusd.deploy.prod.yaml
@@ -10,7 +10,7 @@ env:
 jobs:
   promote-image:
     name: promote-image
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Install oc
         uses: redhat-actions/openshift-tools-installer@v1
@@ -28,7 +28,7 @@ jobs:
           ${{ secrets.NS_TOOLS }}/tusd:${{ env.PROMOTE_TAG }}
 
   trigger-gitops:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     needs: promote-image
     steps:
@@ -50,7 +50,7 @@ jobs:
         run: ./gitops/watch-deployment.sh tusd prod ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGO_CD_CLI_JWT }}
 
   run-if-failed:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: [trigger-gitops]
     if: always() && (needs.trigger-gitops.result == 'failure')
     steps:

--- a/.github/workflows/tusd.deploy.test.yaml
+++ b/.github/workflows/tusd.deploy.test.yaml
@@ -10,7 +10,7 @@ env:
 jobs:
   promote-image:
     name: promote-image
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Install oc
         uses: redhat-actions/openshift-tools-installer@v1
@@ -28,7 +28,7 @@ jobs:
           ${{ secrets.NS_TOOLS }}/tusd:${{ env.PROMOTE_TAG }}
 
   trigger-gitops:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     needs: promote-image
     steps:
@@ -50,7 +50,7 @@ jobs:
         run: ./gitops/watch-deployment.sh tusd test ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGO_CD_CLI_JWT }}
 
   run-if-failed:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: [trigger-gitops]
     if: always() && (needs.trigger-gitops.result == 'failure')
     steps:


### PR DESCRIPTION
## Objective 
- because ubuntu 20 is deprecated and our actions aren't running
- today it's a scheduled brownout, but in the future they just won't work
- was going to try running a couple of workflows from the branch to test it out
- BONUS: added a workflow_dispatch trigger to MS unit tests (because I tried to manually run it and I couldn't)