### PR TITLE
[MDS-6450] identify same report

### DIFF
--- a/bin/setenv.sh
+++ b/bin/setenv.sh
@@ -76,7 +76,7 @@ function loadExternalSecrets() {
         echo -e "If you already have access, click here to generate a token and paste it into the terminal: ${bold}https://oauth-openshift.apps.silver.devops.gov.bc.ca/oauth/token/request${normal}\n\n"
         echo -e "${bold}...Paste Token Here...${normal}"
         read OC_TOKEN
-
+        
         # Log in to openshift and verify that you have access
         oc login --token=$OC_TOKEN --server=https://api.silver.devops.gov.bc.ca:6443
         OC_ACCESS=$(oc get project | grep 4c2ba9-dev)
@@ -101,7 +101,7 @@ function loadExternalSecrets() {
     for S in $SERVICES
     do
         echo "Configuring secrets for $S service"
-        for KEY in $SECRET_KEYS
+        for KEY in $SECRET_KEYS        
         do
             SECRET=$(kubectl get secret local-dev-secrets --namespace 4c2ba9-dev -o go-template="{{index .data.${KEY} | base64decode}}")
             if [ "$SECRET" = "" ]; then

--- a/bin/setenv.sh
+++ b/bin/setenv.sh
@@ -76,7 +76,7 @@ function loadExternalSecrets() {
         echo -e "If you already have access, click here to generate a token and paste it into the terminal: ${bold}https://oauth-openshift.apps.silver.devops.gov.bc.ca/oauth/token/request${normal}\n\n"
         echo -e "${bold}...Paste Token Here...${normal}"
         read OC_TOKEN
-        
+
         # Log in to openshift and verify that you have access
         oc login --token=$OC_TOKEN --server=https://api.silver.devops.gov.bc.ca:6443
         OC_ACCESS=$(oc get project | grep 4c2ba9-dev)
@@ -101,7 +101,7 @@ function loadExternalSecrets() {
     for S in $SERVICES
     do
         echo "Configuring secrets for $S service"
-        for KEY in $SECRET_KEYS        
+        for KEY in $SECRET_KEYS
         do
             SECRET=$(kubectl get secret local-dev-secrets --namespace 4c2ba9-dev -o go-template="{{index .data.${KEY} | base64decode}}")
             if [ "$SECRET" = "" ]; then

--- a/services/core-api/app/api/mines/permits/permit_extraction/create_permit_condition_report_requirement.py
+++ b/services/core-api/app/api/mines/permits/permit_extraction/create_permit_condition_report_requirement.py
@@ -1,6 +1,8 @@
+from numbers import Number
 from typing import Optional
 from datetime import date
 
+from app.extensions import db
 from app.api.mines.permits.permit_conditions.models.permit_conditions import (
     PermitConditions,
 )
@@ -15,6 +17,11 @@ from flask import current_app
 from ..permit_conditions.services.permit_condition_comparer import ConditionChangeType
 from .models.permit_condition_result import PermitConditionResult
 
+def append_condition_id(condition_id: Number, requirement_conditions: PermitConditions):
+    condition_ids = [condition_id]
+    for condition in requirement_conditions:
+        condition_ids.append(condition.permit_condition_id)
+    return condition_ids
 
 def create_permit_condition_report_requirement(
     task, condition: PermitConditions
@@ -71,23 +78,47 @@ def create_permit_condition_report_requirement(
     # Calculate due_date_period_months based on frequency
     due_date_period_months = _parse_due_date_period(recurring, frequency)
 
-    # Create the MineReportPermitRequirement
-    mine_report_permit_requirement = MineReportPermitRequirement(
-        report_name=report_name,
-        permit_amendment_id=task.permit_amendment.permit_amendment_id,
-        cim_or_cpo=cim_or_cpo,
-        due_date_period_months=due_date_period_months or 0,
-        initial_due_date=initial_due_date,
-        ministry_recipient=None,  # Not specified in permits themselves.
-    )
-    xref = MineReportReqPermitConditionXref(
-        mine_report_permit_requirement=mine_report_permit_requirement,
-        permit_condition_id=condition.permit_condition_id
-    )
-    mine_report_permit_requirement.mine_report_req_permit_conditions.append(xref)
+    if report_name is None:
+        report_name = f"Unknown Report Name - {condition.permit_condition_id}"
 
-    return mine_report_permit_requirement
+    # Check for report_requirements that have been added to the session, but not yet committed
+    existing_requirement_in_session = None
+    for obj in db.session.identity_map.values():
+        if isinstance(obj, MineReportPermitRequirement):
+            if obj.report_name == report_name and obj.permit_amendment_id == condition.permit_amendment_id:
+                existing_requirement_in_session = obj
 
+    # Check for report_requirements that have been committed to the DB
+    existing_requirement_in_db = MineReportPermitRequirement.query.filter_by(report_name=report_name, permit_amendment_id=task.permit_amendment.permit_amendment_id, deleted_ind=False).first()
+
+    # if there is an existing requirement in the session or the db, append this condition id to it
+    if existing_requirement_in_session is not None:
+        condition_ids = append_condition_id(condition.permit_condition_id, existing_requirement_in_session.permit_conditions)
+        existing_requirement_in_session.update_permit_conditions(condition_ids)
+        return None
+    elif existing_requirement_in_db is not None:
+        condition_ids = append_condition_id(condition.permit_condition_id, existing_requirement_in_db.permit_conditions)
+        existing_requirement_in_db.update_permit_conditions(condition_ids)
+        return None
+    else:
+        # Create the MineReportPermitRequirement
+        mine_report_permit_requirement = MineReportPermitRequirement(
+            report_name=report_name,
+            permit_amendment_id=task.permit_amendment.permit_amendment_id,
+            cim_or_cpo=cim_or_cpo,
+            due_date_period_months=due_date_period_months or 0,
+            initial_due_date=initial_due_date,
+            ministry_recipient=None,  # Not specified in permits themselves.
+        )
+        xref = MineReportReqPermitConditionXref(
+            mine_report_permit_requirement=mine_report_permit_requirement,
+            permit_condition_id=condition.permit_condition_id
+        )
+        mine_report_permit_requirement.mine_report_req_permit_conditions.append(xref)
+        mine_report_permit_requirement.save()
+
+
+        return mine_report_permit_requirement
 
 def _parse_due_date_period(recurring, frequency):
     due_date_period_months = None
@@ -151,7 +182,6 @@ def _parse_initial_due_date(condition_id, initial_due_date) -> Optional[date]:
             initial_due_date = None
     return initial_due_date
 
-
 def create_or_copy_permit_condition_report_requirements(
     task, condition, comparison
 ):
@@ -172,6 +202,5 @@ def create_or_copy_permit_condition_report_requirements(
                 [comparison.previous_condition.permit_condition_id, 
                  condition.permit_condition_id]
             )
-            return existing_requirements
     # No match found, create new requirement
     return create_permit_condition_report_requirement(task, condition)

--- a/services/core-api/app/api/mines/permits/permit_extraction/create_permit_condition_report_requirement.py
+++ b/services/core-api/app/api/mines/permits/permit_extraction/create_permit_condition_report_requirement.py
@@ -83,7 +83,8 @@ def create_permit_condition_report_requirement(
 
     # Check for report_requirements that have been added to the session, but not yet committed
     existing_requirement_in_session = None
-    for obj in db.session.identity_map.values():
+    session_values = db.session.identity_map.values() if db.session else []
+    for obj in session_values:
         if isinstance(obj, MineReportPermitRequirement):
             if obj.report_name == report_name and obj.permit_amendment_id == condition.permit_amendment_id:
                 existing_requirement_in_session = obj

--- a/services/core-api/tests/permits/permit_extraction/test_create_permit_condition_report_requirement.py
+++ b/services/core-api/tests/permits/permit_extraction/test_create_permit_condition_report_requirement.py
@@ -65,7 +65,7 @@ def test_create_report_requirement_basic(mock_task):
 def test_create_report_requirement_both_cim_cpo(mock_task):
     condition = PermitConditions(
         condition="Test condition text",
-        permit_condition_id=22,
+        permit_condition_id=mock_task.permit_amendment.permit_amendment_id,
         meta={
             "questions": [
                 {"question_key": "require_report", "answer": True},

--- a/services/core-api/tests/permits/permit_extraction/test_create_permit_condition_report_requirement.py
+++ b/services/core-api/tests/permits/permit_extraction/test_create_permit_condition_report_requirement.py
@@ -65,7 +65,10 @@ def test_create_report_requirement_basic(mock_task):
 def test_create_report_requirement_both_cim_cpo(mock_task):
     condition = PermitConditions(
         condition="Test condition text",
-        permit_condition_id=mock_task.permit_amendment.permit_amendment_id,
+        permit_amendment_id=mock_task.permit_amendment.permit_amendment_id,
+        condition_category_code="GEC",
+        condition_type_code="CON",
+        display_order=1,
         meta={
             "questions": [
                 {"question_key": "require_report", "answer": True},
@@ -74,6 +77,8 @@ def test_create_report_requirement_both_cim_cpo(mock_task):
             ]
         },
     )
+
+    condition.save()
 
     result = create_permit_condition_report_requirement(mock_task, condition)
     assert result is not None

--- a/services/core-api/tests/permits/permit_extraction/test_create_permit_condition_report_requirement.py
+++ b/services/core-api/tests/permits/permit_extraction/test_create_permit_condition_report_requirement.py
@@ -8,12 +8,15 @@ from app.api.mines.permits.permit_conditions.models.permit_conditions import (
 from app.api.mines.permits.permit_extraction.create_permit_condition_report_requirement import (
     create_permit_condition_report_requirement,
 )
+from tests.factories import PermitAmendmentFactory, create_mine_and_permit
 
 
 @pytest.fixture
-def mock_task():
+def mock_task(db_session):
+    mine, permit = create_mine_and_permit()
+    permit_amendment = PermitAmendmentFactory(permit=permit, mine=mine)
     task = MagicMock()
-    task.permit_amendment.permit_amendment_id = "test-amendment-id"
+    task.permit_amendment = permit_amendment
     return task
 
 
@@ -30,8 +33,11 @@ def test_create_report_requirement_with_no_report_required(mock_task):
 
 def test_create_report_requirement_basic(mock_task):
     condition = PermitConditions(
-        permit_condition_id="test-id",
         condition="Test condition text",
+        permit_amendment_id=mock_task.permit_amendment.permit_amendment_id,
+        condition_category_code="GEC",
+        condition_type_code="CON",
+        display_order=1,
         meta={
             "questions": [
                 {"question_key": "require_report", "answer": True},
@@ -44,21 +50,22 @@ def test_create_report_requirement_basic(mock_task):
             ]
         },
     )
+    condition.save()
 
     result = create_permit_condition_report_requirement(mock_task, condition)
     assert result is not None
     assert result.report_name == "Test Report"
-    assert result.permit_condition_ids == ["test-id"]
-    assert result.permit_amendment_id == "test-amendment-id"
+    assert result.permit_condition_ids == [condition.permit_condition_id]
+    assert result.permit_amendment_id == mock_task.permit_amendment.permit_amendment_id
     assert result.cim_or_cpo == "CIM"
     assert result.due_date_period_months == 1
-    assert result.initial_due_date == datetime(2023, 12, 31)
+    assert result.initial_due_date == datetime(2023, 12, 31).date()
 
 
 def test_create_report_requirement_both_cim_cpo(mock_task):
     condition = PermitConditions(
         condition="Test condition text",
-        permit_condition_id="test-id",
+        permit_condition_id=22,
         meta={
             "questions": [
                 {"question_key": "require_report", "answer": True},
@@ -82,9 +89,14 @@ def test_create_report_requirement_various_frequencies(mock_task):
         ("every 5 years", 60),
     ]
 
+    id = 1
     for frequency, expected_months in test_cases:
         condition = PermitConditions(
-            permit_condition_id="test-id",
+            permit_condition_id=id,
+            permit_amendment_id=mock_task.permit_amendment.permit_amendment_id,
+            condition_category_code="GEC",
+            condition_type_code="CON",
+            display_order=id,
             condition="Test condition text",
             meta={
                 "questions": [
@@ -95,11 +107,14 @@ def test_create_report_requirement_various_frequencies(mock_task):
             },
         )
 
+        condition.save()
+
         result = create_permit_condition_report_requirement(
             mock_task, condition
         )
         assert result is not None
         assert result.due_date_period_months == expected_months
+        id += 1
 
 
 @patch(
@@ -109,8 +124,12 @@ def test_create_report_requirement_invalid_date(
     mock_current_app, mock_task, test_client
 ):
     condition = PermitConditions(
-        permit_condition_id="test-id",
+        permit_condition_id=1,
         condition="Test condition text",
+        permit_amendment_id=mock_task.permit_amendment.permit_amendment_id,
+        condition_category_code="GEC",
+        condition_type_code="CON",
+        display_order=1,
         meta={
             "questions": [
                 {"question_key": "require_report", "answer": True},
@@ -118,8 +137,51 @@ def test_create_report_requirement_invalid_date(
             ]
         },
     )
+    condition.save()
 
     result = create_permit_condition_report_requirement(mock_task, condition)
     assert result is not None
     assert result.initial_due_date is None
     mock_current_app.logger.error.assert_called_once()
+
+def test_create_report_requirement_with_same_meta(mock_task, db_session):
+    """
+    Test creating two conditions with the same report name.
+    Verifies that a single report requirement is created and shared between the conditions.
+    """
+
+    shared_meta = {
+        "questions": [
+            {"question_key": "report_name", "answer": "Test Report"},
+            {"question_key": "require_report", "answer": True},
+            {"question_key": "mention_chief_inspector", "answer": True},
+            {"question_key": "mention_chief_permitting_officer", "answer": True},
+        ]
+    }
+
+    condition_one = PermitConditions(
+        permit_condition_id=1,
+        condition="Test condition text 1",
+        permit_amendment_id=mock_task.permit_amendment.permit_amendment_id,
+        condition_category_code="GEC",
+        condition_type_code="CON",
+        display_order=1,
+        meta=shared_meta
+    )
+    condition_two = PermitConditions(
+        permit_condition_id=2,
+        condition="Test condition text 1",
+        permit_amendment_id=mock_task.permit_amendment.permit_amendment_id,
+        condition_category_code="GEC",
+        condition_type_code="CON",
+        display_order=2,
+        meta=shared_meta
+    )
+    condition_one.save()
+    condition_two.save()
+
+    result_one = create_permit_condition_report_requirement(mock_task, condition_one)
+    create_permit_condition_report_requirement(mock_task, condition_two)
+
+    assert result_one is not None
+    assert result_one.permit_condition_ids == [condition_one.permit_condition_id, condition_two.permit_condition_id]


### PR DESCRIPTION
## Objective 

**Note: This is set to merge into Tara's report PR, not into dev**

Added logic in the function that creates report requirements within the permit extraction flow so that it will append condition ids if that report_name already exists on that amendment.

Took some time to figure out the correct logic for checking/updating objects in the uncommitted session.

<img width="1323" alt="image" src="https://github.com/user-attachments/assets/418e762f-eac5-4a33-bfbf-22da24b8f2f9" />


[MDS-6450](https://bcmines.atlassian.net/browse/MDS-6450)
