### PR TITLE
[MDS-6410] Use new TSF form in core

### DIFF
--- a/services/core-web/src/components/mine/Tailings/MineTailingsInfoTabs.tsx
+++ b/services/core-web/src/components/mine/Tailings/MineTailingsInfoTabs.tsx
@@ -35,7 +35,11 @@ import { userHasRole } from "@mds/common/redux/selectors/authenticationSelectors
 import { USER_ROLES } from "@mds/common/constants/environment";
 import ResponsivePagination from "@mds/common/components/common/ResponsivePagination";
 import { useAppDispatch, useAppSelector } from "@mds/common/redux/rootState";
-import { useParams } from "react-router-dom";
+import { useHistory, useParams } from "react-router-dom";
+import { ADD_TAILINGS_STORAGE_FACILITY } from "@/constants/routes";
+import { resetForm } from "@mds/common/redux/utils/helpers";
+import { FORM } from "@mds/common/constants/forms";
+import { clearTsf } from "@mds/common/redux/actions/tailingsActions";
 
 
 /**
@@ -52,6 +56,7 @@ const defaultParams = {
 
 export const MineTailingsInfoTabs: FC<MineTailingsInfoTabsProps> = (props) => {
   const dispatch = useAppDispatch();
+  const history = useHistory();
 
   const { mineGuid } = useParams<{ mineGuid: string }>();
   const mine: IMine = useAppSelector(getMineById(mineGuid));
@@ -144,6 +149,22 @@ export const MineTailingsInfoTabs: FC<MineTailingsInfoTabsProps> = (props) => {
     }));
   };
 
+  const handleCreateTailings = async (event) => {
+    if(tsfV2Enabled){
+      navigateToCreateTailings(event);
+    } else {
+      openTailingsModal(event, handleAddTailings, "Add TSF")
+    }
+  }
+
+  const navigateToCreateTailings = async (event) => {
+    event.preventDefault();
+    resetForm(FORM.ADD_TAILINGS_STORAGE_FACILITY);
+    await dispatch(clearTsf());
+    const url = ADD_TAILINGS_STORAGE_FACILITY.dynamicRoute(mine.mine_guid);
+    history.push(url);
+  };
+
   const openTailingsModal = (event, onSubmit, title) => {
     event.preventDefault();
     dispatch(openModal({
@@ -185,7 +206,7 @@ export const MineTailingsInfoTabs: FC<MineTailingsInfoTabsProps> = (props) => {
           <h4 className="uppercase">Tailings Storage Facilities</h4>
           {canEditTSF && (
             <AddButton
-              onClick={(event) => openTailingsModal(event, handleAddTailings, "Add TSF")}
+              onClick={(event) => handleCreateTailings(event)}
             >
               Add TSF
             </AddButton>

--- a/services/core-web/src/constants/routes.ts
+++ b/services/core-web/src/constants/routes.ts
@@ -316,6 +316,14 @@ export const MINE_TAILINGS_DETAILS = {
   helpKey: "Mine-Tailings-Details",
 };
 
+export const ADD_TAILINGS_STORAGE_FACILITY = {
+  route: "/mine-dashboard/:mineGuid/permits-and-approvals/tailings/new/:tab",
+  dynamicRoute: (mineGuid, tab = "basic-information") =>
+    `/mine-dashboard/${mineGuid}/permits-and-approvals/tailings/new/${tab}`,
+  component: MineTailingsDetailsPage,
+  helpKey: "Add-Tailings-Storage-Facility",
+};
+
 export const EDIT_TAILINGS_STORAGE_FACILITY = {
   route:
     "/mine-dashboard/:id/permits-and-approvals/tailings/:tailingsStorageFacilityGuid/:tab/:userAction",

--- a/services/core-web/src/routes/MineDashboardRoutes.js
+++ b/services/core-web/src/routes/MineDashboardRoutes.js
@@ -63,12 +63,12 @@ const MineDashboardRoutes = () => (
     <Route
       exact
       path={routes.EDIT_TAILINGS_STORAGE_FACILITY.route}
-      component={routes.MINE_TAILINGS_DETAILS.component}
+      component={routes.EDIT_TAILINGS_STORAGE_FACILITY.component}
     />
     <Route
       exact
       path={routes.ADD_TAILINGS_STORAGE_FACILITY.route}
-      component={routes.MINE_TAILINGS_DETAILS.component}
+      component={routes.ADD_TAILINGS_STORAGE_FACILITY.component}
     />
     <Route exact path={routes.EDIT_DAM.route} component={routes.EDIT_DAM.component} />
     <Route exact path={routes.MINE_DOCUMENTS.route} component={routes.MINE_DOCUMENTS.component} />

--- a/services/core-web/src/routes/MineDashboardRoutes.js
+++ b/services/core-web/src/routes/MineDashboardRoutes.js
@@ -65,6 +65,11 @@ const MineDashboardRoutes = () => (
       path={routes.EDIT_TAILINGS_STORAGE_FACILITY.route}
       component={routes.MINE_TAILINGS_DETAILS.component}
     />
+    <Route
+      exact
+      path={routes.ADD_TAILINGS_STORAGE_FACILITY.route}
+      component={routes.MINE_TAILINGS_DETAILS.component}
+    />
     <Route exact path={routes.EDIT_DAM.route} component={routes.EDIT_DAM.component} />
     <Route exact path={routes.MINE_DOCUMENTS.route} component={routes.MINE_DOCUMENTS.component} />
     <Route

--- a/services/core-web/src/tests/routes/__snapshots__/DashboardRoutes.spec.js.snap
+++ b/services/core-web/src/tests/routes/__snapshots__/DashboardRoutes.spec.js.snap
@@ -380,6 +380,12 @@ exports[`DashboardRoutes  renders properly 1`] = `
   <Route
     component={[Function]}
     exact={true}
+    key="/mine-dashboard/:mineGuid/permits-and-approvals/tailings/new/:tab"
+    path="/mine-dashboard/:mineGuid/permits-and-approvals/tailings/new/:tab"
+  />
+  <Route
+    component={[Function]}
+    exact={true}
     key="/mine-dashboard/:id/permits-and-approvals/tailings/:tailingsStorageFacilityGuid/:tab/:userAction"
     path="/mine-dashboard/:id/permits-and-approvals/tailings/:tailingsStorageFacilityGuid/:tab/:userAction"
   />


### PR DESCRIPTION
## [Core] When a user creates a new TSF records it directs to the new form

[MDS-6410](https://bcmines.atlassian.net/browse/MDS-6410)

- Added and registered route for adding a TSF.
- Updated the event handler to check the feature flag and if enabled redirect the user.
- Updated snap
