### PR TITLE
[CHORE] Make command for user access data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -187,3 +187,21 @@ restart:
 
 help:
 	@./bin/help.sh
+
+# Adds mine subscription (idir) and/or access (bceid) to given user(s)
+# Creates MS user if BCEID is given and user doesn't already exist
+# picks first 5 mine names in alphabet (A) for major mines, and last 5 (Z) for regional
+# Usage: make seed_user_data IDIR=myidir BCEID=mybceid
+# Do not pass in IDIR as "idir\myidir" or BCEID as "mybceid@bceid"
+seed_user_data:
+	@if [ -z "$(IDIR)" ] && [ -z "$(BCEID)" ]; then \
+		echo "must pass in an IDIR or BCEID"; exit 1; \
+	fi
+	@if [ -n "$(IDIR)" ]; then \
+		echo "Seeding user data for IDIR: $(IDIR)"; \
+		docker compose $(DC_FILE) exec backend flask seed_user_data "$(IDIR)" true; \
+	fi
+	@if [ -n "$(BCEID)" ]; then \
+		echo "Seeding user data for BCEID: $(BCEID)"; \
+		docker compose $(DC_FILE) exec backend flask seed_user_data "$(BCEID)" false; \
+	fi

--- a/services/core-api/app/commands.py
+++ b/services/core-api/app/commands.py
@@ -243,9 +243,8 @@ def register_commands(app):
         - core user isn't a foreign key so no user created/queried
 
         Example usage:
-            flask seed_user_data IDIR=myidir
-            flask seed_user_data BCEID=mybceid
-            flask seed_user_data IDIR=myidir BCEID=mybceid        
+            flask seed_user_data myidir true
+            flask seed_user_data mybceid false    
         """
         _seed_user_data(user_name, is_idir)
 

--- a/services/core-api/app/commands.py
+++ b/services/core-api/app/commands.py
@@ -262,19 +262,32 @@ def register_commands(app):
 
             if is_idir:
                 from app.api.mines.subscription.models.subscription import Subscription
+                existing_subscriptions = Subscription.query.filter_by(user_name=full_user_name).all()
+                subscribed_mine_guids = [s.mine_guid for s in existing_subscriptions]
                 for mine in all_mines:
-                    print(f'Creating mine subscription. Username: {full_user_name}, Mine: {mine.mine_name}')
-                    subscription = Subscription(mine_guid=mine.mine_guid, user_name=full_user_name)
-                    db.session.add(subscription)                    
+                    if mine.mine_guid in subscribed_mine_guids:
+                        print(f'Skipping already subscribed mine. Username: {full_user_name}, Mine: {mine.mine_name}')
+                    else:
+                        print(f'Creating mine subscription. Username: {full_user_name}, Mine: {mine.mine_name}')
+                        subscription = Subscription(mine_guid=mine.mine_guid, user_name=full_user_name)
+                        db.session.add(subscription)                    
             else:
                 minespace_user = MinespaceUser.find_by_email(full_user_name)
+                subscribed_mine_guids = []
                 if not minespace_user:
                     minespace_user = MinespaceUserFactory(
                         email_or_username=full_user_name,
-                        keycloak_guid='b28dfc3a-5e5c-4501-ab2f-399d8e64f2c8')               
+                        keycloak_guid='b28dfc3a-5e5c-4501-ab2f-399d8e64f2c8')
+                else:
+                    from app.api.users.minespace.models.minespace_user_mine import MinespaceUserMine
+                    existing_subscriptions = MinespaceUserMine.query.filter_by(user_id=minespace_user.user_id).all()
+                    subscribed_mine_guids = [s.mine_guid for s in existing_subscriptions]
                 for mine in all_mines:
-                    print(f'Creating mine subscription. Username: {full_user_name}, Mine: {mine.mine_name}')
-                    MinespaceSubscriptionFactory(mine=mine, minespace_user=minespace_user)                        
+                    if mine.mine_guid in subscribed_mine_guids:
+                        print(f'Skipping already subscribed mine. Username: {full_user_name}, Mine: {mine.mine_name}')
+                    else:
+                        print(f'Creating mine subscription. Username: {full_user_name}, Mine: {mine.mine_name}')
+                        MinespaceSubscriptionFactory(mine=mine, minespace_user=minespace_user)                        
 
             try:
                 db.session.commit()

--- a/services/core-api/app/commands.py
+++ b/services/core-api/app/commands.py
@@ -14,7 +14,8 @@ from tests.factories import (
     MinespaceUserFactory,
     NOWApplicationIdentityFactory,
 )
-
+from app.api.mines.mine.models.mine import Mine
+from app.api.users.minespace.models.minespace_user import MinespaceUser
 from .cli_commands.generate_history_table_migration import (
     generate_history_table_migration,
     generate_table_migration,
@@ -229,6 +230,62 @@ def register_commands(app):
             flask generate_table_migration mine_tailings_storage_facility
         """
         generate_table_migration(table)
