### PR TITLE
[MDS-6057] Report select condition UI tweaks

### DIFF
--- a/services/common/src/components/reports/PermitRequiredReportFields.tsx
+++ b/services/common/src/components/reports/PermitRequiredReportFields.tsx
@@ -21,6 +21,7 @@ import { PermitReportInfoBox } from "./ReportInfoBox";
 import ArrowRightOutlined from "@ant-design/icons/ArrowRightOutlined";
 import { useFeatureFlag } from "@mds/common/providers/featureFlags/useFeatureFlag";
 import { Feature } from "@mds/common/utils/featureFlag";
+import { uniqBy} from "lodash"
 
 export const ConditionCategories: FC<{ permitGuid: string; formName: FORM }> = ({
   permitGuid,
@@ -34,7 +35,7 @@ export const ConditionCategories: FC<{ permitGuid: string; formName: FORM }> = (
   }
 
   return (
-    <>
+    <div className="report-options">
       {conditionCategories?.map((category) => (
         <div key={category.condition_category_code}>
           <Typography.Paragraph strong className="margin-large--top" style={{ marginBottom: 0 }}>
@@ -61,7 +62,7 @@ export const ConditionCategories: FC<{ permitGuid: string; formName: FORM }> = (
           ))}
         </div>
       ))}
-    </>
+    </div>
   );
 };
 
