### PR TITLE
[MDS-6483] Update AMS auth address formation and field name

### DIFF
--- a/services/core-api/app/api/services/ams_api_service.py
+++ b/services/core-api/app/api/services/ams_api_service.py
@@ -38,7 +38,9 @@ class AMSApiService():
 
     @classmethod
     def __create_full_address(cls, address_line1, city, sub_division_code, post_code, suite_no):
-        return f"{suite_no} {address_line1}, {city}, {sub_division_code}, {post_code}"
+        components = [suite_no, address_line1, city, sub_division_code, post_code]
+        # Filter out empty values and join them to form the full address
+        return ', '.join(filter(None, components))
 
     @classmethod
     def __get_authorization_details(cls, ams_authorizations, detail_type):
@@ -364,8 +366,7 @@ class AMSApiService():
                             'sourceofdatadescription': facility_coords_source_desc,
                             'legallanddescription': legal_land_desc,
                             'pidpincrownfilenumber': facility_pid_pin_crown_file_no,
-                            'facilityaddress': cls.__set_facility_address_details(facility_operator,
-                                                                                  "Other / International"),
+                            'facilityaddress': cls.__set_facility_address_details(facility_operator, "Other"),
                             'facilityopphonenumberext': facility_operator.get('phone_ext', ''),
                             'isappropriatezoning': cls.__boolean_to_yes_no(zoning),
                             'isappropriatezoningreason': zoning_reason,
@@ -539,8 +540,7 @@ class AMSApiService():
                         'newsourceofdatadescription': facility_coords_source_desc,
                         'newlegallanddescription': legal_land_desc,
                         'newpidpincrownfilenumber': facility_pid_pin_crown_file_no,
-                        'newfacilityaddress': cls.__set_facility_address_details(facility_operator,
-                                                                                 "Other / International"),
+                        'newfacilityaddress': cls.__set_facility_address_details(facility_operator, "Other"),
                         'newisappropriatezoning': cls.__boolean_to_yes_no(zoning),
                         'newisappropriatezoningreason': zoning_reason,
                         'newfacilityoperator': facility_operator.get('name', ''),


### PR DESCRIPTION
## Objective 

Refactored the formation of addresses sent to AMS to eliminate the potential for 'None' strings.
Changed the fieldName from `Other International Address` to `Other Address`

[MDS-6483](https://bcmines.atlassian.net/browse/MDS-6483)


