### PR TITLE
[MDS-5041] Don't allow EOR or QTF to be an organization

### DIFF
--- a/services/core-api/app/api/parties/party_appt/resources/mine_party_appt_resource.py
+++ b/services/core-api/app/api/parties/party_appt/resources/mine_party_appt_resource.py
@@ -149,6 +149,9 @@ class MinePartyApptResource(Resource, UserMixin):
             if tsf is None:
                 raise NotFound('TSF not found')
 
+            if party.party_type_code is not "PER":
+                raise Forbidden(f"A contact for {mine_party_appt_type_code} must be a person not an organization")
+
             if not can_edit_mines():
                 # if this party was not created by the current user, check if they have the correct role
                 if not tsf or mine.mine_guid != tsf.mine_guid:

--- a/services/core-web/src/components/Forms/PartyRelationships/AddPartyRelationshipForm.tsx
+++ b/services/core-web/src/components/Forms/PartyRelationships/AddPartyRelationshipForm.tsx
@@ -87,7 +87,7 @@ const AddPartyRelationshipForm: FC<AddPartyRelationshipFormProps> = ({
   const partyRelationshipDescription = partyRelationshipTypeHash[mine_party_appt_type_code];
   const matchingAppointments = useAppSelector(getMatchingPartyRelationships(mine_party_appt_type_code, related_guid));
   const currentAppointment = matchingAppointments.filter((mpa) => mpa.end_date === null)[0];
-
+  const personOnly = ["EOR","TQP"].includes(mine_party_appt_type_code);
 
   const showEndCurrent = () => {
     const hasStartDateValidation = ["PMT", "EOR"].includes(mine_party_appt_type_code) &&
@@ -185,6 +185,7 @@ const AddPartyRelationshipForm: FC<AddPartyRelationshipFormProps> = ({
           <PartySelectField
             id="party_guid"
             name="party_guid"
+            person={personOnly}
             required
             validate={[required]}
             onSelect={(val) => {

--- a/services/minespace-web/src/components/Forms/contacts/AddContactForm.tsx
+++ b/services/minespace-web/src/components/Forms/contacts/AddContactForm.tsx
@@ -30,9 +30,10 @@ export const AddContactForm: FC<AddContactFormProps> = (props) => {
 
   const contacts = uniqBy(parties || [], (partyAppt) => partyAppt.party.party_guid)
     .filter(
-      ({ mine_party_appt_type_code }) =>
-        !props.mine_party_appt_type_code ||
-        mine_party_appt_type_code === props.mine_party_appt_type_code
+      ({ mine_party_appt_type_code, party }) =>
+        (!props.mine_party_appt_type_code ||
+          mine_party_appt_type_code === props.mine_party_appt_type_code) &&
+        party.party_type_code === "PER"
     )
     .map(({ party: { name, party_guid } }) => ({
       label: name,


### PR DESCRIPTION
## Objective 

[MDS-5041](https://bcmines.atlassian.net/browse/MDS-5041)

Engineers of record and Qualified persons are not allowed to be organizations.

In turns out this change was a lot simpler than I initially thought, I was attempting to add party filtering on the backend but filtering already existed on the frontend.

In minespace the AddContactForm appears to have no support for creating organizations and has a really bad time if you select an organization from the existing contacts so just filtered out organizations entirely.
