### PR TITLE
[MDS-6536] Remove duration and update stage names on Minespace NOW table

### DIFF
--- a/services/minespace-web/src/components/pages/NoticeOfWork/NoticeOfWorkOverviewTab.tsx
+++ b/services/minespace-web/src/components/pages/NoticeOfWork/NoticeOfWorkOverviewTab.tsx
@@ -41,7 +41,7 @@ export const NoticeOfWorkOverviewTab: FC = () => {
         ? noticeOfWorkProgress[stageCode].status
         : NOT_STARTED;
       const inStatusSince = noticeOfWorkProgress[stageCode]
-        ? `${formatDate(noticeOfWorkProgress[stageCode].start_date)} / ${noticeOfWorkProgress[stageCode].duration.trim() || "0 Days"}`
+        ? `${formatDate(noticeOfWorkProgress[stageCode].start_date)}`
         : EMPTY_FIELD;
       return {
         ...stage,

--- a/services/minespace-web/src/components/pages/NoticeOfWork/NoticeOfWorkOverviewTab.tsx
+++ b/services/minespace-web/src/components/pages/NoticeOfWork/NoticeOfWorkOverviewTab.tsx
@@ -5,31 +5,29 @@ import { formatDate } from "@mds/common/redux/utils/helpers";
 import { EMPTY_FIELD, NOT_STARTED } from "@mds/common/constants/strings";
 
 import { getNOWProgress } from "@mds/common/redux/selectors/noticeOfWorkSelectors";
-import { getNoticeOfWorkApplicationProgressStatusCodeOptionsHash } from "@mds/common/redux/selectors/staticContentSelectors";
 import NoticeOfWorkStagesTable from "./NoticeOfWorkStagesTable";
 
 export const NoticeOfWorkOverviewTab: FC = () => {
   const noticeOfWorkProgress = useSelector(getNOWProgress) ?? {};
-  const progressStatusHash = useSelector(getNoticeOfWorkApplicationProgressStatusCodeOptionsHash);
   const nowApplicationStages = [
     {
-      title: "Application",
+      title: "Technical Review",
       stageCode: "REV",
     },
     {
-      title: progressStatusHash["REF"],
+      title: "Referral to Other Agencies",
       stageCode: "REF",
     },
     {
-      title: progressStatusHash["CON"],
+      title: "First Nations Consultation",
       stageCode: "CON",
     },
     {
-      title: progressStatusHash["PUB"],
+      title: "Open for Public Comment",
       stageCode: "PUB",
     },
     {
-      title: "Permit",
+      title: "Permit Considerations in Review",
       stageCode: "DFT",
     },
   ];

--- a/services/minespace-web/src/tests/components/pages/__snapshots__/noticeOfWOrkPage.spec.tsx.snap
+++ b/services/minespace-web/src/tests/components/pages/__snapshots__/noticeOfWOrkPage.spec.tsx.snap
@@ -227,7 +227,7 @@ exports[`NoticeOfWorkPage renders properly 1`] = `
                                             class="light"
                                             title="Application Stage"
                                           >
-                                            Application
+                                            Technical Review
                                           </b>
                                         </td>
                                         <td
@@ -269,89 +269,9 @@ exports[`NoticeOfWorkPage renders properly 1`] = `
                                           <b
                                             class="light"
                                             title="Application Stage"
-                                          />
-                                        </td>
-                                        <td
-                                          class="ant-table-cell"
-                                        >
-                                          <div
-                                            title="Stage Status"
                                           >
-                                            <span
-                                              class="ant-badge ant-badge-status ant-badge-not-a-wrapper"
-                                            >
-                                              <span
-                                                class="ant-badge-status-dot ant-badge-status-default"
-                                              />
-                                              <span
-                                                class="ant-badge-status-text"
-                                              >
-                                                Not Started
-                                              </span>
-                                            </span>
-                                          </div>
-                                        </td>
-                                        <td
-                                          class="ant-table-cell"
-                                        >
-                                          <div
-                                            title="In status since"
-                                          >
-                                            N/A
-                                          </div>
-                                        </td>
-                                      </tr>
-                                      <tr
-                                        class="ant-table-row ant-table-row-level-0"
-                                      >
-                                        <td
-                                          class="ant-table-cell"
-                                        >
-                                          <b
-                                            class="light"
-                                            title="Application Stage"
-                                          />
-                                        </td>
-                                        <td
-                                          class="ant-table-cell"
-                                        >
-                                          <div
-                                            title="Stage Status"
-                                          >
-                                            <span
-                                              class="ant-badge ant-badge-status ant-badge-not-a-wrapper"
-                                            >
-                                              <span
-                                                class="ant-badge-status-dot ant-badge-status-default"
-                                              />
-                                              <span
-                                                class="ant-badge-status-text"
-                                              >
-                                                Not Started
-                                              </span>
-                                            </span>
-                                          </div>
-                                        </td>
-                                        <td
-                                          class="ant-table-cell"
-                                        >
-                                          <div
-                                            title="In status since"
-                                          >
-                                            N/A
-                                          </div>
-                                        </td>
-                                      </tr>
-                                      <tr
-                                        class="ant-table-row ant-table-row-level-0"
-                                      >
-                                        <td
-                                          class="ant-table-cell"
-                                        >
-                                          <b
-                                            class="light"
-                                            title="Application Stage"
-                                          />
+                                            Referral to Other Agencies
+                                          </b>
                                         </td>
                                         <td
                                           class="ant-table-cell"
@@ -393,7 +313,93 @@ exports[`NoticeOfWorkPage renders properly 1`] = `
                                             class="light"
                                             title="Application Stage"
                                           >
-                                            Permit
+                                            First Nations Consultation
+                                          </b>
+                                        </td>
+                                        <td
+                                          class="ant-table-cell"
+                                        >
+                                          <div
+                                            title="Stage Status"
+                                          >
+                                            <span
+                                              class="ant-badge ant-badge-status ant-badge-not-a-wrapper"
+                                            >
+                                              <span
+                                                class="ant-badge-status-dot ant-badge-status-default"
+                                              />
+                                              <span
+                                                class="ant-badge-status-text"
+                                              >
+                                                Not Started
+                                              </span>
+                                            </span>
+                                          </div>
+                                        </td>
+                                        <td
+                                          class="ant-table-cell"
+                                        >
+                                          <div
+                                            title="In status since"
+                                          >
+                                            N/A
+                                          </div>
+                                        </td>
+                                      </tr>
+                                      <tr
+                                        class="ant-table-row ant-table-row-level-0"
+                                      >
+                                        <td
+                                          class="ant-table-cell"
+                                        >
+                                          <b
+                                            class="light"
+                                            title="Application Stage"
+                                          >
+                                            Open for Public Comment
+                                          </b>
+                                        </td>
+                                        <td
+                                          class="ant-table-cell"
+                                        >
+                                          <div
+                                            title="Stage Status"
+                                          >
+                                            <span
+                                              class="ant-badge ant-badge-status ant-badge-not-a-wrapper"
+                                            >
+                                              <span
+                                                class="ant-badge-status-dot ant-badge-status-default"
+                                              />
+                                              <span
+                                                class="ant-badge-status-text"
+                                              >
+                                                Not Started
+                                              </span>
+                                            </span>
+                                          </div>
+                                        </td>
+                                        <td
+                                          class="ant-table-cell"
+                                        >
+                                          <div
+                                            title="In status since"
+                                          >
+                                            N/A
+                                          </div>
+                                        </td>
+                                      </tr>
+                                      <tr
+                                        class="ant-table-row ant-table-row-level-0"
+                                      >
+                                        <td
+                                          class="ant-table-cell"
+                                        >
+                                          <b
+                                            class="light"
+                                            title="Application Stage"
+                                          >
+                                            Permit Considerations in Review
                                           </b>
                                         </td>
                                         <td


### PR DESCRIPTION
## Objective 

[MDS-6536](https://bcmines.atlassian.net/browse/MDS-6536)
[MDS-6535](https://bcmines.atlassian.net/browse/MDS-6535)

Remove the stage duration from the Minespace NOW table and update the stage names.

![image](https://github.com/user-attachments/assets/45b355dd-dadb-4a2e-baf0-386840316ceb)
