### PR TITLE
[MDS-6292] Upgraded to redis 7 for local development, bumped client library version

### DIFF
--- a/docker-compose.M1.yaml
+++ b/docker-compose.M1.yaml
@@ -166,7 +166,7 @@ services:
 
   ####################### Redis Definition #######################
   redis:
-    image: redis:3.2-alpine
+    image: redis:7.4-alpine
     container_name: mds_cache
     restart: always
     command: redis-server --requirepass redis-password

--- a/docker-compose.ci.yaml
+++ b/docker-compose.ci.yaml
@@ -103,7 +103,7 @@ services:
 
   ####################### Redis Definition #######################
   redis:
-    image: redis:3.2-alpine
+    image: redis:7.4-alpine
     container_name: mds_cache
     restart: always
     command: redis-server --requirepass redis-password

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -164,7 +164,7 @@ services:
 
   ####################### Redis Definition #######################
   redis:
-    image: redis:3.2-alpine
+    image: redis:7.4-alpine
     container_name: mds_cache
     restart: always
     command: redis-server --requirepass redis-password

--- a/services/document-manager/backend/requirements.txt
+++ b/services/document-manager/backend/requirements.txt
@@ -15,7 +15,7 @@ pytest==7.4.0
 pytest-cov==4.1.0
 python-dateutil==2.8.2
 python-dotenv==1.0.0
-redis==4.6.0
+redis==5.2.1
 requests==2.32.3
 SQLAlchemy==2.0.19
 uwsgi==2.0.23

--- a/services/nris-api/backend/requirements.txt
+++ b/services/nris-api/backend/requirements.txt
@@ -15,7 +15,7 @@ pytest==8.0.0
 pytest-cov==2.7.1
 python-dateutil==2.8.2
 python-dotenv==0.10.3
-redis==4.6.0
+redis==5.2.1
 SQLAlchemy==1.4.51
 uwsgi==2.0.23
 requests==2.32.3

--- a/services/permits/requirements.txt
+++ b/services/permits/requirements.txt
@@ -26,7 +26,7 @@ diff-match-patch==20230430
 celery[redis,elasticsearch]==5.4.0
 openpyxl==3.1.5
 python-multipart==0.0.20
-redis==4.6.0
+redis==5.2.1
 watchdog==4.0.1
 pytest-cov==5.0.0
 pytest-asyncio==0.23.8


### PR DESCRIPTION
## Objective 

[MDS-6292](https://bcmines.atlassian.net/browse/MDS-6292)

Bumped `redis` for local development to 7, seeing as redis 8 is still in pre-release.

Tested celery, file uploads, and file downloads without any issues. Will test out VFCBC imports and NRIS once in test.