### PR TITLE
[MDS-6491] Condition search - Fix now documents, add tenure to index

### DIFF
--- a/services/common/src/interfaces/search/facet-search.interface.ts
+++ b/services/common/src/interfaces/search/facet-search.interface.ts
@@ -20,6 +20,7 @@ export interface HaystackDocumentMeta {
         sibling_contexts?: SiblingContexts;
         child_contexts?: ContextItem[];
     }
+    tenure: string[]
 }
 
 export interface ContextItem {

--- a/services/common/src/tests/mocks/dataMocks.tsx
+++ b/services/common/src/tests/mocks/dataMocks.tsx
@@ -3561,7 +3561,8 @@ export const MOCK_PERMIT_SEARCH_RESULT: HaystackDocumentSearchResult = {
       child_contexts: [
         { id: 'child1', content: 'Child 1', step: 'B', hierarchy: 'B' }
       ]
-    }
+    },
+    tenure: ["Coal", "Placer"],
   }
 };
 

--- a/services/core-api/app/cli_commands/export_permit_conditions.py
+++ b/services/core-api/app/cli_commands/export_permit_conditions.py
@@ -13,7 +13,7 @@ headers = [
     'permit', 'mine_number', 'mine_name', 'document_name',
     'document_manager_guid', 'id', 'condition', 'permit_guid',
     'mine_guid', 'permit_amendment_guid', 'permit_condition_guid',
-    'step_path', 'parent_ids', 'sibling_ids', 'child_ids', 'report_name', 'permit_type'
+    'step_path', 'parent_ids', 'sibling_ids', 'child_ids', 'report_name', 'permit_type', 'tenure'
 ]
 
 
@@ -52,10 +52,20 @@ def export_permit_conditions(permit_amendment_guid, csv_writer=None):
     document_name = ''
     document_guid = ''
 
-    if latest_task and latest_task.permit_amendment_document:
+    if amendment.now_application_guid and amendment.now_application_documents:
+        doc = amendment.now_application_documents[0].mine_document
+        document_name = doc.document_name
+        document_guid = doc.document_manager_guid
+
+    elif latest_task and latest_task.permit_amendment_document:
         doc = latest_task.permit_amendment_document
         document_name = doc.document_name
         document_guid = doc.document_manager_guid
+
+    tenure = []
+
+    for property in permit.site_properties:
+        tenure.append(property.mine_tenure_type.description)
 
     condition_rows = []
     processed_ids = set()
@@ -86,6 +96,7 @@ def export_permit_conditions(permit_amendment_guid, csv_writer=None):
                 'permit_amendment_guid': str(amendment.permit_amendment_guid),
                 'permit_condition_guid': str(condition.permit_condition_guid),
                 'report_name': report_name,
+                'tenure': tenure,
                 **merged_data  # Include merged data
             }
             processed_ids.add(str(condition.permit_condition_guid))
@@ -108,6 +119,7 @@ def export_permit_conditions(permit_amendment_guid, csv_writer=None):
                 'permit_amendment_guid': str(amendment.permit_amendment_guid),
                 'permit_condition_guid': str(condition.permit_condition_guid),
                 'permit_type': 'Notice of Work' if amendment.now_application_guid else 'Major Mine',
+                'tenure': tenure,
                 'id': str(condition.permit_condition_guid),
                 'condition': condition.condition,
                 'report_name': report_name,

--- a/services/permits/app/pipelines/permit_condition_search/create_search_index.py
+++ b/services/permits/app/pipelines/permit_condition_search/create_search_index.py
@@ -206,6 +206,14 @@ fields = [
         sortable=True,
         facetable=True,
     ),
+    SearchField(
+        name="tenure",
+        type="Collection(Edm.String)",
+        searchable=False,
+        filterable=True,
+        sortable=False,
+        facetable=True,
+    ),
 ]
 
 # Vector search configuration

--- a/services/permits/app/pipelines/permit_condition_search/create_search_indexer.py
+++ b/services/permits/app/pipelines/permit_condition_search/create_search_indexer.py
@@ -151,7 +151,11 @@ def create_indexer():
             FieldMapping(
                 source_field_name="/document/embedding",
                 target_field_name="embedding"
-            )
+            ),
+            FieldMapping(
+                source_field_name="/document/tenure",
+                target_field_name="tenure"
+            ),
         ],
     )
     

--- a/services/permits/app/pipelines/permit_condition_search/permit_condition_search_pipeline.py
+++ b/services/permits/app/pipelines/permit_condition_search/permit_condition_search_pipeline.py
@@ -62,6 +62,7 @@ doc_metadata_fields = {
     "sibling_ids": List[str],  # Add sibling_ids
     "child_ids": List[str],  # Add child_ids
     "report_name": str,  # Add report_name field
+    "tenure": List[str],
 }
 
 vector_search_config = VectorSearch()
@@ -153,6 +154,7 @@ def create_permit_condition_search_retrieval_pipeline():
             "mine_name",
             "document_name",
             "permit_type",
+            "tenure"
         ],
     )
 


### PR DESCRIPTION
## Objective 

[MDS-6491](https://bcmines.atlassian.net/browse/MDS-6491)

Address acceptance criteria that was missed from the original PR.

1. Missing NOW documents. I've added some logic to grab the first mine_document from the now documents. Is this the best logic to use?
![image](https://github.com/user-attachments/assets/36316f48-7166-4dd4-bef6-0952a9d8a028)


2. Add Tenure as a filter. I have presumed the logic is the same for this regardless if its a NOW or Major Mine permit.
![image](https://github.com/user-attachments/assets/d1196ddc-2232-4580-b46c-80f8c0dba9d4)