+
+    @app.cli.command('seed_user_data')
+    @click.argument('user_name')
+    @click.argument('is_idir', default=True)
+    def do_seed_user_data(user_name, is_idir):
+        """
+        Creates subscriptions for MS/Core users
+        - first 5 (alphabetical) major mines
+        - last 5 regional mines
+        - uses MS user if they already exist, or else creates a new one
+        - core user isn't a foreign key so no user created/queried
+
+        Example usage:
+            flask seed_user_data IDIR=myidir
+            flask seed_user_data BCEID=mybceid
+            flask seed_user_data IDIR=myidir BCEID=mybceid        
+        """
+        _seed_user_data(user_name, is_idir)
+
+    def _seed_user_data(user_name, is_idir):
+        major_mine_count = 5
+        regional_mine_count = 5        
+
+        full_user_name = f'idir\\{user_name}' if is_idir else f'{user_name}@bceid'
+        print(f'Seeding user data for {full_user_name}')
+
+        with app.app_context():
+            major_mines = db.session.query(Mine).filter_by(major_mine_ind=True).order_by(Mine.mine_name).limit(major_mine_count)
+            regional_mines = db.session.query(Mine).filter_by(major_mine_ind=False).order_by(Mine.mine_name.desc()).limit(regional_mine_count)
+            all_mines = list(major_mines) + list(regional_mines)
+
+            if is_idir:
+                from app.api.mines.subscription.models.subscription import Subscription
+                for mine in all_mines:
+                    print(f'Creating mine subscription. Username: {full_user_name}, Mine: {mine.mine_name}')
+                    subscription = Subscription(mine_guid=mine.mine_guid, user_name=full_user_name)
+                    db.session.add(subscription)                    
+            else:
+                minespace_user = MinespaceUser.find_by_email(full_user_name)
+                if not minespace_user:
+                    minespace_user = MinespaceUserFactory(
+                        email_or_username=full_user_name,
+                        keycloak_guid='b28dfc3a-5e5c-4501-ab2f-399d8e64f2c8')               
+                for mine in all_mines:
+                    print(f'Creating mine subscription. Username: {full_user_name}, Mine: {mine.mine_name}')
+                    MinespaceSubscriptionFactory(mine=mine, minespace_user=minespace_user)                        
+
+            try:
+                db.session.commit()
+                print(f'Successfully created user access data for {full_user_name}.')
+            except DBAPIError:
+                print(f'Failed to create user access data for {user_name}.')
+                db.session.rollback()
+                raise
+                
+                
 
     @app.cli.command('export_permit_conditions')
     @click.argument('permit_amendment_guid')


### PR DESCRIPTION
## Objective 
Does exactly what the code comments says it does
So that devs don't need to hunt for mines or manually make subscriptions or MS user access
Maybe needs a reference in setup documentation

_Why are you making this change? Provide a short explanation and/or screenshots_
Results in Core:
![image](https://github.com/user-attachments/assets/75c8084e-aa7b-4395-b54c-bf782873a7d2)
Results in MS:
![image](https://github.com/user-attachments/assets/95b60b2b-f209-411e-911f-0047832062f8)
