### PR TITLE
[MDS-6594] Permit conditions ordering bug in search

### DIFF
--- a/services/permits/app/pipelines/permit_condition_search/components/context_enricher.py
+++ b/services/permits/app/pipelines/permit_condition_search/components/context_enricher.py
@@ -43,7 +43,7 @@ class ContextEnricher:
     def _format_context_chain(
         self,
         parents: List[Document],
-        siblings: List[Document],
+        siblings: List[Tuple[str, Document]],
         children: List[Document],
     ) -> Dict[str, dict]:
         """
@@ -70,16 +70,13 @@ class ContextEnricher:
             }
 
         # Format sibling contexts - use step_path
-        for i, sibling in enumerate(siblings):
-            position = "previous" if i < len(siblings) // 2 else "next"
-            context["sibling_contexts"][position].append(
-                {
-                    "id": sibling.id,
-                    "content": sibling.content,
-                    "step": sibling.meta.get("step", ""),
-                    "hierarchy": sibling.meta.get("step_path", ""),
-                }
-            )
+        for position, sibling in siblings:
+            context["sibling_contexts"][position].append({
+                "id": sibling.id,
+                "content": sibling.content,
+                "step": sibling.meta.get("step", ""),
+                "hierarchy": sibling.meta.get("step_path", ""),
+            })
 
         # Format child contexts - use step_path
         for child in children:
@@ -196,15 +193,23 @@ class ContextEnricher:
 
             # Get siblings
             if sibling_ids := doc.meta.get("sibling_ids", []):
-                mid = len(sibling_ids) // 2
-                selected_siblings = (
-                    sibling_ids[max(0, mid - 2) : mid] + sibling_ids[mid : mid + 2]
-                )
                 siblings = [
                     related_docs[sid]
-                    for sid in selected_siblings
+                    for sid in sibling_ids 
                     if sid in related_docs
                 ]
+
+                all_current_related_docs = siblings + [doc]
+                all_current_related_docs.sort(key=lambda d: d.meta.get("step", ""))
+                mid = next((i for i, d in enumerate(all_current_related_docs) if d.id == doc.id), None)
+                if mid is not None:
+                    previous_siblings = all_current_related_docs[max(0, mid - 3):mid]
+                    next_siblings = all_current_related_docs[mid + 1:mid + 4]
+                else:
+                    previous_siblings = []
+                    next_siblings = []
+                                   
+                siblings = [("previous", s) for s in previous_siblings] + [("next", s) for s in next_siblings]
 
             # Get children
             if child_ids := doc.meta.get("child_ids", []):

--- a/services/permits/tests/pipelines/permit_condition_search/components/test_context_enricher.py
+++ b/services/permits/tests/pipelines/permit_condition_search/components/test_context_enricher.py
@@ -64,7 +64,7 @@ def test_format_context_chain():
     ]
     
     siblings = [
-        create_test_document("sib1", "Sibling 1", {"step": "2", "step_path": "A.2"})
+        ("next", create_test_document("sib1", "Sibling 1", {"step": "2", "step_path": "A.2"}))
     ]
     
     children = [


### PR DESCRIPTION
## Objective 

[MDS-6594](https://bcmines.atlassian.net/browse/MDS-6594)

- It was found that in `context_enricher.py` inside the `run` function and the `_format_context_chain` function when it was formatting the list of siblings it was splitting the list in half by 2 to get the mid. but in our case using whatever position the current document object we are looking at as the mid should work better. If  we use the position of the current document object we can better split the siblings list into the two sections of `previous` and `next` to get an accurate ordering.

<img width="1214" height="714" alt="image" src="https://github.com/user-attachments/assets/a9f6b58d-bfe2-4822-8ca5-93ae56c85582" />



<img width="1270" height="293" alt="image" src="https://github.com/user-attachments/assets/80635bef-8dd5-49d5-b214-821a6d51e269" />
