### PR TITLE
[FIX] Minespace header styling

### DIFF
--- a/services/minespace-web/src/styles/components/Button.scss
+++ b/services/minespace-web/src/styles/components/Button.scss
@@ -8,18 +8,21 @@
   padding: 0 16px;
   font-weight: variables.$semi-bold;
 
-  // these and the hover rules are really only for default,
-  // but due to precendence rules, kept at top level
-  color: variables.$secondary-btn-color; // #medium-grey
-  border: 2px solid variables.$secondary-btn-color;
+  .ant-btn-default,
+  .ant-btn-secondary {
+    color: variables.$secondary-btn-color; // #medium-grey
+    border: 2px solid variables.$secondary-btn-color;
 
-  &:hover {
-    color: variables.$secondary-btn-color-hover;
-    border-color: variables.$secondary-btn-border-color-hover;
+    &:hover {
+      color: variables.$secondary-btn-color-hover;
+      border-color: variables.$secondary-btn-border-color-hover;
+    }
   }
 
-  span {
-    font-size: 14px;
+  &:not(.ant-btn-icon-only) {
+    span {
+      font-size: 14px;
+    }
   }
 
   &-primary {

--- a/services/minespace-web/src/styles/components/Header.scss
+++ b/services/minespace-web/src/styles/components/Header.scss
@@ -62,11 +62,15 @@
   z-index: 1001;
 }
 
-.header-dropdown-button {
+.ant-btn.header-dropdown-button {
   color: $gov-yellow;
   border: none;
   background-color: transparent !important;
   font-weight: bold;
+
+  span {
+    font-size: 16px !important;
+  }
 
   &:active,
   &:focus,
@@ -80,6 +84,11 @@
   background-color: transparent !important;
   box-shadow: none !important;
   font-weight: bold !important;
+  margin-bottom: 0 !important;
+
+  span {
+    font-size: 16px !important;
+  }
 
   & a {
     text-decoration: none;
@@ -215,36 +224,44 @@
 }
 
 .notification-button {
-  &:hover {
+
+  &:hover,
+  &:focus {
     background-color: unset !important;
+
+    .notification-icon {
+      svg {
+        scale: 1.1;
+      }
+    }
   }
-}
 
-.notification-button-all-container {
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  background-color: #FFFFFF;
-}
+  .notification-button-all-container {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    background-color: #FFFFFF;
+  }
 
-.notification-button-all,
-.notification-button-all:active {
-  border: none;
-  background-color: #FFFFFF;
-  display: flex;
-  align-items: center;
-  transition: 0.3s ease-in-out;
-}
+  .notification-button-all,
+  .notification-button-all:active {
+    border: none;
+    background-color: #FFFFFF;
+    display: flex;
+    align-items: center;
+    transition: 0.3s ease-in-out;
+  }
 
-.notification-button-all>span {
-  font-size: 12px;
-}
+  .notification-button-all>span {
+    font-size: 12px;
+  }
 
-.notification-button-all:hover {
-  background-color: #FFFFFF;
-  border: none;
-}
+  .notification-button-all:hover {
+    background-color: #FFFFFF;
+    border: none;
+  }
 
-.notification-button-all:hover>span {
-  text-decoration: underline;
+  .notification-button-all:hover>span {
+    text-decoration: underline;
+  }
 }

--- a/services/minespace-web/src/styles/components/Header.scss
+++ b/services/minespace-web/src/styles/components/Header.scss
@@ -214,6 +214,12 @@
   height: 16px;
 }
 
+.notification-button {
+  &:hover {
+    background-color: unset !important;
+  }
+}
+
 .notification-button-all-container {
   display: flex;
   align-items: center;

--- a/services/minespace-web/src/styles/components/HelpGuide.scss
+++ b/services/minespace-web/src/styles/components/HelpGuide.scss
@@ -8,12 +8,13 @@
     }
 }
 
-.help-open {
+.ant-btn.help-open {
     font-size: 18px;
     margin-bottom: 0;
     border: none;
     color: white;
     margin-right: 20px;
+    margin-left: 16px;
 
     &:hover,
     &:focus,


### PR DESCRIPTION
## Objective 

Make it look like this again:
![image](https://github.com/user-attachments/assets/3795af3f-d5c7-4662-8148-777841949387)

Made a little tweak too where hovering over the notification bell icon doesn't make a giant white rectangle, but instead the icon grows a little bit (from the centre so it doesn't make the spacing odd)
