### PR TITLE
[FIX] Update role mapping endpoint for CSS API

### DIFF
--- a/services/core-api/app/api/services/css_sso_service.py
+++ b/services/core-api/app/api/services/css_sso_service.py
@@ -58,7 +58,7 @@ class CSSService():
         :return: list
         '''
         
-        url = f'{Config.CSS_API_URL}/{Config.CSS_ENV}/user-role-mappings?roleName={rolename}'
+        url = f'{Config.CSS_API_URL}/{Config.CSS_ENV}/roles/{rolename}/users'
         auth_token = CSSService.get_css_auth_token()
         headers = {'Authorization': f'Bearer {auth_token}'}
 
@@ -77,7 +77,7 @@ class CSSService():
             current_app.logger.error(message)
             return            
 
-        users = resp_data.get('users') 
+        users = resp_data.get('data') 
         user_emails = [user['email'] for user in users]
 
         return user_emails


### PR DESCRIPTION
## Objective 
Endpoint we were using was deprecated- update URL, and make it look at the `data` attribute rather than `users` as that has also been updated
https://api.loginproxy.gov.bc.ca/openapi/swagger/

[MDS-](https://bcmines.atlassian.net/browse/MDS-0000)
_Why are you making this change? Provide a short explanation and/or screenshots_
<img width="1211" height="423" alt="image" src="https://github.com/user-attachments/assets/d745d6c6-b6af-4d0d-b1f3-977aa6bd5df1" />
