### PR TITLE
[MDS-6524] Fix rsbuild globals config

### DIFF
--- a/services/core-web/rsbuild.config.ts
+++ b/services/core-web/rsbuild.config.ts
@@ -4,7 +4,7 @@ import dotenv from "dotenv";
 import { pluginSass } from '@rsbuild/plugin-sass';
 import { pluginLess } from '@rsbuild/plugin-less';
 import { pluginReact } from '@rsbuild/plugin-react';
-import { defineConfig } from '@rsbuild/core';
+import { defineConfig, rspack } from '@rsbuild/core';
 import { pluginTypeCheck } from '@rsbuild/plugin-type-check';
 
 
@@ -83,9 +83,6 @@ export default defineConfig({
     assetsInclude: /\.(?:png|jpe?g|gif|svg|mp3|pdf|docx?|xlsx?|woff2?|ttf|eot)$/,
     define: {
       "process.env": JSON.stringify(envFile),
-      REQUEST_HEADER: JSON.stringify(path.resolve(__dirname, "common/utils/RequestHeaders.js")),
-      GLOBAL_ROUTES: JSON.stringify(path.resolve(__dirname, "src/constants/routes.ts")),
-
     }
   },
   resolve: {
@@ -109,6 +106,14 @@ export default defineConfig({
         }
       }
 
+    },
+    rspack: {
+      plugins: [
+        new rspack.ProvidePlugin({
+          REQUEST_HEADER: path.resolve(__dirname, "common/utils/RequestHeaders.js"),
+          GLOBAL_ROUTES: path.resolve(__dirname, "src/constants/routes.ts"),
+        })
+      ]
     }
 
   }


### PR DESCRIPTION
## Objective 

[MDS-6524](https://bcmines.atlassian.net/browse/MDS-6524)

Turns out it was a quick fix to resolve the rsbuild issues we encountered when uploading files and viewing a permit.
 
<img width="419" alt="image" src="https://github.com/user-attachments/assets/c9d80c68-a660-4548-966c-f0218c8915a9" />

Fix? Correctly define the REQUEST_HEADER and GLOBAL_ROUTES globals