### PR TITLE
[MDS-6476] Allow duplicate report definition names

### DIFF
--- a/migrations/sql/V2025.04.30.11.25__remove_duplicate_report_definition_name_constraint.sql
+++ b/migrations/sql/V2025.04.30.11.25__remove_duplicate_report_definition_name_constraint.sql
@@ -1,0 +1,5 @@
+ALTER TABLE mine_report_definition
+    DROP CONSTRAINT mine_report_definition_report_name_unique;
+
+ALTER TABLE mine_report_definition
+    DROP CONSTRAINT uq_report_name;

--- a/services/core-api/app/api/mines/reports/models/mine_report_definition.py
+++ b/services/core-api/app/api/mines/reports/models/mine_report_definition.py
@@ -72,11 +72,6 @@ class MineReportDefinition(Base, AuditMixin):
         if not mine_report_due_date_type:
             raise BadRequest('Mine Report Due Date Type not found.')
 
-        # Check if a report with the same name already exists
-        existing_report = cls.query.filter_by(report_name=report_name).first()
-        if existing_report:
-            raise BadRequest(f"A report with the name '{report_name}' already exists.")
-
         is_prr_only = True if report_type == 'PRR' else False
 
         mine_report_definition = cls(report_name=report_name,

--- a/services/core-api/tests/reports/resource/test_mine_report_definition_list_resource.py
+++ b/services/core-api/tests/reports/resource/test_mine_report_definition_list_resource.py
@@ -343,26 +343,3 @@ def test_post_mine_report_definition_missing_required_fields(test_client, auth_h
     # Assertions
     assert post_resp.status_code == 400
     assert "Input payload validation failed" in post_data['message']
-
-
-def test_post_mine_report_definition_duplicate_report_name(test_client, db_session, auth_headers):
-    mine_report_definition = db_session.query(MineReportDefinition).first()
-
-    request_data = {
-        "report_name": mine_report_definition.report_name,
-        "description": "This is a test description for the report.",
-        "mine_report_due_date_type_code": 'ANV',
-        "mine_report_due_date_period_months": 12,
-        "report_type": "CRR",
-        "is_common": False
-    }
-
-    post_resp = test_client.post(
-        '/mines/reports/definitions',
-        headers=auth_headers['core_edit_code'],
-        json=request_data
-    )
-
-    # Assertions
-    assert post_resp.status_code == 400
-


### PR DESCRIPTION
## Objective 

The inability to create report definitions using existing names, was causing issues when creating a new version of an expired report.
Removed the API check for this as well as two db constraints that did the same thing.
Removed test asserting the blocking of duplicate names

[MDS-6476](https://bcmines.atlassian.net/browse/MDS-6476)
