### PR TITLE
[MDS-6537] Fix scss rule, add enableGetPopupContainer

### DIFF
--- a/services/common/src/components/forms/RenderMultiSelect.tsx
+++ b/services/common/src/components/forms/RenderMultiSelect.tsx
@@ -17,6 +17,7 @@ interface MultiSelectProps extends BaseInputProps {
   onSearch?: any;
   loading?: boolean;
   viewDisplay?: (opts: IOption[]) => ReactNode;
+  enableGetPopupContainer?: boolean;
 }
 
 const defaultViewDisplay = (opts: IOption[]): ReactNode => {
@@ -43,6 +44,7 @@ export const RenderMultiSelect: FC<MultiSelectProps> = (props) => {
     disabled = false,
     onSearch = () => { },
     filterOption = false,
+    enableGetPopupContainer = false,
     label = "",
     viewDisplay = defaultViewDisplay,
     showNA,
@@ -66,7 +68,7 @@ export const RenderMultiSelect: FC<MultiSelectProps> = (props) => {
           </div>
         }
 
-        const extraProps = isModal ? null : { getPopupContainer: (trigger) => trigger.parentNode };
+        const extraProps = isModal || enableGetPopupContainer ? null : { getPopupContainer: (trigger) => trigger.parentNode };
         return (
           <div className="form-multiselect">
             <Form.Item

--- a/services/common/src/components/permits/PermitConditionForm.tsx
+++ b/services/common/src/components/permits/PermitConditionForm.tsx
@@ -258,7 +258,6 @@ const PermitConditionForm: FC<PermitConditionFormProps> = ({
                 touchOnChange: false,
                 touchOnBlur: true,
             }}
-            isModal={true}
         >
             {isEditMode && isExtracted && categoryOptions && (
                 <Row>
@@ -335,6 +334,7 @@ const PermitConditionForm: FC<PermitConditionFormProps> = ({
                                                 name="condition_tags"
                                                 component={RenderMultiSelect}
                                                 placeholder="Select tags"
+                                                enableGetPopupContainer={true}
                                                 data={conditionTags.map((tag) => ({
                                                     label: tag.description,
                                                     value: tag.permit_condition_tag_guid}))}

--- a/services/core-web/src/styles/components/PermitConditions.scss
+++ b/services/core-web/src/styles/components/PermitConditions.scss
@@ -129,10 +129,7 @@ div.condition-layer {
       font-size: 0.875rem;
     }
   }
-}
 
-.ant-select-dropdown {
-  z-index: 950;
 }
 
 .horizontal-form-item {


### PR DESCRIPTION
## Objective 

[MDS-6537](https://bcmines.atlassian.net/browse/MDS-6537)

Good catches from @taraepp! Removed the scss rule that fixed the dropdown appearing above the header, as it broke dropdowns on other forms. Added enableGetPopupContainer on RenderSelect to disable getPopupContainer without having to use isModal?

 