### PR TITLE
[MDS-6406] Filter out mine report definitions with expired compliance codes

### DIFF
--- a/services/core-api/app/api/mines/reports/models/mine_report_definition.py
+++ b/services/core-api/app/api/mines/reports/models/mine_report_definition.py
@@ -157,7 +157,7 @@ class MineReportDefinition(Base, AuditMixin):
         return query
 
     @classmethod
-    def _apply_filters(cls, query, regulatory_authority, is_prr_only, active_ind, section):
+    def _apply_filters(cls, query, regulatory_authority, is_prr_only, active_ind, section, show_expired):
         filters = []
         if regulatory_authority:
             reg_auth_filter = []
@@ -196,6 +196,19 @@ class MineReportDefinition(Base, AuditMixin):
                 field_name = section_order[index]
                 filters.append(field_name.ilike(part))
 
+        if not show_expired:
+            now = datetime.now(timezone('US/Pacific'))
+            # Filter by effective_date and expiry_date
+            filters.append(
+                and_(
+                    ComplianceArticle.effective_date <= now,
+                    or_(
+                        ComplianceArticle.expiry_date.is_(None),
+                        ComplianceArticle.expiry_date >= now
+                    )
+                )
+            )
+
         return query.filter(*filters)
 
     @classmethod
@@ -219,7 +232,7 @@ class MineReportDefinition(Base, AuditMixin):
 
     @classmethod
     def apply_filters_and_pagination(cls, query, page, per_page, sort_field, sort_dir, regulatory_authority,
-                                     is_prr_only, active_ind, section):
+                                     is_prr_only, active_ind, section, show_expired):
 
         regulatory_authority = None if len(regulatory_authority) == 0 or len(regulatory_authority) == len(
             CimOrCpo) + 1 else regulatory_authority
@@ -227,7 +240,7 @@ class MineReportDefinition(Base, AuditMixin):
         compliance_sort = True if sort_field in ['section', 'regulatory_authority'] else False
         compliance_filter = True if regulatory_authority or section else False
 
-        if compliance_sort or compliance_filter:
+        if compliance_sort or compliance_filter or not show_expired:
             query = query.join(MineReportDefinitionComplianceArticleXref,
                                MineReportDefinitionComplianceArticleXref.mine_report_definition_id == MineReportDefinition.mine_report_definition_id,
                                isouter=True)
@@ -236,7 +249,7 @@ class MineReportDefinition(Base, AuditMixin):
                                isouter=True)
 
         query = cls._apply_sort(query, sort_field, sort_dir)
-        query = cls._apply_filters(query, regulatory_authority, is_prr_only, active_ind, section)
+        query = cls._apply_filters(query, regulatory_authority, is_prr_only, active_ind, section, show_expired)
         return cls._apply_pagination(query, page, per_page)
 
     @classmethod

--- a/services/core-api/app/api/mines/reports/resources/mine_report_definition_resource.py
+++ b/services/core-api/app/api/mines/reports/resources/mine_report_definition_resource.py
@@ -36,6 +36,9 @@ class MineReportDefinitionListResource(Resource, UserMixin):
     parser.add_argument(
         'section', type=str, help='article # of compliance report', location='args', store_missing=False
     )
+    parser.add_argument(
+        'show_expired', type=bool, help='true to show expired reports', location='args', store_missing=False
+    )
     @api.doc(
         params={
             'page': 'The page number of paginated records to return',
@@ -45,7 +48,8 @@ class MineReportDefinitionListResource(Resource, UserMixin):
             'regulatory_authority': 'CIM, CPO, Both, NONE',
             'is_prr_only': '[true] for only prr, [false] to exclude, [true, false] for both',
             'active_ind': '[true] for only active (default), [false] for only inactive, [true, false] for both',
-            'section': 'article # of compliance report'
+            'section': 'article # of compliance report',
+            'show_expired': 'true to show expired reports'
         },
         description='returns the report definitions for possible reports.')
     @api.marshal_with(PAGINATED_MINE_REPORT_DEFINITION_MODEL, code=200)
@@ -59,6 +63,7 @@ class MineReportDefinitionListResource(Resource, UserMixin):
         is_prr_only = request.args.getlist('is_prr_only', type=str)
         active_ind = request.args.getlist('active_ind', type=str)
         section = request.args.get('section', None, type=str)
