### PR TITLE
[MDS-6416] Bug around Minespace users getting Core email template

### DIFF
--- a/services/core-api/app/api/mines/reports/models/mine_report.py
+++ b/services/core-api/app/api/mines/reports/models/mine_report.py
@@ -227,10 +227,7 @@ class MineReport(SoftDeleteMixin, AuditMixin, Base):
         ms_recipients = []
         # Adding submitter's email
         if self.submitter_email:
-            if is_proponent:
-                ms_recipients.append(self.submitter_email)
-            else:
-                core_recipients.append(self.submitter_email)
+            ms_recipients.append(self.submitter_email)
 
         # Adding submitter's email
         contacts_email = [


### PR DESCRIPTION
## Objective 

[MDS-6416](https://bcmines.atlassian.net/browse/MDS-6416)

- It turns out the creator of the report mentioned in the story bug is not the submitter listed in the form. The submitter does have the correct role to be considered a proponent but the actual creator of the report doesn't. This causes the submitter email to be added to the core recipient list.

- Spoke to the team and it was decided that we make it so the submitter email is added to minespace recipients only
