### PR TITLE
[MDS-6062] Fix NOW transfer

### DIFF
--- a/migrations/sql/V2025.05.15.15.40__alter_mine_permit_xref.sql
+++ b/migrations/sql/V2025.05.15.15.40__alter_mine_permit_xref.sql
@@ -1,0 +1,34 @@
+CREATE UNIQUE INDEX mine_permit_xref_unique ON mine_permit_xref (mine_guid, permit_id) WHERE deleted_ind = false;
+
+-- Cleanup transferred now_applications with mismatched mine_guids
+-- Create new mine_permit_xref records
+INSERT INTO mine_permit_xref (mine_guid, permit_id, create_user, create_timestamp)
+SELECT 
+    na.mine_guid AS now_application_mine_guid,
+    pa.permit_id,
+    'migration_script',
+    NOW()
+FROM now_application na
+JOIN permit_amendment pa ON pa.now_application_guid = na.now_application_guid
+WHERE pa.permit_amendment_status_code = 'DFT'
+  AND pa.mine_guid != na.mine_guid;
+
+-- Update mine_guid
+UPDATE permit_amendment pa
+SET mine_guid = na.mine_guid
+FROM now_application na
+WHERE pa.now_application_guid = na.now_application_guid
+  AND pa.permit_amendment_status_code = 'DFT'
+  AND pa.mine_guid != na.mine_guid;
+
+-- Soft delete old mine_permit_xref records
+UPDATE mine_permit_xref mp
+SET deleted_ind = TRUE,
+    update_user = 'migration_script',
+    update_timestamp = NOW()
+FROM permit_amendment pa
+JOIN now_application na ON pa.now_application_guid = na.now_application_guid
+WHERE mp.mine_guid = pa.mine_guid
+  AND mp.permit_id = pa.permit_id
+  AND pa.permit_amendment_status_code = 'DFT'
+  AND pa.mine_guid != na.mine_guid;

--- a/migrations/sql/V2025.05.15.15.40__alter_mine_permit_xref.sql
+++ b/migrations/sql/V2025.05.15.15.40__alter_mine_permit_xref.sql
@@ -1,34 +1,43 @@
 CREATE UNIQUE INDEX mine_permit_xref_unique ON mine_permit_xref (mine_guid, permit_id) WHERE deleted_ind = false;
 
--- Cleanup transferred now_applications with mismatched mine_guids
--- Create new mine_permit_xref records
-INSERT INTO mine_permit_xref (mine_guid, permit_id, create_user, create_timestamp)
+-- MDS-6062, Cleanup draft permits of transferred now applications
+CREATE TEMPORARY TABLE original_now_permits AS (
+	SELECT
+		pa.permit_id,
+		pa.mine_guid AS old_mine_guid,
+		na.mine_guid AS new_mine_guid
+	FROM permit_amendment pa
+	JOIN now_application_identity na ON pa.now_application_guid = na.now_application_guid
+	WHERE pa.permit_amendment_status_code = 'DFT'
+	AND pa.mine_guid != na.mine_guid
+);
+
+-- Create new xref
+INSERT INTO mine_permit_xref (mine_guid, permit_id, create_user, create_timestamp, update_user, update_timestamp, start_date)
 SELECT 
-    na.mine_guid AS now_application_mine_guid,
-    pa.permit_id,
-    'migration_script',
-    NOW()
-FROM now_application na
-JOIN permit_amendment pa ON pa.now_application_guid = na.now_application_guid
-WHERE pa.permit_amendment_status_code = 'DFT'
-  AND pa.mine_guid != na.mine_guid;
+  new_mine_guid,
+  permit_id,
+  'system-mds',
+  NOW(),
+  'system-mds',
+  NOW(),
+  NOW()
+FROM original_now_permits;
 
 -- Update mine_guid
 UPDATE permit_amendment pa
-SET mine_guid = na.mine_guid
-FROM now_application na
-WHERE pa.now_application_guid = na.now_application_guid
-  AND pa.permit_amendment_status_code = 'DFT'
-  AND pa.mine_guid != na.mine_guid;
+SET mine_guid = onp.new_mine_guid
+FROM original_now_permits onp
+WHERE pa.permit_id = onp.permit_id;
 
