### PR TITLE
[MDS-6601]fix for index runner being passed search endpoint that isn't a string

### DIFF
--- a/services/permits/app/pipelines/permit_condition_search/permit_condition_search_pipeline.py
+++ b/services/permits/app/pipelines/permit_condition_search/permit_condition_search_pipeline.py
@@ -92,7 +92,7 @@ def create_permit_condition_search_indexing_pipeline():
     assert api_key is not None, "API key must be provided to create the indexer"
 
     indexer_runner = IndexerRunner(
-        search_endpoint=config.search.endpoint,
+        search_endpoint=config.search.endpoint.resolve_value(),
         search_api_key=api_key,
     )
 


### PR DESCRIPTION
## Objective 

[MDS-6601](https://bcmines.atlassian.net/browse/MDS-6601)

- Adjusted `create_permit_condition_search_indexing_pipeline` function's `search_endpoint` property being passed to `IndexRunner` to be the string value instead of `EnvVarSecret` object

<img width="1858" height="676" alt="image" src="https://github.com/user-attachments/assets/181e4572-8a4a-4c59-bad3-0e7b8aaf442d" />
