### PR TITLE
[MDS-5997] Improved VFCBC login error handlong, added cli command to easily test VFCBC downloads

### DIFF
--- a/services/document-manager/backend/app/__init__.py
+++ b/services/document-manager/backend/app/__init__.py
@@ -1,26 +1,21 @@
 import os
+from logging.config import dictConfig
 
+from app.commands import register_commands
+from app.docman.models import *
+from app.docman.resources import *
+from app.extensions import api, cache, db, jwt, jwt_cypress, jwt_main, migrate
+from app.routes import register_routes
+from app.utils.celery_health_check import HealthCheckProbe
+from celery import Celery
 from flask import Flask, current_app, request
 from flask_cors import CORS
 from flask_restx.apidoc import apidoc
-
-from app.docman.models import *
-from app.docman.resources import *
-
-from app.commands import register_commands
-from app.routes import register_routes
-from app.extensions import api, cache, db, jwt, migrate, jwt_main, jwt_cypress
-from app.utils.celery_health_check import HealthCheckProbe
+from opentelemetry import trace
+from opentelemetry.instrumentation.flask import FlaskInstrumentor
+from opentelemetry.sdk.trace import TracerProvider
 
 from .config import Config, TestConfig
-
-from celery import Celery
-
-from opentelemetry import trace
-from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.instrumentation.flask import FlaskInstrumentor
-from logging.config import dictConfig
-
 from .date_time_helper import get_formatted_current_time
 
 
@@ -60,6 +55,10 @@ def create_app(test_config=None):
 
     register_routes(app)
     register_commands(app)
+
+    # Register CLI commands
+    from app.cli import document_cli
+    app.cli.add_command(document_cli)
 
     @api.errorhandler(Exception)
     def default_error_handler(error):

--- a/services/document-manager/backend/app/cli.py
+++ b/services/document-manager/backend/app/cli.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+"""
+Command Line Interface for Document Manager
+This module defines CLI commands that can be called using the Flask CLI
+"""
+import sys
+
+import click
+from app.services.vfcbc_download_service import VFCBCDownloadService
+from flask.cli import with_appcontext
+
+
+@click.group(name='document')
+def document_cli():
+    """Document manager commands."""
+    pass
+
+
+@document_cli.command('vfcbc-download')
+@click.argument('url')
+@click.argument('output')
+@with_appcontext
+def vfcbc_download_command(url, output):
+    """Download a file from VFCBC.
+    
+    URL: The URL of the file to download
+    OUTPUT: Path where the downloaded file will be saved
+
+    Example Usage: flask document vfcbc-download https://j200.gov.bc.ca/int/vfcbc/Download.aspx?PosseObjectId=<OBJ_ID> FIGURE1.pdf
+    """
+    try:
+        # Use download method with use_cache=False to bypass caching
+        file_data = VFCBCDownloadService.download(url, use_cache=False)
+        with open(output, 'wb') as f:
+            f.write(file_data.getbuffer())
+        click.echo(f"File successfully downloaded and saved to {output}")
+    except Exception as e:
+        click.echo(f"Error downloading file: {e}", err=True)
+        sys.exit(1)

--- a/services/document-manager/backend/app/services/vfcbc_download_service.py
+++ b/services/document-manager/backend/app/services/vfcbc_download_service.py
@@ -43,6 +43,7 @@ def vfcbc_login(download_session):
         postlogin_url = f'https://{login_netloc}/clp-cgi/int01/private/postLogon.cgi'
         postlogin_req = download_session.get(postlogin_url)
 
+        # A successful IDIR login sets the "SMSESSION" cookie (from Siteminder).
         cooks = loginfcc_req.cookies.get_dict()
 
         if not cooks or 'SMSESSION' not in cooks:

--- a/services/document-manager/backend/app/services/vfcbc_download_service.py
+++ b/services/document-manager/backend/app/services/vfcbc_download_service.py
@@ -1,9 +1,10 @@
-import requests, io
-from flask import current_app
+import io
 from urllib.parse import urlparse
 
+import requests
+from app.constants import TIMEOUT_60_MINUTES, VFCBC_COOKIES
 from app.extensions import cache
-from app.constants import VFCBC_COOKIES, TIMEOUT_60_MINUTES
+from flask import current_app
 
 
 def vfcbc_login(download_session):
@@ -42,18 +43,38 @@ def vfcbc_login(download_session):
         postlogin_url = f'https://{login_netloc}/clp-cgi/int01/private/postLogon.cgi'
         postlogin_req = download_session.get(postlogin_url)
 
+        cooks = loginfcc_req.cookies.get_dict()
+
+        if not cooks or 'SMSESSION' not in cooks:
+            raise Exception('vFCBC login failed! SMSESSION cookie not found')
 
 class VFCBCDownloadService():
-    def download(file_url):
+    @staticmethod
+    def download(file_url, use_cache=True):
+        """
+        Download a file from VFCBC.
+        
+        Args:
+            file_url (str): URL of the file to download
+            use_cache (bool): Whether to use/update the cached cookies or always perform a fresh login
+                            Default is True (use cache)
+        
+        Returns:
+            BytesIO: File content as a BytesIO object
+        """
         download_session = requests.session()
 
-        _vfcbc_cookies = cache.get(VFCBC_COOKIES)
-        if _vfcbc_cookies is None:
-            vfcbc_login(download_session)
-            cache.set(VFCBC_COOKIES, download_session.cookies, timeout=TIMEOUT_60_MINUTES)
+        if use_cache:
+            _vfcbc_cookies = cache.get(VFCBC_COOKIES)
+            if _vfcbc_cookies is None:
+                vfcbc_login(download_session)
+                cache.set(VFCBC_COOKIES, download_session.cookies, timeout=TIMEOUT_60_MINUTES)
+            else:
+                download_session.cookies = _vfcbc_cookies
         else:
-            download_session.cookies = _vfcbc_cookies
-
+            # Always perform a fresh login when use_cache is False
+            vfcbc_login(download_session)
+            
         resp = download_session.get(file_url, stream=True)
         if resp.status_code != requests.codes.ok:
             raise Exception(f'vFCBC file download failed! Error {resp.status_code}: {resp.content}')


### PR DESCRIPTION

## Objective 

[MDS-5997](https://bcmines.atlassian.net/browse/MDS-5997)

- Added a CLI command to easily test out VFCBC downloads for debugging purposes. 

Example:
```python
flask document vfcbc-download https://j200.gov.bc.ca/int/vfcbc/Download.aspx?PosseObjectId=<OBJ_ID> FIGURE1.pdf
```

- Improved handling of failed logins for VFCBC downloads. Previously, failed auths were not handled - documents would be imported into the system containing the IDIR login page. With this change, an error would be thrown if login fails for any reason (SMSESSION cookie) is not set.

![image](https://github.com/user-attachments/assets/037d9b55-0365-432f-97d3-63a639d7fda4)
![image](https://github.com/user-attachments/assets/81c2295f-4a72-4ee4-87ed-e9fbce7b244c)

