### PR TITLE
[MDS-6430] TSF reports page blank

### DIFF
--- a/services/core-web/src/components/mine/Tailings/MineTailingsInfoTabs.tsx
+++ b/services/core-web/src/components/mine/Tailings/MineTailingsInfoTabs.tsx
@@ -17,7 +17,7 @@ import {
 import { getMineReports, getReportsPageData } from "@mds/common/redux/selectors/reportSelectors";
 import { getMineById } from "@mds/common/redux/selectors/mineSelectors";
 import { closeModal, openModal } from "@mds/common/redux/actions/modalActions";
-import { getMineReportDefinitionOptions } from "@mds/common/redux/slices/complianceReportsSlice";
+import { fetchComplianceReports, getMineReportDefinitionOptions, getReportDefinitionsLoaded, reportParamsGetAll } from "@mds/common/redux/slices/complianceReportsSlice";
 import * as Strings from "@mds/common/constants/strings";
 import DamsPage from "@mds/common/components/tailings/dam/DamsPage";
 import MineReportTable from "@/components/mine/Reports/MineReportTable";
@@ -70,6 +70,7 @@ export const MineTailingsInfoTabs: FC<MineTailingsInfoTabsProps> = (props) => {
   const pageData = useAppSelector(getReportsPageData);
 
   const [isLoaded, setIsLoaded] = useState(false);
+  const reportDefinitionsLoaded = useAppSelector(getReportDefinitionsLoaded(reportParamsGetAll));
   const [params, setParams] = useState({ sort_field: "received_date", sort_dir: "desc" });
 
   const canEditTSF = useAppSelector(userHasRole(USER_ROLES.role_edit_tsf));
@@ -82,6 +83,12 @@ export const MineTailingsInfoTabs: FC<MineTailingsInfoTabsProps> = (props) => {
     dispatch(fetchMineReports(mineGuid, defaultParams.mineReportType)).then(() => {
       setIsLoaded(true);
     });
+  }, []);
+
+  useEffect(() => {
+    if (!reportDefinitionsLoaded) {
+      dispatch(fetchComplianceReports(reportParamsGetAll));
+    }
   }, []);
 
   const handleEditTailings = (values) => {

--- a/services/core-web/src/components/mine/Tailings/MineTailingsInfoTabs.tsx
+++ b/services/core-web/src/components/mine/Tailings/MineTailingsInfoTabs.tsx
@@ -17,7 +17,6 @@ import {
 import { getMineReports, getReportsPageData } from "@mds/common/redux/selectors/reportSelectors";
 import { getMineById } from "@mds/common/redux/selectors/mineSelectors";
 import { closeModal, openModal } from "@mds/common/redux/actions/modalActions";
-import { fetchComplianceReports, getMineReportDefinitionOptions, getReportDefinitionsLoaded, reportParamsGetAll } from "@mds/common/redux/slices/complianceReportsSlice";
 import * as Strings from "@mds/common/constants/strings";
 import DamsPage from "@mds/common/components/tailings/dam/DamsPage";
 import MineReportTable from "@/components/mine/Reports/MineReportTable";
@@ -62,7 +61,6 @@ export const MineTailingsInfoTabs: FC<MineTailingsInfoTabsProps> = (props) => {
   const mine: IMine = useAppSelector(getMineById(mineGuid));
 
   const mineReports: IMineReport[] = useAppSelector(getMineReports);
-  const mineReportDefinitionOptions = useAppSelector(getMineReportDefinitionOptions);
   const TSFOperatingStatusCodeHash = useAppSelector(getTSFOperatingStatusCodeOptionsHash);
   const consequenceClassificationStatusCodeHash = useAppSelector(getConsequenceClassificationStatusCodeOptionsHash);
   const itrbExemptionStatusCodeHash = useAppSelector(getITRBExemptionStatusCodeOptionsHash);
@@ -70,11 +68,9 @@ export const MineTailingsInfoTabs: FC<MineTailingsInfoTabsProps> = (props) => {
   const pageData = useAppSelector(getReportsPageData);
 
   const [isLoaded, setIsLoaded] = useState(false);
-  const reportDefinitionsLoaded = useAppSelector(getReportDefinitionsLoaded(reportParamsGetAll));
   const [params, setParams] = useState({ sort_field: "received_date", sort_dir: "desc" });
 
   const canEditTSF = useAppSelector(userHasRole(USER_ROLES.role_edit_tsf));
-
 
   const { isFeatureEnabled } = useFeatureFlag();
   const tsfV2Enabled = isFeatureEnabled(Feature.TSF_V2);
@@ -83,12 +79,6 @@ export const MineTailingsInfoTabs: FC<MineTailingsInfoTabsProps> = (props) => {
     dispatch(fetchMineReports(mineGuid, defaultParams.mineReportType)).then(() => {
       setIsLoaded(true);
     });
-  }, []);
-
-  useEffect(() => {
-    if (!reportDefinitionsLoaded) {
-      dispatch(fetchComplianceReports(reportParamsGetAll));
-    }
   }, []);
 
   const handleEditTailings = (values) => {
@@ -180,19 +170,6 @@ export const MineTailingsInfoTabs: FC<MineTailingsInfoTabsProps> = (props) => {
     }));
   };
 
-  const filteredReportDefinitionGuids =
-    mineReportDefinitionOptions?.filter((option) =>
-      option.categories.map((category) => category.mine_report_category).includes("TSF")
-    )
-      .map((definition) => definition.mine_report_definition_guid);
-
-  const filteredReports =
-    mineReports?.filter(
-      (report) =>
-        report.mine_report_definition_guid &&
-        filteredReportDefinitionGuids.includes(report.mine_report_definition_guid.toLowerCase())
-    );
-
   const tabItems = [
     {
       key: "tsfDetails",
@@ -238,7 +215,7 @@ export const MineTailingsInfoTabs: FC<MineTailingsInfoTabsProps> = (props) => {
         <br />
         <MineReportTable
           isLoaded={isLoaded}
-          mineReports={filteredReports}
+          mineReports={mineReports}
           handleRemoveReport={handleRemoveReport}
           handleTableChange={handleReportFilterSubmit}
           sortField={params.sort_field}


### PR DESCRIPTION
[MDS-6430](https://bcmines.atlassian.net/browse/MDS-6430)

Mine reports were filtered by mine report definitions with a category of "TSF", and the issue was that mine report definitions were not being loaded and therefore all the reports were getting filtered out.

Initially I fixed this with:
`  useEffect(() => {
    if (!reportDefinitionsLoaded) {
      dispatch(fetchComplianceReports(reportParamsGetAll));
    }
  }, []);
`
However, since we are now only fetching mine reports with a type of Strings.MINE_REPORTS_TYPE.tailingsReports I believe all this filtering logic is unnecessary,.

I don't fully understand the existing logic so please correct me this assumption is incorrect and I will revert back to my initial fix.
