### PR TITLE
[MDS-6563] Add termination report trigger for EOR and TQP appointments

### DIFF
--- a/services/core-api/app/api/parties/party_appt/models/mine_party_appt.py
+++ b/services/core-api/app/api/parties/party_appt/models/mine_party_appt.py
@@ -497,7 +497,7 @@ class MinePartyAppointment(SoftDeleteMixin, AuditMixin, DraftMixin, Base):
             mpa.save(commit=False)
         return mpa
     
-    def request_termination_report_if_required(self):
+    def request_termination_report_if_required(self, trigger_with_pending_assignment = False):
         if not is_feature_enabled(Feature.TSF_TERMINATE_APPTS):
             return
 
@@ -507,12 +507,12 @@ class MinePartyAppointment(SoftDeleteMixin, AuditMixin, DraftMixin, Base):
             'TQP': ['10', '4', '2', '1(d)'],
         }
         section = required_reports.get(self.mine_party_appt_type_code, None)
-        if section and self.end_date:
+        if section and (self.end_date or trigger_with_pending_assignment):
             mine_report_definition = MineReportDefinition.find_one_by_section(*section)
             if not mine_report_definition:
                 section_output = '.'.join(section)
                 raise NotFound(f'{self.mine_party_appt_type_code} Report definition not found by section {section_output}')
-            calculated_due_date = self.end_date + timedelta(hours=72)
+            calculated_due_date = self.end_date + timedelta(hours=72) if self.end_date else datetime.now() + timedelta(hours=72)
             report = MineReport.create(
                 mine_report_definition_id=mine_report_definition.mine_report_definition_id,
                 mine_guid=self.mine_guid,

--- a/services/core-api/app/api/parties/party_appt/resources/mine_party_appt_resource.py
+++ b/services/core-api/app/api/parties/party_appt/resources/mine_party_appt_resource.py
@@ -184,7 +184,7 @@ class MinePartyApptResource(Resource, UserMixin):
             mine_party_acknowledgement_status = MinePartyAcknowledgedStatus.not_acknowledged
         elif mine_party_appt_type_code == 'EOR':
             mine_party_acknowledgement_status = MinePartyAcknowledgedStatus.acknowledged
-        
+
         if end_current and (not is_minespace_user() or mine_party_appt_type_code == 'TQP'):
             new_status = MinePartyAppointmentStatus.active
             MinePartyAppointment.end_current(
@@ -249,6 +249,16 @@ class MinePartyApptResource(Resource, UserMixin):
                         'mine_tailings_storage_facility_guid': str(tsf.mine_tailings_storage_facility_guid),
                     }}
                 )
+
+        if end_current and mine_party_appt_type_code in ['EOR', 'TQP']:
+            if mine_party_appt_type_code == 'EOR':
+                current_eor_list = MinePartyAppointment.find_current_appointments(mine_guid, 'EOR', None, tsf.mine_tailings_storage_facility_guid)
+                if len(current_eor_list) > 0:
+                    current_eor_list[0].request_termination_report_if_required(True)
+            if mine_party_appt_type_code == 'TQP':
+                current_tqp_list = MinePartyAppointment.find_current_appointments(mine_guid, 'TQP', None, tsf.mine_tailings_storage_facility_guid)
+                if len(current_tqp_list) > 0:
+                    current_tqp_list[0].request_termination_report_if_required(True)
 
         return new_mpa.json()
 

--- a/services/core-api/app/api/parties/party_appt/resources/mine_party_appt_resource.py
+++ b/services/core-api/app/api/parties/party_appt/resources/mine_party_appt_resource.py
@@ -251,14 +251,9 @@ class MinePartyApptResource(Resource, UserMixin):
                 )
 
         if end_current and mine_party_appt_type_code in ['EOR', 'TQP']:
-            if mine_party_appt_type_code == 'EOR':
-                current_eor_list = MinePartyAppointment.find_current_appointments(mine_guid, 'EOR', None, tsf.mine_tailings_storage_facility_guid)
-                if len(current_eor_list) > 0:
-                    current_eor_list[0].request_termination_report_if_required(True)
-            if mine_party_appt_type_code == 'TQP':
-                current_tqp_list = MinePartyAppointment.find_current_appointments(mine_guid, 'TQP', None, tsf.mine_tailings_storage_facility_guid)
-                if len(current_tqp_list) > 0:
-                    current_tqp_list[0].request_termination_report_if_required(True)
+            current_appt_list = MinePartyAppointment.find_current_appointments(mine_guid, mine_party_appt_type_code, None, tsf.mine_tailings_storage_facility_guid)
+            if len(current_appt_list) > 0:
+                current_appt_list[0].request_termination_report_if_required(True)
 
         return new_mpa.json()
 


### PR DESCRIPTION
## Objective 

- Added a trigger to generate report requests for the termination (change) of EOR/QP assignments when a new assignment is created, and an active one already exists.
- These will trigger when the new assignment is made from Core or Minespace.

[MDS-6563](https://bcmines.atlassian.net/browse/MDS-6563)

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/b7fb92c3-37b0-4c96-972f-881631a435cb" />
