### PR TITLE
[MDS-6507] Fix for Page not found when clicking view minespace in Core

### DIFF
--- a/services/core-web/src/constants/routes.ts
+++ b/services/core-web/src/constants/routes.ts
@@ -605,7 +605,7 @@ const MINESPACE_URLS = {
 
 export const VIEW_MINESPACE = (mineGuid) => {
   const MINESPACE_URL = MINESPACE_URLS[getEnvironment() ?? "production"];
-  return `${MINESPACE_URL}mines/${mineGuid}/overview?redirectingFromCore=true`;
+  return `${MINESPACE_URL}mines/${mineGuid}/dashboard/overview?redirectingFromCore=true`;
 };
 
 const ORGBOOK_URL = "https://orgbook.gov.bc.ca";


### PR DESCRIPTION
## Objective 

[MDS-6507](https://bcmines.atlassian.net/browse/MDS-6507)

- Adjusted VIEW_MINESPACE route in Core so mine page in Minespace can be displayed
