### PR TITLE
[MDS-6505] Can't click Submit Report button on MS

### DIFF
--- a/services/minespace-web/src/constants/routes.ts
+++ b/services/minespace-web/src/constants/routes.ts
@@ -212,9 +212,9 @@ const getQueryString = (filterParams?) => {
 };
 
 export const MINE_DASHBOARD = {
-  route: "/mines/:id/:activeTab/:subTab?",
+  route: "/mines/:id/dashboard/:activeTab/:subTab?",
   dynamicRoute: (id, activeTab = "overview", subTab?, filterParams?: any) =>
-    `/mines/${id}/${activeTab}${subTab ? `/${subTab}` : ""}${getQueryString(filterParams)}`,
+    `/mines/${id}/dashboard/${activeTab}${subTab ? `/${subTab}` : ""}${getQueryString(filterParams)}`,
   component: MineDashboard,
   helpKey: "Mine-Dashboard",
 };

--- a/services/minespace-web/src/tests/components/dashboard/mine/__snapshots__/MineDashboard.spec.tsx.snap
+++ b/services/minespace-web/src/tests/components/dashboard/mine/__snapshots__/MineDashboard.spec.tsx.snap
@@ -38,7 +38,7 @@ exports[`MineDashboard renders properly 1`] = `
         <li
           class="ant-menu-item ant-menu-item-selected"
           data-menu-id="rc-menu-uuid-test-overview"
-          path="/mines/18133c75-49ad-4101-85f3-a43e35ae989a/overview"
+          path="/mines/18133c75-49ad-4101-85f3-a43e35ae989a/dashboard/overview"
           role="menuitem"
           tabindex="-1"
         >
@@ -67,7 +67,7 @@ exports[`MineDashboard renders properly 1`] = `
         <li
           class="ant-menu-item"
           data-menu-id="rc-menu-uuid-test-applications"
-          path="/mines/18133c75-49ad-4101-85f3-a43e35ae989a/applications"
+          path="/mines/18133c75-49ad-4101-85f3-a43e35ae989a/dashboard/applications"
           role="menuitem"
           tabindex="-1"
         >
@@ -96,7 +96,7 @@ exports[`MineDashboard renders properly 1`] = `
         <li
           class="ant-menu-item"
           data-menu-id="rc-menu-uuid-test-permits"
-          path="/mines/18133c75-49ad-4101-85f3-a43e35ae989a/permits"
+          path="/mines/18133c75-49ad-4101-85f3-a43e35ae989a/dashboard/permits"
           role="menuitem"
           tabindex="-1"
         >
@@ -125,7 +125,7 @@ exports[`MineDashboard renders properly 1`] = `
         <li
           class="ant-menu-item"
           data-menu-id="rc-menu-uuid-test-inspections"
-          path="/mines/18133c75-49ad-4101-85f3-a43e35ae989a/inspections"
+          path="/mines/18133c75-49ad-4101-85f3-a43e35ae989a/dashboard/inspections"
           role="menuitem"
           tabindex="-1"
         >
@@ -154,7 +154,7 @@ exports[`MineDashboard renders properly 1`] = `
         <li
           class="ant-menu-item"
           data-menu-id="rc-menu-uuid-test-reports"
-          path="/mines/18133c75-49ad-4101-85f3-a43e35ae989a/reports"
+          path="/mines/18133c75-49ad-4101-85f3-a43e35ae989a/dashboard/reports"
           role="menuitem"
           tabindex="-1"
         >
@@ -183,7 +183,7 @@ exports[`MineDashboard renders properly 1`] = `
         <li
           class="ant-menu-item"
           data-menu-id="rc-menu-uuid-test-incidents"
-          path="/mines/18133c75-49ad-4101-85f3-a43e35ae989a/incidents"
+          path="/mines/18133c75-49ad-4101-85f3-a43e35ae989a/dashboard/incidents"
           role="menuitem"
           tabindex="-1"
         >