@@ -76,7 +77,7 @@ export const PermitReportCodeRequirement: FC<{
   const conditionCategories = useAppSelector(getCategoriesWithReports(permitGuid));
   const reports = amendment?.mine_report_permit_requirements;
   const reportOptions = createDropDownList(
-    reports,
+    uniqBy(reports,"report_name"),
     "report_name",
     "mine_report_permit_requirement_id"
   );

--- a/services/common/src/components/reports/ReportInfoBox.tsx
+++ b/services/common/src/components/reports/ReportInfoBox.tsx
@@ -8,120 +8,123 @@ import { Alert, Typography, Button, Row, Col } from "antd";
 import ExportOutlined from "@ant-design/icons/ExportOutlined";
 import React, { FC } from "react";
 
-export const CodeReportInfoBox: FC<{ mineReportDefinition: IMineReportDefinition; verb: string }> = ({
-    mineReportDefinition,
-    verb,
-  }) => {
+export const CodeReportInfoBox: FC<{
+  mineReportDefinition: IMineReportDefinition;
+  verb: string;
+}> = ({ mineReportDefinition, verb }) => {
+  if (mineReportDefinition) {
     return (
       <div className="report-info-box">
-        {mineReportDefinition && (
-          <div>
-            {mineReportDefinition.is_prr_only && (
-              <Alert
-                showIcon
-                description="Please submit this report as a permit required report."
-                type="warning"
-                className="margin-large--bottom"
-              />
-            )}
-            <Typography.Title level={4} className="primary-colour">
-              You are {verb}
-            </Typography.Title>
-            <Typography.Title level={5}>
-              {formatComplianceCodeReportName(mineReportDefinition)}
-            </Typography.Title>
-  
-            {mineReportDefinition.compliance_articles[0].long_description && (
-              <>
-                <Typography.Title level={5}>About this submission type:</Typography.Title>
-                <Typography.Paragraph>
-                  {mineReportDefinition.compliance_articles[0].long_description}
-                </Typography.Paragraph>
-              </>
-            )}
-            {mineReportDefinition.compliance_articles[0].help_reference_link && (
-              <Button
-                target="_blank"
-                rel="noopener noreferrer"
-                href={mineReportDefinition.compliance_articles[0].help_reference_link}
-                type="default"
-              >
-                More information <ExportOutlined />
-              </Button>
-            )}
-          </div>
-        )}
+        <div>
+          {mineReportDefinition.is_prr_only && (
+            <Alert
+              showIcon
+              description="Please submit this report as a permit required report."
+              type="warning"
+              className="margin-large--bottom"
+            />
+          )}
+          <Typography.Title level={4} className="primary-colour">
+            You are {verb}
+          </Typography.Title>
+          <Typography.Title level={5}>
+            {formatComplianceCodeReportName(mineReportDefinition)}
+          </Typography.Title>
+
+          {mineReportDefinition.compliance_articles[0].long_description && (
+            <>
+              <Typography.Title level={5}>About this submission type:</Typography.Title>
+              <Typography.Paragraph>
+                {mineReportDefinition.compliance_articles[0].long_description}
+              </Typography.Paragraph>
+            </>
+          )}
+          {mineReportDefinition.compliance_articles[0].help_reference_link && (
+            <Button
+              target="_blank"
+              rel="noopener noreferrer"
+              href={mineReportDefinition.compliance_articles[0].help_reference_link}
+              type="default"
+            >
+              More information <ExportOutlined />
+            </Button>
+          )}
+        </div>
       </div>
     );
+  }
+  return null;
 };
-  
-export const PermitReportInfoBox: FC<{ summary?: boolean, twoColumn?: boolean, mineGuid: string, permitGuid: string, permitAmendmentGuid: string, permitReport: IMineReportPermitRequirement, verb: string }> = ({
-    summary = false,
-    twoColumn = false,
-    permitReport,
-    mineGuid,
-    permitGuid,
-    permitAmendmentGuid,
-    verb,
-  }) => {
-  
-    const isCore = useAppSelector(getIsCore);
-    const transformedReport = transformPermitReportRequirement(permitReport);
-    const { conditionMap } = useAppSelector(getPermitConditionCategories(permitGuid, permitAmendmentGuid));
-    const condition = conditionMap[permitReport?.permit_condition_id]
-  
-    function getConditionHref() {
-      return GLOBAL_ROUTES?.VIEW_MINE_PERMIT_AMENDMENT.hashRoute(
-        mineGuid,
-        permitGuid,
-        permitAmendmentGuid,
-        "conditions",
-        "#" + permitReport?.condition_category_code
-      ).toString()
-    }
-  
+
+export const PermitReportInfoBox: FC<{
+  summary?: boolean;
+  twoColumn?: boolean;
+  mineGuid: string;
+  permitGuid: string;
+  permitAmendmentGuid: string;
+  permitReport: IMineReportPermitRequirement;
+  verb: string;
+}> = ({
+  summary = false,
+  twoColumn = false,
+  permitReport,
+  mineGuid,
+  permitGuid,
+  permitAmendmentGuid,
+  verb,
+}) => {
+  const isCore = useAppSelector(getIsCore);
+  const transformedReport = transformPermitReportRequirement(permitReport);
+  const { conditionMap } = useAppSelector(
+    getPermitConditionCategories(permitGuid, permitAmendmentGuid)
+  );
+  const condition = conditionMap[permitReport?.permit_condition_id];
+
+  function getConditionHref() {
+    return GLOBAL_ROUTES?.VIEW_MINE_PERMIT_AMENDMENT.hashRoute(
+      mineGuid,
+      permitGuid,
+      permitAmendmentGuid,
+      "conditions",
+      "#" + permitReport?.condition_category_code
+    ).toString();
+  }
+
+  if (transformedReport) {
     return (
       <div className={`${summary ? "report-summary-box" : "report-info-box"}`}>
-        {transformedReport && (
-          <div>
-            <Typography.Title level={4} className="primary-colour">
-              You are {verb}:
-            </Typography.Title>
-            <Typography.Title level={5}>
-              {transformedReport.report_name}
-            </Typography.Title>
-  
-            <Typography.Title level={5}>Condition:</Typography.Title>
-            <Typography.Paragraph>
-              {condition?.stepPath ?? "Not Specified"}
-            </Typography.Paragraph>
-  
-            <Row>
-              <Col span={twoColumn ? 12 : 24}>
-                <Typography.Title level={5}>Frequency:</Typography.Title>
-                <Typography.Paragraph>
-                  {transformedReport.frequency}
-                </Typography.Paragraph>
-  
-                <Typography.Title level={5}>Due Date:</Typography.Title>
-                <Typography.Paragraph>
-                  {transformedReport.initial_due_date ? formatDate(transformedReport.initial_due_date) : "Not Specified"}
-                </Typography.Paragraph>
-              </Col>
-              <Col span={twoColumn ? 12 : 24}>
-                <Typography.Title level={5}>Regulatory Authority:</Typography.Title>
-                <Typography.Paragraph>
-                  {transformedReport.regulatory_authority}
-                </Typography.Paragraph>
-  
-                <Typography.Title level={5}>Ministry Recipient:</Typography.Title>
-                <Typography.Paragraph>
-                  {transformedReport.ministry_recipient}
-                </Typography.Paragraph>
-              </Col>
-            </Row>
-  
-            {isCore && getConditionHref && (<Button
+        <div>
+          <Typography.Title level={4} className="primary-colour">
+            You are {verb}:
+          </Typography.Title>
+          <Typography.Title level={5}>{transformedReport.report_name}</Typography.Title>
+
+          <Typography.Title level={5}>Condition:</Typography.Title>
+          <Typography.Paragraph>{condition?.stepPath ?? "Not Specified"}</Typography.Paragraph>
+
+          <Row>
+            <Col span={twoColumn ? 12 : 24}>
+              <Typography.Title level={5}>Frequency:</Typography.Title>
+              <Typography.Paragraph>{transformedReport.frequency}</Typography.Paragraph>
+
+              <Typography.Title level={5}>Due Date:</Typography.Title>
+              <Typography.Paragraph>
+                {transformedReport.initial_due_date
+                  ? formatDate(transformedReport.initial_due_date)
+                  : "Not Specified"}
+              </Typography.Paragraph>
+            </Col>
+            <Col span={twoColumn ? 12 : 24}>
+              <Typography.Title level={5}>Regulatory Authority:</Typography.Title>
+              <Typography.Paragraph>{transformedReport.regulatory_authority}</Typography.Paragraph>
+
+              <Typography.Title level={5}>Ministry Recipient:</Typography.Title>
+              <Typography.Paragraph>{transformedReport.ministry_recipient}</Typography.Paragraph>
+            </Col>
+          </Row>
+
+          {isCore && getConditionHref && (
+            <Button
               target="_blank"
               rel="noopener noreferrer"
               href={getConditionHref()}
@@ -129,10 +132,10 @@ export const PermitReportInfoBox: FC<{ summary?: boolean, twoColumn?: boolean, m
             >
               View Permit Condition <ExportOutlined />
             </Button>
-            )}
-  
-          </div>
-        )}
+          )}
+        </div>
       </div>
     );
+  }
+  return null;
 };

--- a/services/common/src/redux/selectors/permitSelectors.ts
+++ b/services/common/src/redux/selectors/permitSelectors.ts
@@ -124,7 +124,7 @@ export const getMineReportPermitRequirementById = (permitGuid, reportId) =>
 
 export const getCategoriesWithReports = (permitGuid) => createSelector([getLatestAmendmentByPermitGuid(permitGuid)], (latestAmendment) => {
   return latestAmendment?.condition_categories.map((category) => {
-    const reports = latestAmendment.mine_report_permit_requirements.filter((report) => category.condition_category_code === report.condition_category_code);
+    const reports = uniqBy(latestAmendment.mine_report_permit_requirements,"report_name").filter((report) => category.condition_category_code === report.condition_category_code);
     return {
       ...category,
       reports

--- a/services/core-web/src/styles/components/Reports.scss
+++ b/services/core-web/src/styles/components/Reports.scss
@@ -51,7 +51,7 @@
   text-align: left;
 }
 
-.report-link span{
+.report-link span {
   display: inline;
 }
 
@@ -64,11 +64,16 @@
   padding: 16px;
 }
 
+.report-options {
+  max-height: 80vh;
+  overflow-y: auto;
+}
+
 .report-info-box {
-  height: 100%;
   padding: 16px;
   border: 1px solid $light-violet;
-
+  position: sticky;
+  top: 80px;
   background: #fff;
 
   h5 {

--- a/services/minespace-web/src/styles/components/Reports.scss
+++ b/services/minespace-web/src/styles/components/Reports.scss
@@ -27,8 +27,13 @@
   height: unset;
 }
 
-.report-link span{
+.report-link span {
   display: inline;
+}
+
+.report-options {
+  max-height: 80vh;
+  overflow-y: auto;
 }
 
 .report-summary-box {
@@ -43,8 +48,9 @@
 }
 
 .report-info-box {
-  height: 100%;
   padding: 16px;
   border: 1px solid #96ABC0;
   background: #fff;
+  position: sticky;
+  top: 100px;
 }


### PR DESCRIPTION
## Objective 

[MDS-6057](https://bcmines.atlassian.net/browse/MDS-6057)
Additional UI tweaks to when submitting a report using verified permit conditions.

![image](https://github.com/user-attachments/assets/400b493e-b287-4641-a193-fa2750fa0bba)

Used uniqBy() to dedupe the options based on the report name/type so that the same report doesn't appear multiple times to the user.

Changed the default behavior to not show the empty info box when a report isn't selected.
Modified scss rules so if there's a large number of report options it will instead overflow and scroll.
Also made the info box sticky so it stays on the page as a user scrolls down.

I've been having haystack issues all day so haven't been able to test against a wide range of permits.