### PR TITLE
[MDS-6500] Restore historical tables on TSF EORs and QPs

### DIFF
--- a/services/common/src/components/tailings/TailingsSummaryPage.tsx
+++ b/services/common/src/components/tailings/TailingsSummaryPage.tsx
@@ -5,9 +5,7 @@ import {
   addPartyRelationship,
   fetchPartyRelationships,
 } from "@mds/common/redux/actionCreators/partiesActionCreator";
-import {
-  fetchMineRecordById,
-} from "@mds/common/redux/actionCreators/mineActionCreator";
+import { fetchMineRecordById } from "@mds/common/redux/actionCreators/mineActionCreator";
 import {
   createTailingsStorageFacility,
   fetchTailingsStorageFacility,
@@ -24,10 +22,7 @@ import { getMineById } from "@mds/common/redux/selectors/mineSelectors";
 import EngineerOfRecord from "./EngineerOfRecord";
 import QualifiedPerson from "./QualifiedPerson";
 import AssociatedDams from "./AssociatedDams";
-import {
-  getEngineersOfRecord,
-  getQualifiedPersons,
-} from "@mds/common/redux/selectors/partiesSelectors";
+import { getMatchingPartyRelationships } from "@mds/common/redux/selectors/partiesSelectors";
 import {
   ICreateTailingsStorageFacility,
   IMine,
@@ -63,8 +58,8 @@ export const TailingsSummaryPage: FC = () => {
   const isCore = useAppSelector(getIsCore);
   const coreCanEditTsf = useAppSelector(userHasRole(USER_ROLES.role_edit_tsf));
   const isFormDirty = useAppSelector(isDirty(formName));
-  const engineers_of_record = useAppSelector(getEngineersOfRecord);
-  const qualified_persons = useAppSelector(getQualifiedPersons);
+  const engineers_of_record = useAppSelector(getMatchingPartyRelationships("EOR", tsfGuid));
+  const qualified_persons = useAppSelector(getMatchingPartyRelationships("TQP", tsfGuid));
   const initialValues = {
     ...tsf,
     mine_guid: mineGuid,
@@ -117,7 +112,7 @@ export const TailingsSummaryPage: FC = () => {
       const payload = {
         mine_tailings_storage_facility_guid: tsfGuid,
         mine_guid: mineGuid,
-        ...submitValues
+        ...submitValues,
       };
       const resp = await dispatch(updateTailingsStorageFacility(payload));
       if (!isCore && resp?.payload) {
@@ -152,7 +147,10 @@ export const TailingsSummaryPage: FC = () => {
           }
         } else {
           const resp = await dispatch(
-            createTailingsStorageFacility({ mine_guid: mineGuid, ...values } as ICreateTailingsStorageFacility)
+            createTailingsStorageFacility({
+              mine_guid: mineGuid,
+              ...values,
+            } as ICreateTailingsStorageFacility)
           );
           newTsf = resp?.payload;
         }
@@ -188,7 +186,7 @@ export const TailingsSummaryPage: FC = () => {
                 start_date: values[attr].start_date,
                 end_date: values[attr].end_date,
                 end_current: true,
-                is_draft: tsf.is_draft
+                is_draft: tsf.is_draft,
               },
               successMessage
             )
@@ -258,7 +256,13 @@ export const TailingsSummaryPage: FC = () => {
               title="You have unsaved changes. Are you sure you want to leave this page?"
               onConfirm={() => history.push(GLOBAL_ROUTES?.MINE_TAILINGS.dynamicRoute(mineGuid))}
             >
-              <LinkButton onClick={disablePopConfirm ? () => history.push(GLOBAL_ROUTES?.MINE_TAILINGS.dynamicRoute(mineGuid)) : undefined}>
+              <LinkButton
+                onClick={
+                  disablePopConfirm
+                    ? () => history.push(GLOBAL_ROUTES?.MINE_TAILINGS.dynamicRoute(mineGuid))
+                    : undefined
+                }
+              >
                 <ArrowLeftOutlined className="padding-sm--right" />
                 {`Back to: ${mineName} Tailings`}
               </LinkButton>

--- a/services/common/src/redux/reducers/partiesReducer.ts
+++ b/services/common/src/redux/reducers/partiesReducer.ts
@@ -1,4 +1,3 @@
-import { uniqBy } from "lodash";
 import * as actionTypes from "@mds/common/constants/actionTypes";
 import { PARTIES } from "@mds/common/constants/reducerTypes";
 import { createItemMap, createItemIdsArray } from "../utils/helpers";
@@ -67,31 +66,9 @@ export const partiesReducer = (state = initialState, action) => {
         partyIds: createItemIdsArray([action.payload], "party_guid"),
       };
     case actionTypes.STORE_PARTY_RELATIONSHIPS: {
-      const tsfGuid = action.mine_tailings_storage_facility_guid;
-      const eors = action.payload
-        .filter((p) => p.mine_party_appt_type_code === "EOR")
-        .map((p) => ({
-          value: p.party_guid,
-          label: p.party?.name,
-        }));
-
-      const eorRecords = tsfGuid
-        ? action.payload.filter(
-            (p) => p.mine_party_appt_type_code === "EOR" && p.related_guid === tsfGuid
-          )
-        : [];
-      const tqpRecords = tsfGuid
-        ? action.payload.filter(
-            (p) => p.mine_party_appt_type_code === "TQP" && p.related_guid === tsfGuid
-          )
-        : [];
-
       return {
         ...state,
         partyRelationships: action.payload,
-        engineersOfRecord: tsfGuid ? eorRecords : state.engineersOfRecord,
-        qualifiedPersons: tsfGuid ? tqpRecords : state.qualifiedPersons,
-        engineersOfRecordOptions: uniqBy(eors, "value"),
       };
     }
     case actionTypes.STORE_ALL_PARTY_RELATIONSHIPS:
@@ -140,8 +117,5 @@ export const getAddPartyFormState = (state: RootState) => state[PARTIES].addPart
 export const getLastCreatedParty = (state: RootState) => state[PARTIES].lastCreatedParty;
 export const getInspectors = (state: RootState) => state[PARTIES].inspectors;
 export const getProjectLeads = (state: RootState) => state[PARTIES].projectLeads;
-export const getEngineersOfRecordOptions = (state: RootState) =>
-  state[PARTIES].engineersOfRecordOptions;
-export const getEngineersOfRecord = (state: RootState) => state[PARTIES].engineersOfRecord;
-export const getQualifiedPersons = (state: RootState) => state[PARTIES].qualifiedPersons;
+
 export default partiesReducerObject;

--- a/services/common/src/redux/selectors/partiesSelectors.js
+++ b/services/common/src/redux/selectors/partiesSelectors.js
@@ -15,9 +15,6 @@ export const {
   getInspectors,
   getProjectLeads,
   getAllPartyRelationships,
-  getEngineersOfRecordOptions,
-  getEngineersOfRecord,
-  getQualifiedPersons,
 } = partiesReducer;
 
 export const getSummaryPartyRelationships = createSelector(


### PR DESCRIPTION
## Objective 

The previous method with which historical EORs and QPs were retrieved had been adjusted to allow selection of EORs and QPs from other TSFs on the same mine.  As a result they weren't being populated for the table.

- Updated to use a selector to fetch the relevent entries.
- Removed the old methods as they were not being used elsewhere.

[MDS-6500](https://bcmines.atlassian.net/browse/MDS-6500)

<img width="1281" alt="image" src="https://github.com/user-attachments/assets/aa148105-a249-479f-a08d-2180f3853c50" />