--- Soft delete old mine_permit_xref records
+-- Soft delete old xref
 UPDATE mine_permit_xref mp
 SET deleted_ind = TRUE,
-    update_user = 'migration_script',
-    update_timestamp = NOW()
-FROM permit_amendment pa
-JOIN now_application na ON pa.now_application_guid = na.now_application_guid
-WHERE mp.mine_guid = pa.mine_guid
-  AND mp.permit_id = pa.permit_id
-  AND pa.permit_amendment_status_code = 'DFT'
-  AND pa.mine_guid != na.mine_guid;
+  update_user = 'system-mds',
+  update_timestamp = NOW()
+FROM original_now_permits onp
+WHERE mp.mine_guid = onp.old_mine_guid
+  AND mp.permit_id = onp.permit_id;
+
+-- Cleanup
+DROP TABLE original_now_permits;

--- a/migrations/sql/V2025.05.15.15.40__update_mine_permit_xref.sql
+++ b/migrations/sql/V2025.05.15.15.40__update_mine_permit_xref.sql
@@ -1,4 +1,3 @@
-CREATE UNIQUE INDEX mine_permit_xref_unique ON mine_permit_xref (mine_guid, permit_id) WHERE deleted_ind = false;
 
 -- MDS-6062, Cleanup draft permits of transferred now applications
 CREATE TEMPORARY TABLE original_now_permits AS (

--- a/services/core-api/app/api/mines/permits/permit/models/mine_permit_xref.py
+++ b/services/core-api/app/api/mines/permits/permit/models/mine_permit_xref.py
@@ -16,3 +16,11 @@ class MinePermitXref(SoftDeleteMixin, AuditMixin, Base):
     end_date = db.Column(db.DateTime)
 
     mine = db.relationship('Mine')
+
+    @classmethod
+    def create(cls, mine_guid, permit_id, start_date, end_date=None, add_to_session=True):
+        new_xref = cls(start_date=start_date, end_date=end_date, mine_guid=mine_guid, permit_id=permit_id)
+
+        if add_to_session:
+            new_xref.save(commit=False)
+        return new_xref

--- a/services/core-api/app/api/now_applications/models/now_application_identity.py
+++ b/services/core-api/app/api/now_applications/models/now_application_identity.py
@@ -64,19 +64,37 @@ class NOWApplicationIdentity(Base, AuditMixin):
         self.now_number = NOWApplicationIdentity.create_now_number(mine, self.now_number_year)
         self.mine = mine
 
+        if self.now_application.documents:
+            for document in self.now_application.documents:
+                document.mine_document.mine_guid = mine.mine_guid
+                document.mine_document.save()
+
         if self.now_application.draft_permit:
-            #Create new xref, replace, then delete old one
-            MinePermitXref.create(
-                permit_id = self.now_application.draft_permit.permit_id,
-                mine_guid=mine.mine_guid,
-                start_date=datetime.now()
-            )
+
+            existing_xref = MinePermitXref.query.filter_by(
+                permit_id=self.now_application.draft_permit.permit_id,
+                mine_guid=mine.mine_guid
+            ).one_or_none()
+            if existing_xref:
+                existing_xref.is_deleted = False
+                existing_xref.start_date = datetime.now()
+                existing_xref.save()
+            
+            else:
+                MinePermitXref.create(
+                    permit_id = self.now_application.draft_permit.permit_id,
+                    mine_guid=mine.mine_guid,
+                    start_date=datetime.now()
+                )
+                self.now_application.draft_permit.mine_permit_xref.delete()
+
             self.now_application.draft_permit.mine_guid = mine.mine_guid
-            self.now_application.draft_permit.mine_permit_xref.delete()
+            self.now_application.draft_permit.save()
+
             if self.now_application.site_property:
                 self.now_application.site_property.mine_guid = mine.mine_guid
                 self.now_application.site_property.save()
-            self.now_application.draft_permit.save()
+            
 
     @hybrid_property
     def now_number_year(self):

--- a/services/core-api/app/api/now_applications/models/now_application_identity.py
+++ b/services/core-api/app/api/now_applications/models/now_application_identity.py
@@ -6,7 +6,8 @@ from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.schema import FetchedValue
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.sql.expression import and_, cast
-
+from werkzeug.exceptions import BadRequest
+from app.api.mines.permits.permit.models.mine_permit_xref import MinePermitXref
 from app.api.utils.models_mixins import Base, AuditMixin
 from app.extensions import db
 
@@ -56,8 +57,26 @@ class NOWApplicationIdentity(Base, AuditMixin):
         return f'{self.__class__.__name__} {self.now_application_guid}'
 
     def transfer(self, mine):
+
+        if self.now_application.now_application_status_code in ['AIA','REJ', 'WDN', 'NPR']:
+            raise BadRequest(f'Unable to transfer NOW application with status {self.now_application.now_application_status_code}')
+        
         self.now_number = NOWApplicationIdentity.create_now_number(mine, self.now_number_year)
         self.mine = mine
+
+        if self.now_application.draft_permit:
+            #Create new xref, replace, then delete old one
+            MinePermitXref.create(
+                permit_id = self.now_application.draft_permit.permit_id,
+                mine_guid=mine.mine_guid,
+                start_date=datetime.now()
+            )
+            self.now_application.draft_permit.mine_guid = mine.mine_guid
+            self.now_application.draft_permit.mine_permit_xref.delete()
+            if self.now_application.site_property:
+                self.now_application.site_property.mine_guid = mine.mine_guid
+                self.now_application.site_property.save()
+            self.now_application.draft_permit.save()
 
     @hybrid_property
     def now_number_year(self):

--- a/services/core-api/tests/now_applications/resources/test_now_application_identity_transfer.py
+++ b/services/core-api/tests/now_applications/resources/test_now_application_identity_transfer.py
@@ -1,0 +1,47 @@
+from tests.now_application_factories import NOWApplicationIdentityFactory, NOWApplicationFactory
+from tests.factories import MineFactory, PermitAmendmentFactory, PermitFactory
+
+class TestNOWApplicationIdentityTransfer:
+
+    def test_transfer_now_application_without_draft_permit(self, db_session):
+        # Create a NOW application without a draft permit
+        mine = MineFactory(minimal=True)
+        now_application_identity = NOWApplicationIdentityFactory(
+            now_application=NOWApplicationFactory(), mine=mine, now_number=str(mine.mine_no) + '-2023'
+        )
+
+        # Transfer the application to a new mine
+        new_mine = MineFactory()
+        now_application_identity.transfer(new_mine)
+
+        assert now_application_identity.mine == new_mine
+        assert now_application_identity.now_number.startswith(new_mine.mine_no)
+        for document in now_application_identity.now_application.documents:
+            assert document.mine_document.mine_guid == new_mine.mine_guid
+
+    def test_transfer_now_application_with_draft_permit(self, db_session):
+        # Create a NOW application with a draft permit
+        mine = MineFactory()
+        permit = PermitFactory()
+        permit._all_mines.append(mine)   
+        permit._context_mine = mine 
+
+        now_application_identity = NOWApplicationIdentityFactory(
+            now_application=NOWApplicationFactory(), mine=mine, now_number=str(mine.mine_no) + '-2023'
+        )
+
+        draft_permit_amendment = PermitAmendmentFactory(
+            mine=mine,
+            permit=permit,
+            now_application_guid=now_application_identity.now_application_guid,
+            permit_amendment_status_code='DFT'
+        )
+
+        # Transfer the application to a new mine
+        new_mine = MineFactory()
+        now_application_identity.transfer(new_mine)
+
+        assert now_application_identity.mine == new_mine
+        assert now_application_identity.now_number.startswith(new_mine.mine_no)
+        for document in now_application_identity.now_application.documents:
+            assert document.mine_document.mine_guid == new_mine.mine_guid


### PR DESCRIPTION
## Objective 

Fix transferring a Notice of Work between mines where a Draft permit has already been created

[MDS-6062](https://bcmines.atlassian.net/browse/MDS-6062)

- Updates the Draft permit on transfer, including creating a new xref if needed.
- Updates the mine_guid of documents
- Migration to correct any exisiting draft permits with mismatching mine_guids