@@ -212,7 +212,7 @@ exports[`MineDashboard renders properly 1`] = `
         <li
           class="ant-menu-item"
           data-menu-id="rc-menu-uuid-test-nods"
-          path="/mines/18133c75-49ad-4101-85f3-a43e35ae989a/nods"
+          path="/mines/18133c75-49ad-4101-85f3-a43e35ae989a/dashboard/nods"
           role="menuitem"
           tabindex="-1"
         >
@@ -241,7 +241,7 @@ exports[`MineDashboard renders properly 1`] = `
         <li
           class="ant-menu-item"
           data-menu-id="rc-menu-uuid-test-variances"
-          path="/mines/18133c75-49ad-4101-85f3-a43e35ae989a/variances"
+          path="/mines/18133c75-49ad-4101-85f3-a43e35ae989a/dashboard/variances"
           role="menuitem"
           tabindex="-1"
         >
@@ -270,7 +270,7 @@ exports[`MineDashboard renders properly 1`] = `
         <li
           class="ant-menu-item"
           data-menu-id="rc-menu-uuid-test-bonds"
-          path="/mines/18133c75-49ad-4101-85f3-a43e35ae989a/bonds"
+          path="/mines/18133c75-49ad-4101-85f3-a43e35ae989a/dashboard/bonds"
           role="menuitem"
           tabindex="-1"
         >
@@ -299,7 +299,7 @@ exports[`MineDashboard renders properly 1`] = `
         <li
           class="ant-menu-item"
           data-menu-id="rc-menu-uuid-test-tailings"
-          path="/mines/18133c75-49ad-4101-85f3-a43e35ae989a/tailings"
+          path="/mines/18133c75-49ad-4101-85f3-a43e35ae989a/dashboard/tailings"
           role="menuitem"
           tabindex="-1"
         >

--- a/services/minespace-web/src/tests/components/dashboard/mine/tailings/__snapshots__/TailingsSubmitSuccess.spec.tsx.snap
+++ b/services/minespace-web/src/tests/components/dashboard/mine/tailings/__snapshots__/TailingsSubmitSuccess.spec.tsx.snap
@@ -114,7 +114,7 @@ exports[`TailingsSubmitSuccess renders properly 1`] = `
       >
         <a
           class="ant-btn ant-btn-default"
-          href="/mines/18133c75-49ad-4101-85f3-a43e35ae989a/reports"
+          href="/mines/18133c75-49ad-4101-85f3-a43e35ae989a/dashboard/reports"
         >
           <span>
             Submit Written Acknowledgement in Reports

--- a/services/minespace-web/src/tests/components/incident/__snapshots__/IncidentSuccessPage.spec.js.snap
+++ b/services/minespace-web/src/tests/components/incident/__snapshots__/IncidentSuccessPage.spec.js.snap
@@ -16,7 +16,7 @@ exports[`IncidentSuccessPage renders properly 1`] = `
       span={24}
     >
       <Link
-        to="/mines/undefined/incidents"
+        to="/mines/undefined/dashboard/incidents"
       >
         <ForwardRef(ArrowLeftOutlined)
           className="padding-sm--right"
@@ -70,7 +70,7 @@ exports[`IncidentSuccessPage renders properly 1`] = `
         <div>
           <p>
             <Link
-              to="/mines/undefined/incidents"
+              to="/mines/undefined/dashboard/incidents"
             >
               <Button
                 type="primary"

--- a/services/minespace-web/src/tests/routes/__snapshots__/Routes.spec.js.snap
+++ b/services/minespace-web/src/tests/routes/__snapshots__/Routes.spec.js.snap
@@ -39,7 +39,7 @@ exports[`PrivateRoutes  renders properly 1`] = `
         }
       }
       exact={true}
-      path="/mines/:id/:activeTab/:subTab?"
+      path="/mines/:id/dashboard/:activeTab/:subTab?"
     />
     <Route
       component={[Function]}


### PR DESCRIPTION
## Objective 
- same for incidents
- problem was that "reports/new" was getting read as ":activeTab/:subTab"
- so put the word "dashboard" in dashboard routes to prevent overlaps from happening

[MDS-6505](https://bcmines.atlassian.net/browse/MDS-6505)

_Why are you making this change? Provide a short explanation and/or screenshots_
