### PR TITLE
[MDS-6497] Fix for mine showing alerts from another mine

### DIFF
--- a/services/common/src/tests/mocks/dataMocks.tsx
+++ b/services/common/src/tests/mocks/dataMocks.tsx
@@ -7672,6 +7672,7 @@ export const MINE_ALERTS = {
       contact_name: "mock name",
       contact_phone: "337-588-3109",
       message: "Mine under construction",
+      mine_guid: "18133c75-49ad-4101-85f3-a43e35ae989a",
     },
   ],
 };

--- a/services/core-web/src/components/mine/MineAlert.tsx
+++ b/services/core-web/src/components/mine/MineAlert.tsx
@@ -26,8 +26,7 @@ const MineAlert: FC<MineAlertProps> = ({ mine }) => {
   const [activeMineAlert, setActiveMineAlert] = useState<IMineAlert>();
   const [pastMineAlerts, setPastMineAlerts] = useState<IMineAlert[]>([]);
   const mineAlerts = useAppSelector(getMineAlerts);
-  const [loaded, setLoaded] = useState(mineAlerts.length > 0);
-
+  const [loaded, setLoaded] = useState(mineAlerts.some(alert => alert.mine_guid === mine.mine_guid));
 
   const fetchAlerts = async () => {
     setLoaded(false);

--- a/services/minespace-web/src/components/dashboard/mine/projects/NoticeOfWorkTable.tsx
+++ b/services/minespace-web/src/components/dashboard/mine/projects/NoticeOfWorkTable.tsx
@@ -101,7 +101,7 @@ export const NoticeOfWorkTable: FC<NoticeOfWorkTableProps> = ({ isLoaded, applic
             dataIndex: "project",
             render: (text, record) => {
               return (
-                <div title="">
+                <div>
                   <Row gutter={1}>
                     <Col span={12}>
                       <Link

--- a/services/minespace-web/src/tests/components/dashboard/mine/projects/project/__snapshots__/ViewProjects.spec.tsx.snap
+++ b/services/minespace-web/src/tests/components/dashboard/mine/projects/project/__snapshots__/ViewProjects.spec.tsx.snap
@@ -1183,9 +1183,7 @@ exports[`ViewProjects renders now application tab properly 1`] = `
                                   <td
                                     class="ant-table-cell"
                                   >
-                                    <div
-                                      title=""
-                                    >
+                                    <div>
                                       <div
                                         class="ant-row"
                                         style="margin-left: -0.5px; margin-right: -0.5px;"
@@ -1263,9 +1261,7 @@ exports[`ViewProjects renders now application tab properly 1`] = `
                                   <td
                                     class="ant-table-cell"
                                   >
-                                    <div
-                                      title=""
-                                    >
+                                    <div>
                                       <div
                                         class="ant-row"
                                         style="margin-left: -0.5px; margin-right: -0.5px;"


### PR DESCRIPTION
## Objective 

[MDS-6497](https://bcmines.atlassian.net/browse/MDS-6497)

- Changed the default value of `loaded` react state so we can trigger the fetch to retrieve alert data when viewing a different mine.
- Also small change to get rid of unnecessary `title` in `NoticeOfWorkTable`.