+        show_expired = request.args.get('show_expired', False, type=bool)
 
         if (page and page < 1) or per_page and per_page < 0:
             raise BadRequest(f'Invalid pagination values: page {page}, per_page {per_page}')
@@ -77,7 +82,8 @@ class MineReportDefinitionListResource(Resource, UserMixin):
             regulatory_authority,
             is_prr_only,
             active_ind,
-            section
+            section,
+            show_expired
         )
 
 

--- a/services/core-api/tests/reports/resource/test_mine_report_definition_resource.py
+++ b/services/core-api/tests/reports/resource/test_mine_report_definition_resource.py
@@ -1,13 +1,18 @@
 import json
 import math
 from urllib import parse
+
+from app.api.compliance.models.compliance_article import ComplianceArticle
 from app.api.mines.reports.models.mine_report_definition import MineReportDefinition
+from app.api.mines.reports.models.mine_report_definition_compliance_article_xref import \
+    MineReportDefinitionComplianceArticleXref
+
 
 # test non-paginated results
 def test_post_mine_report_definition_no_pagination(test_client, db_session, auth_headers):
     active_records = db_session.query(MineReportDefinition).filter_by(active_ind=True).all()
     record_count = len(active_records)
-    request_data = {}
+    request_data = { "show_expired": True }
     
     get_resp = test_client.get(
         f'/mines/reports/definitions?{parse.urlencode(request_data)}',
@@ -20,8 +25,53 @@ def test_post_mine_report_definition_no_pagination(test_client, db_session, auth
     assert(get_data['current_page']) == 1
     assert(get_data['total_pages']) == 1
     assert(get_data['items_per_page']) == record_count
-    assert(get_data['total']) == record_count   
-    
+    assert(get_data['total']) == record_count
+
+from datetime import datetime
+from pytz import timezone
+from sqlalchemy import and_, or_
+
+
+def test_get_mine_report_definition_without_expired(test_client, db_session, auth_headers):
+    # Current datetime in the 'US/Pacific' timezone
+    now = datetime.now(timezone('US/Pacific'))
+
+    # Query only active MineReportDefinition records with valid ComplianceArticle dates
+    active_records = (
+        db_session.query(MineReportDefinition)
+        .join(
+            MineReportDefinitionComplianceArticleXref,
+            MineReportDefinitionComplianceArticleXref.mine_report_definition_id == MineReportDefinition.mine_report_definition_id
+        )
+        .join(
+            ComplianceArticle,
+            ComplianceArticle.compliance_article_id == MineReportDefinitionComplianceArticleXref.compliance_article_id
+        )
+        .filter(MineReportDefinition.active_ind == True)
+        .filter(
+            and_(
+                ComplianceArticle.effective_date <= now,
+                or_(
+                    ComplianceArticle.expiry_date.is_(None),
+                    ComplianceArticle.expiry_date >= now
+                )
+            )
+        )
+        .all()
+    )
+
+    record_count = len(active_records)
+
+    request_data = {}
+
+    get_resp = test_client.get(
+        f'/mines/reports/definitions?{parse.urlencode(request_data)}',
+        headers=auth_headers['full_auth_header'],
+    )
+    get_data = json.loads(get_resp.data.decode())
+
+    assert get_resp.status_code == 200
+    assert len(get_data['records']) == record_count
 
 # test pagination
 def test_post_mine_report_definition_pagination(test_client, db_session, auth_headers):
@@ -29,7 +79,7 @@ def test_post_mine_report_definition_pagination(test_client, db_session, auth_he
     PER_PAGE = 10
     active_records = db_session.query(MineReportDefinition).filter_by(active_ind=True).all()
     record_count = len(active_records)
-    request_data = {"page": PAGE, "per_page": PER_PAGE}
+    request_data = {"page": PAGE, "per_page": PER_PAGE, "show_expired": True}
 
     get_resp = test_client.get(
         f'/mines/reports/definitions?{parse.urlencode(request_data)}',
@@ -48,8 +98,9 @@ def test_post_mine_report_definition_pagination(test_client, db_session, auth_he
 def test_mine_report_definition_active_filter(test_client, db_session, auth_headers):
     all_records = db_session.query(MineReportDefinition).all()
     all_record_count = len(all_records)
-    request_all_data = "active_ind=true&active_ind=false"
-    request_inactive_data = "active_ind=false"
+    request_all_data = "active_ind=true&active_ind=false&show_expired=true"
+    request_inactive_data = "active_ind=false&show_expired=true"
+    print(request_all_data)
 
     get_all_resp = test_client.get(
         f'/mines/reports/definitions?{request_all_data}',
@@ -74,7 +125,7 @@ def test_mine_report_definition_active_filter(test_client, db_session, auth_head
 
 def test_mine_report_definition_section_filter(test_client, db_session, auth_headers):    
     section_search = "2.3.1"
-    request_data = {"section": section_search}
+    request_data = {"section": section_search, "show_expired": True}
 
     get_resp = test_client.get(
         f'/mines/reports/definitions?{parse.urlencode(request_data)}',
@@ -101,7 +152,7 @@ def test_mine_report_definition_section_alpha_filter(test_client, db_session, au
     # uppercase the sub_paragraph for searching
     section_data = [article_search.section, article_search.sub_section, article_search.paragraph, article_search.sub_paragraph.upper()]
     section_search_string = ".".join(section_data)
-    request_data = {"section": section_search_string}
+    request_data = {"section": section_search_string, "show_expired": True}
 
     get_resp = test_client.get(
         f'/mines/reports/definitions?{parse.urlencode(request_data)}',
@@ -123,8 +174,8 @@ def test_mine_report_definition_section_alpha_filter(test_client, db_session, au
     
 
 def test_mine_report_definition_report_type_filter(test_client, db_session, auth_headers):
-    crr_request_data = {"is_prr_only": "false"}
-    prr_request_data = {"is_prr_only": "true"}
+    crr_request_data = {"is_prr_only": "false", "show_expired": True}
+    prr_request_data = {"is_prr_only": "true", "show_expired": True}
 
     crr_get_resp = test_client.get(
         f'/mines/reports/definitions?{parse.urlencode(crr_request_data)}',
@@ -227,7 +278,7 @@ def test_mine_report_definition_sort_by_section(test_client, db_session, auth_he
 
 def test_mine_report_definition_sort_by_regulatory_authority(test_client, db_session, auth_headers):
 
-    request_data = {'sort_field': 'regulatory_authority', 'sort_dir': 'asc'}
+    request_data = {'sort_field': 'regulatory_authority', 'sort_dir': 'asc', 'show_expired': True}
     
     get_resp = test_client.get(
         f'/mines/reports/definitions?{parse.urlencode(request_data)}',
@@ -250,7 +301,7 @@ def test_post_mine_report_definition_success(test_client, db_session, auth_heade
         "mine_report_due_date_type_code": 'ANV',
         "mine_report_due_date_period_months": 12,
         "report_type": "CRR",
-        "is_common": True
+        "is_common": True,
     }
 
     post_resp = test_client.post(

--- a/services/core-api/tests/reports/resource/test_mine_report_definition_resource.py
+++ b/services/core-api/tests/reports/resource/test_mine_report_definition_resource.py
@@ -200,8 +200,8 @@ def test_mine_report_definition_report_type_filter(test_client, db_session, auth
 
 def test_mine_report_definition_reg_auth_filter(test_client, db_session, auth_headers):
     active_records = db_session.query(MineReportDefinition).filter_by(active_ind=True).all()
-    cpo_none_request_data = "regulatory_authority=CPO&regulatory_authority=NONE"
-    cpo_cim_request_data = "regulatory_authority=CPO&regulatory_authority=CIM"
+    cpo_none_request_data = "regulatory_authority=CPO&regulatory_authority=NONE&show_expired=true"
+    cpo_cim_request_data = "regulatory_authority=CPO&regulatory_authority=CIM&show_expired=true"
 
     # include a "None" value
     cn_get_resp = test_client.get(

--- a/services/core-web/src/components/admin/complianceCodes/ComplianceReportManagement.tsx
+++ b/services/core-web/src/components/admin/complianceCodes/ComplianceReportManagement.tsx
@@ -36,6 +36,7 @@ import { closeModal, openModal } from "@mds/common/redux/actions/modalActions";
 const defaultParams = {
   page: 1,
   per_page: 50,
+  show_expired: true,
 };
 
 const ComplianceReportManagement: FC = () => {


### PR DESCRIPTION
- Added a filter in the mine_report_definitions list to remove definitions with an expired compliance code from the list
- Added a param to `show_expired` codes and set it to true on the report management page in Core

## Objective 

[MDS-6406](https://bcmines.atlassian.net/browse/MDS-6406)
