### PR TITLE
[MDS-6360] Create EOR/QP report requests on TSF submit

### DIFF
--- a/services/common/src/components/forms/BaseInput.tsx
+++ b/services/common/src/components/forms/BaseInput.tsx
@@ -77,6 +77,7 @@ export interface BaseInputProps extends WrappedFieldProps {
   showNA?: boolean;
   autoFocus?: boolean;
   className?: string;
+  fieldEditMode?: boolean;
 }
 
 interface BaseViewInputProps {

--- a/services/common/src/components/forms/RenderDate.tsx
+++ b/services/common/src/components/forms/RenderDate.tsx
@@ -14,6 +14,7 @@ interface DateInputProps extends BaseInputProps {
   yearMode?: boolean;
   disabledDate?: (currentDate) => boolean;
   formatViewDate?: boolean;
+  fieldEditMode?: boolean;
 }
 
 const RenderDate: FC<DateInputProps> = ({
@@ -29,11 +30,12 @@ const RenderDate: FC<DateInputProps> = ({
   yearMode = false,
   disabledDate,
   formatViewDate = false,
+  fieldEditMode,
 }) => {
   return (
     <FormConsumer>
       {(value) => {
-        if (!value.isEditMode) {
+        if (!value.isEditMode || (typeof fieldEditMode !== "undefined" && !fieldEditMode)) {
           return (
             <BaseViewInput
               label={label}

--- a/services/common/src/components/forms/RenderDate.tsx
+++ b/services/common/src/components/forms/RenderDate.tsx
@@ -14,7 +14,6 @@ interface DateInputProps extends BaseInputProps {
   yearMode?: boolean;
   disabledDate?: (currentDate) => boolean;
   formatViewDate?: boolean;
-  fieldEditMode?: boolean;
 }
 
 const RenderDate: FC<DateInputProps> = ({

--- a/services/common/src/components/tailings/EngineerOfRecord.spec.tsx
+++ b/services/common/src/components/tailings/EngineerOfRecord.spec.tsx
@@ -32,8 +32,6 @@ describe("Tailings EngineerOfRecord", () => {
             <ReduxWrapper initialState={initialState}>
                 <FormWrapper name={FORM.ADD_TAILINGS_STORAGE_FACILITY}>
                     <EngineerOfRecord
-                        uploadedFiles={[]}
-                        setUploadedFiles={jest.fn()}
                         mineGuid={"18133c75-49ad-4101-85f3-a43e35ae989a"}
                         canEditTSF={true}
                         isEditMode={true}

--- a/services/common/src/components/tailings/EngineerOfRecord.tsx
+++ b/services/common/src/components/tailings/EngineerOfRecord.tsx
@@ -1,395 +1,254 @@
 import { Alert, Button, Col, Empty, Popconfirm, Row, Typography } from "antd";
 import { change, Field, getFormValues } from "@mds/common/components/forms/form";
-import React, { FC, useContext, useEffect, useState } from "react";
+import React, { FC, useContext, useState } from "react";
 import { closeModal, openModal } from "@mds/common/redux/actions/modalActions";
-import {
-    IDocument,
-    IMine,
-    IMinePartyAppt,
-    ITailingsStorageFacilityForm,
-} from "@mds/common/interfaces";
+import { IMine, IMinePartyAppt, ITailingsStorageFacilityForm } from "@mds/common/interfaces";
 import { TailingsContext } from "./TailingsContext";
-import { MINE_PARTY_APPOINTMENT_DOCUMENTS } from "@mds/common/constants/API";
 import PlusCircleFilled from "@ant-design/icons/PlusCircleFilled";
-import { downloadFileFromDocumentManager } from "@mds/common/redux/utils/actionlessNetworkCalls";
 import { getPartyRelationships } from "@mds/common/redux/selectors/partiesSelectors";
 import {
-    dateInFuture,
-    dateNotInFuture,
-    required,
-    validateDateRanges,
+  dateInFuture,
+  dateNotInFuture,
+  required,
+  validateDateRanges,
 } from "@mds/common/redux/utils/Validate";
-import { formatDateTime, truncateFilename } from "@mds/common/redux/utils/helpers";
-import { PDF } from "@mds/common/constants/fileTypes";
-import moment from "moment";
-import { isNumber } from "lodash";
+import { formatDateTime } from "@mds/common/redux/utils/helpers";
 import { getMineById } from "@mds/common/redux/selectors/mineSelectors";
 import PartyAppointmentTable from "./PartyAppointmentTable";
-import { ColumnsType } from "antd/lib/table";
-import CoreTable from "@mds/common/components/common/CoreTable";
 import { PARTY_APPOINTMENT_STATUS } from "@mds/common/constants/strings";
-import FileUpload from "../forms/RenderFileUpload";
 import RenderDate from "../forms/RenderDate";
 import { FORM } from "@mds/common/constants/forms";
-import { getIsCore } from "@mds/common/redux/reducers/authenticationReducer";
 import { useAppDispatch, useAppSelector } from "@mds/common/redux/rootState";
-import LinkButton from "../common/LinkButton";
 import ContactDetails from "./ContactDetails";
 import { MinePartyAppointmentTypeCodeEnum } from "@mds/common/constants/enums";
 
+const { Paragraph } = Typography;
 
 interface EngineerOfRecordProps {
-    uploadedFiles: IDocument[];
-    setUploadedFiles: (value: Partial<IDocument>[]) => void;
-    mineGuid: string;
-    loading?: boolean;
-    canEditTSF: boolean;
-    isEditMode: boolean;
+  mineGuid: string;
+  loading?: boolean;
+  canEditTSF: boolean;
+  isEditMode: boolean;
 }
 
-const columns = (LinkButton): ColumnsType<IDocument> => [
-    {
-        title: "File Name",
-        dataIndex: "document_name",
-        render: (text, record) => {
-            return (
-                <div title="File Name" key={record.mine_document_guid}>
-                    <LinkButton title={text} onClick={() => downloadFileFromDocumentManager(record)}>
-                        {truncateFilename(text)}
-                    </LinkButton>
-                </div>
-            );
-        },
-    },
-];
-
 export const EngineerOfRecord: FC<EngineerOfRecordProps> = (props) => {
-    const {
-        mineGuid,
-        uploadedFiles,
-        setUploadedFiles,
-        loading,
-        canEditTSF,
-        isEditMode,
-    } = props;
+  const { mineGuid, loading, canEditTSF, isEditMode } = props;
 
-    const dispatch = useAppDispatch();
-    const [openPopConfirm, setOpenPopConfirm] = useState(false);
+  const dispatch = useAppDispatch();
+  const [openPopConfirm, setOpenPopConfirm] = useState(false);
 
-    const {
-        addContactModalConfig,
-    } = useContext(TailingsContext);
-    const tsfFormName = FORM.ADD_TAILINGS_STORAGE_FACILITY;
-    const isCore = useAppSelector(getIsCore);
-    const partyRelationships: IMinePartyAppt[] = useAppSelector(getPartyRelationships)
-    const mine: IMine = useAppSelector(getMineById(mineGuid));
+  const { addContactModalConfig } = useContext(TailingsContext);
+  const tsfFormName = FORM.ADD_TAILINGS_STORAGE_FACILITY;
+  const partyRelationships: IMinePartyAppt[] = useAppSelector(getPartyRelationships);
+  const mine: IMine = useAppSelector(getMineById(mineGuid));
 
-    const formValues = useAppSelector(getFormValues(tsfFormName)
-    ) as ITailingsStorageFacilityForm;
+  const formValues = useAppSelector(getFormValues(tsfFormName)) as ITailingsStorageFacilityForm;
 
-    const [currentEor, setCurrentEor] = useState(null);
-    const handleCreateEOR = (value) => {
-        dispatch(change(tsfFormName, "engineer_of_record.party_guid", value.party_guid));
-        dispatch(change(tsfFormName, "engineer_of_record.party", value));
-        dispatch(change(tsfFormName, "engineer_of_record.start_date", null));
-        dispatch(change(tsfFormName, "engineer_of_record.end_date", null));
-        dispatch(change(tsfFormName, "engineer_of_record.mine_party_appt_guid", null));
-        setCurrentEor(null);
-        dispatch(closeModal());
-    };
+  const handleCreateEOR = (value) => {
+    dispatch(change(tsfFormName, "engineer_of_record.party_guid", value.party_guid));
+    dispatch(change(tsfFormName, "engineer_of_record.party", value));
+    dispatch(change(tsfFormName, "engineer_of_record.start_date", null));
+    dispatch(change(tsfFormName, "engineer_of_record.end_date", null));
+    dispatch(change(tsfFormName, "engineer_of_record.mine_party_appt_guid", null));
+    dispatch(closeModal());
+  };
 
-    const canEditTSFAndEditMode = canEditTSF && isEditMode;
+  const canEditTSFAndEditMode = canEditTSF && isEditMode;
 
-    useEffect(() => {
-        if (partyRelationships.length > 0) {
-            const activeEor = partyRelationships.find(
-                (eor) => eor.mine_party_appt_guid === formValues?.engineer_of_record?.mine_party_appt_guid
-            );
+  const openCreateEORModal = (event) => {
+    event?.preventDefault();
+    setOpenPopConfirm(false);
 
-            if (activeEor) {
-                setCurrentEor(activeEor);
-            }
-        }
-    }, [partyRelationships]);
-
-    const openCreateEORModal = (event) => {
-        event?.preventDefault();
-        setOpenPopConfirm(false);
-
-        dispatch(openModal({
-            props: {
-                onSubmit: handleCreateEOR,
-                title: "Select Contact",
-                partyRelationships,
-                mine_party_appt_type_code: MinePartyAppointmentTypeCodeEnum.EOR,
-                mine: mine,
-                createPartyOnly: true,
-            },
-            content: addContactModalConfig,
-        }));
-    };
-
-    const onFileLoad = (documentName, document_manager_guid) => {
-        setUploadedFiles([
-            ...uploadedFiles,
-            {
-                document_name: documentName,
-                document_manager_guid,
-            },
-        ]);
-        dispatch(change(tsfFormName, "engineer_of_record.eor_document_guid", document_manager_guid));
-    };
-
-    const onRemoveFile = (_, fileItem) => {
-        setUploadedFiles(
-            uploadedFiles.filter((file) => file.document_manager_guid !== fileItem.serverId)
-        );
-        dispatch(change(tsfFormName, "engineer_of_record.eor_document_guid", null));
-    };
-
-    const existingEors = partyRelationships?.filter(
-        (p) =>
-            p.mine_party_appt_type_code === "EOR" &&
-            p.mine_guid === mineGuid &&
-            p.related_guid === formValues.mine_tailings_storage_facility_guid
+    dispatch(
+      openModal({
+        props: {
+          onSubmit: handleCreateEOR,
+          title: "Select Contact",
+          partyRelationships,
+          mine_party_appt_type_code: MinePartyAppointmentTypeCodeEnum.EOR,
+          mine: mine,
+          createPartyOnly: true,
+        },
+        content: addContactModalConfig,
+      })
     );
+  };
 
-    const validateEorStartDateOverlap = (val) => {
-        if (formValues?.engineer_of_record?.mine_party_appt_guid || loading) {
-            // Skip validation for existing EoRs
-            return undefined;
-        }
+  const existingEors = partyRelationships?.filter(
+    (p) =>
+      p.mine_party_appt_type_code === "EOR" &&
+      p.mine_guid === mineGuid &&
+      p.related_guid === formValues.mine_tailings_storage_facility_guid
+  );
 
-        return (
-            validateDateRanges(
-                existingEors || [],
-                { ...formValues?.engineer_of_record, start_date: val },
-                "Engineer of Record",
-                true
-            )?.start_date || undefined
-        );
-    };
-
-    const daysToEORExpiry =
-        currentEor?.end_date &&
-        moment(currentEor.end_date).startOf("day").diff(moment().startOf("day"), "days");
-
-    // Enable editing of the EoR when a new EoR party has been selected (party_guid is set),
-    // but it has yet to be assigned to the TSF (mine_party_appt_guid is not set).
-    const canEditEOR =
-        formValues?.engineer_of_record?.party_guid &&
-        !formValues?.engineer_of_record?.mine_party_appt_guid;
-
-    const fieldsDisabled = !canEditEOR || loading || !canEditTSFAndEditMode;
-
-    const hasPendingEOR = formValues?.engineers_of_record?.some(
-        (eor) => PARTY_APPOINTMENT_STATUS[eor.status] === PARTY_APPOINTMENT_STATUS.pending
-    );
-
-    const hasCurrentEOR = formValues?.engineers_of_record?.some(
-        (eor) => PARTY_APPOINTMENT_STATUS[eor.status] === PARTY_APPOINTMENT_STATUS
-    );
-
-    const handleCreateEORModal = (newOpen: boolean) => {
-        if (!newOpen) {
-            setOpenPopConfirm(newOpen);
-            return;
-        }
-        if (hasCurrentEOR || hasPendingEOR) {
-            setOpenPopConfirm(true);
-        } else {
-            openCreateEORModal(undefined);
-        }
-    };
+  const validateEorStartDateOverlap = (val) => {
+    if (formValues?.engineer_of_record?.mine_party_appt_guid || loading) {
+      // Skip validation for existing EoRs
+      return undefined;
+    }
 
     return (
-        <>
-            <Row>
-                <Col span={24}>
-                    <Row justify="space-between">
-                        <Typography.Title level={3}>Engineer of Record</Typography.Title>
-
-                        <Col span={12}>
-                            <Row justify="end">
-                                {canEditTSFAndEditMode && (
-                                    <Popconfirm
-                                        style={{ maxWidth: "150px" }}
-                                        open={openPopConfirm}
-                                        placement="top"
-                                        title="Once acknowledged by the Ministry, assigning a new Engineer of Record will replace the current one and set the previous status to inactive. Continue?"
-                                        okText="Yes"
-                                        cancelText="No"
-                                        onOpenChange={handleCreateEORModal}
-                                        onConfirm={openCreateEORModal}
-                                        onCancel={() => setOpenPopConfirm(false)}
-                                    >
-                                        <Button style={{ display: "inline", float: "right" }} type="primary">
-                                            <PlusCircleFilled />
-                                            Assign a new Engineer of Record
-                                        </Button>
-                                    </Popconfirm>
-                                )}
-                                {formValues?.engineer_of_record?.update_timestamp && (
-                                    <Typography.Paragraph style={{ textAlign: "right" }}>
-                                        <b>Last Updated</b>
-                                        <br />
-                                        {formatDateTime(formValues.engineer_of_record.update_timestamp)}
-                                    </Typography.Paragraph>
-                                )}
-                            </Row>
-                        </Col>
-                    </Row>
-
-                    {canEditTSFAndEditMode && (
-                        <div>
-                            {(formValues?.engineer_of_record?.party_guid ? (
-                                <Alert
-                                    description="Assigning a new Engineer of Record will replace the current Engineer of Record and set the previous Engineer of Record’s status to inactive."
-                                    showIcon
-                                    type="info"
-                                    message={""}
-                                />
-                            ) : (
-                                <Alert
-                                    description="Assigning a new Engineer of Record (EoR) will replace the current listed contact and set their status to Inactive. When a new EoR is assigned, a notification will be sent to the Ministry of changes in the record, and must include an acknowledgement by the EoR to be active."
-                                    showIcon
-                                    type="info"
-                                    message={""}
-                                />
-                            ))}
-
-                            {hasPendingEOR && isCore && (
-                                <Alert
-                                    description="An Engineer of Record for this facility is awaiting Ministry acknowledgment below. Please contact the mine directly for any issues."
-                                    showIcon
-                                    type="warning"
-                                    message={""}
-                                />
-                            )}
-
-                            {isNumber(daysToEORExpiry) && daysToEORExpiry >= 0 && daysToEORExpiry <= 60 && (
-                                <Alert
-                                    message="Engineer of Record will Expire within 60 Days"
-                                    description="To be in compliance, you must have a current, Ministry-acknowledged Engineer of Record on file."
-                                    showIcon
-                                    type="warning"
-                                />
-                            )}
-
-                            {isNumber(daysToEORExpiry) && daysToEORExpiry < 0 && (
-                                <Alert
-                                    message="No Engineer of Record"
-                                    description="To be in compliance, you must have a current, Ministry-acknowledged Engineer of Record on file."
-                                    showIcon
-                                    type="error"
-                                />
-                            )}
-                        </div>
-                    )}
-
-                    <Typography.Title level={4} className="margin-large--top">
-                        Contact Information
-                    </Typography.Title>
-
-                    {formValues?.engineer_of_record?.party_guid ? (
-                        <ContactDetails contact={formValues.engineer_of_record.party} />
-                    ) : (
-                        <Row justify="center">
-                            <Col span={24}>
-                                <Empty
-                                    image={Empty.PRESENTED_IMAGE_SIMPLE}
-                                    imageStyle={{ transform: "scale(1.5)" }}
-                                    description={false}
-                                />
-                            </Col>
-
-                            <Typography.Paragraph>No Data</Typography.Paragraph>
-                        </Row>
-                    )}
-                    {currentEor && currentEor.documents.length > 0 && (
-                        <div>
-                            <Typography.Title level={4} className="margin-large--top">
-                                Acceptance Letter
-                            </Typography.Title>
-                            <CoreTable
-                                columns={columns(LinkButton)}
-                                dataSource={currentEor.documents}
-                                emptyText="This Engineer of Record does not currently have any documents"
-                            />
-                        </div>
-                    )}
-
-                    {canEditTSFAndEditMode && !formValues?.engineer_of_record?.mine_party_appt_guid && (
-                        <>
-                            <div className="margin-large--top margin-large--bottom">
-                                <Typography.Title level={4}>
-                                    {!fieldsDisabled ? "Upload Acceptance Letter *" : "Upload Acceptance Letter"}
-                                </Typography.Title>
-                                <Typography.Text>
-                                    Letter must be officially signed. A notification will be sent to the Mine Manager
-                                    upon upload.
-                                </Typography.Text>
-                            </div>
-                            <Field
-                                name="engineer_of_record.eor_document_guid"
-                                id="engineer_of_record.eor_document_guid"
-                                onFileLoad={onFileLoad}
-                                onRemoveFile={onRemoveFile}
-                                validate={!fieldsDisabled && [required]}
-                                component={FileUpload}
-                                disabled={fieldsDisabled}
-                                uploadUrl={MINE_PARTY_APPOINTMENT_DOCUMENTS(mineGuid)}
-                                acceptedFileTypesMap={{ ...PDF }}
-                                labelIdle='<strong>Drag & Drop your files or <span class="filepond--label-action">Browse</span></strong><br>
-                <div>Accepted formats: pdf</div>'
-                                allowRevert
-                            />
-                        </>
-                    )}
-
-                    <Typography.Title level={4} className="margin-large--top">
-                        Engineer of Record Term
-                    </Typography.Title>
-                    <Typography.Paragraph>
-                        Enter the start, and if known, the end date of the Engineer of Record including a
-                        termination date if applicable.
-                    </Typography.Paragraph>
-                    <Row gutter={16}>
-                        <Col span={12}>
-                            <Field
-                                id="engineer_of_record.start_date"
-                                name="engineer_of_record.start_date"
-                                label="Start Date"
-                                disabled={fieldsDisabled}
-                                component={RenderDate}
-                                required={!fieldsDisabled}
-                                validate={
-                                    !fieldsDisabled && [required, dateNotInFuture, validateEorStartDateOverlap]
-                                }
-                            />
-                        </Col>
-                        <Col span={12}>
-                            <Field
-                                id="engineer_of_record.end_date"
-                                name="engineer_of_record.end_date"
-                                label="End Date"
-                                disabled={fieldsDisabled}
-                                validate={!fieldsDisabled && [dateInFuture]}
-                                component={RenderDate}
-                            />
-                        </Col>
-                    </Row>
-                </Col>
-            </Row>
-            <Row>
-                <Col span={24}>
-                    <PartyAppointmentTable
-                        canEditTSF={canEditTSFAndEditMode}
-                    />
-                </Col>
-            </Row>
-        </>
+      validateDateRanges(
+        existingEors || [],
+        { ...formValues?.engineer_of_record, start_date: val },
+        "Engineer of Record",
+        true
+      )?.start_date || undefined
     );
+  };
+
+  // Enable editing of the EoR when a new EoR party has been selected (party_guid is set),
+  // but it has yet to be assigned to the TSF (mine_party_appt_guid is not set).
+  const canEditEOR =
+    formValues?.engineer_of_record?.party_guid &&
+    !formValues?.engineer_of_record?.mine_party_appt_guid;
+
+  const showEditFields = canEditEOR && !loading && canEditTSFAndEditMode;
+
+  const hasPendingEOR = formValues?.engineers_of_record?.some(
+    (eor) => PARTY_APPOINTMENT_STATUS[eor.status] === PARTY_APPOINTMENT_STATUS.pending
+  );
+
+  const hasCurrentEOR = formValues?.engineers_of_record?.some(
+    (eor) => PARTY_APPOINTMENT_STATUS[eor.status] === PARTY_APPOINTMENT_STATUS
+  );
+
+  const handleCreateEORModal = (newOpen: boolean) => {
+    if (!newOpen) {
+      setOpenPopConfirm(newOpen);
+      return;
+    }
+    if (hasCurrentEOR || hasPendingEOR) {
+      setOpenPopConfirm(true);
+    } else {
+      openCreateEORModal(undefined);
+    }
+  };
+
+  return (
+    <>
+      <Row>
+        <Col span={24}>
+          <Row justify="space-between">
+            <Typography.Title level={3}>Engineer of Record</Typography.Title>
+
+            <Col span={12}>
+              <Row justify="end">
+                {canEditTSFAndEditMode && (
+                  <Popconfirm
+                    style={{ maxWidth: "150px" }}
+                    open={openPopConfirm}
+                    placement="top"
+                    title="Once acknowledged by the Ministry, assigning a new Engineer of Record will replace the current one and set the previous status to inactive. Continue?"
+                    okText="Yes"
+                    cancelText="No"
+                    onOpenChange={handleCreateEORModal}
+                    onConfirm={openCreateEORModal}
+                    onCancel={() => setOpenPopConfirm(false)}
+                  >
+                    <Button style={{ display: "inline", float: "right" }} type="primary">
+                      <PlusCircleFilled />
+                      Assign a new Engineer of Record
+                    </Button>
+                  </Popconfirm>
+                )}
+                {formValues?.engineer_of_record?.update_timestamp && (
+                  <div>
+                    <Typography.Paragraph
+                      className="margin-none--bottom margin-large--top"
+                      style={{ textAlign: "right" }}
+                    >
+                      Updated By: {formValues.engineer_of_record.update_user}
+                    </Typography.Paragraph>
+                    <Typography.Paragraph style={{ textAlign: "right" }}>
+                      Updated Date: {formatDateTime(formValues.engineer_of_record.update_timestamp)}
+                    </Typography.Paragraph>
+                  </div>
+                )}
+              </Row>
+            </Col>
+          </Row>
+          <Alert
+            description={
+              <Paragraph>
+                As{" "}
+                <a
+                  href="https://www2.gov.bc.ca/gov/content/industry/mineral-exploration-mining/health-safety/health-safety-and-reclamation-code-for-mines-in-british-columbia"
+                  target="_blank"
+                >
+                  Per Health, Safety and Reclamation Code
+                </a>
+                , written acknowledgement to the Chief Inspector is required within 72 hours when an
+                Engineer of Record (EoR) is retained or accepts the role. A report request will be
+                generated upon changes to the EoR.
+              </Paragraph>
+            }
+            showIcon
+            type="info"
+            message={""}
+          />
+
+          <Typography.Title level={4} className="margin-large--top">
+            Contact Information
+          </Typography.Title>
+
+          {formValues?.engineer_of_record?.party_guid ? (
+            <ContactDetails contact={formValues.engineer_of_record.party} />
+          ) : (
+            <Row justify="center">
+              <Col span={24}>
+                <Empty
+                  image={Empty.PRESENTED_IMAGE_SIMPLE}
+                  imageStyle={{ transform: "scale(1.5)" }}
+                  description={false}
+                />
+              </Col>
+
+              <Typography.Paragraph>No Data</Typography.Paragraph>
+            </Row>
+          )}
+          <Typography.Title level={4} className="margin-large--top">
+            Engineer of Record Term
+          </Typography.Title>
+          <Typography.Paragraph>
+            Enter the start, and if known, the end date of the Engineer of Record including a
+            termination date if applicable.
+          </Typography.Paragraph>
+          <Row gutter={16}>
+            <Col span={12}>
+              <Field
+                id="engineer_of_record.start_date"
+                name="engineer_of_record.start_date"
+                label="Start Date"
+                disabled={!showEditFields}
+                fieldEditMode={showEditFields}
+                component={RenderDate}
+                required={!!showEditFields}
+                validate={
+                  showEditFields && [required, dateNotInFuture, validateEorStartDateOverlap]
+                }
+              />
+            </Col>
+            <Col span={12}>
+              <Field
+                id="engineer_of_record.end_date"
+                name="engineer_of_record.end_date"
+                label="End Date"
+                fieldEditMode={showEditFields}
+                validate={showEditFields && [dateInFuture]}
+                component={RenderDate}
+              />
+            </Col>
+          </Row>
+        </Col>
+      </Row>
+      <Row>
+        <Col span={24}>
+          <PartyAppointmentTable canEditTSF={canEditTSFAndEditMode} />
+        </Col>
+      </Row>
+    </>
+  );
 };
 
 export default EngineerOfRecord;

--- a/services/common/src/components/tailings/EngineerOfRecord.tsx
+++ b/services/common/src/components/tailings/EngineerOfRecord.tsx
@@ -169,6 +169,7 @@ export const EngineerOfRecord: FC<EngineerOfRecordProps> = (props) => {
             </Col>
           </Row>
           <Alert
+            message={<Paragraph strong>Engineer of Record Assignment</Paragraph>}
             description={
               <Paragraph>
                 As{" "}
@@ -185,7 +186,6 @@ export const EngineerOfRecord: FC<EngineerOfRecordProps> = (props) => {
             }
             showIcon
             type="info"
-            message={""}
           />
 
           <Typography.Title level={4} className="margin-large--top">

--- a/services/common/src/components/tailings/PartyAppointmentTable.tsx
+++ b/services/common/src/components/tailings/PartyAppointmentTable.tsx
@@ -1,208 +1,171 @@
 import React, { FC, useState } from "react";
-import { Col, Row, Typography } from "antd";
+import { Badge, Col, Row, Typography } from "antd";
 import { Field, FieldArray, change } from "@mds/common/components/forms/form";
 import {
-    updatePartyRelationship,
-    fetchPartyRelationships,
+  updatePartyRelationship,
+  fetchPartyRelationships,
 } from "@mds/common/redux/actionCreators/partiesActionCreator";
-import DocumentLink from "../documents/DocumentLink";
 import CoreTable from "@mds/common/components/common/CoreTable";
 import {
-    MINISTRY_ACKNOWLEDGED_STATUS,
-    PARTY_APPOINTMENT_STATUS,
+  PARTY_APPOINTMENT_STATUS,
 } from "@mds/common/constants/strings";
 import RenderSelect from "../forms/RenderSelect";
 import { FORM } from "@mds/common/constants/forms";
 import { useAppDispatch, useAppSelector } from "@mds/common/redux/rootState";
 import { getIsCore } from "@mds/common/redux/reducers/authenticationReducer";
 import { useParams } from "react-router-dom";
-
+import { formatDate } from "@mds/common/redux/utils/helpers";
 
 interface PartyAppointmentTableProps {
-    canEditTSF: boolean;
+  canEditTSF: boolean;
 }
 
 const PartyAppointmentTable: FC<PartyAppointmentTableProps> = (props) => {
-    const { canEditTSF } = props;
-    const dispatch = useAppDispatch();
-    const tsfFormName = FORM.ADD_TAILINGS_STORAGE_FACILITY;
-    const isCore = useAppSelector(getIsCore);
-    const commonColumns = ["name", "status", "dates", "letters"];
-    const columns = isCore ? [...commonColumns, "ministryAcknowledged"] : commonColumns;
+  const { canEditTSF } = props;
+  const dispatch = useAppDispatch();
+  const tsfFormName = FORM.ADD_TAILINGS_STORAGE_FACILITY;
+  const isCore = useAppSelector(getIsCore);
+  const commonColumns = ["name", "status", "term"];
+  const columns = isCore ? [...commonColumns, "ministryAcknowledged"] : commonColumns;
 
-    const { mineGuid, tsfGuid } = useParams<{ mineGuid: string, tsfGuid: string }>();
+  const statusMapping = (status) => {
+    switch (status) {
+      case PARTY_APPOINTMENT_STATUS.active:
+        return "success";
+      case PARTY_APPOINTMENT_STATUS.pending:
+        return "processing";
+      case PARTY_APPOINTMENT_STATUS.inactive:
+        return "warning";
+      default:
+        return "processing";
+    }
+  };
 
-    const [loadingField, setLoadingField] = useState({});
+  const { mineGuid, tsfGuid } = useParams<{ mineGuid: string; tsfGuid: string }>();
 
-    const ministryAcknowledgedColumns = Object.entries(MINISTRY_ACKNOWLEDGED_STATUS).map(
-        ([value, label]) => ({ value, label })
-    );
-    const statusColumns = Object.entries(PARTY_APPOINTMENT_STATUS).map(([value, label]) => ({
-        value,
-        label,
-    }));
+  const [loadingField, setLoadingField] = useState({});
 
-    const partyAppointmentChanged = async (rowName, mine_party_appt_guid, key, value) => {
-        const formPropName = `${rowName}.${key}`;
+  const statusColumns = Object.entries(PARTY_APPOINTMENT_STATUS).map(([value, label]) => ({
+    value,
+    label,
+  }));
 
-        setLoadingField({
-            ...loadingField,
-            [formPropName]: true,
-        });
+  const partyAppointmentChanged = async (rowName, mine_party_appt_guid, key, value) => {
+    const formPropName = `${rowName}.${key}`;
 
-        dispatch(change(tsfFormName, formPropName, value));
+    setLoadingField({
+      ...loadingField,
+      [formPropName]: true,
+    });
 
-        try {
-            await dispatch(updatePartyRelationship(
-                {
-                    mine_party_appt_guid,
-                    [key]: value,
-                },
-                "Successfully updated Engineer of Record"
-            ));
+    dispatch(change(tsfFormName, formPropName, value));
 
-            await dispatch(fetchPartyRelationships({
-                mine_guid: mineGuid,
-                relationships: "party",
-                include_permit_contacts: "true",
-                mine_tailings_storage_facility_guid: tsfGuid,
-            }));
-        } finally {
-            setLoadingField({
-                ...loadingField,
-                [formPropName]: undefined,
-            });
+    try {
+      await dispatch(
+        updatePartyRelationship(
+          {
+            mine_party_appt_guid,
+            [key]: value,
+          },
+          "Successfully updated Engineer of Record"
+        )
+      );
+
+      await dispatch(
+        fetchPartyRelationships({
+          mine_guid: mineGuid,
+          relationships: "party",
+          include_permit_contacts: "true",
+          mine_tailings_storage_facility_guid: tsfGuid,
+        })
+      );
+    } finally {
+      setLoadingField({
+        ...loadingField,
+        [formPropName]: undefined,
+      });
+    }
+  };
+
+  const columnDefinitions = [
+    {
+      title: "Name",
+      dataIndex: "name",
+      render: (text) => <div title="name">{text}</div>,
+    },
+    {
+      title: "Status",
+      dataIndex: "status",
+      render: (status, record) => {
+        if (isCore) {
+          return (
+            <Field
+              id={`${record.rowName}.status`}
+              name={`${record.rowName}.status`}
+              component={RenderSelect}
+              props={{ allowClear: false }}
+              data={statusColumns}
+              loading={loadingField[`${record.rowName}.status`]}
+              onChange={(val) => partyAppointmentChanged(record.rowName, record.key, "status", val)}
+              disabled={!canEditTSF}
+            />
+          );
         }
-    };
 
-    const columnDefinitions = [
-        {
-            title: "Name",
-            dataIndex: "name",
-            render: (text) => <div title="name">{text}</div>,
-        },
-        {
-            title: "Status",
-            dataIndex: "status",
-            render: (status, record) => {
-                if (isCore) {
-                    return (
-                        <Field
-                            id={`${record.rowName}.status`}
-                            name={`${record.rowName}.status`}
-                            component={RenderSelect}
-                            props={{ allowClear: false }}
-                            data={statusColumns}
-                            loading={loadingField[`${record.rowName}.status`]}
-                            onChange={(val) => partyAppointmentChanged(record.rowName, record.key, "status", val)}
-                            disabled={!canEditTSF}
-                        />
-                    );
-                }
+        const displayStatus = PARTY_APPOINTMENT_STATUS[status];
+        return <Badge status={statusMapping(displayStatus)} text={displayStatus} />;
+      },
+    },
+    {
+      title: "Term",
+      key: "term",
+      dataIndex: "term",
+    },
+  ];
 
-                return <div title="status">{PARTY_APPOINTMENT_STATUS[status]}</div>;
-            },
-        },
-        {
-            title: "Date",
-            key: "dates",
-            render: (record) => (
-                <div title="Dates">
-                    {record.startDate} - {record.endDate}
-                </div>
-            ),
-        },
-        {
-            title: "Letters",
-            dataIndex: "letters",
-            render: (documents) =>
-                documents.map((d) => (
-                    <DocumentLink
-                        key={d.document_manager_guid}
-                        openDocument
-                        documentManagerGuid={d.document_manager_guid}
-                        documentName={d.document_name}
-                        linkTitleOverride="Acceptance"
-                    />
-                )),
-        },
-        {
-            title: "Ministry Acknowledged",
-            key: "ministryAcknowledged",
-            render: (record) => {
-                return (
-                    <Field
-                        id={`${record.rowName}.mine_party_acknowledgement_status`}
-                        name={`${record.rowName}.mine_party_acknowledgement_status`}
-                        component={RenderSelect}
-                        props={{ allowClear: false }}
-                        data={ministryAcknowledgedColumns}
-                        loading={loadingField[`${record.rowName}.mine_party_acknowledgement_status`]}
-                        onChange={(val) =>
-                            partyAppointmentChanged(
-                                record.rowName,
-                                record.key,
-                                "mine_party_acknowledgement_status",
-                                val
-                            )
-                        }
-                    />
-                );
-            },
-        },
-    ];
+  const columnsToDisplay = columnDefinitions.filter(
+    (c) => !columns?.length || columns.includes(c.dataIndex)
+  );
 
-    const columnsToDisplay = columnDefinitions.filter(
-        (c) => !columns?.length || columns.includes(c.dataIndex)
-    );
+  const transformRowData = (rows) => {
+    return rows.map((rowName, ind) => {
+      const r = rows.get(ind);
 
-    const transformRowData = (rows) => {
-        return rows.map((rowName, ind) => {
-            const r = rows.get(ind);
-            let endDate = r.end_date;
+      const term = `${formatDate(r.start_date)} - ${r.end_date ? formatDate(r.end_date) : "Present"}`;
 
-            if (!endDate && r.start_date) {
-                endDate = "Present";
-            } else if (!endDate) {
-                endDate = "Unknown";
-            }
+      return {
+        index: ind,
+        rowName,
+        key: r.mine_party_appt_guid,
+        name: r.party?.name,
+        term: term,
+        status: r.status,
+        ministryAcknowledged: r.mine_party_acknowledgement_status,
+      };
+    });
+  };
 
-            return {
-                index: ind,
-                rowName,
-                key: r.mine_party_appt_guid,
-                name: r.party?.name,
-                startDate: r.start_date || "Unknown",
-                endDate,
-                letters: r.documents || [],
-                status: r.status,
-                ministryAcknowledged: r.mine_party_acknowledgement_status,
-            };
-        });
-    };
+  return (
+    <Row>
+      <Col span={24}>
+        <Typography.Title level={4} className="margin-large--top">
+          Historical Engineer of Record List
+        </Typography.Title>
 
-    return (
-        <Row>
-            <Col span={24}>
-                <Typography.Title level={4} className="margin-large--top">
-                    Historical Engineer of Record List
-                </Typography.Title>
-
-                <FieldArray
-                    name="engineers_of_record"
-                    props={{}}
-                    component={({ fields }) => (
-                        <CoreTable
-                            pagination={false}
-                            columns={columnsToDisplay}
-                            dataSource={transformRowData(fields || [])}
-                        />
-                    )}
-                />
-            </Col>
-        </Row>
-    );
+        <FieldArray
+          name="engineers_of_record"
+          props={{}}
+          component={({ fields }) => (
+            <CoreTable
+              pagination={false}
+              columns={columnsToDisplay}
+              dataSource={transformRowData(fields || [])}
+            />
+          )}
+        />
+      </Col>
+    </Row>
+  );
 };
-
 
 export default PartyAppointmentTable;

--- a/services/common/src/components/tailings/PartyAppointmentTable.tsx
+++ b/services/common/src/components/tailings/PartyAppointmentTable.tsx
@@ -6,9 +6,7 @@ import {
   fetchPartyRelationships,
 } from "@mds/common/redux/actionCreators/partiesActionCreator";
 import CoreTable from "@mds/common/components/common/CoreTable";
-import {
-  PARTY_APPOINTMENT_STATUS,
-} from "@mds/common/constants/strings";
+import { PARTY_APPOINTMENT_STATUS } from "@mds/common/constants/strings";
 import RenderSelect from "../forms/RenderSelect";
 import { FORM } from "@mds/common/constants/forms";
 import { useAppDispatch, useAppSelector } from "@mds/common/redux/rootState";
@@ -18,10 +16,11 @@ import { formatDate } from "@mds/common/redux/utils/helpers";
 
 interface PartyAppointmentTableProps {
   canEditTSF: boolean;
+  eor_or_qp?: "engineers_of_record" | "qualified_persons";
 }
 
 const PartyAppointmentTable: FC<PartyAppointmentTableProps> = (props) => {
-  const { canEditTSF } = props;
+  const { canEditTSF, eor_or_qp = "engineers_of_record" } = props;
   const dispatch = useAppDispatch();
   const tsfFormName = FORM.ADD_TAILINGS_STORAGE_FACILITY;
   const isCore = useAppSelector(getIsCore);
@@ -149,11 +148,12 @@ const PartyAppointmentTable: FC<PartyAppointmentTableProps> = (props) => {
     <Row>
       <Col span={24}>
         <Typography.Title level={4} className="margin-large--top">
-          Historical Engineer of Record List
+          Historical{" "}
+          {eor_or_qp === "engineers_of_record" ? "Engineer of Record" : "Qualified Persons"} List
         </Typography.Title>
 
         <FieldArray
-          name="engineers_of_record"
+          name={eor_or_qp}
           props={{}}
           component={({ fields }) => (
             <CoreTable

--- a/services/common/src/components/tailings/QualifiedPerson.spec.tsx
+++ b/services/common/src/components/tailings/QualifiedPerson.spec.tsx
@@ -14,6 +14,19 @@ const initialState = {
     },
 };
 
+function mockFunction() {
+    const original = jest.requireActual("react-router-dom");
+    return {
+        ...original,
+        useParams: jest.fn().mockReturnValue({
+            tsfGuid: "e2629897-053e-4218-9299-479375e47f78",
+            mineGuid: "18133c75-49ad-4101-85f3-a43e35ae989a",
+        }),
+    };
+}
+
+jest.mock("react-router-dom", () => mockFunction());
+
 describe("Tailings QualifiedPerson", () => {
     it("renders properly", () => {
         const { container } = render(

--- a/services/common/src/components/tailings/QualifiedPerson.tsx
+++ b/services/common/src/components/tailings/QualifiedPerson.tsx
@@ -1,242 +1,212 @@
 import { Alert, Button, Col, Empty, Popconfirm, Row, Typography } from "antd";
 import { change, Field, getFormValues } from "@mds/common/components/forms/form";
-import React, { FC, useContext, useEffect, useState } from "react";
+import React, { FC, useContext } from "react";
 import { closeModal, openModal } from "@mds/common/redux/actions/modalActions";
 import { getPartyRelationships } from "@mds/common/redux/selectors/partiesSelectors";
 import PlusCircleFilled from "@ant-design/icons/PlusCircleFilled";
 import {
-    dateInFuture,
-    dateNotInFuture,
-    required,
-    validateDateRanges,
+  dateInFuture,
+  dateNotInFuture,
+  required,
+  validateDateRanges,
 } from "@mds/common/redux/utils/Validate";
 import ContactDetails from "./ContactDetails";
 import { TailingsContext } from "@mds/common/components/tailings/TailingsContext";
-import moment from "moment";
 import { ICreateTailingsStorageFacility } from "@mds/common/interfaces";
 import RenderDate from "../forms/RenderDate";
 import { FORM } from "@mds/common/constants/forms";
 import { useAppDispatch, useAppSelector } from "@mds/common/redux/rootState";
-import { getIsCore } from "@mds/common/redux/reducers/authenticationReducer";
 import { MinePartyAppointmentTypeCodeEnum } from "@mds/common/constants/enums";
+import PartyAppointmentTable from "@mds/common/components/tailings/PartyAppointmentTable";
+import { formatDateTime } from "@mds/common/redux/utils/helpers";
+
+const { Paragraph } = Typography;
 
 interface QualifiedPersonProps {
-    mineGuid: string;
-    loading?: boolean;
-    canEditTSF: boolean;
-    isEditMode: boolean;
+  mineGuid: string;
+  loading?: boolean;
+  canEditTSF: boolean;
+  isEditMode: boolean;
 }
 
 export const QualifiedPerson: FC<QualifiedPersonProps> = (props) => {
-    const dispatch = useAppDispatch();
-    const { mineGuid, canEditTSF, isEditMode } = props;
-    const { addContactModalConfig } = useContext(TailingsContext);
-    const tsfFormName = FORM.ADD_TAILINGS_STORAGE_FACILITY;
-    const formValues = useAppSelector(getFormValues(tsfFormName)) as ICreateTailingsStorageFacility;
-    const partyRelationships = useAppSelector(getPartyRelationships);
-    const isCore = useAppSelector(getIsCore);
-    const [currentQp, setCurrentQp] = useState(null);
+  const dispatch = useAppDispatch();
+  const { mineGuid, canEditTSF, isEditMode } = props;
+  const { addContactModalConfig } = useContext(TailingsContext);
+  const tsfFormName = FORM.ADD_TAILINGS_STORAGE_FACILITY;
+  const formValues = useAppSelector(getFormValues(tsfFormName)) as ICreateTailingsStorageFacility;
+  const partyRelationships = useAppSelector(getPartyRelationships);
 
-    const canEditTSFAndEditMode = canEditTSF && isEditMode;
+  const canEditTSFAndEditMode = canEditTSF && isEditMode;
 
-    const handleCreateQP = (value) => {
-        dispatch(change(tsfFormName, "qualified_person.party_guid", value.party_guid));
-        dispatch(change(tsfFormName, "qualified_person.party", value));
-        dispatch(change(tsfFormName, "qualified_person.start_date", null));
-        dispatch(change(tsfFormName, "qualified_person.end_date", null));
-        dispatch(change(tsfFormName, "qualified_person.mine_party_appt_guid", null));
-        dispatch(closeModal());
-    };
+  const handleCreateQP = (value) => {
+    dispatch(change(tsfFormName, "qualified_person.party_guid", value.party_guid));
+    dispatch(change(tsfFormName, "qualified_person.party", value));
+    dispatch(change(tsfFormName, "qualified_person.start_date", null));
+    dispatch(change(tsfFormName, "qualified_person.end_date", null));
+    dispatch(change(tsfFormName, "qualified_person.mine_party_appt_guid", null));
+    dispatch(closeModal());
+  };
 
-    useEffect(() => {
-        if (partyRelationships.length > 0) {
-            const activeQp = partyRelationships.find(
-                (qp) => qp.mine_party_appt_guid === formValues?.qualified_person?.mine_party_appt_guid
-            );
-            if (activeQp) {
-                setCurrentQp(activeQp);
-            }
-        }
-    }, [partyRelationships]);
+  const openCreateQPModal = (event) => {
+    event.preventDefault();
+    dispatch(
+      openModal({
+        props: {
+          onSubmit: handleCreateQP,
+          title: "Select Contact",
+          mine_party_appt_type_code: MinePartyAppointmentTypeCodeEnum.TQP,
+          mine: mineGuid,
+          createPartyOnly: true,
+        },
+        content: addContactModalConfig,
+      })
+    );
+  };
 
-    const daysToQPExpiry =
-        currentQp?.end_date &&
-        moment(currentQp?.end_date).startOf("day").diff(moment().startOf("day"), "days");
+  const validateQPStartDateOverlap = (val) => {
+    if (formValues?.qualified_person?.mine_party_appt_guid || props.loading) {
+      // Skip validation for existing TQPs
+      return undefined;
+    }
 
-    const openCreateQPModal = (event) => {
-        event.preventDefault();
-        dispatch(openModal({
-            props: {
-                onSubmit: handleCreateQP,
-                title: "Select Contact",
-                mine_party_appt_type_code: MinePartyAppointmentTypeCodeEnum.TQP,
-                mine: mineGuid,
-                createPartyOnly: true,
-            },
-            content: addContactModalConfig,
-        }));
-    };
-
-    const validateQPStartDateOverlap = (val) => {
-        if (formValues?.qualified_person?.mine_party_appt_guid || props.loading) {
-            // Skip validation for existing TQPs
-            return undefined;
-        }
-
-        const existingEors = partyRelationships?.filter(
-            (p) =>
-                p.mine_party_appt_type_code === "TQP" &&
-                p.mine_guid === props.mineGuid &&
-                p.related_guid === formValues?.mine_tailings_storage_facility_guid
-        );
-
-        return (
-            validateDateRanges(
-                existingEors || [],
-                { ...formValues?.qualified_person, start_date: val },
-                "Qualified Person",
-                true
-            )?.start_date || undefined
-        );
-    };
-
-    // Enable editing of the QFP when a new EoR party has been selected (party_guid is set),
-    // but it has yet to be assigned to the TSF (mine_party_appt_guid is not set).
-    const canEditQFP =
-        formValues?.qualified_person?.party_guid &&
-        !formValues?.qualified_person?.mine_party_appt_guid;
-
-    const fieldsDisabled = !canEditQFP || props.loading || !canEditTSFAndEditMode;
+    const existingEors = partyRelationships?.filter(
+      (p) =>
+        p.mine_party_appt_type_code === "TQP" &&
+        p.mine_guid === props.mineGuid &&
+        p.related_guid === formValues?.mine_tailings_storage_facility_guid
+    );
 
     return (
-        <Row>
-            <Col span={24}>
-                <Row justify="space-between">
-                    <Typography.Title level={3}>TSF Qualified Person</Typography.Title>
-                    {isCore ? (
-                        <Col span={12}>
-                            <Row justify="end">
-                                {canEditTSFAndEditMode && (
-                                    <Popconfirm
-                                        placement="top"
-                                        title="Once acknowledged by the Ministry, assigning a new Qualified Person will replace the current one and set the previous status to inactive. Continue?"
-                                        okText="Yes"
-                                        cancelText="No"
-                                        onConfirm={openCreateQPModal}
-                                    >
-                                        <Button style={{ whiteSpace: "normal" }} type="primary">
-                                            <PlusCircleFilled />
-                                            Update TSF Qualified Person
-                                        </Button>
-                                    </Popconfirm>
-                                )}
-                                {formValues?.qualified_person?.update_timestamp && (
-                                    <Typography.Paragraph style={{ textAlign: "right" }}>
-                                        <b>Last Updated</b>
-                                        <br />
-                                        {moment(formValues?.qualified_person.update_timestamp).format(
-                                            "DD-MM-YYYY H:mm"
-                                        )}
-                                    </Typography.Paragraph>
-                                )}
-                            </Row>
-                        </Col>
-                    ) : (
-                        <Col>
-                            {canEditTSFAndEditMode && (
-                                <Popconfirm
-                                    style={{ maxWidth: "150px" }}
-                                    placement="top"
-                                    title="Once acknowledged by the Ministry, assigning a new Qualified Person will replace the current one and set the previous status to inactive. Continue?"
-                                    okText="Yes"
-                                    cancelText="No"
-                                    onConfirm={openCreateQPModal}
-                                >
-                                    <Button style={{ display: "inline", float: "right" }} type="primary">
-                                        <PlusCircleFilled />
-                                        Assign a new Qualified Person
-                                    </Button>
-                                </Popconfirm>
-                            )}
-                        </Col>
-                    )}
-                </Row>
-
-                {canEditTSFAndEditMode && (
-                    <div>
-                        {formValues?.qualified_person?.party_guid ? (
-                            <Alert
-                                description="Assigning a new Qualified Person will replace the current Qualified Person and set the previous Qualified Person’s status to inactive."
-                                showIcon
-                                type="info"
-                                message={""}
-                            />
-                        ) : (
-                            <Alert
-                                description="There is no Qualified Person (QP) on file for this facility. Click above to assign a new Qualified Person."
-                                showIcon
-                                type="info"
-                                message={""}
-                            />
-                        )}
-                        {daysToQPExpiry && daysToQPExpiry < 0 && (
-                            <Alert
-                                message="The Qualified Person's term has expired."
-                                description=""
-                                showIcon
-                                type="error"
-                            />
-                        )}
-                    </div>
-                )}
-                <Typography.Title level={4} className="margin-large--top">
-                    Contact Information
-                </Typography.Title>
-
-                {formValues?.qualified_person?.party_guid ? (
-                    <ContactDetails contact={formValues.qualified_person.party} />
-                ) : (
-                    <Row justify="center">
-                        <Col span={24}>
-                            <Empty
-                                image={Empty.PRESENTED_IMAGE_SIMPLE}
-                                imageStyle={{ transform: "scale(1.5)" }}
-                                description={false}
-                            />
-                        </Col>
-
-                        <Typography.Paragraph>No Data</Typography.Paragraph>
-                    </Row>
-                )}
-                <Typography.Title level={4} className="margin-large--top">
-                    TSF Qualified Person Term
-                </Typography.Title>
-                <Row gutter={16}>
-                    <Col span={12}>
-                        <Field
-                            id="qualified_person.start_date"
-                            name="qualified_person.start_date"
-                            label="Start Date"
-                            disabled={fieldsDisabled}
-                            component={RenderDate}
-                            required={!fieldsDisabled}
-                            validate={!fieldsDisabled && [required, dateNotInFuture, validateQPStartDateOverlap]}
-                        />
-                    </Col>
-                    <Col span={12}>
-                        <Field
-                            id="qualified_person.end_date"
-                            name="qualified_person.end_date"
-                            label="End Date"
-                            disabled={fieldsDisabled}
-                            validate={!fieldsDisabled && [dateInFuture]}
-                            component={RenderDate}
-                        />
-                    </Col>
-                </Row>
-            </Col>
-        </Row>
+      validateDateRanges(
+        existingEors || [],
+        { ...formValues?.qualified_person, start_date: val },
+        "Qualified Person",
+        true
+      )?.start_date || undefined
     );
+  };
+
+  // Enable editing of the QFP when a new EoR party has been selected (party_guid is set),
+  // but it has yet to be assigned to the TSF (mine_party_appt_guid is not set).
+  const canEditQFP =
+    formValues?.qualified_person?.party_guid && !formValues?.qualified_person?.mine_party_appt_guid;
+
+  const fieldsDisabled = !canEditQFP || props.loading || !canEditTSFAndEditMode;
+
+  return (
+    <Row>
+      <Col span={24}>
+        <Row justify="space-between" gutter={[16, 16]}>
+          <Typography.Title level={3}>TSF Qualified Person</Typography.Title>
+          <Col span={12}>
+            <Row justify="end">
+              {canEditTSFAndEditMode && (
+                <Popconfirm
+                  style={{ maxWidth: "150px" }}
+                  placement="top"
+                  title="Once acknowledged by the Ministry, assigning a new Qualified Person will replace the current one and set the previous status to inactive. Continue?"
+                  okText="Yes"
+                  cancelText="No"
+                  onConfirm={openCreateQPModal}
+                >
+                  <Button style={{ display: "inline", float: "right" }} type="primary">
+                    <PlusCircleFilled />
+                    Assign a new Qualified Person
+                  </Button>
+                </Popconfirm>
+              )}
+              {formValues?.qualified_person?.update_timestamp && (
+                <div>
+                  <Typography.Paragraph
+                    className="margin-none--bottom margin-large--top"
+                    style={{ textAlign: "right" }}
+                  >
+                    Updated By: {formValues.qualified_person.update_user}
+                  </Typography.Paragraph>
+                  <Typography.Paragraph style={{ textAlign: "right" }}>
+                    Updated Date: {formatDateTime(formValues.qualified_person.update_timestamp)}
+                  </Typography.Paragraph>
+                </div>
+              )}
+            </Row>
+          </Col>
+        </Row>
+        <Alert
+          message={<Paragraph strong>Qualified Person Assignment</Paragraph>}
+          description={
+            <Paragraph>
+              As{" "}
+              <a
+                href="https://www2.gov.bc.ca/gov/content/industry/mineral-exploration-mining/health-safety/health-safety-and-reclamation-code-for-mines-in-british-columbia"
+                target="_blank"
+              >
+                Per Health, Safety and Reclamation Code
+              </a>
+              , written acknowledgement to the Chief Inspector is required within 72 hours when an
+              Qualified Person (QP) is retained or accepts the role. A report request will be
+              generated upon changes to the EoR
+            </Paragraph>
+          }
+          showIcon
+          type="info"
+        />
+        <Typography.Title level={4} className="margin-large--top">
+          Contact Information
+        </Typography.Title>
+
+        {formValues?.qualified_person?.party_guid ? (
+          <ContactDetails contact={formValues.qualified_person.party} />
+        ) : (
+          <Row justify="center">
+            <Col span={24}>
+              <Empty
+                image={Empty.PRESENTED_IMAGE_SIMPLE}
+                imageStyle={{ transform: "scale(1.5)" }}
+                description={false}
+              />
+            </Col>
+
+            <Typography.Paragraph>No Data</Typography.Paragraph>
+          </Row>
+        )}
+        <Typography.Title level={4} className="margin-large--top">
+          TSF Qualified Person Term
+        </Typography.Title>
+        <Row gutter={16}>
+          <Col span={12}>
+            <Field
+              id="qualified_person.start_date"
+              name="qualified_person.start_date"
+              label="Start Date"
+              disabled={fieldsDisabled}
+              component={RenderDate}
+              required={!fieldsDisabled}
+              validate={!fieldsDisabled && [required, dateNotInFuture, validateQPStartDateOverlap]}
+            />
+          </Col>
+          <Col span={12}>
+            <Field
+              id="qualified_person.end_date"
+              name="qualified_person.end_date"
+              label="End Date"
+              disabled={fieldsDisabled}
+              validate={!fieldsDisabled && [dateInFuture]}
+              component={RenderDate}
+            />
+          </Col>
+        </Row>
+        <Row>
+          <Col span={24}>
+            <PartyAppointmentTable
+              canEditTSF={canEditTSFAndEditMode}
+              eor_or_qp="qualified_persons"
+            />
+          </Col>
+        </Row>
+      </Col>
+    </Row>
+  );
 };
 
 export default QualifiedPerson;

--- a/services/common/src/components/tailings/TailingsSummaryPage.tsx
+++ b/services/common/src/components/tailings/TailingsSummaryPage.tsx
@@ -2,16 +2,16 @@ import { Col, Divider, notification, Row, Typography } from "antd";
 import { Link, useHistory, useParams } from "react-router-dom";
 import React, { FC, useEffect, useState } from "react";
 import {
-    addDocumentToRelationship,
-    addPartyRelationship,
-    fetchPartyRelationships,
+  addDocumentToRelationship,
+  addPartyRelationship,
+  fetchPartyRelationships,
 } from "@mds/common/redux/actionCreators/partiesActionCreator";
 import { clearTsf } from "@mds/common/redux/actions/tailingsActions";
 import {
-    createTailingsStorageFacility,
-    fetchMineRecordById,
-    fetchTailingsStorageFacility,
-    updateTailingsStorageFacility,
+  createTailingsStorageFacility,
+  fetchMineRecordById,
+  fetchTailingsStorageFacility,
+  updateTailingsStorageFacility,
 } from "@mds/common/redux/actionCreators/mineActionCreator";
 import { isDirty } from "@mds/common/components/forms/form";
 import ArrowLeftOutlined from "@ant-design/icons/ArrowLeftOutlined";
@@ -25,13 +25,13 @@ import EngineerOfRecord from "./EngineerOfRecord";
 import QualifiedPerson from "./QualifiedPerson";
 import AssociatedDams from "./AssociatedDams";
 import {
-    getEngineersOfRecord,
-    getQualifiedPersons,
+  getEngineersOfRecord,
+  getQualifiedPersons,
 } from "@mds/common/redux/selectors/partiesSelectors";
 import {
-    ICreateTailingsStorageFacility,
-    IMine,
-    ITailingsStorageFacility,
+  ICreateTailingsStorageFacility,
+  IMine,
+  ITailingsStorageFacility,
 } from "@mds/common/interfaces";
 import { userHasRole } from "@mds/common/redux/selectors/authenticationSelectors";
 import { USER_ROLES } from "@mds/common/constants/environment";
@@ -41,251 +41,281 @@ import Loading from "../common/Loading";
 import { getIsCore } from "@mds/common/redux/reducers/authenticationReducer";
 import { FORM } from "@mds/common/constants/forms";
 
-
 export const TailingsSummaryPage: FC = () => {
+  const {
+    mineGuid,
+    tailingsStorageFacilityGuid: tsfGuid,
+    tab,
+    userAction = "edit",
+  } = useParams<{
+    mineGuid: string;
+    tailingsStorageFacilityGuid: string;
+    tab: string;
+    userAction: string;
+  }>();
 
-    const { mineGuid, tailingsStorageFacilityGuid: tsfGuid, tab, userAction = "edit" } = useParams<
-        { mineGuid: string, tailingsStorageFacilityGuid: string, tab: string, userAction: string }
-    >();
+  const formName = FORM.ADD_TAILINGS_STORAGE_FACILITY;
+  const history = useHistory();
+  const dispatch = useAppDispatch();
+  const tsf: ITailingsStorageFacility = useAppSelector(getTsf);
+  const mine: IMine = useAppSelector(getMineById(mineGuid));
+  const isCore = useAppSelector(getIsCore);
+  const coreCanEditTsf = useAppSelector(userHasRole(USER_ROLES.role_edit_tsf));
+  const isFormDirty = useAppSelector(isDirty(formName));
+  const engineers_of_record = useAppSelector(getEngineersOfRecord);
+  const qualified_persons = useAppSelector(getQualifiedPersons);
+  const initialValues = {
+    ...tsf,
+    engineers_of_record,
+    qualified_persons,
+  };
 
-    const formName = FORM.ADD_TAILINGS_STORAGE_FACILITY;
-    const history = useHistory();
-    const dispatch = useAppDispatch();
-    const tsf: ITailingsStorageFacility = useAppSelector(getTsf);
-    const mine: IMine = useAppSelector(getMineById(mineGuid));
-    const isCore = useAppSelector(getIsCore);
-    const coreCanEditTsf = useAppSelector(userHasRole(USER_ROLES.role_edit_tsf));
-    const isFormDirty = useAppSelector(isDirty(formName));
-    const engineers_of_record = useAppSelector(getEngineersOfRecord);
-    const qualified_persons = useAppSelector(getQualifiedPersons);
-    const initialValues = {
-        ...tsf,
-        engineers_of_record,
-        qualified_persons
-    };
+  const [isLoaded, setIsLoaded] = useState(false);
+  const [isReloading, setIsReloading] = useState(false);
+  const [uploadedFiles, setUploadedFiles] = useState([]);
+  const canEditTSF = !isCore || coreCanEditTsf;
 
-    const [isLoaded, setIsLoaded] = useState(false);
-    const [isReloading, setIsReloading] = useState(false);
-    const [uploadedFiles, setUploadedFiles] = useState([]);
-    const canEditTSF = !isCore || coreCanEditTsf;
+  const isUserActionEdit = canEditTSF && userAction === "edit";
 
-    const isUserActionEdit = canEditTSF && userAction === "edit";
+  const handleFetchData = async (forceReload = false) => {
+    setIsReloading(true);
+    await dispatch(fetchPermits(mineGuid));
 
-    const handleFetchData = async (forceReload = false) => {
-        setIsReloading(true);
-        await dispatch(fetchPermits(mineGuid));
+    if (tsfGuid) {
+      if (!initialValues.mine_tailings_storage_facility_guid || forceReload) {
+        await Promise.all([
+          dispatch(fetchMineRecordById(mineGuid)),
+          dispatch(fetchTailingsStorageFacility(mineGuid, tsfGuid)),
+        ]);
 
-        if (tsfGuid) {
-            if (!initialValues.mine_tailings_storage_facility_guid || forceReload) {
-                await Promise.all([
-                    dispatch(fetchMineRecordById(mineGuid)),
-                    dispatch(fetchTailingsStorageFacility(mineGuid, tsfGuid)),
-                ]);
-
-                await dispatch(fetchPartyRelationships({
-                    mine_guid: mineGuid,
-                    relationships: "party",
-                    include_permit_contacts: "true",
-                    mine_tailings_storage_facility_guid: tsfGuid,
-                }));
-            }
-        }
-        setIsLoaded(true);
-        setIsReloading(false);
-    };
-
-    useEffect(() => {
-        handleFetchData(true);
-    }, [mineGuid, tsfGuid]);
-
-
-    const handleAddDocuments = async (minePartyApptGuid) => {
-        await Promise.all(
-            uploadedFiles.map((document) =>
-                dispatch(addDocumentToRelationship(
-                    { mineGuid, minePartyApptGuid },
-                    {
-                        document_name: document.document_name,
-                        document_manager_guid: document.document_manager_guid,
-                    }
-                ))
-            )
+        await dispatch(
+          fetchPartyRelationships({
+            mine_guid: mineGuid,
+            relationships: "party",
+            include_permit_contacts: "true",
+            mine_tailings_storage_facility_guid: tsfGuid,
+          })
         );
-        setUploadedFiles([]);
-    };
-
-    const submissionComplete = () => {
-        notification.success({
-            message: "Successfully submitted Tailings Storage Facility",
-            duration: 10
-        });
+      }
     }
+    setIsLoaded(true);
+    setIsReloading(false);
+  };
 
-    const handleSaveData = async (values, newActiveTab) => {
-        let newTsf = null;
+  useEffect(() => {
+    handleFetchData(true);
+  }, [mineGuid, tsfGuid]);
 
-        switch (tab) {
-            case "basic-information":
-                if (tsfGuid) {
-                    if (isFormDirty) {
-                        await dispatch(updateTailingsStorageFacility(mineGuid, tsfGuid, values));
-                    }
-                } else {
-                    newTsf = await dispatch(createTailingsStorageFacility(
-                        mineGuid,
-                        values as ICreateTailingsStorageFacility
-                    ));
-                    await dispatch(clearTsf());
-                }
-                break;
-            case "engineer-of-record":
-            case "qualified-person":
-                if (!isFormDirty) {
-                    break;
-                }
-
-                const { attr, apptType, successMessage } = {
-                    "engineer-of-record": {
-                        attr: "engineer_of_record",
-                        apptType: MinePartyAppointmentTypeCodeEnum.EOR,
-                        successMessage: "Successfully assigned Engineer of Record",
-                    },
-                    "qualified-person": {
-                        attr: "qualified_person",
-                        apptType: MinePartyAppointmentTypeCodeEnum.TQP,
-                        successMessage: "Successfully assigned Qualified Person",
-                    },
-                }[tab];
-
-                if (!values[attr].mine_party_appt_guid && values[attr].party_guid) {
-                    // Only add party relationship if changed
-                    const relationship = await dispatch(addPartyRelationship(
-                        {
-                            mine_guid: mineGuid,
-                            party_guid: values[attr].party_guid,
-                            mine_party_appt_type_code: apptType,
-                            related_guid: tsfGuid,
-                            start_date: values[attr].start_date,
-                            end_date: values[attr].end_date,
-                            end_current: true,
-                        },
-                        successMessage
-                    ));
-
-                    if (uploadedFiles.length > 0) {
-                        await handleAddDocuments(relationship.data.mine_party_appt_guid);
-                    }
-
-                    await handleFetchData(true);
-                }
-                break;
-            default:
-                break;
-        }
-
-        if (newActiveTab) {
-            history.push(
-                GLOBAL_ROUTES?.EDIT_TAILINGS_STORAGE_FACILITY.dynamicRoute(
-                    newTsf?.data.mine_tailings_storage_facility_guid || tsfGuid,
-                    mineGuid,
-                    newActiveTab,
-                    isUserActionEdit
-                )
-            );
-        } else {
-            submissionComplete();
-        }
-    }
-
-
-    const handleTabChange = async (newActiveTab) => {
-        if (!newActiveTab) { return; }
-        let url;
-
-        if (tsfGuid) {
-            url = GLOBAL_ROUTES?.EDIT_TAILINGS_STORAGE_FACILITY.dynamicRoute(
-                tsfGuid,
-                mineGuid,
-                newActiveTab,
-                isUserActionEdit
-            );
-        } else {
-            url = GLOBAL_ROUTES?.ADD_TAILINGS_STORAGE_FACILITY.dynamicRoute(newActiveTab);
-        }
-        history.push(url);
-    };
-
-    const mineName = mine?.mine_name || "";
-    const hasCreatedTSF = !!initialValues?.mine_tailings_storage_facility_guid;
-
-    return (
-        (isLoaded && (
-            <div>
-                <Row>
-                    <Col span={24}>
-                        <Typography.Title>
-                            {hasCreatedTSF
-                                ? initialValues.mine_tailings_storage_facility_name
-                                : "Create facility"}
-                        </Typography.Title>
-                    </Col>
-                </Row>
-                <Row>
-                    <Col span={24}>
-                        <Link to={GLOBAL_ROUTES?.MINE_TAILINGS.dynamicRoute(mineGuid)}>
-                            <ArrowLeftOutlined className="padding-sm--right" />
-                            {`Back to: ${mineName} Tailings`}
-                        </Link>
-                    </Col>
-                </Row>
-                <Divider />
-                <SteppedForm
-                    initialValues={initialValues}
-                    name={formName}
-                    isEditMode={isUserActionEdit}
-                    handleSaveData={handleSaveData}
-                    handleTabChange={handleTabChange}
-                    activeTab={tab}
-                    sectionChangeText={isUserActionEdit ? undefined : "Continue"}
-                    reduxFormConfig={{
-                        touchOnBlur: true,
-                        touchOnChange: false,
-                        enableReinitialize: true,
-                        destroyOnUnmount: true,
-                    }}
-                >
-                    <Step key="basic-information">
-                        <BasicInformation
-                            mineName={mineName}
-                            canEditTSF={canEditTSF}
-                            isEditMode={isUserActionEdit}
-                        />
-                    </Step>
-                    <Step key="engineer-of-record" disabled={!hasCreatedTSF}>
-                        <EngineerOfRecord
-                            loading={isReloading}
-                            mineGuid={mineGuid}
-                            uploadedFiles={uploadedFiles}
-                            setUploadedFiles={setUploadedFiles}
-                            canEditTSF={canEditTSF}
-                            isEditMode={isUserActionEdit}
-                        />
-                    </Step>
-                    <Step key="qualified-person" disabled={!hasCreatedTSF}>
-                        <QualifiedPerson
-                            loading={isReloading}
-                            mineGuid={mineGuid}
-                            canEditTSF={canEditTSF}
-                            isEditMode={isUserActionEdit}
-                        />
-                    </Step>
-                    <Step key="associated-dams" disabled={!hasCreatedTSF}>
-                        <AssociatedDams canEditTSF={canEditTSF} isEditMode={isUserActionEdit} />
-                    </Step>
-                </SteppedForm>
-            </div>
-        )) || <Loading />
+  const handleAddDocuments = async (minePartyApptGuid) => {
+    await Promise.all(
+      uploadedFiles.map((document) =>
+        dispatch(
+          addDocumentToRelationship(
+            { mineGuid, minePartyApptGuid },
+            {
+              document_name: document.document_name,
+              document_manager_guid: document.document_manager_guid,
+            }
+          )
+        )
+      )
     );
+    setUploadedFiles([]);
+  };
+
+  const submissionComplete = async (values) => {
+    const submitValues = {
+      ...values,
+      eor_party_guid: values.engineer_of_record?.mine_party_appt_guid,
+      tqp_party_guid: values.qualified_person?.mine_party_appt_guid,
+      is_submitting: true,
+    };
+    try {
+      await dispatch(updateTailingsStorageFacility(mineGuid, tsfGuid, submitValues));
+      if (!isCore) {
+        history.push(
+          GLOBAL_ROUTES?.TAILINGS_SUBMIT_SUCCESS.dynamicRoute(
+            mineGuid,
+            initialValues.mine_tailings_storage_facility_guid
+          )
+        );
+      }
+    } catch (error) {
+      notification.error({
+        message: "Error",
+        description: error.message,
+      });
+    }
+  };
+
+  const handleSaveData = async (values, newActiveTab) => {
+    let newTsf = null;
+
+    switch (tab) {
+      case "basic-information":
+        if (tsfGuid) {
+          if (isFormDirty) {
+            await dispatch(updateTailingsStorageFacility(mineGuid, tsfGuid, values));
+          }
+        } else {
+          newTsf = await dispatch(
+            createTailingsStorageFacility(mineGuid, values as ICreateTailingsStorageFacility)
+          );
+          await dispatch(clearTsf());
+        }
+        break;
+      case "engineer-of-record":
+      case "qualified-person": {
+        if (!isFormDirty) {
+          break;
+        }
+
+        const { attr, apptType, successMessage } = {
+          "engineer-of-record": {
+            attr: "engineer_of_record",
+            apptType: MinePartyAppointmentTypeCodeEnum.EOR,
+            successMessage: "Successfully assigned Engineer of Record",
+          },
+          "qualified-person": {
+            attr: "qualified_person",
+            apptType: MinePartyAppointmentTypeCodeEnum.TQP,
+            successMessage: "Successfully assigned Qualified Person",
+          },
+        }[tab];
+
+        if (!values[attr].mine_party_appt_guid && values[attr].party_guid) {
+          // Only add party relationship if changed
+          const relationship = await dispatch(
+            addPartyRelationship(
+              {
+                mine_guid: mineGuid,
+                party_guid: values[attr].party_guid,
+                mine_party_appt_type_code: apptType,
+                related_guid: tsfGuid,
+                start_date: values[attr].start_date,
+                end_date: values[attr].end_date,
+                end_current: true,
+              },
+              successMessage
+            )
+          );
+
+          if (uploadedFiles.length > 0) {
+            await handleAddDocuments(relationship.data.mine_party_appt_guid);
+          }
+
+          await handleFetchData(true);
+        }
+        break;
+      }
+      default:
+        break;
+    }
+
+    if (newActiveTab) {
+      history.push(
+        GLOBAL_ROUTES?.EDIT_TAILINGS_STORAGE_FACILITY.dynamicRoute(
+          newTsf?.data.mine_tailings_storage_facility_guid || tsfGuid,
+          mineGuid,
+          newActiveTab,
+          isUserActionEdit
+        )
+      );
+    } else {
+      submissionComplete(values);
+    }
+  };
+
+  const handleTabChange = async (newActiveTab) => {
+    if (!newActiveTab) {
+      return;
+    }
+    let url;
+
+    if (tsfGuid) {
+      url = GLOBAL_ROUTES?.EDIT_TAILINGS_STORAGE_FACILITY.dynamicRoute(
+        tsfGuid,
+        mineGuid,
+        newActiveTab,
+        isUserActionEdit
+      );
+    } else {
+      url = GLOBAL_ROUTES?.ADD_TAILINGS_STORAGE_FACILITY.dynamicRoute(newActiveTab);
+    }
+    history.push(url);
+  };
+
+  const mineName = mine?.mine_name || "";
+  const hasCreatedTSF = !!initialValues?.mine_tailings_storage_facility_guid;
+
+  return (
+    (isLoaded && (
+      <div>
+        <Row>
+          <Col span={24}>
+            <Typography.Title>
+              {hasCreatedTSF
+                ? initialValues.mine_tailings_storage_facility_name
+                : "Create facility"}
+            </Typography.Title>
+          </Col>
+        </Row>
+        <Row>
+          <Col span={24}>
+            <Link to={GLOBAL_ROUTES?.MINE_TAILINGS.dynamicRoute(mineGuid)}>
+              <ArrowLeftOutlined className="padding-sm--right" />
+              {`Back to: ${mineName} Tailings`}
+            </Link>
+          </Col>
+        </Row>
+        <Divider />
+        <SteppedForm
+          initialValues={initialValues}
+          name={formName}
+          isEditMode={isUserActionEdit}
+          handleSaveData={handleSaveData}
+          handleTabChange={handleTabChange}
+          activeTab={tab}
+          sectionChangeText={isUserActionEdit ? undefined : "Continue"}
+          reduxFormConfig={{
+            touchOnBlur: true,
+            touchOnChange: false,
+            enableReinitialize: true,
+            destroyOnUnmount: true,
+          }}
+        >
+          <Step key="basic-information">
+            <BasicInformation
+              mineName={mineName}
+              canEditTSF={canEditTSF}
+              isEditMode={isUserActionEdit}
+            />
+          </Step>
+          <Step key="engineer-of-record" disabled={!hasCreatedTSF}>
+            <EngineerOfRecord
+              loading={isReloading}
+              mineGuid={mineGuid}
+              uploadedFiles={uploadedFiles}
+              setUploadedFiles={setUploadedFiles}
+              canEditTSF={canEditTSF}
+              isEditMode={isUserActionEdit}
+            />
+          </Step>
+          <Step key="qualified-person" disabled={!hasCreatedTSF}>
+            <QualifiedPerson
+              loading={isReloading}
+              mineGuid={mineGuid}
+              canEditTSF={canEditTSF}
+              isEditMode={isUserActionEdit}
+            />
+          </Step>
+          <Step key="associated-dams" disabled={!hasCreatedTSF}>
+            <AssociatedDams canEditTSF={canEditTSF} isEditMode={isUserActionEdit} />
+          </Step>
+        </SteppedForm>
+      </div>
+    )) || <Loading />
+  );
 };
 
 export default TailingsSummaryPage;

--- a/services/common/src/components/tailings/TailingsSummaryPage.tsx
+++ b/services/common/src/components/tailings/TailingsSummaryPage.tsx
@@ -2,7 +2,6 @@ import { Col, Divider, notification, Row, Typography } from "antd";
 import { Link, useHistory, useParams } from "react-router-dom";
 import React, { FC, useEffect, useState } from "react";
 import {
-  addDocumentToRelationship,
   addPartyRelationship,
   fetchPartyRelationships,
 } from "@mds/common/redux/actionCreators/partiesActionCreator";
@@ -72,7 +71,6 @@ export const TailingsSummaryPage: FC = () => {
 
   const [isLoaded, setIsLoaded] = useState(false);
   const [isReloading, setIsReloading] = useState(false);
-  const [uploadedFiles, setUploadedFiles] = useState([]);
   const canEditTSF = !isCore || coreCanEditTsf;
 
   const isUserActionEdit = canEditTSF && userAction === "edit";
@@ -105,23 +103,6 @@ export const TailingsSummaryPage: FC = () => {
   useEffect(() => {
     handleFetchData(true);
   }, [mineGuid, tsfGuid]);
-
-  const handleAddDocuments = async (minePartyApptGuid) => {
-    await Promise.all(
-      uploadedFiles.map((document) =>
-        dispatch(
-          addDocumentToRelationship(
-            { mineGuid, minePartyApptGuid },
-            {
-              document_name: document.document_name,
-              document_manager_guid: document.document_manager_guid,
-            }
-          )
-        )
-      )
-    );
-    setUploadedFiles([]);
-  };
 
   const submissionComplete = async (values) => {
     const submitValues = {
@@ -185,7 +166,7 @@ export const TailingsSummaryPage: FC = () => {
 
         if (!values[attr].mine_party_appt_guid && values[attr].party_guid) {
           // Only add party relationship if changed
-          const relationship = await dispatch(
+          await dispatch(
             addPartyRelationship(
               {
                 mine_guid: mineGuid,
@@ -199,10 +180,6 @@ export const TailingsSummaryPage: FC = () => {
               successMessage
             )
           );
-
-          if (uploadedFiles.length > 0) {
-            await handleAddDocuments(relationship.data.mine_party_appt_guid);
-          }
 
           await handleFetchData(true);
         }
@@ -295,8 +272,6 @@ export const TailingsSummaryPage: FC = () => {
             <EngineerOfRecord
               loading={isReloading}
               mineGuid={mineGuid}
-              uploadedFiles={uploadedFiles}
-              setUploadedFiles={setUploadedFiles}
               canEditTSF={canEditTSF}
               isEditMode={isUserActionEdit}
             />

--- a/services/common/src/components/tailings/__snapshots__/EngineerOfRecord.spec.tsx.snap
+++ b/services/common/src/components/tailings/__snapshots__/EngineerOfRecord.spec.tsx.snap
@@ -89,6 +89,17 @@ exports[`Tailings EngineerOfRecord renders properly 1`] = `
             class="ant-alert-content"
           >
             <div
+              class="ant-alert-message"
+            >
+              <div
+                class="ant-typography"
+              >
+                <strong>
+                  Engineer of Record Assignment
+                </strong>
+              </div>
+            </div>
+            <div
               class="ant-alert-description"
             >
               <div
@@ -396,7 +407,10 @@ exports[`Tailings EngineerOfRecord renders properly 1`] = `
             <h4
               class="ant-typography margin-large--top"
             >
-              Historical Engineer of Record List
+              Historical
+               
+              Engineer of Record
+               List
             </h4>
             <div
               class="ant-table-wrapper  core-table"

--- a/services/common/src/components/tailings/__snapshots__/EngineerOfRecord.spec.tsx.snap
+++ b/services/common/src/components/tailings/__snapshots__/EngineerOfRecord.spec.tsx.snap
@@ -58,41 +58,51 @@ exports[`Tailings EngineerOfRecord renders properly 1`] = `
             </div>
           </div>
         </div>
-        <div>
-          <div
-            class="ant-alert ant-alert-info ant-alert-with-description"
-            data-show="true"
-            role="alert"
+        <div
+          class="ant-alert ant-alert-info ant-alert-with-description"
+          data-show="true"
+          role="alert"
+        >
+          <span
+            aria-label="info-circle"
+            class="anticon anticon-info-circle ant-alert-icon"
+            role="img"
           >
-            <span
-              aria-label="info-circle"
-              class="anticon anticon-info-circle ant-alert-icon"
-              role="img"
+            <svg
+              aria-hidden="true"
+              data-icon="info-circle"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
             >
-              <svg
-                aria-hidden="true"
-                data-icon="info-circle"
-                fill="currentColor"
-                focusable="false"
-                height="1em"
-                viewBox="64 64 896 896"
-                width="1em"
-              >
-                <path
-                  d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
-                />
-                <path
-                  d="M464 336a48 48 0 1096 0 48 48 0 10-96 0zm72 112h-48c-4.4 0-8 3.6-8 8v272c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V456c0-4.4-3.6-8-8-8z"
-                />
-              </svg>
-            </span>
+              <path
+                d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+              />
+              <path
+                d="M464 336a48 48 0 1096 0 48 48 0 10-96 0zm72 112h-48c-4.4 0-8 3.6-8 8v272c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V456c0-4.4-3.6-8-8-8z"
+              />
+            </svg>
+          </span>
+          <div
+            class="ant-alert-content"
+          >
             <div
-              class="ant-alert-content"
+              class="ant-alert-description"
             >
               <div
-                class="ant-alert-description"
+                class="ant-typography"
               >
-                Assigning a new Engineer of Record (EoR) will replace the current listed contact and set their status to Inactive. When a new EoR is assigned, a notification will be sent to the Ministry of changes in the record, and must include an acknowledgement by the EoR to be active.
+                As
+                 
+                <a
+                  href="https://www2.gov.bc.ca/gov/content/industry/mineral-exploration-mining/health-safety/health-safety-and-reclamation-code-for-mines-in-british-columbia"
+                  target="_blank"
+                >
+                  Per Health, Safety and Reclamation Code
+                </a>
+                , written acknowledgement to the Chief Inspector is required within 72 hours when an Engineer of Record (EoR) is retained or accepts the role. A report request will be generated upon changes to the EoR.
               </div>
             </div>
           </div>
@@ -155,77 +165,6 @@ exports[`Tailings EngineerOfRecord renders properly 1`] = `
             class="ant-typography"
           >
             No Data
-          </div>
-        </div>
-        <div
-          class="margin-large--top margin-large--bottom"
-        >
-          <h4
-            class="ant-typography"
-          >
-            Upload Acceptance Letter
-          </h4>
-          <span
-            class="ant-typography"
-          >
-            Letter must be officially signed. A notification will be sent to the Mine Manager upon upload.
-          </span>
-        </div>
-        <div
-          class="whirlpool-container"
-        >
-          <div
-            class="ant-form-item ant-form-item-with-help"
-          >
-            <div
-              class="ant-row ant-form-item-row"
-            >
-              <div
-                class="ant-col ant-form-item-label"
-              >
-                <label
-                  class=""
-                  for="ADD_TAILINGS_STORAGE_FACILITY_engineer_of_record.eor_document_guid"
-                  title=""
-                />
-              </div>
-              <div
-                class="ant-col ant-form-item-control"
-              >
-                <div
-                  class="ant-form-item-control-input"
-                >
-                  <div
-                    class="ant-form-item-control-input-content"
-                  >
-                    <div
-                      class="filepond--wrapper"
-                    >
-                      <input
-                        accept="application/pdf"
-                        id="engineer_of_record.eor_document_guid"
-                        multiple=""
-                        name="file"
-                        type="file"
-                      />
-                    </div>
-                  </div>
-                </div>
-                <div
-                  style="display: flex; flex-wrap: nowrap;"
-                >
-                  <div
-                    class="ant-form-item-explain ant-form-item-explain-connected"
-                    id="ADD_TAILINGS_STORAGE_FACILITY_engineer_of_record.eor_document_guid_help"
-                    role="alert"
-                  >
-                    <div
-                      class=""
-                    />
-                  </div>
-                </div>
-              </div>
-            </div>
           </div>
         </div>
         <h4
@@ -380,14 +319,13 @@ exports[`Tailings EngineerOfRecord renders properly 1`] = `
                       class="ant-form-item-control-input-content"
                     >
                       <div
-                        class="ant-picker ant-picker-disabled"
+                        class="ant-picker"
                       >
                         <div
                           class="ant-picker-input"
                         >
                           <input
                             autocomplete="off"
-                            disabled=""
                             id="engineer_of_record.end_date"
                             name="engineer_of_record.end_date"
                             placeholder=""
@@ -499,7 +437,7 @@ exports[`Tailings EngineerOfRecord renders properly 1`] = `
                               <th
                                 class="ant-table-cell"
                               >
-                                Letters
+                                Term
                               </th>
                             </tr>
                           </thead>

--- a/services/common/src/components/tailings/__snapshots__/PartyAppointmentTable.spec.tsx.snap
+++ b/services/common/src/components/tailings/__snapshots__/PartyAppointmentTable.spec.tsx.snap
@@ -15,7 +15,10 @@ exports[`Tailings PartyAppointmentTable renders properly 1`] = `
         <h4
           class="ant-typography margin-large--top"
         >
-          Historical Engineer of Record List
+          Historical
+           
+          Engineer of Record
+           List
         </h4>
         <div
           class="ant-table-wrapper  core-table"
@@ -56,7 +59,7 @@ exports[`Tailings PartyAppointmentTable renders properly 1`] = `
                           <th
                             class="ant-table-cell"
                           >
-                            Letters
+                            Term
                           </th>
                         </tr>
                       </thead>

--- a/services/common/src/components/tailings/__snapshots__/QualifiedPerson.spec.tsx.snap
+++ b/services/common/src/components/tailings/__snapshots__/QualifiedPerson.spec.tsx.snap
@@ -14,6 +14,7 @@ exports[`Tailings QualifiedPerson renders properly 1`] = `
       >
         <div
           class="ant-row ant-row-space-between"
+          style="margin: -8px -8px -8px -8px;"
         >
           <h3
             class="ant-typography"
@@ -21,74 +22,100 @@ exports[`Tailings QualifiedPerson renders properly 1`] = `
             TSF Qualified Person
           </h3>
           <div
-            class="ant-col"
+            class="ant-col ant-col-12"
+            style="padding: 8px 8px 8px 8px;"
           >
-            <button
-              class="ant-btn ant-btn-primary"
-              style="display: inline; float: right;"
-              type="button"
+            <div
+              class="ant-row ant-row-end"
             >
-              <span
-                aria-label="plus-circle"
-                class="anticon anticon-plus-circle"
-                role="img"
+              <button
+                class="ant-btn ant-btn-primary"
+                style="display: inline; float: right;"
+                type="button"
               >
-                <svg
-                  aria-hidden="true"
-                  class=""
-                  data-icon="plus-circle"
-                  fill="currentColor"
-                  focusable="false"
-                  height="1em"
-                  viewBox="64 64 896 896"
-                  width="1em"
+                <span
+                  aria-label="plus-circle"
+                  class="anticon anticon-plus-circle"
+                  role="img"
                 >
-                  <path
-                    d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm192 472c0 4.4-3.6 8-8 8H544v152c0 4.4-3.6 8-8 8h-48c-4.4 0-8-3.6-8-8V544H328c-4.4 0-8-3.6-8-8v-48c0-4.4 3.6-8 8-8h152V328c0-4.4 3.6-8 8-8h48c4.4 0 8 3.6 8 8v152h152c4.4 0 8 3.6 8 8v48z"
-                  />
-                </svg>
-              </span>
-              <span>
-                Assign a new Qualified Person
-              </span>
-            </button>
+                  <svg
+                    aria-hidden="true"
+                    class=""
+                    data-icon="plus-circle"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm192 472c0 4.4-3.6 8-8 8H544v152c0 4.4-3.6 8-8 8h-48c-4.4 0-8-3.6-8-8V544H328c-4.4 0-8-3.6-8-8v-48c0-4.4 3.6-8 8-8h152V328c0-4.4 3.6-8 8-8h48c4.4 0 8 3.6 8 8v152h152c4.4 0 8 3.6 8 8v48z"
+                    />
+                  </svg>
+                </span>
+                <span>
+                  Assign a new Qualified Person
+                </span>
+              </button>
+            </div>
           </div>
         </div>
-        <div>
-          <div
-            class="ant-alert ant-alert-info ant-alert-with-description"
-            data-show="true"
-            role="alert"
+        <div
+          class="ant-alert ant-alert-info ant-alert-with-description"
+          data-show="true"
+          role="alert"
+        >
+          <span
+            aria-label="info-circle"
+            class="anticon anticon-info-circle ant-alert-icon"
+            role="img"
           >
-            <span
-              aria-label="info-circle"
-              class="anticon anticon-info-circle ant-alert-icon"
-              role="img"
+            <svg
+              aria-hidden="true"
+              data-icon="info-circle"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
             >
-              <svg
-                aria-hidden="true"
-                data-icon="info-circle"
-                fill="currentColor"
-                focusable="false"
-                height="1em"
-                viewBox="64 64 896 896"
-                width="1em"
-              >
-                <path
-                  d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
-                />
-                <path
-                  d="M464 336a48 48 0 1096 0 48 48 0 10-96 0zm72 112h-48c-4.4 0-8 3.6-8 8v272c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V456c0-4.4-3.6-8-8-8z"
-                />
-              </svg>
-            </span>
+              <path
+                d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+              />
+              <path
+                d="M464 336a48 48 0 1096 0 48 48 0 10-96 0zm72 112h-48c-4.4 0-8 3.6-8 8v272c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V456c0-4.4-3.6-8-8-8z"
+              />
+            </svg>
+          </span>
+          <div
+            class="ant-alert-content"
+          >
             <div
-              class="ant-alert-content"
+              class="ant-alert-message"
             >
               <div
-                class="ant-alert-description"
+                class="ant-typography"
               >
-                There is no Qualified Person (QP) on file for this facility. Click above to assign a new Qualified Person.
+                <strong>
+                  Qualified Person Assignment
+                </strong>
+              </div>
+            </div>
+            <div
+              class="ant-alert-description"
+            >
+              <div
+                class="ant-typography"
+              >
+                As
+                 
+                <a
+                  href="https://www2.gov.bc.ca/gov/content/industry/mineral-exploration-mining/health-safety/health-safety-and-reclamation-code-for-mines-in-british-columbia"
+                  target="_blank"
+                >
+                  Per Health, Safety and Reclamation Code
+                </a>
+                , written acknowledgement to the Chief Inspector is required within 72 hours when an Qualified Person (QP) is retained or accepts the role. A report request will be generated upon changes to the EoR
               </div>
             </div>
           </div>
@@ -354,6 +381,94 @@ exports[`Tailings QualifiedPerson renders properly 1`] = `
                       <div
                         class=""
                       />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="ant-row"
+        >
+          <div
+            class="ant-col ant-col-24"
+          >
+            <div
+              class="ant-row"
+            >
+              <div
+                class="ant-col ant-col-24"
+              >
+                <h4
+                  class="ant-typography margin-large--top"
+                >
+                  Historical
+                   
+                  Qualified Persons
+                   List
+                </h4>
+                <div
+                  class="ant-table-wrapper  core-table"
+                >
+                  <div
+                    class="ant-spin-nested-loading"
+                  >
+                    <div
+                      class="ant-spin-container"
+                    >
+                      <div
+                        class="ant-table ant-table-empty"
+                      >
+                        <div
+                          class="ant-table-container"
+                        >
+                          <div
+                            class="ant-table-content"
+                          >
+                            <table
+                              style="table-layout: auto;"
+                            >
+                              <colgroup />
+                              <thead
+                                class="ant-table-thead"
+                              >
+                                <tr>
+                                  <th
+                                    class="ant-table-cell"
+                                  >
+                                    Name
+                                  </th>
+                                  <th
+                                    class="ant-table-cell"
+                                  >
+                                    Status
+                                  </th>
+                                  <th
+                                    class="ant-table-cell"
+                                  >
+                                    Term
+                                  </th>
+                                </tr>
+                              </thead>
+                              <tbody
+                                class="ant-table-tbody"
+                              >
+                                <tr
+                                  class="ant-table-placeholder"
+                                >
+                                  <td
+                                    class="ant-table-cell"
+                                    colspan="3"
+                                  >
+                                    No Data Yet
+                                  </td>
+                                </tr>
+                              </tbody>
+                            </table>
+                          </div>
+                        </div>
+                      </div>
                     </div>
                   </div>
                 </div>

--- a/services/common/src/interfaces/party/partyAppt.interface.ts
+++ b/services/common/src/interfaces/party/partyAppt.interface.ts
@@ -3,5 +3,6 @@ import { IAddPartyAppointment, IParty } from "@mds/common/interfaces";
 export interface IPartyAppt extends IAddPartyAppointment {
   mine_party_appt_guid: string;
   update_timestamp?: string;
+  update_user?: string;
   party: IParty;
 }

--- a/services/common/src/redux/reducers/partiesReducer.ts
+++ b/services/common/src/redux/reducers/partiesReducer.ts
@@ -3,7 +3,14 @@ import * as actionTypes from "@mds/common/constants/actionTypes";
 import { PARTIES } from "@mds/common/constants/reducerTypes";
 import { createItemMap, createItemIdsArray } from "../utils/helpers";
 import { RootState } from "@mds/common/redux/rootState";
-import { IParty, ItemMap, IPartyAppt, IPageData, IAddPartyFormState, IOption } from "@mds/common/interfaces";
+import {
+  IParty,
+  ItemMap,
+  IPartyAppt,
+  IPageData,
+  IAddPartyFormState,
+  IOption,
+} from "@mds/common/interfaces";
 
 /**
  * @file partiesReducer.js
@@ -59,7 +66,7 @@ export const partiesReducer = (state = initialState, action) => {
         parties: createItemMap([action.payload], "party_guid"),
         partyIds: createItemIdsArray([action.payload], "party_guid"),
       };
-    case actionTypes.STORE_PARTY_RELATIONSHIPS:
+    case actionTypes.STORE_PARTY_RELATIONSHIPS: {
       const tsfGuid = action.mine_tailings_storage_facility_guid;
       const eors = action.payload
         .filter((p) => p.mine_party_appt_type_code === "EOR")
@@ -70,22 +77,23 @@ export const partiesReducer = (state = initialState, action) => {
 
       const eorRecords = tsfGuid
         ? action.payload.filter(
-          (p) => p.mine_party_appt_type_code === "EOR" && p.related_guid === tsfGuid
-        )
+            (p) => p.mine_party_appt_type_code === "EOR" && p.related_guid === tsfGuid
+          )
         : [];
-      const qfpRecords = tsfGuid
+      const tqpRecords = tsfGuid
         ? action.payload.filter(
-          (p) => p.mine_party_appt_type_code === "QFP" && p.related_guid === tsfGuid
-        )
+            (p) => p.mine_party_appt_type_code === "TQP" && p.related_guid === tsfGuid
+          )
         : [];
 
       return {
         ...state,
         partyRelationships: action.payload,
         engineersOfRecord: tsfGuid ? eorRecords : state.engineersOfRecord,
-        qualifiedPersons: tsfGuid ? qfpRecords : state.qualifiedPersons,
+        qualifiedPersons: tsfGuid ? tqpRecords : state.qualifiedPersons,
         engineersOfRecordOptions: uniqBy(eors, "value"),
       };
+    }
     case actionTypes.STORE_ALL_PARTY_RELATIONSHIPS:
       return {
         ...state,

--- a/services/core-api/app/api/mines/reports/models/mine_report.py
+++ b/services/core-api/app/api/mines/reports/models/mine_report.py
@@ -345,7 +345,8 @@ class MineReport(SoftDeleteMixin, AuditMixin, Base):
                permit_id=None,
                permit_condition_category_code=None,
                submitter_email=None,
-               add_to_session=True):
+               add_to_session=True,
+               system_created=False):
         mine_report = cls(
             mine_report_definition_id=mine_report_definition_id,
             mine_guid=mine_guid,
@@ -356,7 +357,10 @@ class MineReport(SoftDeleteMixin, AuditMixin, Base):
             permit_id=permit_id,
             permit_condition_category_code=permit_condition_category_code,
             submitter_name=submitter_name,
-            submitter_email=submitter_email)
+            submitter_email=submitter_email,
+            created_by_idir='system' if system_created else None,
+            update_user='system' if system_created else None,
+            create_user='system' if system_created else None)
         if add_to_session:
             mine_report.save(commit=False)
         return mine_report

--- a/services/core-api/app/api/mines/reports/models/mine_report_definition.py
+++ b/services/core-api/app/api/mines/reports/models/mine_report_definition.py
@@ -1,11 +1,12 @@
 import uuid
 from datetime import datetime
 from dateutil.relativedelta import relativedelta
+from pytz import timezone
 
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.schema import FetchedValue
 from sqlalchemy.ext.hybrid import hybrid_property
-from sqlalchemy import or_, cast, Integer, nullsfirst, nullslast
+from sqlalchemy import or_, cast, Integer, nullsfirst, nullslast, and_
 from sqlalchemy_filters import apply_pagination
 from werkzeug.exceptions import BadRequest
 
@@ -107,6 +108,33 @@ class MineReportDefinition(Base, AuditMixin):
             return cls.query.filter_by(mine_report_definition_guid=_id).first()
         except ValueError:
             return None
+
+    @classmethod
+    def find_one_by_section(cls, section, sub_section=None, paragraph=None, sub_paragraph=None):
+        try:
+            now = datetime.now(timezone('US/Pacific'))
+
+            query = cls.query.filter_by(active_ind=True).filter(
+                MineReportDefinition.compliance_articles.any(
+                    and_(
+                        ComplianceArticle.section == section,
+                        ComplianceArticle.sub_section == sub_section,
+                        ComplianceArticle.paragraph == paragraph,
+                        ComplianceArticle.sub_paragraph == sub_paragraph,
+                        ComplianceArticle.effective_date <= now,
+                        or_(
+                            ComplianceArticle.expiry_date.is_(None),
+                            ComplianceArticle.expiry_date >= now
+                        )
+                    )
+                )
+            )
+
+            # Fetch and return the first result if available
+            return query.first()
+        except Exception as e:
+            # Handle exceptions and log them as needed
+            raise ValueError(f"Error occurred while querying: {str(e)}")
 
     @classmethod
     def _apply_sort(cls, query, sort_field, sort_dir):

--- a/services/core-api/app/api/mines/response_models.py
+++ b/services/core-api/app/api/mines/response_models.py
@@ -420,6 +420,7 @@ MINE_PARTY_APPT_PARTY = api.model(
         'end_date': fields.Date,
         'party': fields.Nested(PARTY),
         'status': fields.String(enum=MinePartyAppointmentStatus, attribute='status.name'),
+        'update_user': fields.String,
         'mine_party_acknowledgement_status': fields.String(
             enum=MinePartyAcknowledgedStatus, attribute='mine_party_acknowledgement_status.name'),
     })

--- a/services/core-api/app/api/mines/tailings/resources/tailings.py
+++ b/services/core-api/app/api/mines/tailings/resources/tailings.py
@@ -1,6 +1,9 @@
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 from decimal import Decimal
 
+from app.api.utils.feature_flag import Feature, is_feature_enabled
+from app.api.mines.reports.models.mine_report import MineReport
+from app.api.mines.reports.models.mine_report_definition import MineReportDefinition
 from app.api.parties.party_appt.models.mine_party_appt import MinePartyAcknowledgedStatus
 
 from app.api.parties.party_appt.models.mine_party_appt import MinePartyAppointmentStatus
@@ -57,6 +60,12 @@ class MineTailingsStorageFacilityResource(Resource, UserMixin):
         location='json',
         store_missing=False)
     parser.add_argument(
+        'tqp_party_guid',
+        type=str,
+        help='GUID of the party that is the Qualified Person for this TSF.',
+        location='json',
+        store_missing=False)
+    parser.add_argument(
         'notes',
         type=str,
         help='Any additional notes to be added to the tailing.',
@@ -86,6 +95,12 @@ class MineTailingsStorageFacilityResource(Resource, UserMixin):
         help='Mines Act Permit Number',
         location='json',
         store_missing=False)
+    parser.add_argument(
+        'is_submitting',
+        type=bool,
+        location='json',
+        store_missing=False
+    )
 
     @api.doc(description='Get a tailing storage facility for the given mine')
     @requires_any_of([MINESPACE_PROPONENT, EDIT_TSF, VIEW_ALL])
@@ -113,15 +128,17 @@ class MineTailingsStorageFacilityResource(Resource, UserMixin):
         if not mine:
             raise NotFound('Mine not found.')
 
-        mine_tsf = MineTailingsStorageFacility.find_by_tsf_guid(mine_tailings_storage_facility_guid)
+        mine_tsf: MineTailingsStorageFacility = MineTailingsStorageFacility.find_by_tsf_guid(mine_tailings_storage_facility_guid)
 
         if not mine_tsf:
             raise NotFound("Tailing Storage Facility not found")
 
         data = self.parser.parse_args()
+
+        is_submitting = data.get('is_submitting')
         eor_party_guid = data.get('eor_party_guid')
-        if eor_party_guid != None and (mine_tsf.engineer_of_record is None
-                                       or eor_party_guid != mine_tsf.engineer_of_record.party_guid):
+        has_new_eor = eor_party_guid != None and (mine_tsf.engineer_of_record is None or eor_party_guid != mine_tsf.engineer_of_record.party_guid)
+        if has_new_eor:
             if mine_tsf.engineer_of_record:
                 mine_tsf.engineer_of_record.end_date = datetime.now(tz=timezone.utc)
 
@@ -129,10 +146,34 @@ class MineTailingsStorageFacilityResource(Resource, UserMixin):
                 # EORs created through minespace should have a status of "pending"
                 new_status = MinePartyAppointmentStatus.pending
                 mine_party_acknowledgement_status = MinePartyAcknowledgedStatus.not_acknowledged
+
+                if is_feature_enabled(Feature.TSF_V2):
+                    if is_submitting:
+                        calculated_due_date = datetime.now() + timedelta(hours=72)
+                        mine_report_definition = MineReportDefinition.find_one_by_section('10', '4', '1', '2')
+                        if not mine_report_definition:
+                            raise NotFound('EOR report definition not found by section')
+
+                        # Create a report request for a new EOR letter
+                        MineReport.create(
+                            mine_report_definition_id=mine_report_definition.mine_report_definition_id,
+                            mine_guid=mine.mine_guid,
+                            due_date=calculated_due_date,
+                            received_date=None,
+                            submission_year=calculated_due_date.year,
+                            description_comment=None,
+                            submitter_name=None,
+                            permit_id=None,
+                            add_to_session=True,
+                            system_created=True)
             else:
+                # TSF_V2 - this can probably be removed with the feature flag
                 mine_party_acknowledgement_status = MinePartyAcknowledgedStatus.acknowledged
                 new_status = MinePartyAppointmentStatus.active
 
+        # If feature is not enabled, save the appointment in here rather than it have been created
+        # within the TSF draft process
+        if not is_feature_enabled(Feature.TSF_V2):
             new_eor = MinePartyAppointment.create(
                 mine=mine,
                 tsf=mine_tsf,
@@ -143,9 +184,34 @@ class MineTailingsStorageFacilityResource(Resource, UserMixin):
                 status = new_status,
                 mine_party_acknowledgement_status=mine_party_acknowledgement_status
             )
+
             related_guid = mine_tsf.mine_tailings_storage_facility_guid
             new_eor.assign_related_guid('EOR', related_guid)
             new_eor.save(commit=False)
+
+        if is_feature_enabled(Feature.TSF_V2):
+            tqp_party_guid = data.get('tqp_party_guid')
+            has_new_qp = tqp_party_guid != None and (mine_tsf.qualified_person is None or tqp_party_guid != mine_tsf.qualified_person.party_guid)
+            if has_new_qp:
+
+                if is_minespace_user() and is_submitting:
+                    calculated_due_date = datetime.now() + timedelta(hours=72)
+                    mine_report_definition = MineReportDefinition.find_one_by_section('10', '4', '2', '1(c)')
+                    if not mine_report_definition:
+                        raise NotFound('QP report definition not found by section')
+
+                    # Create a report request for a new EOR letter
+                    MineReport.create(
+                        mine_report_definition_id=mine_report_definition.mine_report_definition_id,
+                        mine_guid=mine.mine_guid,
+                        due_date=calculated_due_date,
+                        received_date=None,
+                        submission_year=calculated_due_date.year,
+                        description_comment=None,
+                        submitter_name=None,
+                        permit_id=None,
+                        add_to_session=True,
+                        system_created=True)
 
         for key, value in data.items():
             if key in ('eor_party_guid'):

--- a/services/core-api/app/api/mines/tailings/resources/tailings_list.py
+++ b/services/core-api/app/api/mines/tailings/resources/tailings_list.py
@@ -144,7 +144,7 @@ class MineTailingsStorageFacilityListResource(Resource, UserMixin):
                 tsf_required_reports = MineReportDefinition.find_required_reports_by_category('TSF')
 
                 for tsf_req_doc in tsf_required_reports:
-                    calculated_due_date = tsf_req_doc.default_due_date or datetime.utcnow()
+                    calculated_due_date = tsf_req_doc.default_due_date or datetime.now(tz=timezone.utc)
                     MineReport.create(
                         mine_report_definition_id=tsf_req_doc.mine_report_definition_id,
                         mine_guid=mine.mine_guid,

--- a/services/minespace-web/src/components/pages/Tailings/TailingsSubmitSuccess.tsx
+++ b/services/minespace-web/src/components/pages/Tailings/TailingsSubmitSuccess.tsx
@@ -1,0 +1,98 @@
+import React, { useEffect } from "react";
+import { Button, Col, Row, Typography } from "antd";
+import { Link, useParams } from "react-router-dom";
+import ArrowLeftOutlined from "@ant-design/icons/ArrowLeftOutlined";
+import { MINE_DASHBOARD, MINE_TAILINGS } from "@/constants/routes";
+import { useAppDispatch, useAppSelector } from "@mds/common/redux/rootState";
+import { getMineById } from "@mds/common/redux/selectors/mineSelectors";
+import { getTsf } from "@mds/common/redux/selectors/tailingsSelectors";
+import { ITailingsStorageFacility } from "@mds/common/interfaces";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faCircleCheck } from "@fortawesome/pro-regular-svg-icons";
+import { COLOR } from "@mds/common/constants/styles";
+import {
+  fetchMineRecordById,
+  fetchTailingsStorageFacility,
+} from "@mds/common/redux/actionCreators/mineActionCreator";
+
+const { Title, Paragraph } = Typography;
+
+const TailingsSubmitSuccess = () => {
+  const dispatch = useAppDispatch();
+
+  const { mineGuid, tailingsStorageFacilityGuid } = useParams<{
+    mineGuid: string;
+    tailingsStorageFacilityGuid: string;
+  }>();
+
+  const mine = useAppSelector(getMineById(mineGuid));
+  const tsf: ITailingsStorageFacility = useAppSelector(getTsf);
+
+  useEffect(() => {
+    if (!tsf?.mine_tailings_storage_facility_name) {
+      dispatch(fetchTailingsStorageFacility(mineGuid, tailingsStorageFacilityGuid));
+    }
+  }, [tsf?.mine_tailings_storage_facility_name]);
+
+  useEffect(() => {
+    if (!mine) {
+      dispatch(fetchMineRecordById(mineGuid));
+    }
+  }, [mine]);
+
+  return (
+    <div>
+      <Row className="margin-large--top">
+        <Col>
+          <Title level={1}>{tsf?.mine_tailings_storage_facility_name}</Title>
+        </Col>
+        <Col span={24}>
+          <Link to={MINE_TAILINGS.dynamicRoute(mineGuid)}>
+            <ArrowLeftOutlined className="padding-sm--right" />
+            {`Back to: ${mine?.mine_name} Tailings`}
+          </Link>
+        </Col>
+      </Row>
+      <Row
+        style={{ maxWidth: "648px", margin: "0 auto" }}
+        justify="center"
+        align="middle"
+        className="margin-large--top"
+        gutter={[16, 16]}
+      >
+        <Col span={24} className="center">
+          <FontAwesomeIcon icon={faCircleCheck} color={COLOR.successGreen} size="5x" />
+        </Col>
+        <Col span={24}>
+          <Paragraph strong>
+            Thank you, your Tailings Storage Facility has been updated successfully!
+          </Paragraph>
+          <Paragraph>
+            As Per{" "}
+            <a
+              href="https://www2.gov.bc.ca/gov/content/industry/mineral-exploration-mining/health-safety/health-safety-and-reclamation-code-for-mines-in-british-columbia"
+              target="_blank"
+            >
+              Health, Safety and Reclamation Code
+            </a>
+            , if an Engineer of Record or Qualified Person has been assigned, written acknowledgment
+            is required within 72 hours of designation. Please submit the acknowledgment as
+            requested in the Reports page.
+          </Paragraph>
+        </Col>
+        <Col span={24} className="center">
+          <Button type="primary" href={MINE_TAILINGS.dynamicRoute(mineGuid)}>
+            Back to Tailings and Dams
+          </Button>
+        </Col>
+        <Col span={24} className="center">
+          <Button type="default" href={MINE_DASHBOARD.dynamicRoute(mineGuid, "reports")}>
+            Submit Written Acknowledgement in Reports
+          </Button>
+        </Col>
+      </Row>
+    </div>
+  );
+};
+
+export default TailingsSubmitSuccess;

--- a/services/minespace-web/src/constants/routes.ts
+++ b/services/minespace-web/src/constants/routes.ts
@@ -25,6 +25,10 @@ const ReturnPage = React.lazy(() => import("@/components/pages/ReturnPage"));
 const TailingsSummaryPageWrapper = React.lazy(
   () => import("@/components/pages/Tailings/TailingsSummaryPageWrapper")
 );
+const TailingsSubmitSuccess = React.lazy(
+  () => import("@/components/pages/Tailings/TailingsSubmitSuccess")
+);
+
 const IncidentPage = React.lazy(() => import("@/components/pages/Incidents/IncidentPage"));
 const IncidentSuccessPage = React.lazy(
   () => import("@/components/pages/Incidents/IncidentSuccessPage")
@@ -224,6 +228,14 @@ export const ADD_TAILINGS_STORAGE_FACILITY = {
     `/mines/${mineGuid}/tailings-storage-facility/new/${tab}`,
   component: TailingsSummaryPageWrapper,
   helpKey: "Add-Tailings-Storage-Facility",
+};
+
+export const TAILINGS_SUBMIT_SUCCESS = {
+  route: "/mines/:mineGuid/tailings-storage-facility/:tailingsStorageFacilityGuid/submit-success",
+  dynamicRoute: (mineGuid, tailingsStorageFacilityGuid) =>
+    `/mines/${mineGuid}/tailings-storage-facility/${tailingsStorageFacilityGuid}/submit-success`,
+  component: TailingsSubmitSuccess,
+  helpKey: "Tailings-Submit-Success",
 };
 
 export const EDIT_TAILINGS_STORAGE_FACILITY = {

--- a/services/minespace-web/src/routes/Routes.tsx
+++ b/services/minespace-web/src/routes/Routes.tsx
@@ -126,6 +126,14 @@ const Routes = () => (
         )}
       />
       <Route
+        path={routes.TAILINGS_SUBMIT_SUCCESS.route}
+        component={ColumnWrapper()(
+          FeatureFlagGuard(Feature.TSF_V2)(
+            AuthenticationGuard()(routes.TAILINGS_SUBMIT_SUCCESS.component)
+          )
+        )}
+      />
+      <Route
         path={routes.EDIT_TAILINGS_STORAGE_FACILITY.route}
         component={ColumnWrapper()(
           AuthenticationGuard()(routes.EDIT_TAILINGS_STORAGE_FACILITY.component)

--- a/services/minespace-web/src/styles/generic/layout.scss
+++ b/services/minespace-web/src/styles/generic/layout.scss
@@ -74,6 +74,10 @@
   text-align: right;
 }
 
+.center {
+  text-align: center;
+}
+
 .center-mobile {
   @include mobile {
     display: block;
@@ -208,6 +212,9 @@
 
 .margin-none {
   margin: 0 !important;
+  &--bottom {
+    margin-bottom: 0 !important;
+  }
 }
 
 .margin-small {

--- a/services/minespace-web/src/tests/components/dashboard/mine/tailings/TailingsSubmitSuccess.spec.tsx
+++ b/services/minespace-web/src/tests/components/dashboard/mine/tailings/TailingsSubmitSuccess.spec.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import { MINES, TAILINGS } from "@mds/common/constants/reducerTypes";
+import { render } from "@testing-library/react";
+import { BrowserRouter } from "react-router-dom";
+import { ReduxWrapper } from "@/tests/utils/ReduxWrapper";
+import TailingsSubmitSuccess from "@/components/pages/Tailings/TailingsSubmitSuccess";
+import * as MOCK from "@mds/common/tests/mocks/dataMocks";
+
+const initialState = {
+  [MINES]: MOCK.MINES,
+  [TAILINGS]: { tsf: MOCK.TSF },
+};
+
+function mockFunction() {
+  const original = jest.requireActual("react-router-dom");
+
+  const MOCK = require("@mds/common/tests/mocks/dataMocks");
+  console.log(MOCK.MINES.mineIds[0]);
+  console.log(MOCK.TSF.mine_tailings_storage_facility_guid);
+  return {
+    ...original,
+    useParams: jest.fn().mockReturnValue({
+      mineGuid: MOCK.MINES.mineIds[0],
+      tailingsStorageFacilityGuid: MOCK.TSF.mine_tailings_storage_facility_guid,
+    }),
+  };
+}
+
+jest.mock("react-router-dom", () => mockFunction());
+
+describe("TailingsSubmitSuccess", () => {
+  it("renders properly", () => {
+    const { container } = render(
+      <BrowserRouter>
+        <ReduxWrapper initialState={initialState}>
+          <TailingsSubmitSuccess />
+        </ReduxWrapper>
+      </BrowserRouter>
+    );
+
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/services/minespace-web/src/tests/components/dashboard/mine/tailings/__snapshots__/TailingsSubmitSuccess.spec.tsx.snap
+++ b/services/minespace-web/src/tests/components/dashboard/mine/tailings/__snapshots__/TailingsSubmitSuccess.spec.tsx.snap
@@ -1,0 +1,127 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TailingsSubmitSuccess renders properly 1`] = `
+<div>
+  <div>
+    <div
+      class="ant-row margin-large--top"
+    >
+      <div
+        class="ant-col"
+      >
+        <h1
+          class="ant-typography"
+        >
+          MockTSF
+        </h1>
+      </div>
+      <div
+        class="ant-col ant-col-24"
+      >
+        <a
+          href="/mines/18133c75-49ad-4101-85f3-a43e35ae989a/tailings"
+        >
+          <span
+            aria-label="arrow-left"
+            class="anticon anticon-arrow-left padding-sm--right"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              class=""
+              data-icon="arrow-left"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M872 474H286.9l350.2-304c5.6-4.9 2.2-14-5.2-14h-88.5c-3.9 0-7.6 1.4-10.5 3.9L155 487.8a31.96 31.96 0 000 48.3L535.1 866c1.5 1.3 3.3 2 5.2 2h91.5c7.4 0 10.8-9.2 5.2-14L286.9 550H872c4.4 0 8-3.6 8-8v-60c0-4.4-3.6-8-8-8z"
+              />
+            </svg>
+          </span>
+          Back to: mine3 Tailings
+        </a>
+      </div>
+    </div>
+    <div
+      class="ant-row ant-row-center ant-row-middle margin-large--top"
+      style="margin: 0px auto; max-width: 648px;"
+    >
+      <div
+        class="ant-col ant-col-24 center"
+        style="padding: 8px 8px 8px 8px;"
+      >
+        <svg
+          aria-hidden="true"
+          class="svg-inline--fa fa-circle-check fa-5x "
+          color="#2E8540"
+          data-icon="circle-check"
+          data-prefix="far"
+          focusable="false"
+          role="img"
+          viewBox="0 0 512 512"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M256 48a208 208 0 1 1 0 416 208 208 0 1 1 0-416zm0 464A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM369 209c9.4-9.4 9.4-24.6 0-33.9s-24.6-9.4-33.9 0l-111 111-47-47c-9.4-9.4-24.6-9.4-33.9 0s-9.4 24.6 0 33.9l64 64c9.4 9.4 24.6 9.4 33.9 0L369 209z"
+            fill="currentColor"
+          />
+        </svg>
+      </div>
+      <div
+        class="ant-col ant-col-24"
+        style="padding: 8px 8px 8px 8px;"
+      >
+        <div
+          class="ant-typography"
+        >
+          <strong>
+            Thank you, your Tailings Storage Facility has been updated successfully!
+          </strong>
+        </div>
+        <div
+          class="ant-typography"
+        >
+          As Per
+           
+          <a
+            href="https://www2.gov.bc.ca/gov/content/industry/mineral-exploration-mining/health-safety/health-safety-and-reclamation-code-for-mines-in-british-columbia"
+            target="_blank"
+          >
+            Health, Safety and Reclamation Code
+          </a>
+          , if an Engineer of Record or Qualified Person has been assigned, written acknowledgment is required within 72 hours of designation. Please submit the acknowledgment as requested in the Reports page.
+        </div>
+      </div>
+      <div
+        class="ant-col ant-col-24 center"
+        style="padding: 8px 8px 8px 8px;"
+      >
+        <a
+          class="ant-btn ant-btn-primary"
+          href="/mines/18133c75-49ad-4101-85f3-a43e35ae989a/tailings"
+        >
+          <span>
+            Back to Tailings and Dams
+          </span>
+        </a>
+      </div>
+      <div
+        class="ant-col ant-col-24 center"
+        style="padding: 8px 8px 8px 8px;"
+      >
+        <a
+          class="ant-btn ant-btn-default"
+          href="/mines/18133c75-49ad-4101-85f3-a43e35ae989a/reports"
+        >
+          <span>
+            Submit Written Acknowledgement in Reports
+          </span>
+        </a>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/services/minespace-web/src/tests/routes/__snapshots__/Routes.spec.js.snap
+++ b/services/minespace-web/src/tests/routes/__snapshots__/Routes.spec.js.snap
@@ -121,6 +121,10 @@ exports[`PrivateRoutes  renders properly 1`] = `
     />
     <Route
       component={[Function]}
+      path="/mines/:mineGuid/tailings-storage-facility/:tailingsStorageFacilityGuid/submit-success"
+    />
+    <Route
+      component={[Function]}
       path="/mines/:mineGuid/tailings-storage-facility/:tailingsStorageFacilityGuid/:tab/:userAction"
     />
     <Route

--- a/yarn.lock
+++ b/yarn.lock
@@ -4676,17 +4676,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:1.7.2":
-  version: 1.7.2
-  resolution: "axios@npm:1.7.2"
-  dependencies:
-    follow-redirects: ^1.15.6
-    form-data: ^4.0.0
-    proxy-from-env: ^1.1.0
-  checksum: e457e2b0ab748504621f6fa6609074ac08c824bf0881592209dfa15098ece7e88495300e02cd22ba50b3468fd712fe687e629dcb03d6a3f6a51989727405aedf
-  languageName: node
-  linkType: hard
-
 "axios@npm:1.8.2":
   version: 1.8.2
   resolution: "axios@npm:1.8.2"


### PR DESCRIPTION
- Added logic to create report requests for QP and EOR when a new one is assigned and a TSF is submitted
- Added find logic to search for a report by it's sections (this is needed to find the right reports to request here)
- Added a post-submit page after submitting a TSF that directs users to reports or back to TSFs
- Removed document logic from the EOR page as this is now handled in the reports.
- Updated UI on EOR and QP pages to be inline with new UI

## Objective 

[MDS-6360](https://bcmines.atlassian.net/browse/MDS-6360)

<img width="1466" alt="image" src="https://github.com/user-attachments/assets/4563e900-4954-4274-ad64-15921337d6e9" />
<img width="1725" alt="image" src="https://github.com/user-attachments/assets/7075ae8c-08a4-4dc8-b17f-d81d290b4035" />

