### PR TITLE
[MDS-6164] Updated permit search prompt to match format required by Content Safety. Show LLM errors on frontend

### DIFF
--- a/services/common/src/redux/slices/permitSearchSlice.ts
+++ b/services/common/src/redux/slices/permitSearchSlice.ts
@@ -3,7 +3,7 @@ import { hideLoading, showLoading } from "react-redux-loading-bar";
 import { ENVIRONMENT } from "@mds/common/constants/environment";
 import { RootState } from "../rootState";
 import { createRequestHeader } from "../utils/RequestHeaders";
-import { ConditionOperator, Facet, FilterOperator, SearchQuery, SearchResult } from "@mds/common/interfaces/search/facet-search.interface";
+import { ConditionOperator, Facet, FilterOperator, HaystackPromptSearchResult, SearchQuery, SearchResult } from "@mds/common/interfaces/search/facet-search.interface";
 import { createEventSource } from 'eventsource-client'
 
 import * as API from "@mds/common/constants/API";
@@ -14,7 +14,8 @@ export enum SearchEventType {
     AI_START = 'ai_start',
     PROMPT = 'prompt',
     AI_COMPLETE = 'ai_complete',
-    COMPLETE = 'complete'
+    COMPLETE = 'complete',
+    ERROR = 'error',
 }
 
 export type PermitSearchFilters = Array<{ category: string; value: string }>;
@@ -59,7 +60,7 @@ const permitSearchSlice = createAppSlice({
 
             state.filters = existingFilters;
         }),
