### PR TITLE
[MDS-6491] Add NOW to search index

### DIFF
--- a/services/core-api/app/cli_commands/export_permit_conditions.py
+++ b/services/core-api/app/cli_commands/export_permit_conditions.py
@@ -13,7 +13,7 @@ headers = [
     'permit', 'mine_number', 'mine_name', 'document_name',
     'document_manager_guid', 'id', 'condition', 'permit_guid',
     'mine_guid', 'permit_amendment_guid', 'permit_condition_guid',
-    'step_path', 'parent_ids', 'sibling_ids', 'child_ids', 'report_name'
+    'step_path', 'parent_ids', 'sibling_ids', 'child_ids', 'report_name', 'permit_type'
 ]
 
 
@@ -82,6 +82,7 @@ def export_permit_conditions(permit_amendment_guid, csv_writer=None):
                 'document_manager_guid': document_guid,
                 'permit_guid': str(permit.permit_guid),
                 'mine_guid': str(mine.mine_guid),
+                'permit_type': 'Notice of Work' if amendment.now_application_guid else 'Major Mine',
                 'permit_amendment_guid': str(amendment.permit_amendment_guid),
                 'permit_condition_guid': str(condition.permit_condition_guid),
                 'report_name': report_name,
@@ -106,6 +107,7 @@ def export_permit_conditions(permit_amendment_guid, csv_writer=None):
                 'mine_guid': str(mine.mine_guid),
                 'permit_amendment_guid': str(amendment.permit_amendment_guid),
                 'permit_condition_guid': str(condition.permit_condition_guid),
+                'permit_type': 'Notice of Work' if amendment.now_application_guid else 'Major Mine',
                 'id': str(condition.permit_condition_guid),
                 'condition': condition.condition,
                 'report_name': report_name,

--- a/services/permits/app/pipelines/permit_condition_search/create_search_index.py
+++ b/services/permits/app/pipelines/permit_condition_search/create_search_index.py
@@ -198,6 +198,14 @@ fields = [
         sortable=True,
         facetable=True,
     ),
+    SearchField(
+        name="permit_type",
+        type=SearchFieldDataType.String,
+        searchable=True,
+        filterable=True,
+        sortable=True,
+        facetable=True,
+    ),
 ]
 
 # Vector search configuration

--- a/services/permits/app/pipelines/permit_condition_search/create_search_indexer.py
+++ b/services/permits/app/pipelines/permit_condition_search/create_search_indexer.py
@@ -133,6 +133,10 @@ def create_indexer():
                 target_field_name="permit_guid"
             ),
             FieldMapping(
+                source_field_name="/document/permit_type",
+                target_field_name="permit_type"
+            ),
+            FieldMapping(
                 source_field_name="/document/mine_guid",
                 target_field_name="mine_guid"
             ),

--- a/services/permits/app/pipelines/permit_condition_search/permit_condition_search_pipeline.py
+++ b/services/permits/app/pipelines/permit_condition_search/permit_condition_search_pipeline.py
@@ -47,6 +47,7 @@ doc_metadata_fields = {
     "category": str,
     "issue_date": datetime,
     "permit": str,
+    "permit_type": str,
     "mine_number": str,
     "mine_name": str,
     "document_name": str,

--- a/services/permits/app/pipelines/permit_condition_search/permit_condition_search_pipeline.py
+++ b/services/permits/app/pipelines/permit_condition_search/permit_condition_search_pipeline.py
@@ -151,6 +151,7 @@ def create_permit_condition_search_retrieval_pipeline():
             "mine_number",
             "mine_name",
             "document_name",
+            "permit_type",
         ],
     )
 


### PR DESCRIPTION
## Objective 

[MDS-6491](https://bcmines.atlassian.net/browse/MDS-6491)

The permit_conditions_bulk_export already supported NOW permits without any additional modifications. The only additional changes have been to add a permit_type field that is facetable and filterable.

There is a bug that was identified as part of this work with filters using the 'in' operator and haystack. 
I have submitted a PR to haystack to address this, but until approved this will prevent some of the filters from returning any results when selected. https://github.com/deepset-ai/haystack-core-integrations/pull/1729

The search index and indexer have been rebuilt, and some new data has been added from my local environment, however I have not exported and re-indexed the existing data so for testing you should use these permits:
Q-100000002:
![image](https://github.com/user-attachments/assets/590cef5f-2783-44ff-9bf8-539cb7d508fd)
C-1234:
![image](https://github.com/user-attachments/assets/594ad740-cd1f-4cb4-a5d9-219cbdc3d4e2)
