### PR TITLE
[MDS-6440] Fixed error when running extraction process in test

### DIFF
--- a/services/permits/app/pipelines/permit_condition_extraction/components/azure_document_intelligence_converter.py
+++ b/services/permits/app/pipelines/permit_condition_extraction/components/azure_document_intelligence_converter.py
@@ -63,7 +63,6 @@ class AzureDocumentIntelligenceConverter:
             result = self.run_document_intelligence(file_path)
 
         if DEBUG_MODE:
-
             self.write_to_cache(cache_key, result)
 
         docs = []

--- a/services/permits/app/pipelines/permit_condition_extraction/components/filter_conditions_paragraphs.py
+++ b/services/permits/app/pipelines/permit_condition_extraction/components/filter_conditions_paragraphs.py
@@ -161,11 +161,10 @@ def _identify_bottom_of_first_page_header(paragraphs):
     # Find the first paragraph that is identified as a page header
     is_like_page_header = False
 
-    page_header_start_idx = next(
-        (i for i, p in enumerate(paragraphs) if p.content["role"] == "pageHeader"), None
-    )
 
-    if page_header_start_idx is not None:
+    for page_header_start_idx, p in enumerate(paragraphs):
+        if p.content["role"] != "pageHeader":
+            continue
 
         page_header_end_idx = next(
             (

--- a/services/permits/app/pipelines/permit_condition_extraction/permit_condition_pipeline.py
+++ b/services/permits/app/pipelines/permit_condition_extraction/permit_condition_pipeline.py
@@ -60,9 +60,12 @@ def permit_condition_pipeline():
     """
     index_pipeline = Pipeline()
 
+    doc_intelligence_key = config.document_intelligence.api_key.resolve_value()
+    assert doc_intelligence_key, "Document Intelligence API key is not set"
+
     pdf_converter = AzureDocumentIntelligenceConverter(
         endpoint=config.document_intelligence.endpoint,
-        api_key=config.document_intelligence.api_key,
+        api_key=doc_intelligence_key,
         api_version=config.document_intelligence.api_version,
     )
 


### PR DESCRIPTION
## Objective 

[MDS-6440](https://bcmines.atlassian.net/browse/MDS-6440)

- Fixes an error in the permit condition extraction pipeline in test (doc intelligence api key), preventing testing of the permit condition search
- Noticed that for some permits, the page headers were not properly discarded from extracted results, so updated that logic