-        updatePromptResults: create.reducer((state, action: { payload: any }) => {
+        updatePromptResults: create.reducer((state, action: { payload: HaystackPromptSearchResult }) => {
             if (state.results) {
                 state.results.prompt = action.payload;
             }
@@ -148,6 +149,11 @@ const permitSearchSlice = createAppSlice({
                                     thunkApi.dispatch(updatePromptResults(payload));
                                     break;
                                 case SearchEventType.AI_COMPLETE:
+                                    thunkApi.dispatch(setAiLoading(false));
+                                    break;
+                                case SearchEventType.ERROR:
+                                    thunkApi.dispatch(updatePromptResults({ answers: [payload.message] }));
+                                    thunkApi.dispatch(setDocumentLoading(false));
                                     thunkApi.dispatch(setAiLoading(false));
                                     break;
                             }

--- a/services/permits/app/permit_condition_prompts.yaml
+++ b/services/permits/app/permit_condition_prompts.yaml
@@ -1,65 +1,68 @@
 system_prompt: |
   You are a helpful AI assistant that answer questions about paragraphs in a mining permit. You answer exactly what is asked for and return it in a json format.
 
-permit_condition_search_prompt: |
-  You are an expert assistant that helps users retrieve and reason about permit conditions in the mining industry. When answering questions, use only the information provided in the sources and cite them using square brackets with the prefix "doc" (e.g., [doc:1]).
+permit_condition_search_prompt:
+  system: You are an expert assistant that helps users retrieve and reason about permit conditions in the mining industry.
+  user: |
+    When answering questions, use only the information provided in the sources and cite them using square brackets with the prefix "doc" (e.g., [doc:1]).
 
-  Follow these guidelines:
-  1. Focus on directly answering the user's question using the most relevant permit conditions
-  2. Use context from parent, sibling, or child conditions only when it helps clarify the meaning or implications of the main condition
-  3. If a report requirement exists, mention it as it's an important compliance requirement
-  4. Present information in a clear, concise manner
-  5. Use Markdown blockquotes (>) for direct quotes from permit conditions
-  6. Always maintain the exact wording from the source documents
-  7. If you're unsure or the information isn't in the sources, say so
-  8. Wherever possible, provide the information itself such that the full permit condition is shown as a direct quote
-  9. Output the results as markdown, with appropriate headings.
+    Follow these guidelines:
+    1. Focus on directly answering the user's question using the most relevant permit conditions
+    2. Use context from parent, sibling, or child conditions only when it helps clarify the meaning or implications of the main condition
+    3. If a report requirement exists, mention it as it's an important compliance requirement
+    4. Present information in a clear, concise manner
+    5. Use Markdown blockquotes (>) for direct quotes from permit conditions
+    6. Always maintain the exact wording from the source documents
+    7. If you're unsure or the information isn't in the sources, say so
+    8. Wherever possible, provide the information itself such that the full permit condition is shown as a direct quote
+    9. Output the results as markdown, with appropriate headings.
 
-  Sources:
-  {% for document in documents %}
-      ID: {{ document.id }}
-      {% if document.meta.report_name %}
-      Report Required: {{ document.meta.report_name }}
-      {% endif %}
-      
-      Main Condition:
-      > {{ document.content }}
-      
-      {% if document.meta.context %}
-          {# Only include context if it adds value to understanding the condition #}
-          {% if document.meta.context.parent_contexts %}
-              {% for level_num in range(1, document.meta.context.parent_contexts|length + 1) %}
-                  {% set level = document.meta.context.parent_contexts["level_" ~ level_num] %}
-                  {% if level.content and level.content|length > 0 %}
-      Related Context:
-      > {{ level.content }}
-                  {% endif %}
-              {% endfor %}
-          {% endif %}
+    Question: {{question}}
 
-          {# Include children/siblings only if they provide essential context #}
-          {% if document.meta.context.child_contexts or document.meta.context.sibling_contexts %}
-      Additional Context:
-              {% if document.meta.context.sibling_contexts.previous %}
-                  {% for sibling in document.meta.context.sibling_contexts.previous %}
-      > {{ sibling.content }}
-                  {% endfor %}
-              {% endif %}
-              {% if document.meta.context.sibling_contexts.next %}
-                  {% for sibling in document.meta.context.sibling_contexts.next %}
-      > {{ sibling.content }}
-                  {% endfor %}
-              {% endif %}
-              {% if document.meta.context.child_contexts %}
-                  {% for child in document.meta.context.child_contexts %}
-      > {{ child.content }}
-                  {% endfor %}
-              {% endif %}
-          {% endif %}
-      {% endif %}
-  {% endfor %}
-                      
-  Question: {{question}}
+    """ <documents>
+    {% for document in documents %}
+        ID: {{ document.id }}
+        {% if document.meta.report_name %}
+        Report Required: {{ document.meta.report_name | tojson}}
+        {% endif %}
+
+        Main Condition:
+        > {{ document.content | tojson}}
+        
+        {% if document.meta.context %}
+            {# Only include context if it adds value to understanding the condition #}
+            {% if document.meta.context.parent_contexts %}
+                {% for level_num in range(1, document.meta.context.parent_contexts|length + 1) %}
+                    {% set level = document.meta.context.parent_contexts["level_" ~ level_num] %}
+                    {% if level.content and level.content|length > 0 %}
+        Related Context:
+        > {{ level.content | tojson}}
+                    {% endif %}
+                {% endfor %}
+            {% endif %}
+
+            {# Include children/siblings only if they provide essential context #}
+            {% if document.meta.context.child_contexts or document.meta.context.sibling_contexts %}
+        Additional Context:
+                {% if document.meta.context.sibling_contexts.previous %}
+                    {% for sibling in document.meta.context.sibling_contexts.previous %}
+        > {{ sibling.content | tojson}}
+                    {% endfor %}
+                {% endif %}
+                {% if document.meta.context.sibling_contexts.next %}
+                    {% for sibling in document.meta.context.sibling_contexts.next %}
+        > {{ sibling.content | tojson}}
+                    {% endfor %}
+                {% endif %}
+                {% if document.meta.context.child_contexts %}
+                    {% for child in document.meta.context.child_contexts %}
+        > {{ child.content | tojson}}
+                    {% endfor %}
+                {% endif %}
+            {% endif %}
+        {% endif %}
+    {% endfor %}
+    </documents> """
 
 permit_document_prompt_meta_questions: |
   -----------

--- a/services/permits/app/pipelines/permit_condition_search/permit_condition_search_pipeline.py
+++ b/services/permits/app/pipelines/permit_condition_search/permit_condition_search_pipeline.py
@@ -20,9 +20,13 @@ from app.pipelines.permit_condition_search.stores.ai_search_document_store impor
 )
 from azure.search.documents.indexes.models import VectorSearch
 from haystack import AsyncPipeline, Pipeline
-from haystack.components.builders import PromptBuilder
+from haystack.components.builders import ChatPromptBuilder, PromptBuilder
 from haystack.components.embedders import AzureOpenAITextEmbedder
+from haystack.components.extractors.llm_metadata_extractor import (
+    AzureOpenAIChatGenerator,
+)
 from haystack.components.generators import AzureOpenAIGenerator
+from haystack.dataclasses import ChatMessage
 from haystack_integrations.components.retrievers.azure_ai_search import (
     AzureAISearchHybridRetriever,
 )
@@ -153,9 +157,12 @@ def create_permit_condition_search_retrieval_pipeline():
     context_enricher = ContextEnricher(document_store=azure_search_document_store)
 
     search_template = prompts.get("permit_condition_search_prompt")
-    prompt_builder = PromptBuilder(template=search_template)
+    prompt_builder = ChatPromptBuilder(template=[
+        ChatMessage.from_system(search_template.get("system")),
+        ChatMessage.from_user(search_template.get("user")),
+    ])
 
-    llm = AzureOpenAIGenerator(
+    llm = AzureOpenAIChatGenerator(
         azure_endpoint=config.openai.endpoint,
         azure_deployment=config.openai.deployment_name,
         api_key=config.openai.api_key,

--- a/services/permits/app/pipelines/permit_condition_search/resources/permit_condition_search_resource.py
+++ b/services/permits/app/pipelines/permit_condition_search/resources/permit_condition_search_resource.py
@@ -75,7 +75,6 @@ async def index_permit_conditions(file: UploadFile = File(...)) -> IndexingRespo
 async def search_permit_conditions_endpoint(params: SearchParams) -> EventSourceResponse:
     """Search permit conditions and stream results."""
     logger.info(f"Received search request: {params.query}")
-    ServerSentEvent()
     return EventSourceResponse(
         stream_search_results(params),
         media_type="text/event-stream",
@@ -161,8 +160,8 @@ async def _process_documents(documents):
 
 async def _process_llm_output(replies: list[ChatMessage]):
     """Process LLM replies."""
+    print(replies)
     for reply in replies:
-        logger.info(f"LLM reply: {str(reply.meta)}")
         yield _format_event("prompt", {"answers": [reply.text]})
     yield _format_event("ai_complete", {})
 

--- a/services/permits/app/pipelines/permit_condition_search/resources/permit_condition_search_resource.py
+++ b/services/permits/app/pipelines/permit_condition_search/resources/permit_condition_search_resource.py
@@ -14,6 +14,8 @@ from app.pipelines.permit_condition_search.permit_condition_search_pipeline impo
     permit_condition_search_retrieval_pipeline,
 )
 from fastapi import APIRouter, File, HTTPException, UploadFile
+from haystack.dataclasses import ChatMessage
+from openai import BadRequestError
 from sse_starlette import ServerSentEvent
 from sse_starlette.sse import EventSourceResponse
 
@@ -120,9 +122,16 @@ async def stream_search_results(params: SearchParams) -> AsyncIterator[ServerSen
             if "llm" in partial_output:
                 async for event in _process_llm_output(partial_output["llm"]["replies"]):
                     yield event
+    except BadRequestError as e:
+        logger.info(f"Error during search: {str(e)}")
+
+        err = e.response.json() or {}
+        message = err.get('error', {}).get('message', 'Search failed. Please try again.')
+        yield _format_event("error", {"message": message})
+
     except Exception as e:
         logger.exception(f"Error during search: {str(e)}")
-        yield _format_event("error", {"message": f"Search failed: {str(e)}"})
+        yield _format_event("error", {"message": "Search failed. Please try again."})
 
 
 async def _process_documents(documents):
@@ -150,10 +159,11 @@ async def _process_documents(documents):
     yield _format_event("ai_start", {})
 
 
-async def _process_llm_output(replies):
+async def _process_llm_output(replies: list[ChatMessage]):
     """Process LLM replies."""
     for reply in replies:
-        yield _format_event("prompt", {"answers": [reply]})
+        logger.info(f"LLM reply: {str(reply.meta)}")
+        yield _format_event("prompt", {"answers": [reply.text]})
     yield _format_event("ai_complete", {})
 
 

--- a/services/permits/tests/test_permit_condition_search_pipeline.py
+++ b/services/permits/tests/test_permit_condition_search_pipeline.py
@@ -26,7 +26,6 @@ def mock_components():
     AzureOpenAITextEmbedder.__init__ = MagicMock(return_value=None)
     AzureOpenAIChatGenerator.__init__ = MagicMock(return_value=None)
     AzureAISearchHybridRetriever.__init__ = MagicMock(return_value=None)
-    ChatPromptBuilder.__init__ = MagicMock(return_value=None)
     AzureDocumentIntelligenceConverter.__init__ = MagicMock(return_value=None)
     AzureBlobUploader.__init__ = MagicMock(return_value=None)
 
@@ -37,7 +36,8 @@ def test_create_permit_condition_search_retrieval_pipeline_returns_pipeline(mock
 def test_indexing_pipeline_validates(mock_components):
     pipeline = create_permit_condition_search_retrieval_pipeline()
     try:
-        pipeline._validate_input({"text_embedder": {"text": "test query"}, "retriever": {"query": "test query"}})
+        query = "test query"
+        pipeline._validate_input({"text_embedder": {"text": query}, "retriever": {"query": query}, "prompt_builder": {"question": query}})
 
     except Exception as e:
         pytest.fail(f"Pipeline validation failed with error: {str(e)}")

--- a/services/permits/tests/test_permit_condition_search_resource.py
+++ b/services/permits/tests/test_permit_condition_search_resource.py
@@ -13,6 +13,8 @@ from app.pipelines.permit_condition_search.resources.permit_condition_search_res
     stream_search_results,
 )
 from fastapi import HTTPException, UploadFile
+from haystack import Document
+from haystack.dataclasses import ChatMessage
 from sse_starlette import ServerSentEvent
 
 
@@ -199,15 +201,15 @@ class TestPermitConditionSearchResource:
     async def test_stream_search_results_success(self, mock_retrieval_pipeline):
         search_params = SearchParams(query="mining permit", filters={})
         
-        mock_document = MagicMock()
+        mock_document = MagicMock(spec=Document)
         mock_document.id = "doc1"
-        mock_document.content = "Sample content"
+        mock_document.content = "This is a sample document content."
         mock_document.meta = {"key": "value"}
         mock_document.score = 0.95
         
         async def mock_generator(data, include_outputs_from):
             yield {"context_enricher": {"documents": [mock_document]}}
-            yield {"llm": {"replies": ["This is a generated answer"]}}
+            yield {"llm": {"replies": [ChatMessage.from_system("This is a generated answer")]}}
         
         mock_retrieval_pipeline.run_async_generator.return_value = mock_generator({}, {})
         


### PR DESCRIPTION
## Objective 

[MDS-6164](https://bcmines.atlassian.net/browse/MDS-6164)

Updates prompts used for permit condition search to match a format required for Azure AI Content Safety to apply. https://azure.microsoft.com/en-us/products/ai-services/ai-content-safety

The model itself has been updated with automatic detection of jailbreak and indirect prompt attacks (prompt shield).
![image](https://github.com/user-attachments/assets/ae2a19c3-7209-4bf9-9df4-5f4713255771)

**Examples**

Prompt injection provided by user:
![image](https://github.com/user-attachments/assets/d2ccd150-b24c-473e-9c17-0f39e54aa4db)

Indirect attack - if something malicious had already made it into the search index:
![image](https://github.com/user-attachments/assets/e4a00058-2112-4931-a801-6bf316da6e5f)

Indirect attack - permit contains malicious clause:

![image](https://github.com/user-attachments/assets/314c08e8-fab2-421a-8e30-5dcffb2bdf15)
![image](https://github.com/user-attachments/assets/4e29c709-57a6-44ff-864a-94ad32a49c0e)

