### PR TITLE
[MDS-6578] AMS Final Application bug

### DIFF
--- a/services/common/src/constants/API.ts
+++ b/services/common/src/constants/API.ts
@@ -172,7 +172,7 @@ export const PROJECT_SUMMARY_ENVIRONMENT_AUTHORIZATION_STATUSES = () =>
   "/projects/project-summary-environment-authorization-statuses";
 
 export const PROJECT_SUMMARY_ENVIRONMENT_FINAL_APPLICATION_GET = (projectSummaryGuid: string, project_summary_authorization_guid = "") =>
-  `/projects/${projectSummaryGuid}/ams-final-application?${queryString.stringify(project_summary_authorization_guid)}`;
+  `/projects/${projectSummaryGuid}/ams-final-application?${queryString.stringify({ project_summary_authorization_guid })}`;
 
 export const PROJECT_SUMMARY_ENVIRONMENT_FINAL_APPLICATION = (projectSummaryGuid: string, project_summary_authorization_guid = "") =>
   `/projects/${projectSummaryGuid}/ams-final-application/${project_summary_authorization_guid}`;


### PR DESCRIPTION
## Objective 
- it was doing the fetch wrong, made it do it right

[MDS-6578](https://bcmines.atlassian.net/browse/MDS-6578)

_Why are you making this change? Provide a short explanation and/or screenshots_

this is what the request looked like. Now it'll send it like "ams-final-application?project_summary_application_guid=6ffa5c18-8ed8-4b8b-a8a7-910d407a346a"
![image](https://github.com/user-attachments/assets/75245665-00c5-4fb7-9c98-1f3a43ed6fe2)
