### PR TITLE
[MDS-6491] Add permit_type tag

### DIFF
--- a/services/common/src/interfaces/search/facet-search.interface.ts
+++ b/services/common/src/interfaces/search/facet-search.interface.ts
@@ -1,6 +1,7 @@
 export interface HaystackDocumentMeta {
     permit: string;
     permit_guid: string;
+    permit_type: string;
     mine_name: string;
     mine_guid: string;
     mine_number: string;

--- a/services/common/src/tests/mocks/dataMocks.tsx
+++ b/services/common/src/tests/mocks/dataMocks.tsx
@@ -3535,6 +3535,7 @@ export const MOCK_PERMIT_SEARCH_RESULT: HaystackDocumentSearchResult = {
   meta: {
     mine_guid: 'mine-123',
     permit_guid: 'permit-123',
+    permit_type: 'Major Mine',
     permit_amendment_guid: 'amendment-123',
     mine_name: 'Test Mine',
     permit: 'M-123',

--- a/services/core-api/app/cli_commands/export_permit_conditions.py
+++ b/services/core-api/app/cli_commands/export_permit_conditions.py
@@ -140,7 +140,7 @@ def export_permit_conditions(permit_amendment_guid, csv_writer=None):
         return filename
 
 
-def bulk_export_permit_conditions(csv_path):
+def bulk_export_permit_conditions(csv_path, output_dir):
     """
     Export permit conditions for multiple permits from a CSV file into a single output file.
     CSV should have a column named 'permit_no' containing permit numbers.
@@ -150,7 +150,7 @@ def bulk_export_permit_conditions(csv_path):
     from app.api.mines.permits.permit.models.permit import Permit
 
     timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
-    output_filename = f'permit_conditions_bulk_export_{timestamp}.csv'
+    output_filename = f'{output_dir}/permit_conditions_bulk_export_{timestamp}.csv'
     
     success_count = 0
     error_count = 0

--- a/services/core-api/app/commands.py
+++ b/services/core-api/app/commands.py
@@ -311,7 +311,8 @@ def register_commands(app):
 
     @app.cli.command('bulk_export_permit_conditions')
     @click.argument('csv_path', type=click.Path(exists=True))
-    def bulk_export_permit_conditions(csv_path):
+    @click.option('--output_dir', help='Output directory (optional)', default="/tmp")
+    def bulk_export_permit_conditions(csv_path, output_dir):
         """
         Export permit conditions for multiple permits from a CSV file.
         CSV should have a column named 'permit_no' containing permit numbers.
@@ -325,4 +326,4 @@ def register_commands(app):
         
         auth.apply_security = False
         with current_app.app_context():
-            bulk_export_permit_conditions(csv_path)
+            bulk_export_permit_conditions(csv_path, output_dir)

--- a/services/core-web/src/components/mine/Permit/Search/__snapshots__/PermitConditionSearch.integration.spec.tsx.snap
+++ b/services/core-web/src/components/mine/Permit/Search/__snapshots__/PermitConditionSearch.integration.spec.tsx.snap
@@ -413,6 +413,15 @@ exports[`PermitConditionSearch Integration Tests shows and applies filters 1`] =
                                           style="cursor: pointer;"
                                         />
                                       </div>
+                                      <div
+                                        class="ant-col"
+                                        style="padding: 4px 4px 4px 4px;"
+                                      >
+                                        <span
+                                          class="ant-tag ant-tag-magenta"
+                                          style="cursor: pointer;"
+                                        />
+                                      </div>
                                     </div>
                                   </div>
                                   <div

--- a/services/core-web/src/components/mine/Permit/Search/components/ResultItem.tsx
+++ b/services/core-web/src/components/mine/Permit/Search/components/ResultItem.tsx
@@ -291,6 +291,15 @@ const ResultItem: React.FC<ResultItemProps> = ({ result, onFilterClick }) => {
                                     {meta.mine_number}
                                 </Tag>
                             </Col>
+                            <Col>
+                                <Tag
+                                    color="magenta"
+                                    style={{ cursor: 'pointer' }}
+                                    onClick={() => onFilterClick?.('permit_type', meta.permit_type)}
+                                >
+                                    {meta.permit_type}
+                                </Tag>
+                            </Col>
                         </Row>
                     </Col>
 

--- a/services/core-web/src/components/mine/Permit/Search/tests/__snapshots__/ResultItem.spec.tsx.snap
+++ b/services/core-web/src/components/mine/Permit/Search/tests/__snapshots__/ResultItem.spec.tsx.snap
@@ -209,6 +209,17 @@ exports[`ResultItem Rendering renders basic result information 1`] = `
                 BC-123
               </span>
             </div>
+            <div
+              class="ant-col"
+              style="padding: 4px 4px 4px 4px;"
+            >
+              <span
+                class="ant-tag ant-tag-magenta"
+                style="cursor: pointer;"
+              >
+                Major Mine
+              </span>
+            </div>
           </div>
         </div>
         <div


### PR DESCRIPTION
## Objective 

[MDS-6491](https://bcmines.atlassian.net/browse/MDS-6491)

![image](https://github.com/user-attachments/assets/e09dda83-517f-41ec-8f3d-eccc925454b1)
Add a clickable permit_type tag to the search results that will toggle the permit_type flag
