### PR TITLE
[FIX] Dam version table types- match base table

### DIFF
--- a/migrations/sql/V2025.03.18.15.43__fix_dam_version_types.sql
+++ b/migrations/sql/V2025.03.18.15.43__fix_dam_version_types.sql
@@ -1,0 +1,6 @@
+ALTER TABLE dam_version
+ALTER COLUMN permitted_dam_crest_elevation TYPE numeric(12, 2),
+ALTER COLUMN current_dam_height TYPE numeric(12, 2),
+ALTER COLUMN current_elevation TYPE numeric(12, 2),
+ALTER COLUMN max_pond_elevation TYPE numeric(12, 2),
+ALTER COLUMN min_freeboard_required TYPE numeric(12, 2);


### PR DESCRIPTION
## Objective 
- the base table was numeric(12,2) and the version table was numeric(10,2) causing overflow when backfilling history
- make version table the same

_Why are you making this change? Provide a short explanation and/or screenshots_
