### PR TITLE
[MDS-6423] Fix permit zap scan issues

### DIFF
--- a/services/permits/app/app.py
+++ b/services/permits/app/app.py
@@ -3,6 +3,7 @@ import os
 
 from fastapi import FastAPI
 
+from fastapi.middleware.cors import CORSMiddleware
 from .openid_connect_middleware import OpenIdConnectMiddleware
 from .pipelines.permit_condition_extraction.resources.permit_condition_resource import (
     router as permit_condition_router,
@@ -29,3 +30,17 @@ if DEBUG_MODE:
         os.makedirs("app/cache")
 
 mds.add_middleware(OpenIdConnectMiddleware)
+
+origins = [
+    "http://localhost:8004",
+    "http://localhost:80",
+    "https://*.apps.silver.devops.gov.bc.ca"
+]
+
+mds.add_middleware(
+    CORSMiddleware,
+    allow_origins=origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"]
+)

--- a/services/permits/app/app.py
+++ b/services/permits/app/app.py
@@ -5,6 +5,7 @@ from fastapi import FastAPI
 
 from fastapi.middleware.cors import CORSMiddleware
 from .openid_connect_middleware import OpenIdConnectMiddleware
+from .response_header_middleware import ResponseHeaderMiddleware
 from .pipelines.permit_condition_extraction.resources.permit_condition_resource import (
     router as permit_condition_router,
 )
@@ -14,6 +15,11 @@ from .pipelines.permit_condition_search.resources.permit_condition_search_resour
 
 DEBUG_MODE = os.environ.get("DEBUG_MODE", "False").lower() == "true"
 
+origins = [
+    "http://localhost:8004",
+    "http://localhost:80",
+    "https://*.apps.silver.devops.gov.bc.ca"
+]
 
 logging.basicConfig(
     format="%(asctime)s - %(levelname)s - %(message)s", level=logging.DEBUG
@@ -29,14 +35,8 @@ if DEBUG_MODE:
     if not os.path.exists("app/cache"):
         os.makedirs("app/cache")
 
+mds.add_middleware(ResponseHeaderMiddleware)
 mds.add_middleware(OpenIdConnectMiddleware)
-
-origins = [
-    "http://localhost:8004",
-    "http://localhost:80",
-    "https://*.apps.silver.devops.gov.bc.ca"
-]
-
 mds.add_middleware(
     CORSMiddleware,
     allow_origins=origins,

--- a/services/permits/app/openid_connect_middleware.py
+++ b/services/permits/app/openid_connect_middleware.py
@@ -10,7 +10,10 @@ class OpenIdConnectMiddleware(BaseHTTPMiddleware):
     ) -> JSONResponse:
         if request.url.path == "/docs" or request.url.path == "/openapi.json":
             # Allow swagger UI to load without auth
-            return await call_next(request)
+            response = await call_next(request)
+            headers = {"X-Content-Type-Options":"nosniff","Cross-Origin-Resource-Policy":"same-origin"}
+            response.headers.update(headers)
+            return response
 
         authorization = request.headers.get("Authorization")
         if not authorization:

--- a/services/permits/app/openid_connect_middleware.py
+++ b/services/permits/app/openid_connect_middleware.py
@@ -10,10 +10,7 @@ class OpenIdConnectMiddleware(BaseHTTPMiddleware):
     ) -> JSONResponse:
         if request.url.path == "/docs" or request.url.path == "/openapi.json":
             # Allow swagger UI to load without auth
-            response = await call_next(request)
-            headers = {"X-Content-Type-Options":"nosniff","Cross-Origin-Resource-Policy":"same-origin"}
-            response.headers.update(headers)
-            return response
+            return await call_next(request)
 
         authorization = request.headers.get("Authorization")
         if not authorization:

--- a/services/permits/app/response_header_middleware.py
+++ b/services/permits/app/response_header_middleware.py
@@ -1,0 +1,18 @@
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+
+
+class ResponseHeaderMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        response = await call_next(request)
+        
+        if request.url.path == "/openapi.json" or request.url.path == "/docs":
+            headers = {
+                "X-Content-Type-Options": "nosniff",
+                "Cross-Origin-Resource-Policy": "same-origin",
+                "Cache-Control": "public, max-age=3600, immutable",
+            }
+            response.headers.update(headers)
+        
+        return response


### PR DESCRIPTION
[MDS-6423](https://bcmines.atlassian.net/browse/MDS-6423)

The Zap scan has pointed out a few header issues with the permit service. These are limited in scope as it is not authenticated. This PR hopes to address a number of them, but as the behaviour seems to be different between running the zap scan locally and the action there may be additional changes in a follow up PR.

- Add CORS middleware for CORS headers when using a browser. (Not 100% sure if the origins are correct)
- Add a custom ResponseHeaderMiddleware to add additional headers to the /openapi.json endpoint.