### PR TITLE
[MDS-6478] Updated github actions and commit action to use github deployment key to push to gitops repo

### DIFF
--- a/.github/actions/setup-ssh/action.yml
+++ b/.github/actions/setup-ssh/action.yml
@@ -1,0 +1,18 @@
+name: "Setup SSH Agent"
+description: "Sets up SSH agent with a private key and adds github.com to known_hosts"
+inputs:
+  ssh-private-key:
+    description: "The SSH private key"
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Setup SSH Agent
+      uses: webfactory/ssh-agent@v0.9.0
+      with:
+        ssh-private-key: ${{ inputs.ssh-private-key }}
+    - name: Add GitHub to known hosts
+      shell: bash
+      run: |
+        mkdir -p ~/.ssh
+        ssh-keyscan github.com >> ~/.ssh/known_hosts

--- a/.github/workflows/core-api.build.deploy.dev.yaml
+++ b/.github/workflows/core-api.build.deploy.dev.yaml
@@ -57,7 +57,6 @@ jobs:
     uses: ./.github/workflows/schemaspy-rollout-dev.yaml
     needs: [build-flyway]
     secrets: inherit
-        
 
   trigger-gitops:
     runs-on: ubuntu-24.04
@@ -66,8 +65,20 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Git Ops Push
-        run: ./gitops/commit.sh core-api dev dev ${{ github.actor }} ${{ secrets.GH_TOKEN }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup SSH Agent
+        uses: ./.github/actions/setup-ssh
+        with:
+          ssh-private-key: ${{ secrets.GITOPS_REPO_DEPLOY_KEY }}
+
+      - name: Commit and Push
+        run: ./gitops/commit.sh core-api dev dev ${{ github.actor }}
       - name: Install oc
         uses: redhat-actions/openshift-tools-installer@v1
         with:

--- a/.github/workflows/core-api.build.deploy.dev.yaml
+++ b/.github/workflows/core-api.build.deploy.dev.yaml
@@ -65,18 +65,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Setup SSH Agent
         uses: ./.github/actions/setup-ssh
         with:
           ssh-private-key: ${{ secrets.GITOPS_REPO_DEPLOY_KEY }}
-
       - name: Commit and Push
         run: ./gitops/commit.sh core-api dev dev ${{ github.actor }}
       - name: Install oc

--- a/.github/workflows/core-api.deploy.prod.yaml
+++ b/.github/workflows/core-api.deploy.prod.yaml
@@ -45,8 +45,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Setup SSH Agent
+        uses: ./.github/actions/setup-ssh
+        with:
+          ssh-private-key: ${{ secrets.GITOPS_REPO_DEPLOY_KEY }}
       - name: Git Ops Push
-        run: ./gitops/commit.sh core-api test prod ${{ github.actor }} ${{ secrets.GH_TOKEN }}
+        run: ./gitops/commit.sh core-api test prod ${{ github.actor }}
       - name: Install oc
         uses: redhat-actions/openshift-tools-installer@v1
         with:

--- a/.github/workflows/core-api.deploy.test.yaml
+++ b/.github/workflows/core-api.deploy.test.yaml
@@ -32,7 +32,7 @@ jobs:
           oc -n ${{secrets.NS_TOOLS}} tag \
           ${{ secrets.NS_TOOLS }}/flyway:${{ env.ORIG_TAG }} \
           ${{ secrets.NS_TOOLS }}/flyway:${{ env.PROMOTE_TAG }}
-      
+
   schemaspy-rollout:
     uses: ./.github/workflows/schemaspy-rollout-test.yaml
     needs: [promote-image-to-test]
@@ -45,8 +45,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
+      - name: Setup SSH Agent
+        uses: ./.github/actions/setup-ssh
+        with:
+          ssh-private-key: ${{ secrets.GITOPS_REPO_DEPLOY_KEY }}
+
       - name: Git Ops Push
-        run: ./gitops/commit.sh core-api dev test ${{ github.actor }} ${{ secrets.GH_TOKEN }}
+        run: ./gitops/commit.sh core-api dev test ${{ github.actor }}
       - name: Install oc
         if: ${{ env.NEEDS_ROLLOUT=='true' }}
         uses: redhat-actions/openshift-tools-installer@v1

--- a/.github/workflows/core-web.build.deploy.dev.yaml
+++ b/.github/workflows/core-web.build.deploy.dev.yaml
@@ -44,8 +44,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
+      - name: Setup SSH Agent
+        uses: ./.github/actions/setup-ssh
+        with:
+          ssh-private-key: ${{ secrets.GITOPS_REPO_DEPLOY_KEY }}
+
       - name: Git Ops Push
-        run: ./gitops/commit.sh core-web dev dev ${{ github.actor }} ${{ secrets.GH_TOKEN }}
+        run: ./gitops/commit.sh core-web dev dev ${{ github.actor }}
       - name: Install oc
         uses: redhat-actions/openshift-tools-installer@v1
         with:

--- a/.github/workflows/core-web.deploy.prod.yaml
+++ b/.github/workflows/core-web.deploy.prod.yaml
@@ -34,13 +34,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Setup SSH Agent
         uses: ./.github/actions/setup-ssh
         with:

--- a/.github/workflows/core-web.deploy.prod.yaml
+++ b/.github/workflows/core-web.deploy.prod.yaml
@@ -34,8 +34,20 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Git Ops Push
-        run: ./gitops/commit.sh core-web test prod ${{ github.actor }} ${{ secrets.GH_TOKEN }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup SSH Agent
+        uses: ./.github/actions/setup-ssh
+        with:
+          ssh-private-key: ${{ secrets.GITOPS_REPO_DEPLOY_KEY }}
+
+      - name: Commit and Push
+        run: ./gitops/commit.sh core-web test prod ${{ github.actor }}
       - name: Install oc
         uses: redhat-actions/openshift-tools-installer@v1
         with:

--- a/.github/workflows/core-web.deploy.test.yaml
+++ b/.github/workflows/core-web.deploy.test.yaml
@@ -34,10 +34,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
+      - name: Setup SSH Agent
+        uses: ./.github/actions/setup-ssh
+        with:
+          ssh-private-key: ${{ secrets.GITOPS_REPO_DEPLOY_KEY }}
+
       - name: Git Ops Push
-        run: ./gitops/commit.sh core-web dev test ${{ github.actor }} ${{ secrets.GH_TOKEN }}
-      - name: Checkout
-        uses: actions/checkout@v3
+        run: ./gitops/commit.sh core-web dev test ${{ github.actor }}
       - name: Install oc
         if: ${{ env.NEEDS_ROLLOUT=='true' }}
         uses: redhat-actions/openshift-tools-installer@v1

--- a/.github/workflows/docman.build.deploy.dev.yaml
+++ b/.github/workflows/docman.build.deploy.dev.yaml
@@ -40,8 +40,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
+      - name: Setup SSH Agent
+        uses: ./.github/actions/setup-ssh
+        with:
+          ssh-private-key: ${{ secrets.GITOPS_REPO_DEPLOY_KEY }}
+
       - name: Git Ops Push
-        run: ./gitops/commit.sh docman dev dev ${{ github.actor }} ${{ secrets.GH_TOKEN }}
+        run: ./gitops/commit.sh docman dev dev ${{ github.actor }}
       - name: Install oc
         uses: redhat-actions/openshift-tools-installer@v1
         with:

--- a/.github/workflows/docman.deploy.prod.yaml
+++ b/.github/workflows/docman.deploy.prod.yaml
@@ -35,8 +35,20 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Git Ops Push
-        run: ./gitops/commit.sh ${{ env.IMAGE }} test prod ${{ github.actor }} ${{ secrets.GH_TOKEN }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup SSH Agent
+        uses: ./.github/actions/setup-ssh
+        with:
+          ssh-private-key: ${{ secrets.GITOPS_REPO_DEPLOY_KEY }}
+
+      - name: Commit and Push
+        run: ./gitops/commit.sh ${{ env.IMAGE }} test prod ${{ github.actor }}
       - name: Install oc
         uses: redhat-actions/openshift-tools-installer@v1
         with:

--- a/.github/workflows/docman.deploy.prod.yaml
+++ b/.github/workflows/docman.deploy.prod.yaml
@@ -35,18 +35,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Setup SSH Agent
         uses: ./.github/actions/setup-ssh
         with:
           ssh-private-key: ${{ secrets.GITOPS_REPO_DEPLOY_KEY }}
-
       - name: Commit and Push
         run: ./gitops/commit.sh ${{ env.IMAGE }} test prod ${{ github.actor }}
       - name: Install oc

--- a/.github/workflows/docman.deploy.test.yaml
+++ b/.github/workflows/docman.deploy.test.yaml
@@ -35,8 +35,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
+      - name: Setup SSH Agent
+        uses: ./.github/actions/setup-ssh
+        with:
+          ssh-private-key: ${{ secrets.GITOPS_REPO_DEPLOY_KEY }}
+
       - name: Git Ops Push
-        run: ./gitops/commit.sh ${{ env.IMAGE }} dev test ${{ github.actor }} ${{ secrets.GH_TOKEN }}
+        run: ./gitops/commit.sh ${{ env.IMAGE }} dev test ${{ github.actor }}
       - name: Install oc
         uses: redhat-actions/openshift-tools-installer@v1
         with:

--- a/.github/workflows/filesystem-provider.build.deploy.dev.yaml
+++ b/.github/workflows/filesystem-provider.build.deploy.dev.yaml
@@ -44,8 +44,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
+      - name: Setup SSH Agent
+        uses: ./.github/actions/setup-ssh
+        with:
+          ssh-private-key: ${{ secrets.GITOPS_REPO_DEPLOY_KEY }}
+
       - name: Git Ops Push
-        run: ./gitops/commit.sh filesystem-provider dev dev ${{ github.actor }} ${{ secrets.GH_TOKEN }}
+        run: ./gitops/commit.sh filesystem-provider dev dev ${{ github.actor }}
       - name: Install oc
         uses: redhat-actions/openshift-tools-installer@v1
         with:

--- a/.github/workflows/filesystem-provider.deploy.prod.yaml
+++ b/.github/workflows/filesystem-provider.deploy.prod.yaml
@@ -35,8 +35,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Setup SSH Agent
+        uses: ./.github/actions/setup-ssh
+        with:
+          ssh-private-key: ${{ secrets.GITOPS_REPO_DEPLOY_KEY }}
       - name: Git Ops Push
-        run: ./gitops/commit.sh ${{ env.IMAGE }} test prod ${{ github.actor }} ${{ secrets.GH_TOKEN }}
+        run: ./gitops/commit.sh ${{ env.IMAGE }} test prod ${{ github.actor }}
       - name: Install oc
         uses: redhat-actions/openshift-tools-installer@v1
         with:

--- a/.github/workflows/filesystem-provider.deploy.test.yaml
+++ b/.github/workflows/filesystem-provider.deploy.test.yaml
@@ -35,8 +35,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
+      - name: Setup SSH Agent
+        uses: ./.github/actions/setup-ssh
+        with:
+          ssh-private-key: ${{ secrets.GITOPS_REPO_DEPLOY_KEY }}
+
       - name: Git Ops Push
-        run: ./gitops/commit.sh ${{ env.IMAGE }} dev test ${{ github.actor }} ${{ secrets.GH_TOKEN }}
+        run: ./gitops/commit.sh ${{ env.IMAGE }} dev test ${{ github.actor }}
       - name: Install oc
         uses: redhat-actions/openshift-tools-installer@v1
         with:

--- a/.github/workflows/minespace.build.deploy.dev.yaml
+++ b/.github/workflows/minespace.build.deploy.dev.yaml
@@ -44,8 +44,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Setup SSH Agent
+        uses: ./.github/actions/setup-ssh
+        with:
+          ssh-private-key: ${{ secrets.GITOPS_REPO_DEPLOY_KEY }}
       - name: Git Ops Push
-        run: ./gitops/commit.sh minespace dev dev ${{ github.actor }} ${{ secrets.GH_TOKEN }}
+        run: ./gitops/commit.sh minespace dev dev ${{ github.actor }}
       - name: Install oc
         uses: redhat-actions/openshift-tools-installer@v1
         with:

--- a/.github/workflows/minespace.deploy.prod.yaml
+++ b/.github/workflows/minespace.deploy.prod.yaml
@@ -35,8 +35,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Setup SSH Agent
+        uses: ./.github/actions/setup-ssh
+        with:
+          ssh-private-key: ${{ secrets.GITOPS_REPO_DEPLOY_KEY }}
       - name: Git Ops Push
-        run: ./gitops/commit.sh ${{ env.IMAGE }} test prod ${{ github.actor }} ${{ secrets.GH_TOKEN }}
+        run: ./gitops/commit.sh ${{ env.IMAGE }} test prod ${{ github.actor }}
       - name: Install oc
         uses: redhat-actions/openshift-tools-installer@v1
         with:

--- a/.github/workflows/minespace.deploy.test.yaml
+++ b/.github/workflows/minespace.deploy.test.yaml
@@ -35,8 +35,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Setup SSH Agent
+        uses: ./.github/actions/setup-ssh
+        with:
+          ssh-private-key: ${{ secrets.GITOPS_REPO_DEPLOY_KEY }}
       - name: Git Ops Push
-        run: ./gitops/commit.sh ${{ env.IMAGE }} dev test ${{ github.actor }} ${{ secrets.GH_TOKEN }}
+        run: ./gitops/commit.sh ${{ env.IMAGE }} dev test ${{ github.actor }}
       - name: Install oc
         if: ${{ env.NEEDS_ROLLOUT=='true' }}
         uses: redhat-actions/openshift-tools-installer@v1

--- a/.github/workflows/nris.build.deploy.dev.yaml
+++ b/.github/workflows/nris.build.deploy.dev.yaml
@@ -40,8 +40,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Setup SSH Agent
+        uses: ./.github/actions/setup-ssh
+        with:
+          ssh-private-key: ${{ secrets.GITOPS_REPO_DEPLOY_KEY }}
       - name: Git Ops Push
-        run: ./gitops/commit.sh nris dev dev ${{ github.actor }} ${{ secrets.GH_TOKEN }}
+        run: ./gitops/commit.sh nris dev dev ${{ github.actor }}
       - name: Install oc
         uses: redhat-actions/openshift-tools-installer@v1
         with:

--- a/.github/workflows/nris.deploy.prod.yaml
+++ b/.github/workflows/nris.deploy.prod.yaml
@@ -35,8 +35,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Setup SSH Agent
+        uses: ./.github/actions/setup-ssh
+        with:
+          ssh-private-key: ${{ secrets.GITOPS_REPO_DEPLOY_KEY }}
       - name: Git Ops Push
-        run: ./gitops/commit.sh ${{ env.IMAGE }} test prod ${{ github.actor }} ${{ secrets.GH_TOKEN }}
+        run: ./gitops/commit.sh ${{ env.IMAGE }} test prod ${{ github.actor }}
       - name: Install oc
         uses: redhat-actions/openshift-tools-installer@v1
         with:

--- a/.github/workflows/nris.deploy.test.yaml
+++ b/.github/workflows/nris.deploy.test.yaml
@@ -35,8 +35,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Setup SSH Agent
+        uses: ./.github/actions/setup-ssh
+        with:
+          ssh-private-key: ${{ secrets.GITOPS_REPO_DEPLOY_KEY }}
       - name: Git Ops Push
-        run: ./gitops/commit.sh ${{ env.IMAGE }} dev test ${{ github.actor }} ${{ secrets.GH_TOKEN }}
+        run: ./gitops/commit.sh ${{ env.IMAGE }} dev test ${{ github.actor }}
       - name: Install oc
         uses: redhat-actions/openshift-tools-installer@v1
         with:

--- a/.github/workflows/permit-service.build.deploy.dev.yaml
+++ b/.github/workflows/permit-service.build.deploy.dev.yaml
@@ -21,21 +21,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      -
-        name: Set up QEMU
+      - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
-      -
-        name: Set up Docker Buildx
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      -
-        name: Login to Openshift image registry
+      - name: Login to Openshift image registry
         uses: docker/login-action@v3
         with:
           registry: ${{ secrets.ARTIFACTORY_CLUSTER_REGISTRY }}
           username: ${{ secrets.ARTIFACTORY_USER }}
           password: ${{ secrets.ARTIFACTORY_PASSWORD }}
-      -
-        name: Build and push
+      - name: Build and push
         uses: docker/build-push-action@v5
         with:
           push: true
@@ -48,8 +44,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Setup SSH Agent
+        uses: ./.github/actions/setup-ssh
+        with:
+          ssh-private-key: ${{ secrets.GITOPS_REPO_DEPLOY_KEY }}
       - name: Git Ops Push
-        run: ./gitops/commit.sh permits dev dev ${{ github.actor }} ${{ secrets.GH_TOKEN }}
+        run: ./gitops/commit.sh permits dev dev ${{ github.actor }}
       - name: Install oc
         uses: redhat-actions/openshift-tools-installer@v1
         with:

--- a/.github/workflows/permit-service.deploy.prod.yaml
+++ b/.github/workflows/permit-service.deploy.prod.yaml
@@ -13,15 +13,13 @@ jobs:
     name: promote-image
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Login to Openshift image registry
+      - name: Login to Openshift image registry
         uses: docker/login-action@v3
         with:
           registry: ${{ secrets.ARTIFACTORY_CLUSTER_REGISTRY }}
           username: ${{ secrets.ARTIFACTORY_USER }}
           password: ${{ secrets.ARTIFACTORY_PASSWORD }}
-      -
-        name: Set up Docker Buildx
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
       - name: Promote from test to prod
@@ -35,8 +33,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Setup SSH Agent
+        uses: ./.github/actions/setup-ssh
+        with:
+          ssh-private-key: ${{ secrets.GITOPS_REPO_DEPLOY_KEY }}
       - name: Git Ops Push
-        run: ./gitops/commit.sh ${{ env.IMAGE }} test prod ${{ github.actor }} ${{ secrets.GH_TOKEN }}
+        run: ./gitops/commit.sh ${{ env.IMAGE }} test prod ${{ github.actor }}
       - name: Install oc
         uses: redhat-actions/openshift-tools-installer@v1
         with:

--- a/.github/workflows/permit-service.deploy.test.yaml
+++ b/.github/workflows/permit-service.deploy.test.yaml
@@ -13,15 +13,13 @@ jobs:
     name: promote-image
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Login to Openshift image registry
+      - name: Login to Openshift image registry
         uses: docker/login-action@v3
         with:
           registry: ${{ secrets.ARTIFACTORY_CLUSTER_REGISTRY }}
           username: ${{ secrets.ARTIFACTORY_USER }}
           password: ${{ secrets.ARTIFACTORY_PASSWORD }}
-      -
-        name: Set up Docker Buildx
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
       - name: Promote from dev to test
@@ -34,8 +32,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Setup SSH Agent
+        uses: ./.github/actions/setup-ssh
+        with:
+          ssh-private-key: ${{ secrets.GITOPS_REPO_DEPLOY_KEY }}
       - name: Git Ops Push
-        run: ./gitops/commit.sh ${{ env.IMAGE }} dev test ${{ github.actor }} ${{ secrets.GH_TOKEN }}
+        run: ./gitops/commit.sh ${{ env.IMAGE }} dev test ${{ github.actor }}
       - name: Install oc
         uses: redhat-actions/openshift-tools-installer@v1
         with:

--- a/.github/workflows/tusd.build.deploy.dev.yaml
+++ b/.github/workflows/tusd.build.deploy.dev.yaml
@@ -40,8 +40,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Setup SSH Agent
+        uses: ./.github/actions/setup-ssh
+        with:
+          ssh-private-key: ${{ secrets.GITOPS_REPO_DEPLOY_KEY }}
       - name: Git Ops Push
-        run: ./gitops/commit.sh tusd dev dev ${{ github.actor }} ${{ secrets.GH_TOKEN }}
+        run: ./gitops/commit.sh tusd dev dev ${{ github.actor }}
       - name: Install oc
         uses: redhat-actions/openshift-tools-installer@v1
         with:

--- a/.github/workflows/tusd.deploy.prod.yaml
+++ b/.github/workflows/tusd.deploy.prod.yaml
@@ -34,8 +34,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
+      - name: Setup SSH Agent
+        uses: ./.github/actions/setup-ssh
+        with:
+          ssh-private-key: ${{ secrets.GITOPS_REPO_DEPLOY_KEY }}
+
       - name: Git Ops Push
-        run: ./gitops/commit.sh tusd test prod ${{ github.actor }} ${{ secrets.GH_TOKEN }}
+        run: ./gitops/commit.sh tusd test prod ${{ github.actor }}
       - name: Install oc
         uses: redhat-actions/openshift-tools-installer@v1
         with:

--- a/.github/workflows/tusd.deploy.test.yaml
+++ b/.github/workflows/tusd.deploy.test.yaml
@@ -34,8 +34,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
+      - name: Setup SSH Agent
+        uses: ./.github/actions/setup-ssh
+        with:
+          ssh-private-key: ${{ secrets.GITOPS_REPO_DEPLOY_KEY }}
+
       - name: Git Ops Push
-        run: ./gitops/commit.sh tusd dev test ${{ github.actor }} ${{ secrets.GH_TOKEN }}
+        run: ./gitops/commit.sh tusd dev test ${{ github.actor }}
       - name: Install oc
         uses: redhat-actions/openshift-tools-installer@v1
         with:

--- a/gitops/commit.sh
+++ b/gitops/commit.sh
@@ -5,7 +5,6 @@ TARGET_APP=${1?"Enter App Name !"}
 SOURCE_ENV=${2?"Enter Source Env Name !"}
 TARGET_ENV=${3?"Enter Target Env Name !"}
 ACTOR_NAME=${4?"Enter Actor Name !"}
-GITHUB_TOKEN=${5?"Enter Github Token !"}
 
 MDS_GIT_HASH=$(git rev-parse --verify HEAD)
 REPO_URL="https://github.com/bcgov/mds/commit"
@@ -37,7 +36,7 @@ function commit() {
 }
 
 if [ ! -d $REPO_LOCATION/gitops/tenant-gitops-4c2ba9 ]; then
-    git clone https://v-y-a-s:$GITHUB_TOKEN@github.com/bcgov-c/tenant-gitops-4c2ba9 $REPO_LOCATION/gitops/tenant-gitops-4c2ba9
+    git clone git@github.com:bcgov-c/tenant-gitops-4c2ba9.git $REPO_LOCATION/gitops/tenant-gitops-4c2ba9
 fi
 
 # Replace the commit id with new commit id of latest push


### PR DESCRIPTION
## Objective 

[MDS-6478](https://bcmines.atlassian.net/browse/MDS-6478)

Updated github actions to use deployment keys to push to gitops repo.
The cert has been added to the `GITOPS_REPO_DEPLOY_KEY` and configured in the gitops repo.

Note: Hard to test this fully locally, so I'm prepared to revert the PR if needed 