### PR TITLE
[MDS-6513] Minor python version bump

### DIFF
--- a/services/core-api/Dockerfile
+++ b/services/core-api/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11.11-slim
+FROM python:3.11.12-slim
 
 WORKDIR /app
 

--- a/services/core-api/Dockerfile.ci
+++ b/services/core-api/Dockerfile.ci
@@ -1,4 +1,4 @@
-FROM python:3.11.11-slim
+FROM python:3.11.12-slim
 
 WORKDIR /app
 

--- a/services/document-manager/backend/Dockerfile
+++ b/services/document-manager/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12.8-bookworm
+FROM python:3.12.10-bookworm
 
 # Create working directory
 WORKDIR /app

--- a/services/document-manager/backend/Dockerfile.ci
+++ b/services/document-manager/backend/Dockerfile.ci
@@ -1,4 +1,4 @@
-FROM python:3.12.8-bookworm
+FROM python:3.12.10-bookworm
 
 # Create working directory
 WORKDIR /app

--- a/services/document-manager/backend/Dockerfile.migrate
+++ b/services/document-manager/backend/Dockerfile.migrate
@@ -1,4 +1,4 @@
-FROM python:3.12.8-bookworm
+FROM python:3.12.10-bookworm
 
 # Update installation utility
 RUN apt-get update

--- a/services/nris-api/backend/Dockerfile
+++ b/services/nris-api/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12.8-bookworm
+FROM python:3.12.10-bookworm
 
 ENV LD_LIBRARY_PATH="/opt/oracle/instantclient:${LD_LIBRARY_PATH}" \
     PATH="/opt/oracle/instantclient:${PATH}" \

--- a/services/nris-api/backend/Dockerfile.ci
+++ b/services/nris-api/backend/Dockerfile.ci
@@ -1,4 +1,4 @@
-FROM python:3.12.8-bookworm
+FROM python:3.12.10-bookworm
 
 ENV LD_LIBRARY_PATH="/opt/oracle/instantclient:${LD_LIBRARY_PATH}" \
     PATH="/opt/oracle/instantclient:${PATH}" \

--- a/services/nris-api/backend/Dockerfile.migrate
+++ b/services/nris-api/backend/Dockerfile.migrate
@@ -1,4 +1,4 @@
-FROM python:3.12.8-bookworm
+FROM python:3.12.10-bookworm
 
 # Create working directory
 RUN mkdir /app


### PR DESCRIPTION
## Objective 

[MDS-6513](https://bcmines.atlassian.net/browse/MDS-6513)

Instead of jumping a major python version to 3.13.3, update core to 3.11.12 and others to 3.12.10