### PR TITLE
[MDS-6404] Fix comments not saving

### DIFF
--- a/services/common/src/components/comments/CommentEditor.tsx
+++ b/services/common/src/components/comments/CommentEditor.tsx
@@ -26,7 +26,7 @@ export const CommentEditor: FC<CommentEditorProps> = ({
     event.preventDefault();
     setSubmitting(true);
 
-    await onSubmit({ comment });
+    await onSubmit({ comment, visible: false });
     handleReset();
   };
 

--- a/services/core-api/app/api/mines/reports/models/mine_report_comment.py
+++ b/services/core-api/app/api/mines/reports/models/mine_report_comment.py
@@ -17,7 +17,7 @@ class MineReportComment(SoftDeleteMixin, AuditMixin, Base):
     minespace_user_id = db.Column(db.Integer, db.ForeignKey('minespace_user.user_id'))
     core_user_id = db.Column(db.Integer, db.ForeignKey('core_user.core_user_id'))
     report_comment = db.Column(db.String, nullable=False)
-    comment_visibility_ind = db.Column(db.Boolean, nullable=False)
+    comment_visibility_ind = db.Column(db.Boolean, nullable=False, default=True)
 
     comment_user = db.Column(db.String(60), nullable=False, default=User().get_user_username)
     comment_datetime = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)


### PR DESCRIPTION
## Objective 

[MDS-6404](https://bcmines.atlassian.net/browse/MDS-0000)

Fixes a bug where internal ministry comments would not save on reports.
During a refactor to TS it appears the visible parameter was lost in onSubmit and so comment_visibility_ind was not getting set.
It appears that the value was originally being set to false, although this parameter doesn't actually appear to be used anywhere. (I'm assuming this functionality was originally intended to be whether or not to show ministry comments on minespace?)

Also added a default to the field comment_visibility_ind of 'True' which matches the db column so this can't crash in the future.
<img width="725" alt="image" src="https://github.com/user-attachments/assets/15561865-9194-4e44-92e0-a76757ac4b67" />


![image](https://github.com/user-attachments/assets/dd0d3480-1619-416e-8059-3ecbf9a447a5)
