### PR TITLE
[MDS-6406] - HSRC Reports update

### DIFF
--- a/services/common/src/components/reports/ReportDefinitionFieldSelect.tsx
+++ b/services/common/src/components/reports/ReportDefinitionFieldSelect.tsx
@@ -1,8 +1,16 @@
 import { formatComplianceCodeReportName } from "@mds/common/redux/utils/helpers";
 import React, { useEffect, useState } from "react";
-import { useAppDispatch as useDispatch, useAppSelector as useSelector } from "@mds/common/redux/rootState";
+import {
+  useAppDispatch as useDispatch,
+  useAppSelector as useSelector,
+} from "@mds/common/redux/rootState";
 import { Field } from "@mds/common/components/forms/form";
-import { fetchComplianceReports, getMineReportDefinitionOptions, getReportDefinitionsLoaded, reportParamsGetAll } from "@mds/common/redux/slices/complianceReportsSlice";
+import {
+  fetchComplianceReports,
+  getMineReportDefinitionOptions,
+  getReportDefinitionsLoaded,
+  reportParamsGetAll,
+} from "@mds/common/redux/slices/complianceReportsSlice";
 import RenderSelect from "../forms/RenderSelect";
 import { uniqBy } from "lodash";
 import moment from "moment";
@@ -21,7 +29,8 @@ export const ReportDefinitionFieldSelect = (props: ReportDefinitionFieldSelectPr
   const dispatch = useDispatch();
   const mineReportDefinitionOptions = useSelector(getMineReportDefinitionOptions);
   const [formattedMineReportDefinitionOptions, setFormattedMineReportDefinitionOptions] = useState([]);
-  const reportDefinitionsLoaded = useSelector(getReportDefinitionsLoaded(reportParamsGetAll));
+  const reportParams = { ...reportParamsGetAll, show_expired: true };
+  const reportDefinitionsLoaded = useSelector(getReportDefinitionsLoaded(reportParams));
 
   useEffect(() => {
     // Format the mine report definition options for the search bar
@@ -38,12 +47,14 @@ export const ReportDefinitionFieldSelect = (props: ReportDefinitionFieldSelectPr
         };
       })
       .sort((a, b) => a.label.localeCompare(b.label));
-    setFormattedMineReportDefinitionOptions(uniqBy(newFormattedMineReportDefinitionOptions, "value"));
+    setFormattedMineReportDefinitionOptions(
+      uniqBy(newFormattedMineReportDefinitionOptions, "value")
+    );
   }, [mineReportDefinitionOptions]);
 
   useEffect(() => {
     if (!reportDefinitionsLoaded) {
-      dispatch(fetchComplianceReports(reportParamsGetAll));
+      dispatch(fetchComplianceReports(reportParams));
     }
   }, []);
 

--- a/services/common/src/redux/slices/complianceReportsSlice.ts
+++ b/services/common/src/redux/slices/complianceReportsSlice.ts
@@ -35,6 +35,7 @@ export interface ComplianceReportParams extends ISearchParams {
   regulatory_authority?: "CPO" | "CIM" | "Both" | "NONE"[];
   active_ind?: boolean[];
   section?: string;
+  show_expired?: boolean;
 }
 
 export const reportParamsGetAll: ComplianceReportParams = {

--- a/services/core-api/app/api/mines/reports/models/mine_report_definition.py
+++ b/services/core-api/app/api/mines/reports/models/mine_report_definition.py
@@ -199,15 +199,12 @@ class MineReportDefinition(Base, AuditMixin):
         if not show_expired:
             now = datetime.now(timezone('US/Pacific'))
             filters.append(
-                or_(
-                    and_(
-                        ComplianceArticle.effective_date <= now,
-                        or_(
-                            ComplianceArticle.expiry_date.is_(None),
-                            ComplianceArticle.expiry_date >= now
-                        )
-                    ),
-                    ComplianceArticle.compliance_article_id.is_(None)
+                and_(
+                    ComplianceArticle.effective_date <= now,
+                    or_(
+                        ComplianceArticle.expiry_date.is_(None),
+                        ComplianceArticle.expiry_date >= now
+                    )
                 )
             )
 
@@ -243,12 +240,10 @@ class MineReportDefinition(Base, AuditMixin):
         compliance_filter = True if regulatory_authority or section else False
 
         if compliance_sort or compliance_filter or not show_expired:
-            query = query.join(MineReportDefinitionComplianceArticleXref,
-                               MineReportDefinitionComplianceArticleXref.mine_report_definition_id == MineReportDefinition.mine_report_definition_id,
-                               isouter=True)
-            query = query.join(ComplianceArticle,
-                               ComplianceArticle.compliance_article_id == MineReportDefinitionComplianceArticleXref.compliance_article_id,
-                               isouter=True)
+            query = query.outerjoin(MineReportDefinitionComplianceArticleXref,
+                               MineReportDefinitionComplianceArticleXref.mine_report_definition_id == MineReportDefinition.mine_report_definition_id)
+            query = query.outerjoin(ComplianceArticle,
+                               ComplianceArticle.compliance_article_id == MineReportDefinitionComplianceArticleXref.compliance_article_id)
 
         query = cls._apply_sort(query, sort_field, sort_dir)
         query = cls._apply_filters(query, regulatory_authority, is_prr_only, active_ind, section, show_expired)

--- a/services/core-api/app/api/mines/reports/models/mine_report_definition.py
+++ b/services/core-api/app/api/mines/reports/models/mine_report_definition.py
@@ -198,14 +198,16 @@ class MineReportDefinition(Base, AuditMixin):
 
         if not show_expired:
             now = datetime.now(timezone('US/Pacific'))
-            # Filter by effective_date and expiry_date
             filters.append(
-                and_(
-                    ComplianceArticle.effective_date <= now,
-                    or_(
-                        ComplianceArticle.expiry_date.is_(None),
-                        ComplianceArticle.expiry_date >= now
-                    )
+                or_(
+                    and_(
+                        ComplianceArticle.effective_date <= now,
+                        or_(
+                            ComplianceArticle.expiry_date.is_(None),
+                            ComplianceArticle.expiry_date >= now
+                        )
+                    ),
+                    ComplianceArticle.compliance_article_id.is_(None)
                 )
             )
 


### PR DESCRIPTION
- Updated the report filtering on the Core admin page to make sure it also fetched reports that don't have a compliance code attached when that table is joined.
- Added the `show_expired` param to another admin instance of the `fetchComplianceReports` action.

## Objective 

[MDS-6406](https://bcmines.atlassian.net/browse/MDS-6406)
