### PR TITLE
[MDS-6541] Handle deleted conditions

### DIFF
--- a/services/common/src/components/permits/ReportPermitRequirementForm.tsx
+++ b/services/common/src/components/permits/ReportPermitRequirementForm.tsx
@@ -150,13 +150,14 @@ export const ReportPermitRequirementForm: FC<ReportPermitRequirementProps> = ({
     const children = condition.sub_conditions.map((c) => conditionToTree(c));
     const value = condition.permit_condition_id;
     const title = condition.stepPath;
-
+    
     return ({
       value,
       key: condition.permit_condition_id,
       title,
       children,
-      checkable: true
+      checkable: true,
+      disabled: condition.mineReportPermitRequirement && condition.mineReportPermitRequirement !== mineReportPermitRequirement
     });
   };
 

--- a/services/common/src/components/reports/PermitRequiredReportFields.tsx
+++ b/services/common/src/components/reports/PermitRequiredReportFields.tsx
@@ -25,7 +25,7 @@ export const PermitReportCodeRequirement: FC<{
   amendment: IPermitAmendment;
   summary?: boolean;
 }> = ({ amendment, summary = false }) => {
-  const reports = amendment?.mine_report_permit_requirements;
+  const reports = amendment?.mine_report_permit_requirements.filter( report => report.permit_condition_ids.length > 0 ) || [];
   const reportOptions = createDropDownList(
     uniqBy(reports, "report_name"),
     "report_name",

--- a/services/core-api/app/api/mines/permits/permit_conditions/resources/permit_conditions_resource.py
+++ b/services/core-api/app/api/mines/permits/permit_conditions/resources/permit_conditions_resource.py
@@ -4,6 +4,7 @@ from werkzeug.exceptions import BadRequest, NotFound, InternalServerError
 from marshmallow.exceptions import MarshmallowError
 from datetime import datetime, timezone
 
+from app.api.mines.reports.models.mine_report_req_permit_condition_xref import MineReportReqPermitConditionXref
 from app.extensions import api, jwt, db
 from app.api.mines.response_models import PERMIT_CONDITION_MODEL
 from app.api.mines.permits.permit_conditions.models.permit_conditions import PermitConditions
@@ -166,7 +167,7 @@ class PermitConditionsResource(Resource, UserMixin):
             raise BadRequest('No permit condition found with that guid.')
 
         permit_condition.deleted_ind = True
-        permit_condition.save()
+        permit_condition.save(commit=False)
 
         conditions = []
         if permit_condition.parent_permit_condition_id is not None:
@@ -181,6 +182,11 @@ class PermitConditionsResource(Resource, UserMixin):
         for i, condition in enumerate(sorted(conditions, key=lambda x: x.display_order)):
             condition.display_order = i + 1
             condition.save(commit=False)
+
+        xref = MineReportReqPermitConditionXref.find_by_permit_condition_id(permit_condition.permit_condition_id)
+        if xref:
+            xref.deleted_ind = True
+            xref.save(commit=False)
 
         set_audit_metadata(permit_amendment, False)
         db.session.commit()

--- a/services/core-api/app/api/mines/permits/permit_extraction/resources/permit_condition_extraction_resource.py
+++ b/services/core-api/app/api/mines/permits/permit_extraction/resources/permit_condition_extraction_resource.py
@@ -19,6 +19,7 @@ from app.api.mines.permits.permit_extraction.models.response_model import (
 from app.api.mines.permits.permit_extraction.tasks import (
     poll_update_permit_extraction_status,
 )
+from app.api.mines.reports.models.mine_report_req_permit_condition_xref import MineReportReqPermitConditionXref
 from app.api.search.search.permit_search_service import PermitSearchService
 from app.api.utils.access_decorators import (
     VIEW_ALL,
@@ -121,6 +122,7 @@ class PermitConditionExtractionResource(Resource, UserMixin):
 
         PermitConditions.delete_all_by_permit_amendment_id(args['permit_amendment_id'], commit=True)
         PermitConditionCategory.delete_all_by_permit_amendment_id(args['permit_amendment_id'])
+        MineReportReqPermitConditionXref.delete_all_by_permit_amendment_id(args['permit_amendment_id'])
 
         permit_amendment = PermitAmendment.find_by_permit_amendment_id(args['permit_amendment_id'])
         permit_extraction_tasks = PermitExtractionTask.get_by_permit_amendment_guid(permit_amendment.permit_amendment_guid)

--- a/services/core-api/app/api/mines/reports/models/mine_report_permit_requirement.py
+++ b/services/core-api/app/api/mines/reports/models/mine_report_permit_requirement.py
@@ -51,6 +51,7 @@ class MineReportPermitRequirement(SoftDeleteMixin, AuditMixin, HistoryMixin, Bas
     permit_conditions = db.relationship(
         'PermitConditions',
         secondary='mine_report_req_permit_condition_xref',
+        secondaryjoin='and_(MineReportReqPermitConditionXref.permit_condition_id == PermitConditions.permit_condition_id, MineReportReqPermitConditionXref.deleted_ind==False)',
         lazy='joined',
         backref=backref('mine_report_permit_requirements', lazy='joined')
     )

--- a/services/core-api/app/api/mines/reports/models/mine_report_req_permit_condition_xref.py
+++ b/services/core-api/app/api/mines/reports/models/mine_report_req_permit_condition_xref.py
@@ -39,3 +39,17 @@ class MineReportReqPermitConditionXref(SoftDeleteMixin, AuditMixin, HistoryMixin
             permit_condition_id=permit_condition_id,    
         )
         return mine_report_req_permit_condition_xref
+    
+    @classmethod
+    def delete_all_by_permit_amendment_id(cls, permit_amendment_id, commit=False):
+        xrefs = (
+            cls.query.join(cls.mine_report_permit_requirement).filter_by(
+                permit_amendment_id=permit_amendment_id,
+                deleted_ind=False,
+            )
+            .all()
+        )
+        for xref in xrefs:
+            xref.delete(commit=commit)
+
+        db.session.commit()

--- a/services/core-api/app/api/mines/reports/resources/mine_reports.py
+++ b/services/core-api/app/api/mines/reports/resources/mine_reports.py
@@ -173,6 +173,8 @@ class MineReportListResource(Resource, UserMixin):
                 permit_requirement = MineReportPermitRequirement.find_by_mine_report_permit_requirement_id(mine_report_permit_requirement_id)
                 if not permit_requirement:
                     raise BadRequest('Mine report permit requirement is required')
+                if permit_requirement.permit_condition_ids is None or len(permit_requirement.permit_condition_ids) == 0:
+                    raise BadRequest('Mine report permit requirement must have at least one permit condition associated with it.')
             if not permit_guid:
                 raise BadRequest('A permit must be selected for Permit Required Report')
 


### PR DESCRIPTION
## Objective 

[MDS-6541](https://bcmines.atlassian.net/browse/MDS-6541)

- Delete xrefs when a condition is deleted
- Delete xrefs when a permit extraction is deleted
- Filter out deleted conditions/xrefs so permit extraction doesn't regenerate them
- Prevent reports with no conditions from being selectable on the FE
- Prevent reports with no conditions from being submitted on the BE
- Prevent conditions from being added to multiple reports by disabling them in the tree

