### PR TITLE
[MDS-6413] Report/condition 1-many: Filter Out Removed Conditions

### DIFF
--- a/services/common/src/components/reports/ReportInfoBox.tsx
+++ b/services/common/src/components/reports/ReportInfoBox.tsx
@@ -78,7 +78,11 @@ export const PermitReportInfoBox: FC<{
     const { conditionMap } = useAppSelector(
       getPermitConditionCategories(permitGuid, permitAmendmentGuid)
     );
-    const conditions = permitReport?.permit_condition_ids.map((id) => conditionMap[id]).sort((a, b) => a.stepPath.localeCompare(b.stepPath))
+
+    const conditions = permitReport?.permit_condition_ids
+      .map((id) => conditionMap[id])
+      .filter(Boolean)
+      .sort((a, b) => a.stepPath.localeCompare(b.stepPath))
 
     const getConditionHref = (condition: IPermitCondition) => {
       return GLOBAL_ROUTES?.VIEW_MINE_PERMIT_AMENDMENT.hashRoute(


### PR DESCRIPTION
## Objective 
- error when submitting reports when a report was associated with a removed condition
- little FE fix to make things more stable (probably won't happen after Sam's PR removes the report/xref on condition delete)

[MDS-6413](https://bcmines.atlassian.net/browse/MDS-6413)

_Why are you making this change? Provide a short explanation and/or screenshots_
