### PR TITLE
[FIX] Add optional chain to status_code to prevent blank screen

### DIFF
--- a/services/core-web/src/components/Forms/incidents/IncidentFormUpdateIncidentStatus.tsx
+++ b/services/core-web/src/components/Forms/incidents/IncidentFormUpdateIncidentStatus.tsx
@@ -25,7 +25,7 @@ const IncidentFormUpdateIncidentStatus: FC<IncidentFormUpdateIncidentStatusProps
 }) => {
   const isNewIncident = !incident?.mine_incident_guid;
   const isClosed = incident?.status_code === "CLD";
-  const selectedStatusCode = formValues.status_code;
+  const selectedStatusCode = formValues?.status_code;
   const responsibleInspector = incident?.responsible_inspector_party;
 
   const alertText = (updateUser, updateDate, responsibleInspector, selectedStatusCode) => {


### PR DESCRIPTION
## Objective 

Fix a bug preventing incidents from being edited from the Incident Home page screen.

Long term we should also address line 94 in MineIncidentTable.tsx which forces a reload.