### PR TITLE
[MDS-6557] Permit Condition Editor UI

### DIFF
--- a/services/common/src/components/forms/RenderCancelButton.tsx
+++ b/services/common/src/components/forms/RenderCancelButton.tsx
@@ -60,7 +60,11 @@ const RenderCancelButton: FC<RenderCancelButtonProps> = ({
   const { formName, isModal, isEditMode } = useContext(FormContext);
   const isFormDirty = useSelector(isDirty(formName));
 
-  const handleCancel = () => {
+  const handleCancel = (e?) => {
+    if (e) {
+      e?.stopPropagation();
+      e?.preventDefault();
+    }
     if (cancelFunction) {
       cancelFunction();
     }

--- a/services/common/src/components/forms/RenderCancelButton.tsx
+++ b/services/common/src/components/forms/RenderCancelButton.tsx
@@ -60,11 +60,7 @@ const RenderCancelButton: FC<RenderCancelButtonProps> = ({
   const { formName, isModal, isEditMode } = useContext(FormContext);
   const isFormDirty = useSelector(isDirty(formName));
 
-  const handleCancel = (e?) => {
-    if (e) {
-      e?.stopPropagation();
-      e?.preventDefault();
-    }
+  const handleCancel = () => {
     if (cancelFunction) {
       cancelFunction();
     }

--- a/services/common/src/components/permits/DeleteConditionModal.tsx
+++ b/services/common/src/components/permits/DeleteConditionModal.tsx
@@ -1,0 +1,60 @@
+import React, { FC } from "react";
+import { useAppDispatch } from "@mds/common/redux/rootState";
+import { closeModal } from "@mds/common/redux/actions/modalActions";
+import { IPermitCondition } from "@mds/common/interfaces";
+import { Button, Result, Row, Typography } from "antd";
+
+
+const label = {
+    SEC: "section? All associated conditions and list items will be removed.",
+    CON: "condition? All associated list items will be removed.",
+    LIS: "list item?",
+};
+
+interface DeleteConditionModalProps {
+    condition: IPermitCondition;
+    onSubmit: () => void | Promise<void>;
+    title: string;
+}
+
+export const DeleteConditionModal: FC<DeleteConditionModalProps> = ({ condition, onSubmit, title }) => {
+
+    const dispatch = useAppDispatch();
+    const onCancel = () => {
+        dispatch(closeModal());
+    }
+    const handleSubmit = () => {
+        onSubmit();
+        dispatch(closeModal());
+    }
+    return (
+        <div>
+            <Result
+                status="warning"
+                title={`Are you sure you want to delete the following ${label[condition.condition_type_code]
+                    }`}
+            />
+            <Typography.Paragraph strong>
+                {condition.stepPath}
+            </Typography.Paragraph>
+            <Typography.Paragraph>
+                {condition.condition}
+            </Typography.Paragraph>
+            <Row justify="end" className="form-button-container-row">
+                <Button
+                    className="form-btn"
+                    onClick={onCancel}
+                >
+                    Cancel
+                </Button>
+                <Button
+                    className="form-btn"
+                    type="primary"
+                    onClick={handleSubmit}
+                >
+                    {title}
+                </Button>
+            </Row>
+        </div>
+    );
+}

--- a/services/common/src/components/permits/PermitConditionForm.tsx
+++ b/services/common/src/components/permits/PermitConditionForm.tsx
@@ -30,6 +30,7 @@ import { formatPermitConditionStep, parsePermitConditionStep } from "@mds/common
 import { FORM } from "@mds/common/constants/forms";
 import RenderGroupedSelect from "@mds/common/components/forms/RenderGroupedSelect";
 import { PermitConditionsProvider, usePermitConditions } from "@mds/common/components/permits/PermitConditionsContext";
+import { DeleteConditionModal } from "./DeleteConditionModal";
 
 interface PermitConditionFormProps {
     isExtracted: boolean;
@@ -142,7 +143,9 @@ const PermitConditionForm: FC<PermitConditionFormProps> = ({
     };
 
     const handleDelete = async () => {
-        deleteConfirmWrapper("Permit Condition", async () => {
+        const title = "Delete Condition";
+
+        const onSubmit = async () => {
             const resp = await dispatch(
                 deletePermitCondition(permitAmendmentGuid, condition.permit_condition_guid)
             );
@@ -151,7 +154,16 @@ const PermitConditionForm: FC<PermitConditionFormProps> = ({
                 refreshData();
                 cancelEdit();
             }
-        });
+        }
+
+        dispatch(openModal({
+            props: {
+                title,
+                condition,
+                onSubmit
+            },
+            content: DeleteConditionModal
+        }))
     };
 
     const handleOpenAddReportModal = (event, reportCondition: IPermitCondition) => {

--- a/services/common/src/components/permits/PermitConditionForm.tsx
+++ b/services/common/src/components/permits/PermitConditionForm.tsx
@@ -1,8 +1,7 @@
 import React, { FC, useEffect, useState } from "react";
-import { useAppDispatch } from "@mds/common/redux/rootState";
-import { useParams } from "react-router-dom";
-import { change, Field, reset } from "@mds/common/components/forms/form";
-import { Row, Col, Button, Typography } from "antd";
+import { useAppDispatch, useAppSelector } from "@mds/common/redux/rootState";
+import { change, Field, isDirty, reset } from "@mds/common/components/forms/form";
+import { Row, Col, Button, Typography, Modal } from "antd";
 import {
     faArrowDown,
     faArrowUp,
@@ -38,8 +37,8 @@ interface PermitConditionFormProps {
     condition: IPermitCondition;
     canEditPermitConditions: boolean;
     onEdit: () => void;
-    setEditingConditionGuid: (condition_guid: string) => void;
-    editingConditionGuid: string;
+    setEditingFormName: (formName: string) => void;
+    editingFormName: string;
     moveUp?: (condition: IPermitCondition) => Promise<void>;
     moveDown?: (condition: IPermitCondition) => Promise<void>;
     refreshData: () => Promise<void>;
@@ -53,8 +52,8 @@ const PermitConditionForm: FC<PermitConditionFormProps> = ({
     canEditPermitConditions,
     condition,
     onEdit,
-    setEditingConditionGuid,
-    editingConditionGuid,
+    setEditingFormName,
+    editingFormName,
     moveUp,
     moveDown,
     refreshData,
@@ -63,22 +62,39 @@ const PermitConditionForm: FC<PermitConditionFormProps> = ({
     categoryOptions,
 }) => {
     const dispatch = useAppDispatch();
-    const { id: mineGuid, permitGuid } = useParams<{ id: string; permitGuid: string }>();
     const [isEditMode, setIsEditMode] = useState<boolean>(false);
     const permitConditionsValue = usePermitConditions();
-    const { currentAmendment, loading, setLoading } = permitConditionsValue;
+    const { loading, setLoading } = permitConditionsValue;
     // the form fails to re-initialize when the category is changed, so concatenating it forces it to make a new one
     const formName = `${FORM.EDIT_PERMIT_CONDITION}_${condition.permit_condition_id}_${condition.condition_category_code}`;
+    const editingFormDirty = useAppSelector(isDirty(editingFormName));
+    const listItemFormDirty = useAppSelector(isDirty(FORM.EDIT_PERMIT_CONDITION));
 
     const startEdit = () => {
-        onEdit();
-        setEditingConditionGuid(condition.permit_condition_guid);
-        setIsEditMode(true);
+        const handleEdit = () => {
+            onEdit();
+            setEditingFormName(formName);
+            setIsEditMode(true);
+        }
+        if (editingFormName && (editingFormDirty || listItemFormDirty)) {
+            Modal.confirm({
+                title: "Discard changes?",
+                content: "Another condition is currently being edited. Do you want to continue editing or discard the changes?",
+                onOk: () => {
+                    dispatch(reset(editingFormName));
+                    handleEdit()
+                },
+                cancelText: "Continue editing",
+                okText: "Discard"
+            })
+        } else {
+            handleEdit();
+        }
     };
 
     const cancelEdit = () => {
         setIsEditMode(false);
-        setEditingConditionGuid(null);
+        setEditingFormName(null);
         setIsAddingListItem(false);
     };
 
@@ -89,6 +105,14 @@ const PermitConditionForm: FC<PermitConditionFormProps> = ({
             setIsEditMode(false);
         }
     }, [canEditPermitConditions]);
+
+    // if edit is cancelled from another form
+    useEffect(() => {
+        if (editingFormName !== formName && isEditMode) {
+            setIsEditMode(false);
+            setIsAddingListItem(false);
+        }
+    }, [editingFormName]);
 
     const handleSubmit = async (values) => {
         setLoading(true);
@@ -145,13 +169,13 @@ const PermitConditionForm: FC<PermitConditionFormProps> = ({
         );
     };
 
-    const editingEnabled = !editingConditionGuid && canEditPermitConditions && !loading;
+    const editingEnabled = editingFormName !== formName && canEditPermitConditions && !loading;
 
     const editableProps = editingEnabled
         ? {
             onClick: startEdit,
-            title: "Edit Condition",
-            "aria-label": "Edit Condition",
+            title: `Edit Condition ${condition.stepPath}`,
+            "aria-label": `Edit Condition ${condition.stepPath}`,
         }
         : {};
 
@@ -164,6 +188,13 @@ const PermitConditionForm: FC<PermitConditionFormProps> = ({
             dispatch(change(formName, name, newVal));
         }
     };
+
+    const childTypeMap = {
+        "SEC": "Condition",
+        "CON": "List Item",
+        "LIS": "List Item"
+    };
+    const childConditionType = childTypeMap[condition.condition_type_code];
 
     return !isEditMode ? (
         <Row
@@ -214,7 +245,7 @@ const PermitConditionForm: FC<PermitConditionFormProps> = ({
             <Row
                 wrap={false}
                 align="top"
-                className={`condition-content ${!editingConditionGuid ? "editable" : ""}${!condition.parent_permit_condition_id ? " top-level-condition" : ""}`}
+                className={`condition-content ${!editingFormName ? "editable" : ""}${!condition.parent_permit_condition_id ? " top-level-condition" : ""}`}
             >
                 <Col className="step-column" style={{ flexShrink: 0 }}>
                     <Field
@@ -233,109 +264,99 @@ const PermitConditionForm: FC<PermitConditionFormProps> = ({
                         component={RenderAutoSizeField}
                         disabled={isAddingListItem || loading}
                     />
-                </Col>
-            </Row>
-            {isEditMode && !isAddingListItem && (
-                <Row justify="space-between" align="middle">
-                    <Col>
-                        <Row gutter={8} className="condition-edit-buttons">
+                    {isEditMode && !isAddingListItem && (
+                        <Row justify="space-between" align="middle">
+                            <Col>
+                                <Row gutter={8} className="condition-edit-buttons">
+                                    {isExtracted && (
+                                        <Col>
+                                            <Button
+                                                loading={loading}
+                                                className="fa-icon-container btn-sm-padding"
+                                                type="default"
+                                                icon={<FontAwesomeIcon icon={faPlus} />}
+                                                onClick={handleAddListItem}
+                                            >
+                                                {childConditionType}
+                                            </Button>
+                                        </Col>
+                                    )}
+                                    <Col>
+                                        <Button
+                                            loading={loading}
+                                            className="fa-icon-container btn-sm-padding"
+                                            type="default"
+                                            icon={<FontAwesomeIcon icon={faClipboard} />}
+                                            onClick={(e) => handleOpenAddReportModal(e, condition)}
+                                            disabled={condition?.mineReportPermitRequirement !== undefined}
+                                        >
+                                            {condition?.mineReportPermitRequirement
+                                                ? "Report Added"
+                                                : "Add Report Requirement"}
+                                        </Button>
+                                    </Col>
+                                    <Col>
+                                        <RenderCancelButton
+                                            disabled={loading}
+                                            cancelFunction={handleCancel}
+                                            buttonProps={{
+                                                type: "primary",
+                                                icon: <FontAwesomeIcon icon={faXmark} />,
+                                            }}
+                                            iconButton
+                                        />
+                                    </Col>
+                                    <Col>
+                                        <RenderSubmitButton
+                                            disabled={loading}
+                                            buttonProps={{
+                                                icon: <FontAwesomeIcon icon={faCheck} />,
+                                            }}
+                                            iconButton
+                                        />
+                                    </Col>
+                                </Row>
+                            </Col>
                             {isExtracted && (
                                 <Col>
-                                    <Button
-                                        loading={loading}
-                                        className="fa-icon-container btn-sm-padding"
-                                        type="default"
-                                        icon={<FontAwesomeIcon icon={faPlus} />}
-                                        onClick={handleAddListItem}
-                                    >
-                                        List Item
-                                    </Button>
+                                    <Row gutter={8} align="middle" className="condition-edit-buttons">
+                                        <Col>
+                                            <Button
+                                                disabled={loading}
+                                                className="fa-icon-container"
+                                                aria-label="Delete Condition"
+                                                type="default"
+                                                icon={<FontAwesomeIcon icon={faTrashCan} />}
+                                                onClick={handleDelete}
+                                            />
+                                        </Col>
+                                        <Col>
+                                            <Button
+                                                className="fa-icon-container"
+                                                aria-label="Move Condition Up"
+                                                type="default"
+                                                disabled={!moveUp || loading}
+                                                icon={<FontAwesomeIcon icon={faArrowUp} />}
+                                                onClick={() => moveUp(condition)}
+                                            />
+                                        </Col>
+                                        <Col>
+                                            <Button
+                                                className="fa-icon-container"
+                                                aria-label="Move Condition Down"
+                                                type="default"
+                                                disabled={!moveDown || loading}
+                                                icon={<FontAwesomeIcon icon={faArrowDown} />}
+                                                onClick={() => moveDown(condition)}
+                                            />
+                                        </Col>
+                                    </Row>
                                 </Col>
                             )}
-                            {/* <Col>
-                                    <Button
-                                        className="fa-icon-container btn-sm-padding"
-                                        type="default"
-                                        icon={<FontAwesomeIcon icon={faLink} />}
-                                        onClick={handleLinkDocument}
-                                    >
-                                        Link Document
-                                    </Button>
-                                </Col> */}
-                            <Col>
-                                <Button
-                                    loading={loading}
-                                    className="fa-icon-container btn-sm-padding"
-                                    type="default"
-                                    icon={<FontAwesomeIcon icon={faClipboard} />}
-                                    onClick={(e) => handleOpenAddReportModal(e, condition)}
-                                    disabled={condition?.mineReportPermitRequirement !== undefined}
-                                >
-                                    {condition?.mineReportPermitRequirement
-                                        ? "Report Added"
-                                        : "Add Report Requirement"}
-                                </Button>
-                            </Col>
-                            <Col>
-                                <RenderCancelButton
-                                    disabled={loading}
-                                    cancelFunction={handleCancel}
-                                    buttonProps={{
-                                        type: "primary",
-                                        icon: <FontAwesomeIcon icon={faXmark} />,
-                                    }}
-                                    iconButton
-                                />
-                            </Col>
-                            <Col>
-                                <RenderSubmitButton
-                                    disabled={loading}
-                                    buttonProps={{
-                                        icon: <FontAwesomeIcon icon={faCheck} />,
-                                    }}
-                                    iconButton
-                                />
-                            </Col>
                         </Row>
-                    </Col>
-                    {isExtracted && (
-                        <Col>
-                            <Row gutter={8} align="middle" className="condition-edit-buttons">
-                                <Col>
-                                    <Button
-                                        disabled={loading}
-                                        className="fa-icon-container"
-                                        aria-label="Delete Condition"
-                                        type="default"
-                                        icon={<FontAwesomeIcon icon={faTrashCan} />}
-                                        onClick={handleDelete}
-                                    />
-                                </Col>
-                                <Col>
-                                    <Button
-                                        className="fa-icon-container"
-                                        aria-label="Move Condition Up"
-                                        type="default"
-                                        disabled={!moveUp || loading}
-                                        icon={<FontAwesomeIcon icon={faArrowUp} />}
-                                        onClick={() => moveUp(condition)}
-                                    />
-                                </Col>
-                                <Col>
-                                    <Button
-                                        className="fa-icon-container"
-                                        aria-label="Move Condition Down"
-                                        type="default"
-                                        disabled={!moveDown || loading}
-                                        icon={<FontAwesomeIcon icon={faArrowDown} />}
-                                        onClick={() => moveDown(condition)}
-                                    />
-                                </Col>
-                            </Row>
-                        </Col>
                     )}
-                </Row>
-            )}
+                </Col>
+            </Row>
         </FormWrapper>
     );
 };

--- a/services/common/src/components/permits/PermitConditionLayer.tsx
+++ b/services/common/src/components/permits/PermitConditionLayer.tsx
@@ -11,6 +11,7 @@ import PermitConditionReportRequirements from "@mds/common/components/permits/Pe
 import { PermitConditionStatus } from "./PermitConditionStatus";
 import { getReportRequirementsByCondition } from "@mds/common/redux/selectors/permitSelectors";
 import { useAppSelector } from "@mds/common/redux/rootState";
+import { FORM } from "@mds/common/constants/forms";
 
 const { Title } = Typography;
 
@@ -21,8 +22,8 @@ interface PermitConditionLayerProps {
   isExpanded?: boolean;
   setParentExpand?: () => void;
   canEditPermitConditions?: boolean;
-  setEditingConditionGuid: (permit_condition_guid: string) => void;
-  editingConditionGuid: string;
+  setEditingFormName: (formName: string) => void;
+  editingFormName: string;
   handleMoveCondition: (condition: IPermitCondition, isMoveUp: boolean) => Promise<void>;
   currentPosition: number;
   conditionCount: number;
@@ -40,8 +41,8 @@ const PermitConditionLayer: FC<PermitConditionLayerProps> = ({
   level = 0,
   setParentExpand = () => { },
   canEditPermitConditions = false,
-  setEditingConditionGuid,
-  editingConditionGuid,
+  setEditingFormName,
+  editingFormName,
   handleMoveCondition,
   currentPosition,
   conditionCount,
@@ -54,8 +55,8 @@ const PermitConditionLayer: FC<PermitConditionLayerProps> = ({
     getReportRequirementsByCondition(permitGuid, permitAmendmentGuid, condition.permit_condition_id)
   );
   const editingCondition = useMemo(
-    () => editingConditionGuid === condition.permit_condition_guid,
-    [condition.permit_condition_guid, editingConditionGuid]
+    () => editingFormName === `${FORM.EDIT_PERMIT_CONDITION}_${condition.permit_condition_id}_${condition.condition_category_code}`,
+    [condition.permit_condition_guid, editingFormName]
   );
   const [isAddingListItem, setIsAddingListItem] = useState<boolean>(false);
   const [expandClass, setExpandClass] = useState(
@@ -126,8 +127,8 @@ const PermitConditionLayer: FC<PermitConditionLayerProps> = ({
           onEdit={setParentExpand}
           condition={condition}
           canEditPermitConditions={canEditPermitConditions}
-          setEditingConditionGuid={setEditingConditionGuid}
-          editingConditionGuid={editingConditionGuid}
+          setEditingFormName={setEditingFormName}
+          editingFormName={editingFormName}
           moveUp={currentPosition > 0 ? moveUp : undefined}
           moveDown={currentPosition < conditionCount - 1 ? moveDown : undefined}
           permitAmendmentGuid={permitAmendmentGuid}
@@ -146,8 +147,8 @@ const PermitConditionLayer: FC<PermitConditionLayerProps> = ({
                 level={level + 1}
                 setParentExpand={handleSetParentExpand}
                 canEditPermitConditions={canEditPermitConditions}
-                setEditingConditionGuid={setEditingConditionGuid}
-                editingConditionGuid={editingConditionGuid}
+                setEditingFormName={setEditingFormName}
+                editingFormName={editingFormName}
                 handleMoveCondition={handleMoveCondition}
                 currentPosition={idx}
                 conditionCount={condition.sub_conditions.length}

--- a/services/common/src/components/permits/PermitConditions.tsx
+++ b/services/common/src/components/permits/PermitConditions.tsx
@@ -60,6 +60,7 @@ import { createDropDownList } from "@mds/common/redux/utils/helpers";
 import PermitConditionLayer from "@mds/common/components/permits/PermitConditionLayer";
 import { LatestAmendmentWarning } from "./LatestAmendmentWarning";
 import { getIsCore } from "@mds/common/redux/reducers/authenticationReducer";
+import { FORM } from "@mds/common/constants/forms";
 
 const { Title } = Typography;
 
@@ -148,7 +149,7 @@ const PermitConditions: FC<PermitConditionProps> = ({
   const [isExpanded, setIsExpanded] = useState(false);
   const [viewPdf, setViewPdf] = useState(false);
   const [selectedCondition, setSelectedCondition] = useState<IPermitCondition | null>(null);
-  const [editingConditionGuid, setEditingConditionGuid] = useState<string>();
+  const [editingFormName, setEditingFormName] = useState<string>();
   const [addingToCategoryCode, setAddingToCategoryCode] = useState<string>();
   const [loading, setLoading] = useState(false);
 
@@ -180,13 +181,19 @@ const PermitConditions: FC<PermitConditionProps> = ({
 
   const refreshData = async () => {
     await dispatch(fetchPermits(mineGuid));
-    setEditingConditionGuid(null);
+    setEditingFormName(null);
   };
 
   useEffect(() => {
     dispatch(searchConditionCategories({}));
     dispatch(fetchReviewAssignments({ permit_amendment_id: currentAmendment.permit_amendment_id }));
   }, []);
+
+  useEffect(() => {
+    if (editingFormName !== FORM.EDIT_PERMIT_CONDITION) {
+      setAddingToCategoryCode(null);
+    }
+  }, [editingFormName]);
 
   const defaultPermitConditionCategories = useAppSelector(getPermitConditionCategoryOptions);
   const condWithoutConditionsText = defaultPermitConditionCategories?.map((cat) => {
@@ -321,6 +328,11 @@ const PermitConditions: FC<PermitConditionProps> = ({
   const handleAddCondition = async () => {
     setAddingToCategoryCode(null);
     await refreshData();
+  };
+
+  const handleClickAddCondition = (category) => {
+    setAddingToCategoryCode(category.condition_category_code);
+    setEditingFormName(FORM.EDIT_PERMIT_CONDITION)
   };
 
   const toggleViewPdf = () => {
@@ -508,11 +520,11 @@ const PermitConditions: FC<PermitConditionProps> = ({
         </Row>
       </Col>
       <Col span={24}>
-        <div className="common-page-content">
+        <div>
           <Row gutter={[16, 16]}>
             {formattedPermitConditionCategories.map((category, idx) => {
               return (
-                <React.Fragment key={category.href}>
+                <div key={category.href} className="common-page-content">
                   <Col span={24}>
                     <Row justify="space-between">
                       <Title level={3} className="margin-none" id={category.href}>
@@ -534,8 +546,8 @@ const PermitConditions: FC<PermitConditionProps> = ({
                         <CoreButton
                           type="primary"
                           loading={showLoading}
-                          disabled={Boolean(addingToCategoryCode) || Boolean(editingConditionGuid)}
-                          onClick={() => setAddingToCategoryCode(category.condition_category_code)}
+                          disabled={Boolean(addingToCategoryCode) || Boolean(editingFormName)}
+                          onClick={() => handleClickAddCondition(category)}
                         >
                           Add Condition
                         </CoreButton>
@@ -558,8 +570,8 @@ const PermitConditions: FC<PermitConditionProps> = ({
                         canEditPermitConditions={canEditPermitConditions(
                           category.condition_category
                         )}
-                        setEditingConditionGuid={setEditingConditionGuid}
-                        editingConditionGuid={editingConditionGuid ?? addingToCategoryCode}
+                        setEditingFormName={setEditingFormName}
+                        editingFormName={editingFormName ?? addingToCategoryCode}
                         refreshData={refreshData}
                         conditionSelected={setSelectedCondition}
                         categoryOptions={dropdownCategories}
@@ -571,13 +583,13 @@ const PermitConditions: FC<PermitConditionProps> = ({
                       <SubConditionForm
                         conditionCategory={category}
                         permitAmendmentGuid={currentAmendment.permit_amendment_guid}
-                        handleCancel={() => setAddingToCategoryCode(null)}
+                        handleCancel={() => { setAddingToCategoryCode(null); setEditingFormName(null); }}
                         onSubmit={handleAddCondition}
                         categoryOptions={dropdownCategories}
                       />
                     </Col>
                   )}
-                </React.Fragment>
+                </div>
               );
             })}
           </Row>

--- a/services/common/src/components/permits/SubConditionForm.tsx
+++ b/services/common/src/components/permits/SubConditionForm.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from "react";
-import { Field } from "@mds/common/components/forms/form";
+import { Field, getFormValues } from "@mds/common/components/forms/form";
 import { Row, Col } from "antd";
 import { faCheck, faXmark } from "@fortawesome/pro-regular-svg-icons";
 import {
@@ -13,11 +13,12 @@ import RenderAutoSizeField from "@mds/common/components/forms/RenderAutoSizeFiel
 import RenderCancelButton from "@mds/common/components/forms/RenderCancelButton";
 import RenderSubmitButton from "@mds/common/components/forms/RenderSubmitButton";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { useAppDispatch } from "@mds/common/redux/rootState";
+import { useAppDispatch, useAppSelector } from "@mds/common/redux/rootState";
 import { createPermitCondition } from "@mds/common/redux/actionCreators/permitActionCreator";
 import { FORM } from "@mds/common/constants/forms";
 import RenderGroupedSelect from "@mds/common/components/forms/RenderGroupedSelect";
 import { usePermitConditions } from "./PermitConditionsContext";
+import { required } from "@mds/common/redux/utils/Validate";
 
 interface SubConditionFormProps {
   level?: number;
@@ -40,6 +41,8 @@ const SubConditionForm: FC<SubConditionFormProps> = ({
 }) => {
   const dispatch = useAppDispatch();
   const { loading, setLoading } = usePermitConditions();
+  const formValues = useAppSelector(getFormValues(FORM.EDIT_PERMIT_CONDITION)) as IPermitCondition;
+
   const handleSubmit = async (values) => {
     setLoading(true);
     const resp = await dispatch(createPermitCondition(permitAmendmentGuid, values));
@@ -59,29 +62,40 @@ const SubConditionForm: FC<SubConditionFormProps> = ({
     }
     return "LIS";
   };
+
+  const getCategoryText = () => {
+    if (!categoryOptions?.length) {
+      return "";
+    }
+    const allOptions = categoryOptions.reduce((acc, group) => { return [...acc, ...group.opt] }, []);
+    const selectedOption = allOptions.find((o) => o.value === formValues?.condition_category_code);
+    return selectedOption?.label;
+  };
+
+  const parentText = parentCondition?.stepPath ?? getCategoryText();
   const getPlaceHolderText = (conditionTypeCode: string = "SEC") => {
     return {
-      SEC: "Enter Sub-Section title",
-      CON: "Enter a condition",
-      LIS: "Enter a list item",
+      SEC: `Enter Sub-Section title for ${parentText}`,
+      CON: `Enter condition text for ${parentText}`,
+      LIS: `Enter list item text for ${parentText}`,
     }[conditionTypeCode];
   };
 
   const emptyCondition = parentCondition
     ? {
-        condition_category_code: parentCondition.condition_category_code,
-        condition_type_code: getConditionTypeCode(),
-        display_order: parentCondition.sub_conditions.length + 1,
-        parent_permit_condition_id: parentCondition.permit_condition_id,
-        top_level_parent_permit_condition_id: parentCondition.top_level_parent_permit_condition_id
-          ? parentCondition.top_level_parent_permit_condition_id
-          : parentCondition.parent_permit_condition_id,
-      }
+      condition_category_code: parentCondition.condition_category_code,
+      condition_type_code: getConditionTypeCode(),
+      display_order: parentCondition.sub_conditions.length + 1,
+      parent_permit_condition_id: parentCondition.permit_condition_id,
+      top_level_parent_permit_condition_id: parentCondition.top_level_parent_permit_condition_id
+        ? parentCondition.top_level_parent_permit_condition_id
+        : parentCondition.parent_permit_condition_id,
+    }
     : {
-        condition_category_code: conditionCategory.condition_category_code,
-        condition_type_code: getConditionTypeCode(),
-        display_order: conditionCategory.conditions.length + 1,
-      };
+      condition_category_code: conditionCategory.condition_category_code,
+      condition_type_code: getConditionTypeCode(),
+      display_order: conditionCategory.conditions.length + 1,
+    };
   return (
     <FormWrapper
       name={FORM.EDIT_PERMIT_CONDITION}
@@ -112,11 +126,13 @@ const SubConditionForm: FC<SubConditionFormProps> = ({
         <Row wrap={false}>
           <Col span={24}>
             <Field
-              placeholder={getPlaceHolderText(emptyCondition.condition_type_code)}
+              label={getPlaceHolderText(emptyCondition.condition_type_code)}
               name="condition"
               component={RenderAutoSizeField}
               autoFocus
               disabled={loading}
+              required
+              validate={[required]}
             />
           </Col>
         </Row>

--- a/services/common/src/tests/permits/PermitConditionForm.spec.tsx
+++ b/services/common/src/tests/permits/PermitConditionForm.spec.tsx
@@ -50,8 +50,8 @@ describe("PermitConditionForm", () => {
                     condition={condition}
                     canEditPermitConditions={true}
                     onEdit={jest.fn()}
-                    setEditingConditionGuid={jest.fn()}
-                    editingConditionGuid={undefined}
+                    setEditingFormName={jest.fn()}
+                    editingFormName={undefined}
                     moveUp={jest.fn()}
                     moveDown={jest.fn()}
                     refreshData={jest.fn()}
@@ -61,7 +61,7 @@ describe("PermitConditionForm", () => {
             </PermitConditionsProvider>
         </ReduxWrapper>);
 
-        const editElement = container.querySelector("[aria-label='Edit Condition']")
+        const editElement = container.querySelector(`[aria-label='Edit Condition ${condition.stepPath}']`)
         fireEvent.click(editElement);
         await findByText("Report Added");
         expect(container).toMatchSnapshot()
@@ -75,8 +75,8 @@ describe("PermitConditionForm", () => {
                     condition={condition}
                     canEditPermitConditions={false}
                     onEdit={jest.fn()}
-                    setEditingConditionGuid={jest.fn()}
-                    editingConditionGuid={undefined}
+                    setEditingFormName={jest.fn()}
+                    editingFormName={undefined}
                     moveUp={jest.fn()}
                     moveDown={jest.fn()}
                     refreshData={jest.fn()}

--- a/services/common/src/tests/permits/SubConditionForm.spec.tsx
+++ b/services/common/src/tests/permits/SubConditionForm.spec.tsx
@@ -71,7 +71,7 @@ describe("SubConditionForm", () => {
                 /></PermitConditionsProvider>
         </ReduxWrapper>);
 
-        const textInput = container.querySelector("textarea");
-        expect(textInput.placeholder).toEqual("Enter Sub-Section title");
+        const label = container.querySelector('label[for="EDIT_PERMIT_CONDITION_condition"]');
+        expect(label?.textContent).toContain("Enter Sub-Section title");
     });
 });

--- a/services/common/src/tests/permits/__snapshots__/PermitConditionForm.spec.tsx.snap
+++ b/services/common/src/tests/permits/__snapshots__/PermitConditionForm.spec.tsx.snap
@@ -56,9 +56,9 @@ exports[`PermitConditionForm renders properly in edit mode 1`] = `
         </div>
       </div>
       <div
-        aria-label="Edit Condition"
+        aria-label="Edit Condition undefined"
         class="ant-col condition-column"
-        title="Edit Condition"
+        title="Edit Condition undefined"
       >
         <div
           class="ant-form-item ant-form-item-with-help"
@@ -100,214 +100,214 @@ exports[`PermitConditionForm renders properly in edit mode 1`] = `
             </div>
           </div>
         </div>
-      </div>
-    </div>
-    <div
-      class="ant-row ant-row-space-between ant-row-middle"
-    >
-      <div
-        class="ant-col"
-      >
         <div
-          class="ant-row condition-edit-buttons"
-          style="margin-left: -4px; margin-right: -4px;"
+          class="ant-row ant-row-space-between ant-row-middle"
         >
           <div
             class="ant-col"
-            style="padding-left: 4px; padding-right: 4px;"
           >
-            <button
-              class="ant-btn ant-btn-default fa-icon-container btn-sm-padding"
-              type="button"
+            <div
+              class="ant-row condition-edit-buttons"
+              style="margin-left: -4px; margin-right: -4px;"
             >
-              <svg
-                aria-hidden="true"
-                class="svg-inline--fa fa-plus "
-                data-icon="plus"
-                data-prefix="far"
-                focusable="false"
-                role="img"
-                viewBox="0 0 448 512"
-                xmlns="http://www.w3.org/2000/svg"
+              <div
+                class="ant-col"
+                style="padding-left: 4px; padding-right: 4px;"
               >
-                <path
-                  d="M248 72c0-13.3-10.7-24-24-24s-24 10.7-24 24V232H40c-13.3 0-24 10.7-24 24s10.7 24 24 24H200V440c0 13.3 10.7 24 24 24s24-10.7 24-24V280H408c13.3 0 24-10.7 24-24s-10.7-24-24-24H248V72z"
-                  fill="currentColor"
-                />
-              </svg>
-              <span>
-                List Item
-              </span>
-            </button>
+                <button
+                  class="ant-btn ant-btn-default fa-icon-container btn-sm-padding"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="svg-inline--fa fa-plus "
+                    data-icon="plus"
+                    data-prefix="far"
+                    focusable="false"
+                    role="img"
+                    viewBox="0 0 448 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M248 72c0-13.3-10.7-24-24-24s-24 10.7-24 24V232H40c-13.3 0-24 10.7-24 24s10.7 24 24 24H200V440c0 13.3 10.7 24 24 24s24-10.7 24-24V280H408c13.3 0 24-10.7 24-24s-10.7-24-24-24H248V72z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                  <span>
+                    Condition
+                  </span>
+                </button>
+              </div>
+              <div
+                class="ant-col"
+                style="padding-left: 4px; padding-right: 4px;"
+              >
+                <button
+                  class="ant-btn ant-btn-default fa-icon-container btn-sm-padding"
+                  disabled=""
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="svg-inline--fa fa-clipboard "
+                    data-icon="clipboard"
+                    data-prefix="far"
+                    focusable="false"
+                    role="img"
+                    viewBox="0 0 384 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M280 64h40c35.3 0 64 28.7 64 64V448c0 35.3-28.7 64-64 64H64c-35.3 0-64-28.7-64-64V128C0 92.7 28.7 64 64 64h40 9.6C121 27.5 153.3 0 192 0s71 27.5 78.4 64H280zM64 112c-8.8 0-16 7.2-16 16V448c0 8.8 7.2 16 16 16H320c8.8 0 16-7.2 16-16V128c0-8.8-7.2-16-16-16H304v24c0 13.3-10.7 24-24 24H192 104c-13.3 0-24-10.7-24-24V112H64zm128-8a24 24 0 1 0 0-48 24 24 0 1 0 0 48z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                  <span>
+                    Report Added
+                  </span>
+                </button>
+              </div>
+              <div
+                class="ant-col"
+                style="padding-left: 4px; padding-right: 4px;"
+              >
+                <button
+                  aria-label="Cancel"
+                  class="ant-btn ant-btn-primary ant-btn-icon-only core-btn core-btn-primary  form-btn"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="svg-inline--fa fa-xmark "
+                    data-icon="xmark"
+                    data-prefix="far"
+                    focusable="false"
+                    role="img"
+                    viewBox="0 0 384 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M345 137c9.4-9.4 9.4-24.6 0-33.9s-24.6-9.4-33.9 0l-119 119L73 103c-9.4-9.4-24.6-9.4-33.9 0s-9.4 24.6 0 33.9l119 119L39 375c-9.4 9.4-9.4 24.6 0 33.9s24.6 9.4 33.9 0l119-119L311 409c9.4 9.4 24.6 9.4 33.9 0s9.4-24.6 0-33.9l-119-119L345 137z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                </button>
+              </div>
+              <div
+                class="ant-col"
+                style="padding-left: 4px; padding-right: 4px;"
+              >
+                <button
+                  aria-label="Submit"
+                  class="ant-btn ant-btn-primary ant-btn-icon-only  form-btn"
+                  disabled=""
+                  type="submit"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="svg-inline--fa fa-check "
+                    data-icon="check"
+                    data-prefix="far"
+                    focusable="false"
+                    role="img"
+                    viewBox="0 0 448 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M441 103c9.4 9.4 9.4 24.6 0 33.9L177 401c-9.4 9.4-24.6 9.4-33.9 0L7 265c-9.4-9.4-9.4-24.6 0-33.9s24.6-9.4 33.9 0l119 119L407 103c9.4-9.4 24.6-9.4 33.9 0z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
           </div>
           <div
             class="ant-col"
-            style="padding-left: 4px; padding-right: 4px;"
           >
-            <button
-              class="ant-btn ant-btn-default fa-icon-container btn-sm-padding"
-              disabled=""
-              type="button"
+            <div
+              class="ant-row ant-row-middle condition-edit-buttons"
+              style="margin-left: -4px; margin-right: -4px;"
             >
-              <svg
-                aria-hidden="true"
-                class="svg-inline--fa fa-clipboard "
-                data-icon="clipboard"
-                data-prefix="far"
-                focusable="false"
-                role="img"
-                viewBox="0 0 384 512"
-                xmlns="http://www.w3.org/2000/svg"
+              <div
+                class="ant-col"
+                style="padding-left: 4px; padding-right: 4px;"
               >
-                <path
-                  d="M280 64h40c35.3 0 64 28.7 64 64V448c0 35.3-28.7 64-64 64H64c-35.3 0-64-28.7-64-64V128C0 92.7 28.7 64 64 64h40 9.6C121 27.5 153.3 0 192 0s71 27.5 78.4 64H280zM64 112c-8.8 0-16 7.2-16 16V448c0 8.8 7.2 16 16 16H320c8.8 0 16-7.2 16-16V128c0-8.8-7.2-16-16-16H304v24c0 13.3-10.7 24-24 24H192 104c-13.3 0-24-10.7-24-24V112H64zm128-8a24 24 0 1 0 0-48 24 24 0 1 0 0 48z"
-                  fill="currentColor"
-                />
-              </svg>
-              <span>
-                Report Added
-              </span>
-            </button>
-          </div>
-          <div
-            class="ant-col"
-            style="padding-left: 4px; padding-right: 4px;"
-          >
-            <button
-              aria-label="Cancel"
-              class="ant-btn ant-btn-primary ant-btn-icon-only core-btn core-btn-primary  form-btn"
-              type="button"
-            >
-              <svg
-                aria-hidden="true"
-                class="svg-inline--fa fa-xmark "
-                data-icon="xmark"
-                data-prefix="far"
-                focusable="false"
-                role="img"
-                viewBox="0 0 384 512"
-                xmlns="http://www.w3.org/2000/svg"
+                <button
+                  aria-label="Delete Condition"
+                  class="ant-btn ant-btn-default ant-btn-icon-only fa-icon-container"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="svg-inline--fa fa-trash-can "
+                    data-icon="trash-can"
+                    data-prefix="far"
+                    focusable="false"
+                    role="img"
+                    viewBox="0 0 448 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M170.5 51.6L151.5 80h145l-19-28.4c-1.5-2.2-4-3.6-6.7-3.6H177.1c-2.7 0-5.2 1.3-6.7 3.6zm147-26.6L354.2 80H368h48 8c13.3 0 24 10.7 24 24s-10.7 24-24 24h-8V432c0 44.2-35.8 80-80 80H112c-44.2 0-80-35.8-80-80V128H24c-13.3 0-24-10.7-24-24S10.7 80 24 80h8H80 93.8l36.7-55.1C140.9 9.4 158.4 0 177.1 0h93.7c18.7 0 36.2 9.4 46.6 24.9zM80 128V432c0 17.7 14.3 32 32 32H336c17.7 0 32-14.3 32-32V128H80zm80 64V400c0 8.8-7.2 16-16 16s-16-7.2-16-16V192c0-8.8 7.2-16 16-16s16 7.2 16 16zm80 0V400c0 8.8-7.2 16-16 16s-16-7.2-16-16V192c0-8.8 7.2-16 16-16s16 7.2 16 16zm80 0V400c0 8.8-7.2 16-16 16s-16-7.2-16-16V192c0-8.8 7.2-16 16-16s16 7.2 16 16z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                </button>
+              </div>
+              <div
+                class="ant-col"
+                style="padding-left: 4px; padding-right: 4px;"
               >
-                <path
-                  d="M345 137c9.4-9.4 9.4-24.6 0-33.9s-24.6-9.4-33.9 0l-119 119L73 103c-9.4-9.4-24.6-9.4-33.9 0s-9.4 24.6 0 33.9l119 119L39 375c-9.4 9.4-9.4 24.6 0 33.9s24.6 9.4 33.9 0l119-119L311 409c9.4 9.4 24.6 9.4 33.9 0s9.4-24.6 0-33.9l-119-119L345 137z"
-                  fill="currentColor"
-                />
-              </svg>
-            </button>
-          </div>
-          <div
-            class="ant-col"
-            style="padding-left: 4px; padding-right: 4px;"
-          >
-            <button
-              aria-label="Submit"
-              class="ant-btn ant-btn-primary ant-btn-icon-only  form-btn"
-              disabled=""
-              type="submit"
-            >
-              <svg
-                aria-hidden="true"
-                class="svg-inline--fa fa-check "
-                data-icon="check"
-                data-prefix="far"
-                focusable="false"
-                role="img"
-                viewBox="0 0 448 512"
-                xmlns="http://www.w3.org/2000/svg"
+                <button
+                  aria-label="Move Condition Up"
+                  class="ant-btn ant-btn-default ant-btn-icon-only fa-icon-container"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="svg-inline--fa fa-arrow-up "
+                    data-icon="arrow-up"
+                    data-prefix="far"
+                    focusable="false"
+                    role="img"
+                    viewBox="0 0 384 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M209.4 39.4C204.8 34.7 198.6 32 192 32s-12.8 2.7-17.4 7.4l-168 176c-9.2 9.6-8.8 24.8 .8 33.9s24.8 8.8 33.9-.8L168 115.9V456c0 13.3 10.7 24 24 24s24-10.7 24-24V115.9L342.6 248.6c9.2 9.6 24.3 9.9 33.9 .8s9.9-24.3 .8-33.9l-168-176z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                </button>
+              </div>
+              <div
+                class="ant-col"
+                style="padding-left: 4px; padding-right: 4px;"
               >
-                <path
-                  d="M441 103c9.4 9.4 9.4 24.6 0 33.9L177 401c-9.4 9.4-24.6 9.4-33.9 0L7 265c-9.4-9.4-9.4-24.6 0-33.9s24.6-9.4 33.9 0l119 119L407 103c9.4-9.4 24.6-9.4 33.9 0z"
-                  fill="currentColor"
-                />
-              </svg>
-            </button>
-          </div>
-        </div>
-      </div>
-      <div
-        class="ant-col"
-      >
-        <div
-          class="ant-row ant-row-middle condition-edit-buttons"
-          style="margin-left: -4px; margin-right: -4px;"
-        >
-          <div
-            class="ant-col"
-            style="padding-left: 4px; padding-right: 4px;"
-          >
-            <button
-              aria-label="Delete Condition"
-              class="ant-btn ant-btn-default ant-btn-icon-only fa-icon-container"
-              type="button"
-            >
-              <svg
-                aria-hidden="true"
-                class="svg-inline--fa fa-trash-can "
-                data-icon="trash-can"
-                data-prefix="far"
-                focusable="false"
-                role="img"
-                viewBox="0 0 448 512"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M170.5 51.6L151.5 80h145l-19-28.4c-1.5-2.2-4-3.6-6.7-3.6H177.1c-2.7 0-5.2 1.3-6.7 3.6zm147-26.6L354.2 80H368h48 8c13.3 0 24 10.7 24 24s-10.7 24-24 24h-8V432c0 44.2-35.8 80-80 80H112c-44.2 0-80-35.8-80-80V128H24c-13.3 0-24-10.7-24-24S10.7 80 24 80h8H80 93.8l36.7-55.1C140.9 9.4 158.4 0 177.1 0h93.7c18.7 0 36.2 9.4 46.6 24.9zM80 128V432c0 17.7 14.3 32 32 32H336c17.7 0 32-14.3 32-32V128H80zm80 64V400c0 8.8-7.2 16-16 16s-16-7.2-16-16V192c0-8.8 7.2-16 16-16s16 7.2 16 16zm80 0V400c0 8.8-7.2 16-16 16s-16-7.2-16-16V192c0-8.8 7.2-16 16-16s16 7.2 16 16zm80 0V400c0 8.8-7.2 16-16 16s-16-7.2-16-16V192c0-8.8 7.2-16 16-16s16 7.2 16 16z"
-                  fill="currentColor"
-                />
-              </svg>
-            </button>
-          </div>
-          <div
-            class="ant-col"
-            style="padding-left: 4px; padding-right: 4px;"
-          >
-            <button
-              aria-label="Move Condition Up"
-              class="ant-btn ant-btn-default ant-btn-icon-only fa-icon-container"
-              type="button"
-            >
-              <svg
-                aria-hidden="true"
-                class="svg-inline--fa fa-arrow-up "
-                data-icon="arrow-up"
-                data-prefix="far"
-                focusable="false"
-                role="img"
-                viewBox="0 0 384 512"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M209.4 39.4C204.8 34.7 198.6 32 192 32s-12.8 2.7-17.4 7.4l-168 176c-9.2 9.6-8.8 24.8 .8 33.9s24.8 8.8 33.9-.8L168 115.9V456c0 13.3 10.7 24 24 24s24-10.7 24-24V115.9L342.6 248.6c9.2 9.6 24.3 9.9 33.9 .8s9.9-24.3 .8-33.9l-168-176z"
-                  fill="currentColor"
-                />
-              </svg>
-            </button>
-          </div>
-          <div
-            class="ant-col"
-            style="padding-left: 4px; padding-right: 4px;"
-          >
-            <button
-              aria-label="Move Condition Down"
-              class="ant-btn ant-btn-default ant-btn-icon-only fa-icon-container"
-              type="button"
-            >
-              <svg
-                aria-hidden="true"
-                class="svg-inline--fa fa-arrow-down "
-                data-icon="arrow-down"
-                data-prefix="far"
-                focusable="false"
-                role="img"
-                viewBox="0 0 384 512"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M174.6 472.6c4.5 4.7 10.8 7.4 17.4 7.4s12.8-2.7 17.4-7.4l168-176c9.2-9.6 8.8-24.8-.8-33.9s-24.8-8.8-33.9 .8L216 396.1 216 56c0-13.3-10.7-24-24-24s-24 10.7-24 24l0 340.1L41.4 263.4c-9.2-9.6-24.3-9.9-33.9-.8s-9.9 24.3-.8 33.9l168 176z"
-                  fill="currentColor"
-                />
-              </svg>
-            </button>
+                <button
+                  aria-label="Move Condition Down"
+                  class="ant-btn ant-btn-default ant-btn-icon-only fa-icon-container"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="svg-inline--fa fa-arrow-down "
+                    data-icon="arrow-down"
+                    data-prefix="far"
+                    focusable="false"
+                    role="img"
+                    viewBox="0 0 384 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M174.6 472.6c4.5 4.7 10.8 7.4 17.4 7.4s12.8-2.7 17.4-7.4l168-176c9.2-9.6 8.8-24.8-.8-33.9s-24.8-8.8-33.9 .8L216 396.1 216 56c0-13.3-10.7-24-24-24s-24 10.7-24 24l0 340.1L41.4 263.4c-9.2-9.6-24.3-9.9-33.9-.8s-9.9 24.3-.8 33.9l168 176z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
           </div>
         </div>
       </div>

--- a/services/common/src/tests/permits/__snapshots__/SubConditionForm.spec.tsx.snap
+++ b/services/common/src/tests/permits/__snapshots__/SubConditionForm.spec.tsx.snap
@@ -22,6 +22,21 @@ exports[`SubConditionForm renders properly for adding list item 1`] = `
               class="ant-row ant-form-item-row"
             >
               <div
+                class="ant-col ant-form-item-label"
+              >
+                <label
+                  class="ant-form-item-required"
+                  for="EDIT_PERMIT_CONDITION_condition"
+                  title=""
+                >
+                  <div
+                    style="width: 100%;"
+                  >
+                    Enter condition text for 
+                  </div>
+                </label>
+              </div>
+              <div
                 class="ant-col ant-form-item-control"
               >
                 <div
@@ -33,7 +48,6 @@ exports[`SubConditionForm renders properly for adding list item 1`] = `
                     <textarea
                       class="ant-input"
                       name="condition"
-                      placeholder="Enter a condition"
                       style="height: 0px; resize: none; min-height: -12px;"
                     />
                   </div>

--- a/services/core-web/src/styles/components/PermitConditions.scss
+++ b/services/core-web/src/styles/components/PermitConditions.scss
@@ -1,9 +1,17 @@
 @use "../base.scss" as *;
 
 div.condition-layer {
+  padding: 2px;
   padding-top: 12px;
   padding-left: 24px;
   font-weight: normal;
+  margin-bottom: 10px;
+  border: 1px solid $disabled-text;
+  border-radius: 4px;
+
+  &.condition-SEC .condition-column>.ant-typography {
+    font-weight: bold;
+  }
 
   .ant-form {
     margin-bottom: 0;
@@ -12,7 +20,7 @@ div.condition-layer {
   .condition-content {
     &.editable:hover {
       cursor: pointer;
-      background-color: #F4F0F0;
+      background-color: $lightest-violet;
     }
 
     .condition-column {
@@ -34,9 +42,11 @@ div.condition-layer {
     opacity: 0.8;
   }
 
+  &--1 .condition-column>.ant-typography {
+    font-weight: normal !important;
+  }
+
   &--0 {
-    border: 1px solid $transparent-dark-grey;
-    border-radius: 4px;
     padding: 16px;
 
     p.condition-layer--0 {
@@ -60,10 +70,6 @@ div.condition-layer {
 
 .top-level-condition {
   font-weight: 600;
-}
-
-.condition-edit-buttons {
-  padding: 0 8px;
 }
 
 .report-collapse-container {

--- a/services/core-web/src/styles/components/PermitConditions.scss
+++ b/services/core-web/src/styles/components/PermitConditions.scss
@@ -18,6 +18,8 @@ div.condition-layer {
   }
 
   .condition-content {
+    padding-right: 6px;
+
     &.editable:hover {
       cursor: pointer;
       background-color: $lightest-violet;

--- a/services/core-web/src/tests/components/mine/Permit/DeleteConditionModal.spec.tsx
+++ b/services/core-web/src/tests/components/mine/Permit/DeleteConditionModal.spec.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import { DeleteConditionModal } from "@mds/common/components/permits/DeleteConditionModal";
+import { IPermitCondition } from "@mds/common/interfaces";
+import { ReduxWrapper } from "@/tests/utils/ReduxWrapper";
+
+const condition = {
+    condition: "This is the condition text",
+    condition_type_code: "CON",
+    stepPath: "General - 1.a"
+} as IPermitCondition;
+
+describe("DeleteConditionModal", () => {
+    it("renders properly", () => {
+        const { container } = render(
+            <ReduxWrapper>
+                <DeleteConditionModal
+                    title="Delete Condition"
+                    onSubmit={jest.fn()}
+                    condition={condition}
+                />
+            </ReduxWrapper>
+        );
+        expect(container).toMatchSnapshot();
+    })
+});

--- a/services/core-web/src/tests/components/mine/Permit/PermitConditions.spec.tsx
+++ b/services/core-web/src/tests/components/mine/Permit/PermitConditions.spec.tsx
@@ -123,7 +123,7 @@ describe("PermitConditions", () => {
   });
 
   it("does not allow any editing without the correct role", async () => {
-    const { container, queryByText, queryByTitle } = render(
+    const { container, queryByText, queryByTitle, queryAllByTitle } = render(
       <ReduxWrapper initialState={noPermissionState}>
         <BrowserRouter>
           <ViewPermit />
@@ -142,14 +142,16 @@ describe("PermitConditions", () => {
     expect(addConditionButton).not.toBeInTheDocument();
     const assignReviewer = container.querySelectorAll('[data-cy="assigned_review_user"]');
     expect(Array.from(assignReviewer)).toEqual([]);
-    const editCondition = queryByTitle("Edit Condition");
-    expect(editCondition).not.toBeInTheDocument();
+    const editCondition = queryAllByTitle((_content, element) =>
+      element.getAttribute("title")?.startsWith("Edit Condition")
+    );
+    expect(editCondition).toHaveLength(0);
     const editCategory = queryByTitle("Click to edit");
     expect(editCategory).not.toBeInTheDocument();
   });
 
   it("only allows specific actions when permit has been generated in Core", async () => {
-    const { container, getByText, queryByText, queryByTitle } = render(
+    const { container, getByText, queryByText, queryAllByTitle, queryByTitle } = render(
       <ReduxWrapper initialState={generatedState}>
         <BrowserRouter>
           <ViewPermit />
@@ -173,7 +175,9 @@ describe("PermitConditions", () => {
     expect(Array.from(assignReviewer).length).toEqual(
       GENERATED_PERMIT.permit_amendments[0].condition_categories.length
     );
-    const editCondition = queryByTitle("Edit Condition");
+    const editCondition = queryAllByTitle((_content, element) =>
+      element.getAttribute("title")?.startsWith("Edit Condition")
+    )[0];
     expect(editCondition).toBeInTheDocument();
 
     editCondition.click();
@@ -201,7 +205,7 @@ describe("PermitConditions", () => {
   });
 
   it("does not allow editing without being assigned to the category", async () => {
-    const { container, queryByText, queryByTitle } = render(
+    const { container, queryByText, queryByTitle, queryAllByTitle } = render(
       <ReduxWrapper initialState={unassignedState}>
         <BrowserRouter>
           <ViewPermit />
@@ -214,8 +218,10 @@ describe("PermitConditions", () => {
     // 3 click to edit category
     const addConditionButton = queryByText("Add Condition");
     expect(addConditionButton).not.toBeInTheDocument();
-    const editCondition = queryByTitle("Edit Condition");
-    expect(editCondition).not.toBeInTheDocument();
+    const editCondition = queryAllByTitle((_content, element) =>
+      element.getAttribute("title")?.startsWith("Edit Condition")
+    );
+    expect(editCondition).toHaveLength(0);
     const editCategory = queryByTitle("Click to edit");
     expect(editCategory).not.toBeInTheDocument();
 
@@ -285,12 +291,14 @@ describe("PermitConditions", () => {
     });
 
     // allows editing of a condition
-    const editCondition = screen.queryByTitle("Edit Condition");
+    const editCondition = screen.queryAllByTitle((_content, element) =>
+      element.getAttribute("title")?.startsWith("Edit Condition")
+    )[0];
     editCondition.click();
     await waitFor(() => {
       const addReport = screen.queryByText("Add Report Requirement");
       expect(addReport).toBeInTheDocument();
-      const addListItem = screen.queryByText("List Item");
+      const addListItem = screen.queryByText("Condition");
       expect(addListItem).toBeInTheDocument();
       const conditionInput = container.querySelector('[name="condition"]');
       expect(conditionInput).toBeInTheDocument();

--- a/services/core-web/src/tests/components/mine/Permit/__snapshots__/DeleteConditionModal.spec.tsx.snap
+++ b/services/core-web/src/tests/components/mine/Permit/__snapshots__/DeleteConditionModal.spec.tsx.snap
@@ -1,0 +1,72 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DeleteConditionModal renders properly 1`] = `
+<div>
+  <div>
+    <div
+      class="ant-result ant-result-warning"
+    >
+      <div
+        class="ant-result-icon"
+      >
+        <span
+          aria-label="warning"
+          class="anticon anticon-warning"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="warning"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M955.7 856l-416-720c-6.2-10.7-16.9-16-27.7-16s-21.6 5.3-27.7 16l-416 720C56 877.4 71.4 904 96 904h832c24.6 0 40-26.6 27.7-48zM480 416c0-4.4 3.6-8 8-8h48c4.4 0 8 3.6 8 8v184c0 4.4-3.6 8-8 8h-48c-4.4 0-8-3.6-8-8V416zm32 352a48.01 48.01 0 010-96 48.01 48.01 0 010 96z"
+            />
+          </svg>
+        </span>
+      </div>
+      <div
+        class="ant-result-title"
+      >
+        Are you sure you want to delete the following condition? All associated list items will be removed.
+      </div>
+    </div>
+    <div
+      class="ant-typography"
+    >
+      <strong>
+        General - 1.a
+      </strong>
+    </div>
+    <div
+      class="ant-typography"
+    >
+      This is the condition text
+    </div>
+    <div
+      class="ant-row ant-row-end form-button-container-row"
+    >
+      <button
+        class="ant-btn ant-btn-default form-btn"
+        type="button"
+      >
+        <span>
+          Cancel
+        </span>
+      </button>
+      <button
+        class="ant-btn ant-btn-primary form-btn"
+        type="button"
+      >
+        <span>
+          Delete Condition
+        </span>
+      </button>
+    </div>
+  </div>
+</div>
+`;

--- a/services/core-web/src/tests/components/mine/Permit/__snapshots__/PermitConditions.spec.tsx.snap
+++ b/services/core-web/src/tests/components/mine/Permit/__snapshots__/PermitConditions.spec.tsx.snap
@@ -773,839 +773,849 @@ exports[`PermitConditions renders properly 1`] = `
                           class="ant-col ant-col-24"
                           style="padding: 8px 5px 8px 5px;"
                         >
-                          <div
-                            class="common-page-content"
-                          >
+                          <div>
                             <div
                               class="ant-row"
                               style="margin: -8px -8px -8px -8px;"
                             >
                               <div
-                                class="ant-col ant-col-24"
-                                style="padding: 8px 8px 8px 8px;"
+                                class="common-page-content"
                               >
                                 <div
-                                  class="ant-row ant-row-space-between"
-                                >
-                                  <h3
-                                    class="ant-typography margin-none"
-                                    id="hsc"
-                                  >
-                                    <div>
-                                      <span
-                                        style="margin-bottom: 0px;"
-                                      >
-                                        A.
-                                         
-                                        Health and Safety
-                                         (
-                                        1
-                                        )
-                                      </span>
-                                    </div>
-                                  </h3>
-                                  <button
-                                    class="ant-btn ant-btn-primary core-btn core-btn-primary"
-                                    type="button"
-                                  >
-                                    <span>
-                                      Add Condition
-                                    </span>
-                                  </button>
-                                </div>
-                                <form
-                                  class="ant-form ant-form-horizontal common-form common-form-PERMIT_CONDITION_REVIEW_ASSIGNMENT-HSC form-edit"
-                                  id="PERMIT_CONDITION_REVIEW_ASSIGNMENT-HSC"
+                                  class="ant-col ant-col-24"
+                                  style="padding: 8px 8px 8px 8px;"
                                 >
                                   <div
-                                    class="ant-row ant-row-start ant-row-top"
-                                    style="margin-left: -8px; margin-right: -8px;"
+                                    class="ant-row ant-row-space-between"
+                                  >
+                                    <h3
+                                      class="ant-typography margin-none"
+                                      id="hsc"
+                                    >
+                                      <div>
+                                        <span
+                                          style="margin-bottom: 0px;"
+                                        >
+                                          A.
+                                           
+                                          Health and Safety
+                                           (
+                                          1
+                                          )
+                                        </span>
+                                      </div>
+                                    </h3>
+                                    <button
+                                      class="ant-btn ant-btn-primary core-btn core-btn-primary"
+                                      type="button"
+                                    >
+                                      <span>
+                                        Add Condition
+                                      </span>
+                                    </button>
+                                  </div>
+                                  <form
+                                    class="ant-form ant-form-horizontal common-form common-form-PERMIT_CONDITION_REVIEW_ASSIGNMENT-HSC form-edit"
+                                    id="PERMIT_CONDITION_REVIEW_ASSIGNMENT-HSC"
                                   >
                                     <div
-                                      class="ant-col"
-                                      style="padding-left: 8px; padding-right: 8px;"
+                                      class="ant-row ant-row-start ant-row-top"
+                                      style="margin-left: -8px; margin-right: -8px;"
                                     >
                                       <div
-                                        class="ant-typography"
-                                      >
-                                        Assigned Reviewer:
-                                      </div>
-                                    </div>
-                                    <div
-                                      class="ant-col ant-col-12"
-                                      style="padding-left: 8px; padding-right: 8px;"
-                                    >
-                                      <div
-                                        class="ant-form-item ant-form-item-with-help"
+                                        class="ant-col"
+                                        style="padding-left: 8px; padding-right: 8px;"
                                       >
                                         <div
-                                          class="ant-row ant-form-item-row"
+                                          class="ant-typography"
+                                        >
+                                          Assigned Reviewer:
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="ant-col ant-col-12"
+                                        style="padding-left: 8px; padding-right: 8px;"
+                                      >
+                                        <div
+                                          class="ant-form-item ant-form-item-with-help"
                                         >
                                           <div
-                                            class="ant-col ant-form-item-control"
+                                            class="ant-row ant-form-item-row"
                                           >
                                             <div
-                                              class="ant-form-item-control-input"
+                                              class="ant-col ant-form-item-control"
                                             >
                                               <div
-                                                class="ant-form-item-control-input-content"
+                                                class="ant-form-item-control-input"
                                               >
                                                 <div
-                                                  class="ant-select ant-select-in-form-item ant-select-single ant-select-show-arrow ant-select-disabled ant-select-loading ant-select-show-search"
-                                                  data-cy="assigned_review_user"
+                                                  class="ant-form-item-control-input-content"
                                                 >
                                                   <div
-                                                    class="ant-select-selector"
+                                                    class="ant-select ant-select-in-form-item ant-select-single ant-select-show-arrow ant-select-disabled ant-select-loading ant-select-show-search"
+                                                    data-cy="assigned_review_user"
                                                   >
-                                                    <span
-                                                      class="ant-select-selection-search"
+                                                    <div
+                                                      class="ant-select-selector"
                                                     >
-                                                      <input
-                                                        aria-activedescendant="assigned_review_user-HSC_list_0"
-                                                        aria-autocomplete="list"
-                                                        aria-controls="assigned_review_user-HSC_list"
-                                                        aria-expanded="false"
-                                                        aria-haspopup="listbox"
-                                                        aria-owns="assigned_review_user-HSC_list"
-                                                        autocomplete="off"
-                                                        class="ant-select-selection-search-input"
-                                                        disabled=""
-                                                        id="assigned_review_user-HSC"
-                                                        role="combobox"
-                                                        type="search"
-                                                        value=""
-                                                      />
-                                                    </span>
+                                                      <span
+                                                        class="ant-select-selection-search"
+                                                      >
+                                                        <input
+                                                          aria-activedescendant="assigned_review_user-HSC_list_0"
+                                                          aria-autocomplete="list"
+                                                          aria-controls="assigned_review_user-HSC_list"
+                                                          aria-expanded="false"
+                                                          aria-haspopup="listbox"
+                                                          aria-owns="assigned_review_user-HSC_list"
+                                                          autocomplete="off"
+                                                          class="ant-select-selection-search-input"
+                                                          disabled=""
+                                                          id="assigned_review_user-HSC"
+                                                          role="combobox"
+                                                          type="search"
+                                                          value=""
+                                                        />
+                                                      </span>
+                                                      <span
+                                                        class="ant-select-selection-item"
+                                                        title="Testerson, Test MCM:EX"
+                                                      >
+                                                        Testerson, Test MCM:EX
+                                                      </span>
+                                                    </div>
                                                     <span
-                                                      class="ant-select-selection-item"
-                                                      title="Testerson, Test MCM:EX"
+                                                      aria-hidden="true"
+                                                      class="ant-select-arrow ant-select-arrow-loading"
+                                                      style="user-select: none;"
+                                                      unselectable="on"
                                                     >
-                                                      Testerson, Test MCM:EX
+                                                      <span
+                                                        aria-label="loading"
+                                                        class="anticon anticon-loading anticon-spin"
+                                                        role="img"
+                                                      >
+                                                        <svg
+                                                          aria-hidden="true"
+                                                          data-icon="loading"
+                                                          fill="currentColor"
+                                                          focusable="false"
+                                                          height="1em"
+                                                          viewBox="0 0 1024 1024"
+                                                          width="1em"
+                                                        >
+                                                          <path
+                                                            d="M988 548c-19.9 0-36-16.1-36-36 0-59.4-11.6-117-34.6-171.3a440.45 440.45 0 00-94.3-139.9 437.71 437.71 0 00-139.9-94.3C629 83.6 571.4 72 512 72c-19.9 0-36-16.1-36-36s16.1-36 36-36c69.1 0 136.2 13.5 199.3 40.3C772.3 66 827 103 874 150c47 47 83.9 101.8 109.7 162.7 26.7 63.1 40.2 130.2 40.2 199.3.1 19.9-16 36-35.9 36z"
+                                                          />
+                                                        </svg>
+                                                      </span>
                                                     </span>
                                                   </div>
-                                                  <span
-                                                    aria-hidden="true"
-                                                    class="ant-select-arrow ant-select-arrow-loading"
-                                                    style="user-select: none;"
-                                                    unselectable="on"
-                                                  >
-                                                    <span
-                                                      aria-label="loading"
-                                                      class="anticon anticon-loading anticon-spin"
-                                                      role="img"
-                                                    >
-                                                      <svg
-                                                        aria-hidden="true"
-                                                        data-icon="loading"
-                                                        fill="currentColor"
-                                                        focusable="false"
-                                                        height="1em"
-                                                        viewBox="0 0 1024 1024"
-                                                        width="1em"
-                                                      >
-                                                        <path
-                                                          d="M988 548c-19.9 0-36-16.1-36-36 0-59.4-11.6-117-34.6-171.3a440.45 440.45 0 00-94.3-139.9 437.71 437.71 0 00-139.9-94.3C629 83.6 571.4 72 512 72c-19.9 0-36-16.1-36-36s16.1-36 36-36c69.1 0 136.2 13.5 199.3 40.3C772.3 66 827 103 874 150c47 47 83.9 101.8 109.7 162.7 26.7 63.1 40.2 130.2 40.2 199.3.1 19.9-16 36-35.9 36z"
-                                                        />
-                                                      </svg>
-                                                    </span>
-                                                  </span>
                                                 </div>
                                               </div>
-                                            </div>
-                                            <div
-                                              style="display: flex; flex-wrap: nowrap;"
-                                            >
                                               <div
-                                                class="ant-form-item-explain ant-form-item-explain-connected"
-                                                id="PERMIT_CONDITION_REVIEW_ASSIGNMENT-HSC_assigned_review_user_help"
-                                                role="alert"
+                                                style="display: flex; flex-wrap: nowrap;"
                                               >
                                                 <div
-                                                  class=""
-                                                />
+                                                  class="ant-form-item-explain ant-form-item-explain-connected"
+                                                  id="PERMIT_CONDITION_REVIEW_ASSIGNMENT-HSC_assigned_review_user_help"
+                                                  role="alert"
+                                                >
+                                                  <div
+                                                    class=""
+                                                  />
+                                                </div>
                                               </div>
                                             </div>
                                           </div>
                                         </div>
                                       </div>
-                                    </div>
-                                    <div
-                                      class="ant-col"
-                                      style="padding-left: 8px; padding-right: 8px;"
-                                    >
-                                      <button
-                                        aria-label="Submit"
-                                        class="ant-btn ant-btn-primary ant-btn-icon-only  form-btn"
-                                        disabled=""
-                                        type="submit"
-                                      >
-                                        <svg
-                                          aria-hidden="true"
-                                          class="svg-inline--fa fa-check "
-                                          data-icon="check"
-                                          data-prefix="far"
-                                          focusable="false"
-                                          role="img"
-                                          viewBox="0 0 448 512"
-                                          xmlns="http://www.w3.org/2000/svg"
-                                        >
-                                          <path
-                                            d="M441 103c9.4 9.4 9.4 24.6 0 33.9L177 401c-9.4 9.4-24.6 9.4-33.9 0L7 265c-9.4-9.4-9.4-24.6 0-33.9s24.6-9.4 33.9 0l119 119L407 103c9.4-9.4 24.6-9.4 33.9 0z"
-                                            fill="currentColor"
-                                          />
-                                        </svg>
-                                      </button>
-                                      <span
-                                        class="ant-popover-disabled-compatible-wrapper form-btn"
-                                        style="display: inline-block; cursor: not-allowed;"
+                                      <div
+                                        class="ant-col"
+                                        style="padding-left: 8px; padding-right: 8px;"
                                       >
                                         <button
-                                          class="ant-btn ant-btn-default ant-btn-icon-only"
+                                          aria-label="Submit"
+                                          class="ant-btn ant-btn-primary ant-btn-icon-only  form-btn"
                                           disabled=""
-                                          style="pointer-events: none;"
-                                          type="button"
+                                          type="submit"
                                         >
                                           <svg
                                             aria-hidden="true"
-                                            class="svg-inline--fa fa-xmark "
-                                            data-icon="xmark"
-                                            data-prefix="fal"
+                                            class="svg-inline--fa fa-check "
+                                            data-icon="check"
+                                            data-prefix="far"
                                             focusable="false"
                                             role="img"
-                                            viewBox="0 0 384 512"
+                                            viewBox="0 0 448 512"
                                             xmlns="http://www.w3.org/2000/svg"
                                           >
                                             <path
-                                              d="M324.5 411.1c6.2 6.2 16.4 6.2 22.6 0s6.2-16.4 0-22.6L214.6 256 347.1 123.5c6.2-6.2 6.2-16.4 0-22.6s-16.4-6.2-22.6 0L192 233.4 59.5 100.9c-6.2-6.2-16.4-6.2-22.6 0s-6.2 16.4 0 22.6L169.4 256 36.9 388.5c-6.2 6.2-6.2 16.4 0 22.6s16.4 6.2 22.6 0L192 278.6 324.5 411.1z"
+                                              d="M441 103c9.4 9.4 9.4 24.6 0 33.9L177 401c-9.4 9.4-24.6 9.4-33.9 0L7 265c-9.4-9.4-9.4-24.6 0-33.9s24.6-9.4 33.9 0l119 119L407 103c9.4-9.4 24.6-9.4 33.9 0z"
                                               fill="currentColor"
                                             />
                                           </svg>
                                         </button>
-                                      </span>
-                                    </div>
-                                  </div>
-                                </form>
-                              </div>
-                              <div
-                                class="ant-col ant-col-24 fade-in"
-                                style="padding: 8px 8px 8px 8px;"
-                              >
-                                <div
-                                  class="condition-layer condition-layer--0 condition-SEC fade-in "
-                                >
-                                  <div
-                                    class="condition-collapsed"
-                                  >
-                                    <div
-                                      class="ant-row ant-row-no-wrap ant-row-top condition-content editable"
-                                    >
-                                      <div
-                                        class="ant-col step-column"
-                                        style="flex-shrink: 0;"
-                                      >
-                                        <div
-                                          class="ant-typography view-item-value"
+                                        <span
+                                          class="ant-popover-disabled-compatible-wrapper form-btn"
+                                          style="display: inline-block; cursor: not-allowed;"
                                         >
-                                          1.
-                                        </div>
-                                      </div>
-                                      <div
-                                        aria-label="Edit Condition"
-                                        class="ant-col condition-column"
-                                        title="Edit Condition"
-                                      >
-                                        <div
-                                          class="ant-typography view-item-value"
-                                        >
-                                          Section decade check including.
-                                        </div>
-                                      </div>
-                                    </div>
-                                  </div>
-                                  <div>
-                                    <div
-                                      class="ant-col ant-col-24"
-                                      style="padding: 8px 8px 8px 8px;"
-                                    >
-                                      <div
-                                        class="ant-row ant-row-space-between"
-                                      >
-                                        <div
-                                          class="ant-space ant-space-horizontal ant-space-align-center"
-                                        >
-                                          <div
-                                            class="ant-space-item"
-                                          >
-                                            <span
-                                              class="ant-tag ant-tag-error condition-tag"
-                                            >
-                                              <svg
-                                                aria-hidden="true"
-                                                class="svg-inline--fa fa-clock-rotate-left margin-small--right"
-                                                data-icon="clock-rotate-left"
-                                                data-prefix="far"
-                                                focusable="false"
-                                                role="img"
-                                                viewBox="0 0 512 512"
-                                                xmlns="http://www.w3.org/2000/svg"
-                                              >
-                                                <path
-                                                  d="M48 106.7V56c0-13.3-10.7-24-24-24S0 42.7 0 56V168c0 13.3 10.7 24 24 24H136c13.3 0 24-10.7 24-24s-10.7-24-24-24H80.7c37-57.8 101.7-96 175.3-96c114.9 0 208 93.1 208 208s-93.1 208-208 208c-42.5 0-81.9-12.7-114.7-34.5c-11-7.3-25.9-4.3-33.3 6.7s-4.3 25.9 6.7 33.3C155.2 496.4 203.8 512 256 512c141.4 0 256-114.6 256-256S397.4 0 256 0C170.3 0 94.4 42.1 48 106.7zM256 128c-13.3 0-24 10.7-24 24V256c0 6.4 2.5 12.5 7 17l72 72c9.4 9.4 24.6 9.4 33.9 0s9.4-24.6 0-33.9l-65-65V152c0-13.3-10.7-24-24-24z"
-                                                  fill="currentColor"
-                                                />
-                                              </svg>
-                                              <span>
-                                                Requires Review
-                                              </span>
-                                            </span>
-                                          </div>
-                                        </div>
-                                        <div
-                                          class="ant-col"
-                                        >
-                                          
                                           <button
-                                            class="ant-btn ant-btn-primary core-btn core-btn-primary"
+                                            class="ant-btn ant-btn-default ant-btn-icon-only"
+                                            disabled=""
+                                            style="pointer-events: none;"
                                             type="button"
                                           >
-                                            <span
-                                              aria-label="check"
-                                              class="anticon anticon-check"
+                                            <svg
+                                              aria-hidden="true"
+                                              class="svg-inline--fa fa-xmark "
+                                              data-icon="xmark"
+                                              data-prefix="fal"
+                                              focusable="false"
                                               role="img"
+                                              viewBox="0 0 384 512"
+                                              xmlns="http://www.w3.org/2000/svg"
                                             >
-                                              <svg
-                                                aria-hidden="true"
-                                                class=""
-                                                data-icon="check"
+                                              <path
+                                                d="M324.5 411.1c6.2 6.2 16.4 6.2 22.6 0s6.2-16.4 0-22.6L214.6 256 347.1 123.5c6.2-6.2 6.2-16.4 0-22.6s-16.4-6.2-22.6 0L192 233.4 59.5 100.9c-6.2-6.2-16.4-6.2-22.6 0s-6.2 16.4 0 22.6L169.4 256 36.9 388.5c-6.2 6.2-6.2 16.4 0 22.6s16.4 6.2 22.6 0L192 278.6 324.5 411.1z"
                                                 fill="currentColor"
-                                                focusable="false"
-                                                height="1em"
-                                                viewBox="64 64 896 896"
-                                                width="1em"
-                                              >
-                                                <path
-                                                  d="M912 190h-69.9c-9.8 0-19.1 4.5-25.1 12.2L404.7 724.5 207 474a32 32 0 00-25.1-12.2H112c-6.7 0-10.4 7.7-6.3 12.9l273.9 347c12.8 16.2 37.4 16.2 50.3 0l488.4-618.9c4.1-5.1.4-12.8-6.3-12.8z"
-                                                />
-                                              </svg>
-                                            </span>
-                                            <span>
-                                               Complete Review
-                                            </span>
+                                              />
+                                            </svg>
                                           </button>
-                                        </div>
+                                        </span>
                                       </div>
                                     </div>
-                                  </div>
+                                  </form>
                                 </div>
-                              </div>
-                              <div
-                                class="ant-col ant-col-24"
-                                style="padding: 8px 8px 8px 8px;"
-                              >
                                 <div
-                                  class="ant-row ant-row-space-between"
-                                >
-                                  <h3
-                                    class="ant-typography margin-none"
-                                    id="rcc"
-                                  >
-                                    <span
-                                      style="margin-bottom: 0px;"
-                                    >
-                                      B.
-                                       
-                                      Reclamation
-                                       (
-                                      1
-                                      )
-                                    </span>
-                                  </h3>
-                                </div>
-                                <form
-                                  class="ant-form ant-form-horizontal common-form common-form-PERMIT_CONDITION_REVIEW_ASSIGNMENT-RCC form-edit"
-                                  id="PERMIT_CONDITION_REVIEW_ASSIGNMENT-RCC"
+                                  class="ant-col ant-col-24 fade-in"
+                                  style="padding: 8px 8px 8px 8px;"
                                 >
                                   <div
-                                    class="ant-row ant-row-start ant-row-top condition-category-reviewer-row"
-                                    style="margin-left: -8px; margin-right: -8px;"
+                                    class="condition-layer condition-layer--0 condition-SEC fade-in "
                                   >
                                     <div
-                                      class="ant-col"
-                                      style="padding-left: 8px; padding-right: 8px;"
+                                      class="condition-collapsed"
                                     >
                                       <div
-                                        class="ant-typography"
-                                      >
-                                        Assigned Reviewer:
-                                      </div>
-                                    </div>
-                                    <div
-                                      class="ant-col ant-col-12"
-                                      style="padding-left: 8px; padding-right: 8px;"
-                                    >
-                                      <div
-                                        class="ant-form-item ant-form-item-with-help"
+                                        class="ant-row ant-row-no-wrap ant-row-top condition-content editable"
                                       >
                                         <div
-                                          class="ant-row ant-form-item-row"
+                                          class="ant-col step-column"
+                                          style="flex-shrink: 0;"
                                         >
                                           <div
-                                            class="ant-col ant-form-item-control"
+                                            class="ant-typography view-item-value"
                                           >
-                                            <div
-                                              class="ant-form-item-control-input"
-                                            >
-                                              <div
-                                                class="ant-form-item-control-input-content"
-                                              >
-                                                <div
-                                                  class="ant-select ant-select-in-form-item ant-select-single ant-select-show-arrow ant-select-disabled ant-select-loading ant-select-show-search"
-                                                  data-cy="assigned_review_user"
-                                                >
-                                                  <div
-                                                    class="ant-select-selector"
-                                                  >
-                                                    <span
-                                                      class="ant-select-selection-search"
-                                                    >
-                                                      <input
-                                                        aria-activedescendant="assigned_review_user-RCC_list_0"
-                                                        aria-autocomplete="list"
-                                                        aria-controls="assigned_review_user-RCC_list"
-                                                        aria-expanded="false"
-                                                        aria-haspopup="listbox"
-                                                        aria-owns="assigned_review_user-RCC_list"
-                                                        autocomplete="off"
-                                                        class="ant-select-selection-search-input"
-                                                        disabled=""
-                                                        id="assigned_review_user-RCC"
-                                                        role="combobox"
-                                                        type="search"
-                                                        value=""
-                                                      />
-                                                    </span>
-                                                    <span
-                                                      class="ant-select-selection-placeholder"
-                                                    >
-                                                      Search for a user
-                                                    </span>
-                                                  </div>
-                                                  <span
-                                                    aria-hidden="true"
-                                                    class="ant-select-arrow ant-select-arrow-loading"
-                                                    style="user-select: none;"
-                                                    unselectable="on"
-                                                  >
-                                                    <span
-                                                      aria-label="loading"
-                                                      class="anticon anticon-loading anticon-spin"
-                                                      role="img"
-                                                    >
-                                                      <svg
-                                                        aria-hidden="true"
-                                                        data-icon="loading"
-                                                        fill="currentColor"
-                                                        focusable="false"
-                                                        height="1em"
-                                                        viewBox="0 0 1024 1024"
-                                                        width="1em"
-                                                      >
-                                                        <path
-                                                          d="M988 548c-19.9 0-36-16.1-36-36 0-59.4-11.6-117-34.6-171.3a440.45 440.45 0 00-94.3-139.9 437.71 437.71 0 00-139.9-94.3C629 83.6 571.4 72 512 72c-19.9 0-36-16.1-36-36s16.1-36 36-36c69.1 0 136.2 13.5 199.3 40.3C772.3 66 827 103 874 150c47 47 83.9 101.8 109.7 162.7 26.7 63.1 40.2 130.2 40.2 199.3.1 19.9-16 36-35.9 36z"
-                                                        />
-                                                      </svg>
-                                                    </span>
-                                                  </span>
-                                                </div>
-                                              </div>
-                                            </div>
-                                            <div
-                                              style="display: flex; flex-wrap: nowrap;"
-                                            >
-                                              <div
-                                                class="ant-form-item-explain ant-form-item-explain-connected"
-                                                id="PERMIT_CONDITION_REVIEW_ASSIGNMENT-RCC_assigned_review_user_help"
-                                                role="alert"
-                                              >
-                                                <div
-                                                  class=""
-                                                />
-                                              </div>
-                                            </div>
+                                            1.
+                                          </div>
+                                        </div>
+                                        <div
+                                          aria-label="Edit Condition Health and Safety - 1"
+                                          class="ant-col condition-column"
+                                          title="Edit Condition Health and Safety - 1"
+                                        >
+                                          <div
+                                            class="ant-typography view-item-value"
+                                          >
+                                            Section decade check including.
                                           </div>
                                         </div>
                                       </div>
                                     </div>
-                                    <div
-                                      class="ant-col"
-                                      style="padding-left: 8px; padding-right: 8px;"
-                                    >
-                                      <button
-                                        aria-label="Submit"
-                                        class="ant-btn ant-btn-primary ant-btn-icon-only  form-btn"
-                                        disabled=""
-                                        type="submit"
-                                      >
-                                        <svg
-                                          aria-hidden="true"
-                                          class="svg-inline--fa fa-check "
-                                          data-icon="check"
-                                          data-prefix="far"
-                                          focusable="false"
-                                          role="img"
-                                          viewBox="0 0 448 512"
-                                          xmlns="http://www.w3.org/2000/svg"
-                                        >
-                                          <path
-                                            d="M441 103c9.4 9.4 9.4 24.6 0 33.9L177 401c-9.4 9.4-24.6 9.4-33.9 0L7 265c-9.4-9.4-9.4-24.6 0-33.9s24.6-9.4 33.9 0l119 119L407 103c9.4-9.4 24.6-9.4 33.9 0z"
-                                            fill="currentColor"
-                                          />
-                                        </svg>
-                                      </button>
-                                    </div>
-                                  </div>
-                                </form>
-                              </div>
-                              <div
-                                class="ant-col ant-col-24 fade-in"
-                                style="padding: 8px 8px 8px 8px;"
-                              >
-                                <div
-                                  class="condition-layer condition-layer--0 condition-SEC fade-in "
-                                >
-                                  <div
-                                    class="condition-collapsed"
-                                  >
-                                    <div
-                                      class="ant-row ant-row-no-wrap ant-row-top condition-content "
-                                    >
+                                    <div>
                                       <div
-                                        class="ant-col step-column"
-                                        style="flex-shrink: 0;"
+                                        class="ant-col ant-col-24"
+                                        style="padding: 8px 8px 8px 8px;"
                                       >
                                         <div
-                                          class="ant-typography view-item-value"
-                                        >
-                                          1.
-                                        </div>
-                                      </div>
-                                      <div
-                                        class="ant-col condition-column"
-                                      >
-                                        <div
-                                          class="ant-typography view-item-value"
-                                        >
-                                          Reflect miss police tough such single force.
-                                        </div>
-                                      </div>
-                                    </div>
-                                  </div>
-                                  <div>
-                                    <div
-                                      class="ant-col ant-col-24"
-                                      style="padding: 8px 8px 8px 8px;"
-                                    >
-                                      <div
-                                        class="ant-row ant-row-space-between"
-                                      >
-                                        <div
-                                          class="ant-space ant-space-horizontal ant-space-align-center"
+                                          class="ant-row ant-row-space-between"
                                         >
                                           <div
-                                            class="ant-space-item"
+                                            class="ant-space ant-space-horizontal ant-space-align-center"
                                           >
-                                            <span
-                                              class="ant-tag ant-tag-error condition-tag"
+                                            <div
+                                              class="ant-space-item"
                                             >
-                                              <svg
-                                                aria-hidden="true"
-                                                class="svg-inline--fa fa-clock-rotate-left margin-small--right"
-                                                data-icon="clock-rotate-left"
-                                                data-prefix="far"
-                                                focusable="false"
-                                                role="img"
-                                                viewBox="0 0 512 512"
-                                                xmlns="http://www.w3.org/2000/svg"
+                                              <span
+                                                class="ant-tag ant-tag-error condition-tag"
                                               >
-                                                <path
-                                                  d="M48 106.7V56c0-13.3-10.7-24-24-24S0 42.7 0 56V168c0 13.3 10.7 24 24 24H136c13.3 0 24-10.7 24-24s-10.7-24-24-24H80.7c37-57.8 101.7-96 175.3-96c114.9 0 208 93.1 208 208s-93.1 208-208 208c-42.5 0-81.9-12.7-114.7-34.5c-11-7.3-25.9-4.3-33.3 6.7s-4.3 25.9 6.7 33.3C155.2 496.4 203.8 512 256 512c141.4 0 256-114.6 256-256S397.4 0 256 0C170.3 0 94.4 42.1 48 106.7zM256 128c-13.3 0-24 10.7-24 24V256c0 6.4 2.5 12.5 7 17l72 72c9.4 9.4 24.6 9.4 33.9 0s9.4-24.6 0-33.9l-65-65V152c0-13.3-10.7-24-24-24z"
-                                                  fill="currentColor"
-                                                />
-                                              </svg>
-                                              <span>
-                                                Requires Review
+                                                <svg
+                                                  aria-hidden="true"
+                                                  class="svg-inline--fa fa-clock-rotate-left margin-small--right"
+                                                  data-icon="clock-rotate-left"
+                                                  data-prefix="far"
+                                                  focusable="false"
+                                                  role="img"
+                                                  viewBox="0 0 512 512"
+                                                  xmlns="http://www.w3.org/2000/svg"
+                                                >
+                                                  <path
+                                                    d="M48 106.7V56c0-13.3-10.7-24-24-24S0 42.7 0 56V168c0 13.3 10.7 24 24 24H136c13.3 0 24-10.7 24-24s-10.7-24-24-24H80.7c37-57.8 101.7-96 175.3-96c114.9 0 208 93.1 208 208s-93.1 208-208 208c-42.5 0-81.9-12.7-114.7-34.5c-11-7.3-25.9-4.3-33.3 6.7s-4.3 25.9 6.7 33.3C155.2 496.4 203.8 512 256 512c141.4 0 256-114.6 256-256S397.4 0 256 0C170.3 0 94.4 42.1 48 106.7zM256 128c-13.3 0-24 10.7-24 24V256c0 6.4 2.5 12.5 7 17l72 72c9.4 9.4 24.6 9.4 33.9 0s9.4-24.6 0-33.9l-65-65V152c0-13.3-10.7-24-24-24z"
+                                                    fill="currentColor"
+                                                  />
+                                                </svg>
+                                                <span>
+                                                  Requires Review
+                                                </span>
                                               </span>
-                                            </span>
-                                          </div>
-                                        </div>
-                                        <div
-                                          class="ant-col"
-                                        >
-                                          
-                                        </div>
-                                      </div>
-                                    </div>
-                                  </div>
-                                </div>
-                              </div>
-                              <div
-                                class="ant-col ant-col-24"
-                                style="padding: 8px 8px 8px 8px;"
-                              >
-                                <div
-                                  class="ant-row ant-row-space-between"
-                                >
-                                  <h3
-                                    class="ant-typography margin-none"
-                                    id="elc"
-                                  >
-                                    <span
-                                      style="margin-bottom: 0px;"
-                                    >
-                                      C.
-                                       
-                                      Environmental Land and Watercourses
-                                       (
-                                      2
-                                      )
-                                    </span>
-                                  </h3>
-                                </div>
-                                <form
-                                  class="ant-form ant-form-horizontal common-form common-form-PERMIT_CONDITION_REVIEW_ASSIGNMENT-ELC form-edit"
-                                  id="PERMIT_CONDITION_REVIEW_ASSIGNMENT-ELC"
-                                >
-                                  <div
-                                    class="ant-row ant-row-start ant-row-top condition-category-reviewer-row"
-                                    style="margin-left: -8px; margin-right: -8px;"
-                                  >
-                                    <div
-                                      class="ant-col"
-                                      style="padding-left: 8px; padding-right: 8px;"
-                                    >
-                                      <div
-                                        class="ant-typography"
-                                      >
-                                        Assigned Reviewer:
-                                      </div>
-                                    </div>
-                                    <div
-                                      class="ant-col ant-col-12"
-                                      style="padding-left: 8px; padding-right: 8px;"
-                                    >
-                                      <div
-                                        class="ant-form-item ant-form-item-with-help"
-                                      >
-                                        <div
-                                          class="ant-row ant-form-item-row"
-                                        >
-                                          <div
-                                            class="ant-col ant-form-item-control"
-                                          >
-                                            <div
-                                              class="ant-form-item-control-input"
-                                            >
-                                              <div
-                                                class="ant-form-item-control-input-content"
-                                              >
-                                                <div
-                                                  class="ant-select ant-select-in-form-item ant-select-single ant-select-show-arrow ant-select-disabled ant-select-loading ant-select-show-search"
-                                                  data-cy="assigned_review_user"
-                                                >
-                                                  <div
-                                                    class="ant-select-selector"
-                                                  >
-                                                    <span
-                                                      class="ant-select-selection-search"
-                                                    >
-                                                      <input
-                                                        aria-activedescendant="assigned_review_user-ELC_list_0"
-                                                        aria-autocomplete="list"
-                                                        aria-controls="assigned_review_user-ELC_list"
-                                                        aria-expanded="false"
-                                                        aria-haspopup="listbox"
-                                                        aria-owns="assigned_review_user-ELC_list"
-                                                        autocomplete="off"
-                                                        class="ant-select-selection-search-input"
-                                                        disabled=""
-                                                        id="assigned_review_user-ELC"
-                                                        role="combobox"
-                                                        type="search"
-                                                        value=""
-                                                      />
-                                                    </span>
-                                                    <span
-                                                      class="ant-select-selection-placeholder"
-                                                    >
-                                                      Search for a user
-                                                    </span>
-                                                  </div>
-                                                  <span
-                                                    aria-hidden="true"
-                                                    class="ant-select-arrow ant-select-arrow-loading"
-                                                    style="user-select: none;"
-                                                    unselectable="on"
-                                                  >
-                                                    <span
-                                                      aria-label="loading"
-                                                      class="anticon anticon-loading anticon-spin"
-                                                      role="img"
-                                                    >
-                                                      <svg
-                                                        aria-hidden="true"
-                                                        data-icon="loading"
-                                                        fill="currentColor"
-                                                        focusable="false"
-                                                        height="1em"
-                                                        viewBox="0 0 1024 1024"
-                                                        width="1em"
-                                                      >
-                                                        <path
-                                                          d="M988 548c-19.9 0-36-16.1-36-36 0-59.4-11.6-117-34.6-171.3a440.45 440.45 0 00-94.3-139.9 437.71 437.71 0 00-139.9-94.3C629 83.6 571.4 72 512 72c-19.9 0-36-16.1-36-36s16.1-36 36-36c69.1 0 136.2 13.5 199.3 40.3C772.3 66 827 103 874 150c47 47 83.9 101.8 109.7 162.7 26.7 63.1 40.2 130.2 40.2 199.3.1 19.9-16 36-35.9 36z"
-                                                        />
-                                                      </svg>
-                                                    </span>
-                                                  </span>
-                                                </div>
-                                              </div>
                                             </div>
-                                            <div
-                                              style="display: flex; flex-wrap: nowrap;"
+                                          </div>
+                                          <div
+                                            class="ant-col"
+                                          >
+                                            
+                                            <button
+                                              class="ant-btn ant-btn-primary core-btn core-btn-primary"
+                                              type="button"
                                             >
-                                              <div
-                                                class="ant-form-item-explain ant-form-item-explain-connected"
-                                                id="PERMIT_CONDITION_REVIEW_ASSIGNMENT-ELC_assigned_review_user_help"
-                                                role="alert"
+                                              <span
+                                                aria-label="check"
+                                                class="anticon anticon-check"
+                                                role="img"
                                               >
-                                                <div
+                                                <svg
+                                                  aria-hidden="true"
                                                   class=""
-                                                />
-                                              </div>
-                                            </div>
+                                                  data-icon="check"
+                                                  fill="currentColor"
+                                                  focusable="false"
+                                                  height="1em"
+                                                  viewBox="64 64 896 896"
+                                                  width="1em"
+                                                >
+                                                  <path
+                                                    d="M912 190h-69.9c-9.8 0-19.1 4.5-25.1 12.2L404.7 724.5 207 474a32 32 0 00-25.1-12.2H112c-6.7 0-10.4 7.7-6.3 12.9l273.9 347c12.8 16.2 37.4 16.2 50.3 0l488.4-618.9c4.1-5.1.4-12.8-6.3-12.8z"
+                                                  />
+                                                </svg>
+                                              </span>
+                                              <span>
+                                                 Complete Review
+                                              </span>
+                                            </button>
                                           </div>
                                         </div>
                                       </div>
-                                    </div>
-                                    <div
-                                      class="ant-col"
-                                      style="padding-left: 8px; padding-right: 8px;"
-                                    >
-                                      <button
-                                        aria-label="Submit"
-                                        class="ant-btn ant-btn-primary ant-btn-icon-only  form-btn"
-                                        disabled=""
-                                        type="submit"
-                                      >
-                                        <svg
-                                          aria-hidden="true"
-                                          class="svg-inline--fa fa-check "
-                                          data-icon="check"
-                                          data-prefix="far"
-                                          focusable="false"
-                                          role="img"
-                                          viewBox="0 0 448 512"
-                                          xmlns="http://www.w3.org/2000/svg"
-                                        >
-                                          <path
-                                            d="M441 103c9.4 9.4 9.4 24.6 0 33.9L177 401c-9.4 9.4-24.6 9.4-33.9 0L7 265c-9.4-9.4-9.4-24.6 0-33.9s24.6-9.4 33.9 0l119 119L407 103c9.4-9.4 24.6-9.4 33.9 0z"
-                                            fill="currentColor"
-                                          />
-                                        </svg>
-                                      </button>
                                     </div>
                                   </div>
-                                </form>
+                                </div>
                               </div>
                               <div
-                                class="ant-col ant-col-24 fade-in"
-                                style="padding: 8px 8px 8px 8px;"
+                                class="common-page-content"
                               >
                                 <div
-                                  class="condition-layer condition-layer--0 condition-SEC fade-in "
+                                  class="ant-col ant-col-24"
+                                  style="padding: 8px 8px 8px 8px;"
                                 >
                                   <div
-                                    class="condition-collapsed"
+                                    class="ant-row ant-row-space-between"
+                                  >
+                                    <h3
+                                      class="ant-typography margin-none"
+                                      id="rcc"
+                                    >
+                                      <span
+                                        style="margin-bottom: 0px;"
+                                      >
+                                        B.
+                                         
+                                        Reclamation
+                                         (
+                                        1
+                                        )
+                                      </span>
+                                    </h3>
+                                  </div>
+                                  <form
+                                    class="ant-form ant-form-horizontal common-form common-form-PERMIT_CONDITION_REVIEW_ASSIGNMENT-RCC form-edit"
+                                    id="PERMIT_CONDITION_REVIEW_ASSIGNMENT-RCC"
                                   >
                                     <div
-                                      class="ant-row ant-row-no-wrap ant-row-top condition-content "
+                                      class="ant-row ant-row-start ant-row-top condition-category-reviewer-row"
+                                      style="margin-left: -8px; margin-right: -8px;"
                                     >
                                       <div
-                                        class="ant-col step-column"
-                                        style="flex-shrink: 0;"
+                                        class="ant-col"
+                                        style="padding-left: 8px; padding-right: 8px;"
                                       >
                                         <div
-                                          class="ant-typography view-item-value"
+                                          class="ant-typography"
                                         >
-                                          1.
+                                          Assigned Reviewer:
                                         </div>
                                       </div>
                                       <div
-                                        class="ant-col condition-column"
+                                        class="ant-col ant-col-12"
+                                        style="padding-left: 8px; padding-right: 8px;"
                                       >
                                         <div
-                                          class="ant-typography view-item-value"
+                                          class="ant-form-item ant-form-item-with-help"
                                         >
-                                          International clear those TV individual look.
+                                          <div
+                                            class="ant-row ant-form-item-row"
+                                          >
+                                            <div
+                                              class="ant-col ant-form-item-control"
+                                            >
+                                              <div
+                                                class="ant-form-item-control-input"
+                                              >
+                                                <div
+                                                  class="ant-form-item-control-input-content"
+                                                >
+                                                  <div
+                                                    class="ant-select ant-select-in-form-item ant-select-single ant-select-show-arrow ant-select-disabled ant-select-loading ant-select-show-search"
+                                                    data-cy="assigned_review_user"
+                                                  >
+                                                    <div
+                                                      class="ant-select-selector"
+                                                    >
+                                                      <span
+                                                        class="ant-select-selection-search"
+                                                      >
+                                                        <input
+                                                          aria-activedescendant="assigned_review_user-RCC_list_0"
+                                                          aria-autocomplete="list"
+                                                          aria-controls="assigned_review_user-RCC_list"
+                                                          aria-expanded="false"
+                                                          aria-haspopup="listbox"
+                                                          aria-owns="assigned_review_user-RCC_list"
+                                                          autocomplete="off"
+                                                          class="ant-select-selection-search-input"
+                                                          disabled=""
+                                                          id="assigned_review_user-RCC"
+                                                          role="combobox"
+                                                          type="search"
+                                                          value=""
+                                                        />
+                                                      </span>
+                                                      <span
+                                                        class="ant-select-selection-placeholder"
+                                                      >
+                                                        Search for a user
+                                                      </span>
+                                                    </div>
+                                                    <span
+                                                      aria-hidden="true"
+                                                      class="ant-select-arrow ant-select-arrow-loading"
+                                                      style="user-select: none;"
+                                                      unselectable="on"
+                                                    >
+                                                      <span
+                                                        aria-label="loading"
+                                                        class="anticon anticon-loading anticon-spin"
+                                                        role="img"
+                                                      >
+                                                        <svg
+                                                          aria-hidden="true"
+                                                          data-icon="loading"
+                                                          fill="currentColor"
+                                                          focusable="false"
+                                                          height="1em"
+                                                          viewBox="0 0 1024 1024"
+                                                          width="1em"
+                                                        >
+                                                          <path
+                                                            d="M988 548c-19.9 0-36-16.1-36-36 0-59.4-11.6-117-34.6-171.3a440.45 440.45 0 00-94.3-139.9 437.71 437.71 0 00-139.9-94.3C629 83.6 571.4 72 512 72c-19.9 0-36-16.1-36-36s16.1-36 36-36c69.1 0 136.2 13.5 199.3 40.3C772.3 66 827 103 874 150c47 47 83.9 101.8 109.7 162.7 26.7 63.1 40.2 130.2 40.2 199.3.1 19.9-16 36-35.9 36z"
+                                                          />
+                                                        </svg>
+                                                      </span>
+                                                    </span>
+                                                  </div>
+                                                </div>
+                                              </div>
+                                              <div
+                                                style="display: flex; flex-wrap: nowrap;"
+                                              >
+                                                <div
+                                                  class="ant-form-item-explain ant-form-item-explain-connected"
+                                                  id="PERMIT_CONDITION_REVIEW_ASSIGNMENT-RCC_assigned_review_user_help"
+                                                  role="alert"
+                                                >
+                                                  <div
+                                                    class=""
+                                                  />
+                                                </div>
+                                              </div>
+                                            </div>
+                                          </div>
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="ant-col"
+                                        style="padding-left: 8px; padding-right: 8px;"
+                                      >
+                                        <button
+                                          aria-label="Submit"
+                                          class="ant-btn ant-btn-primary ant-btn-icon-only  form-btn"
+                                          disabled=""
+                                          type="submit"
+                                        >
+                                          <svg
+                                            aria-hidden="true"
+                                            class="svg-inline--fa fa-check "
+                                            data-icon="check"
+                                            data-prefix="far"
+                                            focusable="false"
+                                            role="img"
+                                            viewBox="0 0 448 512"
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="M441 103c9.4 9.4 9.4 24.6 0 33.9L177 401c-9.4 9.4-24.6 9.4-33.9 0L7 265c-9.4-9.4-9.4-24.6 0-33.9s24.6-9.4 33.9 0l119 119L407 103c9.4-9.4 24.6-9.4 33.9 0z"
+                                              fill="currentColor"
+                                            />
+                                          </svg>
+                                        </button>
+                                      </div>
+                                    </div>
+                                  </form>
+                                </div>
+                                <div
+                                  class="ant-col ant-col-24 fade-in"
+                                  style="padding: 8px 8px 8px 8px;"
+                                >
+                                  <div
+                                    class="condition-layer condition-layer--0 condition-SEC fade-in "
+                                  >
+                                    <div
+                                      class="condition-collapsed"
+                                    >
+                                      <div
+                                        class="ant-row ant-row-no-wrap ant-row-top condition-content "
+                                      >
+                                        <div
+                                          class="ant-col step-column"
+                                          style="flex-shrink: 0;"
+                                        >
+                                          <div
+                                            class="ant-typography view-item-value"
+                                          >
+                                            1.
+                                          </div>
+                                        </div>
+                                        <div
+                                          class="ant-col condition-column"
+                                        >
+                                          <div
+                                            class="ant-typography view-item-value"
+                                          >
+                                            Reflect miss police tough such single force.
+                                          </div>
                                         </div>
                                       </div>
                                     </div>
                                     <div>
                                       <div
-                                        class="condition-layer condition-layer--1 condition-CON fade-in "
+                                        class="ant-col ant-col-24"
+                                        style="padding: 8px 8px 8px 8px;"
                                       >
                                         <div
-                                          class="condition-collapsed"
+                                          class="ant-row ant-row-space-between"
                                         >
                                           <div
-                                            class="ant-row ant-row-no-wrap ant-row-top condition-content "
+                                            class="ant-space ant-space-horizontal ant-space-align-center"
                                           >
                                             <div
-                                              class="ant-col step-column"
-                                              style="flex-shrink: 0;"
+                                              class="ant-space-item"
                                             >
-                                              <div
-                                                class="ant-typography view-item-value"
+                                              <span
+                                                class="ant-tag ant-tag-error condition-tag"
                                               >
-                                                a.
-                                              </div>
+                                                <svg
+                                                  aria-hidden="true"
+                                                  class="svg-inline--fa fa-clock-rotate-left margin-small--right"
+                                                  data-icon="clock-rotate-left"
+                                                  data-prefix="far"
+                                                  focusable="false"
+                                                  role="img"
+                                                  viewBox="0 0 512 512"
+                                                  xmlns="http://www.w3.org/2000/svg"
+                                                >
+                                                  <path
+                                                    d="M48 106.7V56c0-13.3-10.7-24-24-24S0 42.7 0 56V168c0 13.3 10.7 24 24 24H136c13.3 0 24-10.7 24-24s-10.7-24-24-24H80.7c37-57.8 101.7-96 175.3-96c114.9 0 208 93.1 208 208s-93.1 208-208 208c-42.5 0-81.9-12.7-114.7-34.5c-11-7.3-25.9-4.3-33.3 6.7s-4.3 25.9 6.7 33.3C155.2 496.4 203.8 512 256 512c141.4 0 256-114.6 256-256S397.4 0 256 0C170.3 0 94.4 42.1 48 106.7zM256 128c-13.3 0-24 10.7-24 24V256c0 6.4 2.5 12.5 7 17l72 72c9.4 9.4 24.6 9.4 33.9 0s9.4-24.6 0-33.9l-65-65V152c0-13.3-10.7-24-24-24z"
+                                                    fill="currentColor"
+                                                  />
+                                                </svg>
+                                                <span>
+                                                  Requires Review
+                                                </span>
+                                              </span>
                                             </div>
+                                          </div>
+                                          <div
+                                            class="ant-col"
+                                          >
+                                            
+                                          </div>
+                                        </div>
+                                      </div>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                              <div
+                                class="common-page-content"
+                              >
+                                <div
+                                  class="ant-col ant-col-24"
+                                  style="padding: 8px 8px 8px 8px;"
+                                >
+                                  <div
+                                    class="ant-row ant-row-space-between"
+                                  >
+                                    <h3
+                                      class="ant-typography margin-none"
+                                      id="elc"
+                                    >
+                                      <span
+                                        style="margin-bottom: 0px;"
+                                      >
+                                        C.
+                                         
+                                        Environmental Land and Watercourses
+                                         (
+                                        2
+                                        )
+                                      </span>
+                                    </h3>
+                                  </div>
+                                  <form
+                                    class="ant-form ant-form-horizontal common-form common-form-PERMIT_CONDITION_REVIEW_ASSIGNMENT-ELC form-edit"
+                                    id="PERMIT_CONDITION_REVIEW_ASSIGNMENT-ELC"
+                                  >
+                                    <div
+                                      class="ant-row ant-row-start ant-row-top condition-category-reviewer-row"
+                                      style="margin-left: -8px; margin-right: -8px;"
+                                    >
+                                      <div
+                                        class="ant-col"
+                                        style="padding-left: 8px; padding-right: 8px;"
+                                      >
+                                        <div
+                                          class="ant-typography"
+                                        >
+                                          Assigned Reviewer:
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="ant-col ant-col-12"
+                                        style="padding-left: 8px; padding-right: 8px;"
+                                      >
+                                        <div
+                                          class="ant-form-item ant-form-item-with-help"
+                                        >
+                                          <div
+                                            class="ant-row ant-form-item-row"
+                                          >
                                             <div
-                                              class="ant-col condition-column"
+                                              class="ant-col ant-form-item-control"
                                             >
                                               <div
-                                                class="ant-typography view-item-value"
+                                                class="ant-form-item-control-input"
                                               >
-                                                See store understand company interview value factor.
+                                                <div
+                                                  class="ant-form-item-control-input-content"
+                                                >
+                                                  <div
+                                                    class="ant-select ant-select-in-form-item ant-select-single ant-select-show-arrow ant-select-disabled ant-select-loading ant-select-show-search"
+                                                    data-cy="assigned_review_user"
+                                                  >
+                                                    <div
+                                                      class="ant-select-selector"
+                                                    >
+                                                      <span
+                                                        class="ant-select-selection-search"
+                                                      >
+                                                        <input
+                                                          aria-activedescendant="assigned_review_user-ELC_list_0"
+                                                          aria-autocomplete="list"
+                                                          aria-controls="assigned_review_user-ELC_list"
+                                                          aria-expanded="false"
+                                                          aria-haspopup="listbox"
+                                                          aria-owns="assigned_review_user-ELC_list"
+                                                          autocomplete="off"
+                                                          class="ant-select-selection-search-input"
+                                                          disabled=""
+                                                          id="assigned_review_user-ELC"
+                                                          role="combobox"
+                                                          type="search"
+                                                          value=""
+                                                        />
+                                                      </span>
+                                                      <span
+                                                        class="ant-select-selection-placeholder"
+                                                      >
+                                                        Search for a user
+                                                      </span>
+                                                    </div>
+                                                    <span
+                                                      aria-hidden="true"
+                                                      class="ant-select-arrow ant-select-arrow-loading"
+                                                      style="user-select: none;"
+                                                      unselectable="on"
+                                                    >
+                                                      <span
+                                                        aria-label="loading"
+                                                        class="anticon anticon-loading anticon-spin"
+                                                        role="img"
+                                                      >
+                                                        <svg
+                                                          aria-hidden="true"
+                                                          data-icon="loading"
+                                                          fill="currentColor"
+                                                          focusable="false"
+                                                          height="1em"
+                                                          viewBox="0 0 1024 1024"
+                                                          width="1em"
+                                                        >
+                                                          <path
+                                                            d="M988 548c-19.9 0-36-16.1-36-36 0-59.4-11.6-117-34.6-171.3a440.45 440.45 0 00-94.3-139.9 437.71 437.71 0 00-139.9-94.3C629 83.6 571.4 72 512 72c-19.9 0-36-16.1-36-36s16.1-36 36-36c69.1 0 136.2 13.5 199.3 40.3C772.3 66 827 103 874 150c47 47 83.9 101.8 109.7 162.7 26.7 63.1 40.2 130.2 40.2 199.3.1 19.9-16 36-35.9 36z"
+                                                          />
+                                                        </svg>
+                                                      </span>
+                                                    </span>
+                                                  </div>
+                                                </div>
+                                              </div>
+                                              <div
+                                                style="display: flex; flex-wrap: nowrap;"
+                                              >
+                                                <div
+                                                  class="ant-form-item-explain ant-form-item-explain-connected"
+                                                  id="PERMIT_CONDITION_REVIEW_ASSIGNMENT-ELC_assigned_review_user_help"
+                                                  role="alert"
+                                                >
+                                                  <div
+                                                    class=""
+                                                  />
+                                                </div>
                                               </div>
                                             </div>
                                           </div>
-                                          <div>
+                                        </div>
+                                      </div>
+                                      <div
+                                        class="ant-col"
+                                        style="padding-left: 8px; padding-right: 8px;"
+                                      >
+                                        <button
+                                          aria-label="Submit"
+                                          class="ant-btn ant-btn-primary ant-btn-icon-only  form-btn"
+                                          disabled=""
+                                          type="submit"
+                                        >
+                                          <svg
+                                            aria-hidden="true"
+                                            class="svg-inline--fa fa-check "
+                                            data-icon="check"
+                                            data-prefix="far"
+                                            focusable="false"
+                                            role="img"
+                                            viewBox="0 0 448 512"
+                                            xmlns="http://www.w3.org/2000/svg"
+                                          >
+                                            <path
+                                              d="M441 103c9.4 9.4 9.4 24.6 0 33.9L177 401c-9.4 9.4-24.6 9.4-33.9 0L7 265c-9.4-9.4-9.4-24.6 0-33.9s24.6-9.4 33.9 0l119 119L407 103c9.4-9.4 24.6-9.4 33.9 0z"
+                                              fill="currentColor"
+                                            />
+                                          </svg>
+                                        </button>
+                                      </div>
+                                    </div>
+                                  </form>
+                                </div>
+                                <div
+                                  class="ant-col ant-col-24 fade-in"
+                                  style="padding: 8px 8px 8px 8px;"
+                                >
+                                  <div
+                                    class="condition-layer condition-layer--0 condition-SEC fade-in "
+                                  >
+                                    <div
+                                      class="condition-collapsed"
+                                    >
+                                      <div
+                                        class="ant-row ant-row-no-wrap ant-row-top condition-content "
+                                      >
+                                        <div
+                                          class="ant-col step-column"
+                                          style="flex-shrink: 0;"
+                                        >
+                                          <div
+                                            class="ant-typography view-item-value"
+                                          >
+                                            1.
+                                          </div>
+                                        </div>
+                                        <div
+                                          class="ant-col condition-column"
+                                        >
+                                          <div
+                                            class="ant-typography view-item-value"
+                                          >
+                                            International clear those TV individual look.
+                                          </div>
+                                        </div>
+                                      </div>
+                                      <div>
+                                        <div
+                                          class="condition-layer condition-layer--1 condition-CON fade-in "
+                                        >
+                                          <div
+                                            class="condition-collapsed"
+                                          >
                                             <div
-                                              class="condition-layer condition-layer--2 condition-LIS fade-in "
+                                              class="ant-row ant-row-no-wrap ant-row-top condition-content "
                                             >
                                               <div
-                                                class="condition-collapsed"
+                                                class="ant-col step-column"
+                                                style="flex-shrink: 0;"
                                               >
                                                 <div
-                                                  class="ant-row ant-row-no-wrap ant-row-top condition-content "
+                                                  class="ant-typography view-item-value"
+                                                >
+                                                  a.
+                                                </div>
+                                              </div>
+                                              <div
+                                                class="ant-col condition-column"
+                                              >
+                                                <div
+                                                  class="ant-typography view-item-value"
+                                                >
+                                                  See store understand company interview value factor.
+                                                </div>
+                                              </div>
+                                            </div>
+                                            <div>
+                                              <div
+                                                class="condition-layer condition-layer--2 condition-LIS fade-in "
+                                              >
+                                                <div
+                                                  class="condition-collapsed"
                                                 >
                                                   <div
-                                                    class="ant-col step-column"
-                                                    style="flex-shrink: 0;"
+                                                    class="ant-row ant-row-no-wrap ant-row-top condition-content "
                                                   >
                                                     <div
-                                                      class="ant-typography view-item-value"
+                                                      class="ant-col step-column"
+                                                      style="flex-shrink: 0;"
                                                     >
-                                                      i.
+                                                      <div
+                                                        class="ant-typography view-item-value"
+                                                      >
+                                                        i.
+                                                      </div>
                                                     </div>
-                                                  </div>
-                                                  <div
-                                                    class="ant-col condition-column"
-                                                  >
                                                     <div
-                                                      class="ant-typography view-item-value"
+                                                      class="ant-col condition-column"
                                                     >
-                                                      Mr item fall study although.
+                                                      <div
+                                                        class="ant-typography view-item-value"
+                                                      >
+                                                        Mr item fall study although.
+                                                      </div>
                                                     </div>
                                                   </div>
                                                 </div>
@@ -1614,190 +1624,190 @@ exports[`PermitConditions renders properly 1`] = `
                                           </div>
                                         </div>
                                       </div>
-                                    </div>
-                                    <div>
-                                      <div
-                                        class="condition-layer condition-layer--1 condition-SEC fade-in "
-                                      >
+                                      <div>
                                         <div
-                                          class="condition-collapsed"
+                                          class="condition-layer condition-layer--1 condition-SEC fade-in "
                                         >
                                           <div
-                                            class="ant-row ant-row-no-wrap ant-row-top condition-content "
+                                            class="condition-collapsed"
                                           >
                                             <div
-                                              class="ant-col step-column"
-                                              style="flex-shrink: 0;"
+                                              class="ant-row ant-row-no-wrap ant-row-top condition-content "
                                             >
                                               <div
-                                                class="ant-typography view-item-value"
-                                              >
-                                                b.
-                                              </div>
-                                            </div>
-                                            <div
-                                              class="ant-col condition-column"
-                                            >
-                                              <div
-                                                class="ant-typography view-item-value"
-                                              >
-                                                words words words sub-section
-                                              </div>
-                                            </div>
-                                          </div>
-                                          <div>
-                                            <div
-                                              class="condition-layer condition-layer--2 condition-CON fade-in "
-                                            >
-                                              <div
-                                                class="condition-collapsed"
+                                                class="ant-col step-column"
+                                                style="flex-shrink: 0;"
                                               >
                                                 <div
-                                                  class="ant-row ant-row-no-wrap ant-row-top condition-content "
+                                                  class="ant-typography view-item-value"
+                                                >
+                                                  b.
+                                                </div>
+                                              </div>
+                                              <div
+                                                class="ant-col condition-column"
+                                              >
+                                                <div
+                                                  class="ant-typography view-item-value"
+                                                >
+                                                  words words words sub-section
+                                                </div>
+                                              </div>
+                                            </div>
+                                            <div>
+                                              <div
+                                                class="condition-layer condition-layer--2 condition-CON fade-in "
+                                              >
+                                                <div
+                                                  class="condition-collapsed"
                                                 >
                                                   <div
-                                                    class="ant-col step-column"
-                                                    style="flex-shrink: 0;"
+                                                    class="ant-row ant-row-no-wrap ant-row-top condition-content "
                                                   >
                                                     <div
-                                                      class="ant-typography view-item-value"
-                                                    >
-                                                      i.
-                                                    </div>
-                                                  </div>
-                                                  <div
-                                                    class="ant-col condition-column"
-                                                  >
-                                                    <div
-                                                      class="ant-typography view-item-value"
-                                                    >
-                                                      a condition added underneath the section, with a lot of detail added to it, which is probably important for documents like permits
-                                                    </div>
-                                                  </div>
-                                                </div>
-                                                <div>
-                                                  <div
-                                                    class="condition-layer condition-layer--3 condition-LIS fade-in "
-                                                  >
-                                                    <div
-                                                      class="condition-collapsed"
+                                                      class="ant-col step-column"
+                                                      style="flex-shrink: 0;"
                                                     >
                                                       <div
-                                                        class="ant-row ant-row-no-wrap ant-row-top condition-content "
+                                                        class="ant-typography view-item-value"
                                                       >
-                                                        <div
-                                                          class="ant-col step-column"
-                                                          style="flex-shrink: 0;"
-                                                        >
-                                                          <div
-                                                            class="ant-typography view-item-value"
-                                                          >
-                                                            1.
-                                                          </div>
-                                                        </div>
-                                                        <div
-                                                          class="ant-col condition-column"
-                                                        >
-                                                          <div
-                                                            class="ant-typography view-item-value"
-                                                          >
-                                                            a detailed list item desribing exactly what must be done to accomplish the parent condition
-                                                          </div>
-                                                        </div>
+                                                        i.
+                                                      </div>
+                                                    </div>
+                                                    <div
+                                                      class="ant-col condition-column"
+                                                    >
+                                                      <div
+                                                        class="ant-typography view-item-value"
+                                                      >
+                                                        a condition added underneath the section, with a lot of detail added to it, which is probably important for documents like permits
                                                       </div>
                                                     </div>
                                                   </div>
-                                                </div>
-                                                <div>
-                                                  <div
-                                                    class="condition-layer condition-layer--3 condition-LIS fade-in "
-                                                  >
+                                                  <div>
                                                     <div
-                                                      class="condition-collapsed"
+                                                      class="condition-layer condition-layer--3 condition-LIS fade-in "
                                                     >
                                                       <div
-                                                        class="ant-row ant-row-no-wrap ant-row-top condition-content "
+                                                        class="condition-collapsed"
                                                       >
                                                         <div
-                                                          class="ant-col step-column"
-                                                          style="flex-shrink: 0;"
+                                                          class="ant-row ant-row-no-wrap ant-row-top condition-content "
                                                         >
                                                           <div
-                                                            class="ant-typography view-item-value"
-                                                          >
-                                                            2.
-                                                          </div>
-                                                        </div>
-                                                        <div
-                                                          class="ant-col condition-column"
-                                                        >
-                                                          <div
-                                                            class="ant-typography view-item-value"
-                                                          >
-                                                            but, that wasn't quite enough information, another list item will expand on other responsibilities associated with this permit
-                                                          </div>
-                                                        </div>
-                                                      </div>
-                                                    </div>
-                                                  </div>
-                                                </div>
-                                                <div>
-                                                  <div
-                                                    class="condition-layer condition-layer--3 condition-LIS fade-in "
-                                                  >
-                                                    <div
-                                                      class="condition-collapsed"
-                                                    >
-                                                      <div
-                                                        class="ant-row ant-row-no-wrap ant-row-top condition-content "
-                                                      >
-                                                        <div
-                                                          class="ant-col step-column"
-                                                          style="flex-shrink: 0;"
-                                                        >
-                                                          <div
-                                                            class="ant-typography view-item-value"
-                                                          >
-                                                            3.
-                                                          </div>
-                                                        </div>
-                                                        <div
-                                                          class="ant-col condition-column"
-                                                        >
-                                                          <div
-                                                            class="ant-typography view-item-value"
-                                                          >
-                                                            good things come in 3s, so another list item is added to the condition
-                                                          </div>
-                                                        </div>
-                                                      </div>
-                                                      <div>
-                                                        <div
-                                                          class="condition-layer condition-layer--4 condition-LIS fade-in "
-                                                        >
-                                                          <div
-                                                            class="condition-collapsed"
+                                                            class="ant-col step-column"
+                                                            style="flex-shrink: 0;"
                                                           >
                                                             <div
-                                                              class="ant-row ant-row-no-wrap ant-row-top condition-content "
+                                                              class="ant-typography view-item-value"
+                                                            >
+                                                              1.
+                                                            </div>
+                                                          </div>
+                                                          <div
+                                                            class="ant-col condition-column"
+                                                          >
+                                                            <div
+                                                              class="ant-typography view-item-value"
+                                                            >
+                                                              a detailed list item desribing exactly what must be done to accomplish the parent condition
+                                                            </div>
+                                                          </div>
+                                                        </div>
+                                                      </div>
+                                                    </div>
+                                                  </div>
+                                                  <div>
+                                                    <div
+                                                      class="condition-layer condition-layer--3 condition-LIS fade-in "
+                                                    >
+                                                      <div
+                                                        class="condition-collapsed"
+                                                      >
+                                                        <div
+                                                          class="ant-row ant-row-no-wrap ant-row-top condition-content "
+                                                        >
+                                                          <div
+                                                            class="ant-col step-column"
+                                                            style="flex-shrink: 0;"
+                                                          >
+                                                            <div
+                                                              class="ant-typography view-item-value"
+                                                            >
+                                                              2.
+                                                            </div>
+                                                          </div>
+                                                          <div
+                                                            class="ant-col condition-column"
+                                                          >
+                                                            <div
+                                                              class="ant-typography view-item-value"
+                                                            >
+                                                              but, that wasn't quite enough information, another list item will expand on other responsibilities associated with this permit
+                                                            </div>
+                                                          </div>
+                                                        </div>
+                                                      </div>
+                                                    </div>
+                                                  </div>
+                                                  <div>
+                                                    <div
+                                                      class="condition-layer condition-layer--3 condition-LIS fade-in "
+                                                    >
+                                                      <div
+                                                        class="condition-collapsed"
+                                                      >
+                                                        <div
+                                                          class="ant-row ant-row-no-wrap ant-row-top condition-content "
+                                                        >
+                                                          <div
+                                                            class="ant-col step-column"
+                                                            style="flex-shrink: 0;"
+                                                          >
+                                                            <div
+                                                              class="ant-typography view-item-value"
+                                                            >
+                                                              3.
+                                                            </div>
+                                                          </div>
+                                                          <div
+                                                            class="ant-col condition-column"
+                                                          >
+                                                            <div
+                                                              class="ant-typography view-item-value"
+                                                            >
+                                                              good things come in 3s, so another list item is added to the condition
+                                                            </div>
+                                                          </div>
+                                                        </div>
+                                                        <div>
+                                                          <div
+                                                            class="condition-layer condition-layer--4 condition-LIS fade-in "
+                                                          >
+                                                            <div
+                                                              class="condition-collapsed"
                                                             >
                                                               <div
-                                                                class="ant-col step-column"
-                                                                style="flex-shrink: 0;"
+                                                                class="ant-row ant-row-no-wrap ant-row-top condition-content "
                                                               >
                                                                 <div
-                                                                  class="ant-typography view-item-value"
+                                                                  class="ant-col step-column"
+                                                                  style="flex-shrink: 0;"
                                                                 >
-                                                                  a.
+                                                                  <div
+                                                                    class="ant-typography view-item-value"
+                                                                  >
+                                                                    a.
+                                                                  </div>
                                                                 </div>
-                                                              </div>
-                                                              <div
-                                                                class="ant-col condition-column"
-                                                              >
                                                                 <div
-                                                                  class="ant-typography view-item-value"
+                                                                  class="ant-col condition-column"
                                                                 >
-                                                                  we want to show nesting to 5 levels, so one list item gets a child
+                                                                  <div
+                                                                    class="ant-typography view-item-value"
+                                                                  >
+                                                                    we want to show nesting to 5 levels, so one list item gets a child
+                                                                  </div>
                                                                 </div>
                                                               </div>
                                                             </div>
@@ -1813,180 +1823,180 @@ exports[`PermitConditions renders properly 1`] = `
                                         </div>
                                       </div>
                                     </div>
-                                  </div>
-                                  <div>
-                                    <div
-                                      class="ant-col ant-col-24"
-                                      style="padding: 8px 8px 8px 8px;"
-                                    >
+                                    <div>
                                       <div
-                                        class="ant-row ant-row-space-between"
+                                        class="ant-col ant-col-24"
+                                        style="padding: 8px 8px 8px 8px;"
                                       >
                                         <div
-                                          class="ant-space ant-space-horizontal ant-space-align-center"
+                                          class="ant-row ant-row-space-between"
                                         >
                                           <div
-                                            class="ant-space-item"
+                                            class="ant-space ant-space-horizontal ant-space-align-center"
                                           >
-                                            <span
-                                              class="ant-tag ant-tag-success condition-tag"
+                                            <div
+                                              class="ant-space-item"
                                             >
                                               <span
-                                                aria-label="check-circle"
-                                                class="anticon anticon-check-circle"
-                                                role="img"
+                                                class="ant-tag ant-tag-success condition-tag"
                                               >
-                                                <svg
-                                                  aria-hidden="true"
-                                                  class=""
-                                                  data-icon="check-circle"
-                                                  fill="currentColor"
-                                                  focusable="false"
-                                                  height="1em"
-                                                  viewBox="64 64 896 896"
-                                                  width="1em"
+                                                <span
+                                                  aria-label="check-circle"
+                                                  class="anticon anticon-check-circle"
+                                                  role="img"
                                                 >
-                                                  <path
-                                                    d="M699 353h-46.9c-10.2 0-19.9 4.9-25.9 13.3L469 584.3l-71.2-98.8c-6-8.3-15.6-13.3-25.9-13.3H325c-6.5 0-10.3 7.4-6.5 12.7l124.6 172.8a31.8 31.8 0 0051.7 0l210.6-292c3.9-5.3.1-12.7-6.4-12.7z"
-                                                  />
-                                                  <path
-                                                    d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
-                                                  />
-                                                </svg>
+                                                  <svg
+                                                    aria-hidden="true"
+                                                    class=""
+                                                    data-icon="check-circle"
+                                                    fill="currentColor"
+                                                    focusable="false"
+                                                    height="1em"
+                                                    viewBox="64 64 896 896"
+                                                    width="1em"
+                                                  >
+                                                    <path
+                                                      d="M699 353h-46.9c-10.2 0-19.9 4.9-25.9 13.3L469 584.3l-71.2-98.8c-6-8.3-15.6-13.3-25.9-13.3H325c-6.5 0-10.3 7.4-6.5 12.7l124.6 172.8a31.8 31.8 0 0051.7 0l210.6-292c3.9-5.3.1-12.7-6.4-12.7z"
+                                                    />
+                                                    <path
+                                                      d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                                                    />
+                                                  </svg>
+                                                </span>
+                                                <span>
+                                                  Review Completed
+                                                </span>
                                               </span>
-                                              <span>
-                                                Review Completed
-                                              </span>
-                                            </span>
+                                            </div>
                                           </div>
-                                        </div>
-                                        <div
-                                          class="ant-col"
-                                        >
-                                          
+                                          <div
+                                            class="ant-col"
+                                          >
+                                            
+                                          </div>
                                         </div>
                                       </div>
                                     </div>
                                   </div>
                                 </div>
-                              </div>
-                              <div
-                                class="ant-col ant-col-24 fade-in"
-                                style="padding: 8px 8px 8px 8px;"
-                              >
                                 <div
-                                  class="condition-layer condition-layer--0 condition-SEC fade-in "
+                                  class="ant-col ant-col-24 fade-in"
+                                  style="padding: 8px 8px 8px 8px;"
                                 >
                                   <div
-                                    class="condition-collapsed"
+                                    class="condition-layer condition-layer--0 condition-SEC fade-in "
                                   >
                                     <div
-                                      class="ant-row ant-row-no-wrap ant-row-top condition-content "
+                                      class="condition-collapsed"
                                     >
                                       <div
-                                        class="ant-col step-column"
-                                        style="flex-shrink: 0;"
+                                        class="ant-row ant-row-no-wrap ant-row-top condition-content "
                                       >
                                         <div
-                                          class="ant-typography view-item-value"
+                                          class="ant-col step-column"
+                                          style="flex-shrink: 0;"
                                         >
-                                          2.
+                                          <div
+                                            class="ant-typography view-item-value"
+                                          >
+                                            2.
+                                          </div>
+                                        </div>
+                                        <div
+                                          class="ant-col condition-column"
+                                        >
+                                          <div
+                                            class="ant-typography view-item-value"
+                                          >
+                                            Another condition under the ELC condition category code, and it may even be long enough to take up 2 lines
+                                          </div>
                                         </div>
                                       </div>
-                                      <div
-                                        class="ant-col condition-column"
-                                      >
+                                      <div>
                                         <div
-                                          class="ant-typography view-item-value"
+                                          class="condition-layer condition-layer--1 condition-CON fade-in "
                                         >
-                                          Another condition under the ELC condition category code, and it may even be long enough to take up 2 lines
+                                          <div
+                                            class="condition-collapsed"
+                                          >
+                                            <div
+                                              class="ant-row ant-row-no-wrap ant-row-top condition-content "
+                                            >
+                                              <div
+                                                class="ant-col step-column"
+                                                style="flex-shrink: 0;"
+                                              >
+                                                <div
+                                                  class="ant-typography view-item-value"
+                                                >
+                                                  a.
+                                                </div>
+                                              </div>
+                                              <div
+                                                class="ant-col condition-column"
+                                              >
+                                                <div
+                                                  class="ant-typography view-item-value"
+                                                >
+                                                  It should probably have a sub-item because that's pretty fun and normal for permit conditions. Really it should be long enough to have it cut off at some point if we just add more words, but the question is how many will be necessary?
+                                                </div>
+                                              </div>
+                                            </div>
+                                          </div>
                                         </div>
                                       </div>
                                     </div>
                                     <div>
                                       <div
-                                        class="condition-layer condition-layer--1 condition-CON fade-in "
+                                        class="ant-col ant-col-24"
+                                        style="padding: 8px 8px 8px 8px;"
                                       >
                                         <div
-                                          class="condition-collapsed"
+                                          class="ant-row ant-row-space-between"
                                         >
                                           <div
-                                            class="ant-row ant-row-no-wrap ant-row-top condition-content "
+                                            class="ant-space ant-space-horizontal ant-space-align-center"
                                           >
                                             <div
-                                              class="ant-col step-column"
-                                              style="flex-shrink: 0;"
-                                            >
-                                              <div
-                                                class="ant-typography view-item-value"
-                                              >
-                                                a.
-                                              </div>
-                                            </div>
-                                            <div
-                                              class="ant-col condition-column"
-                                            >
-                                              <div
-                                                class="ant-typography view-item-value"
-                                              >
-                                                It should probably have a sub-item because that's pretty fun and normal for permit conditions. Really it should be long enough to have it cut off at some point if we just add more words, but the question is how many will be necessary?
-                                              </div>
-                                            </div>
-                                          </div>
-                                        </div>
-                                      </div>
-                                    </div>
-                                  </div>
-                                  <div>
-                                    <div
-                                      class="ant-col ant-col-24"
-                                      style="padding: 8px 8px 8px 8px;"
-                                    >
-                                      <div
-                                        class="ant-row ant-row-space-between"
-                                      >
-                                        <div
-                                          class="ant-space ant-space-horizontal ant-space-align-center"
-                                        >
-                                          <div
-                                            class="ant-space-item"
-                                          >
-                                            <span
-                                              class="ant-tag ant-tag-success condition-tag"
+                                              class="ant-space-item"
                                             >
                                               <span
-                                                aria-label="check-circle"
-                                                class="anticon anticon-check-circle"
-                                                role="img"
+                                                class="ant-tag ant-tag-success condition-tag"
                                               >
-                                                <svg
-                                                  aria-hidden="true"
-                                                  class=""
-                                                  data-icon="check-circle"
-                                                  fill="currentColor"
-                                                  focusable="false"
-                                                  height="1em"
-                                                  viewBox="64 64 896 896"
-                                                  width="1em"
+                                                <span
+                                                  aria-label="check-circle"
+                                                  class="anticon anticon-check-circle"
+                                                  role="img"
                                                 >
-                                                  <path
-                                                    d="M699 353h-46.9c-10.2 0-19.9 4.9-25.9 13.3L469 584.3l-71.2-98.8c-6-8.3-15.6-13.3-25.9-13.3H325c-6.5 0-10.3 7.4-6.5 12.7l124.6 172.8a31.8 31.8 0 0051.7 0l210.6-292c3.9-5.3.1-12.7-6.4-12.7z"
-                                                  />
-                                                  <path
-                                                    d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
-                                                  />
-                                                </svg>
+                                                  <svg
+                                                    aria-hidden="true"
+                                                    class=""
+                                                    data-icon="check-circle"
+                                                    fill="currentColor"
+                                                    focusable="false"
+                                                    height="1em"
+                                                    viewBox="64 64 896 896"
+                                                    width="1em"
+                                                  >
+                                                    <path
+                                                      d="M699 353h-46.9c-10.2 0-19.9 4.9-25.9 13.3L469 584.3l-71.2-98.8c-6-8.3-15.6-13.3-25.9-13.3H325c-6.5 0-10.3 7.4-6.5 12.7l124.6 172.8a31.8 31.8 0 0051.7 0l210.6-292c3.9-5.3.1-12.7-6.4-12.7z"
+                                                    />
+                                                    <path
+                                                      d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                                                    />
+                                                  </svg>
+                                                </span>
+                                                <span>
+                                                  Review Completed
+                                                </span>
                                               </span>
-                                              <span>
-                                                Review Completed
-                                              </span>
-                                            </span>
+                                            </div>
                                           </div>
-                                        </div>
-                                        <div
-                                          class="ant-col"
-                                        >
-                                          
+                                          <div
+                                            class="ant-col"
+                                          >
+                                            
+                                          </div>
                                         </div>
                                       </div>
                                     </div>

--- a/services/minespace-web/src/styles/components/PermitConditions.scss
+++ b/services/minespace-web/src/styles/components/PermitConditions.scss
@@ -3,19 +3,23 @@
 @use "../settings/variables.scss";
 
 div.condition-layer {
+  padding: 2px;
   padding-top: 12px;
   padding-left: 24px;
   font-weight: normal;
+  margin-bottom: 10px;
+  border: 1px solid variables.$light-grey;
+  border-radius: 4px;
+
+  &.condition-SEC .condition-column>.ant-typography {
+    font-weight: bold;
+  }
 
   .ant-form {
     margin-bottom: 0;
   }
 
   .condition-content {
-    &.editable:hover {
-      cursor: pointer;
-      background-color: #f4f0f0;
-    }
 
     .condition-column {
       width: 100%;
@@ -36,9 +40,11 @@ div.condition-layer {
     opacity: 0.8;
   }
 
+  &--1 .condition-column>.ant-typography {
+    font-weight: normal !important;
+  }
+
   &--0 {
-    border: 1px solid variables.$transparent-dark-grey;
-    border-radius: 4px;
     padding: 16px;
 
     p.condition-layer--0 {

--- a/services/minespace-web/src/styles/components/PermitConditions.scss
+++ b/services/minespace-web/src/styles/components/PermitConditions.scss
@@ -20,6 +20,7 @@ div.condition-layer {
   }
 
   .condition-content {
+    padding-right: 6px;
 
     .condition-column {
       width: 100%;


### PR DESCRIPTION
## Objective 
- make the form more usable
- more clear how things are structured, and what they'll be editing

[MDS-6557](https://bcmines.atlassian.net/browse/MDS-6557)

_Why are you making this change? Provide a short explanation and/or screenshots_
- new condition: moved the placeholder text to a label, made it required. Reference the parent condition, so that user doesn't lose context
- broke up the white between each category so they're visually separate
![image](https://github.com/user-attachments/assets/ae8d211e-43bd-493a-916f-8d15af4aa037)

- put a border around each level so that it's clear when an item is a child of another
- changed the text in the "+" button to reflect the type of condition being added
![image](https://github.com/user-attachments/assets/9a4bcc2f-81c9-4138-a0b0-2900f891451c)

- allow user to change which condition they're editing without clicking the "X" button to cancel changes
- if the first form that they were on is modified, bring up a "discard changes" confirmation
![image](https://github.com/user-attachments/assets/b51c34e6-d123-485b-a9be-c6431d11ac13)

- delete condition modal
- basically the same as NoW delete modal
![image](https://github.com/user-attachments/assets/ec40b641-5953-4bea-97be-44517c192313)

Not included in any screenshots:
- when you hover over a condition to edit it, it'll say something like "Edit Condition General 2.a" now, instead of "Edit Condition"

Couple little things that I neglected or didn't solve:
- you can click another condition to change what you're editing, but not "Add Condition" (stays disabled)
- clicking the cancel button on the "Add Condition" form always triggers the required validation on first click and has to be clicked again. 🤦‍♀️ 
  - e.stopPropagation did not stop it so I don't know what's going on there.
  - this only occurs when you click "Add Condition" (to a category, not a sub-condition), don't enter text, and then cancel it, so I decided it was trivial