### PR TITLE
[MDS-6505] Mine Dashboard navigation - tailings page

### DIFF
--- a/services/minespace-web/src/constants/routes.ts
+++ b/services/minespace-web/src/constants/routes.ts
@@ -220,10 +220,11 @@ export const MINE_DASHBOARD = {
 };
 
 export const MINE_TAILINGS = {
-  route: "/mines/:id/:tailings",
-  dynamicRoute: (id, filterParams?: any) => `/mines/${id}/tailings${getQueryString(filterParams)}`,
-  component: MineDashboard,
-  helpKey: "Mine-Dashboard",
+  route: MINE_DASHBOARD.route,
+  dynamicRoute: (id, filterParams?: any) =>
+    MINE_DASHBOARD.dynamicRoute(id, "tailings", null, filterParams),
+  component: MINE_DASHBOARD.component,
+  helpKey: MINE_DASHBOARD.helpKey,
 };
 
 export const ADD_TAILINGS_STORAGE_FACILITY = {

--- a/services/minespace-web/src/tests/components/dashboard/mine/tailings/__snapshots__/TailingsSubmitSuccess.spec.tsx.snap
+++ b/services/minespace-web/src/tests/components/dashboard/mine/tailings/__snapshots__/TailingsSubmitSuccess.spec.tsx.snap
@@ -19,7 +19,7 @@ exports[`TailingsSubmitSuccess renders properly 1`] = `
         class="ant-col ant-col-24"
       >
         <a
-          href="/mines/18133c75-49ad-4101-85f3-a43e35ae989a/tailings"
+          href="/mines/18133c75-49ad-4101-85f3-a43e35ae989a/dashboard/tailings"
         >
           <span
             aria-label="arrow-left"
@@ -101,7 +101,7 @@ exports[`TailingsSubmitSuccess renders properly 1`] = `
       >
         <a
           class="ant-btn ant-btn-primary"
-          href="/mines/18133c75-49ad-4101-85f3-a43e35ae989a/tailings"
+          href="/mines/18133c75-49ad-4101-85f3-a43e35ae989a/dashboard/tailings"
         >
           <span>
             Back to Tailings and Dams


### PR DESCRIPTION
## Objective 
- the MINE_TAILINGS route was basically a copy of the MINE_DASHBOARD route to be used in common components
- failed to update it.
- Now it copies MINE_DASHBOARD pretty explicitly

[MDS-6505](https://bcmines.atlassian.net/browse/MDS-6505)

_Why are you making this change? Provide a short explanation and/or screenshots_
