### PR TITLE
[MDS-6511] Updated logic to identify where conditions section start

### DIFF
--- a/services/permits/app/pipelines/permit_condition_extraction/components/filter_conditions_paragraphs.py
+++ b/services/permits/app/pipelines/permit_condition_extraction/components/filter_conditions_paragraphs.py
@@ -77,6 +77,8 @@ def filter_paragraphs(paragraphs):
         paragraphs, max_page_header_y
     )
 
+    paragraphs = _exclude_figure_paragraphs(paragraphs)
+
     logger.info(
         f"Found {len(paragraphs)} paragraphs after filtering, {max_page_header_y}"
     )
@@ -117,14 +119,27 @@ def _has_numbering(p):
 
     return bool(p['regex'])
 
+def _looks_like_condition_header(role, text):
+    """
+    Check if the paragraph looks like a condition header based on its role and text.
+    So far, we have yet to see a permit that would no have a condition header that does not fall under these criteria.
+    """
+    return (
+        role in ("title", "sectionHeading")
+        and len(text.split()) <= 4 # The text is not too long (less than 4 words) - Should cover some variants like "Conditions", "Permit Conditions" or "Terms and Conditions"
+        and len(text) < 40 # The text is short (less than 40 characters). If it is longer, it's likely a sentance, not a header.
+        and "condition" in text.lower()
+    )
+
 def _exclude_paragraphs_not_in_conditions_section(paragraphs):
     # Find the first section header / title that contains the word "conditions" in it - this is likely the start of the conditions section
     idx_of_conditions_header = next(
         (
             i
             for i, p in enumerate(paragraphs)
-            if "conditions" in p.content["text"].lower()
-            and p.content["role"] in ("sectionHeading", "title")
+            if _looks_like_condition_header(
+                p.content["role"], p.content["text"]
+            )
         ),
         None,
     )
@@ -147,7 +162,6 @@ def _exclude_paragraphs_not_in_conditions_section(paragraphs):
 
     return filtered_paragraphs
 
-
 def _exclude_paragraphs_with_non_paragraph_roles(paragraphs, max_page_header_y):
     filterf = ["pageNumber", "footnote", "pageFooter"]
 
@@ -158,6 +172,20 @@ def _exclude_paragraphs_with_non_paragraph_roles(paragraphs, max_page_header_y):
 
 def _is_normal_paragraph(p):
     return not p.content["role"] or p.content["role"] not in ["pageHeader","pageNumber"] and p.content
+
+def _looks_like_permitted_area_figure(p):
+    text = p.content.get("text", "").lower().strip()
+    return (
+        text.startswith("figure")
+        and '°' in text 
+        and '"' in text
+    )
+
+def _exclude_figure_paragraphs(paragraphs):
+    """
+    Exclude paragraphs that are figures, i.e. those with a role of 'figure'.
+    """
+    return [p for p in paragraphs if not _looks_like_permitted_area_figure(p)]
 
 def _identify_bottom_of_first_page_header(paragraphs):
     # Find the first paragraph that is identified as a page header

--- a/services/permits/tests/test_conditions_paragraph_filter.py
+++ b/services/permits/tests/test_conditions_paragraph_filter.py
@@ -163,34 +163,34 @@ def test_filter_paragraphs_excludes_page_nr_footnote_page_footer():
     assert result[2].content["text"] == "5"
 
 
-def test_filter_paragraphs_only_includes_paragraphs_in_conditions_section():
+def test_filter_paragraphs_only_includes_paragraphs_in_conditions_section_finds_conditions_header():
     paragraphs = [
         Document(
-            content=json.dumps({"id": "ab1", "text": "paragraph 1", "role": None}),
+            content=json.dumps({"role": None, "text": "paragraph 1"}),
             meta={"page": 1},
         ),
         Document(
-            content=json.dumps({"id": "ab2", "text": "paragraph 2", "role": None}),
-            meta={"page": 1},
-        ),
-        Document(
-            content=json.dumps(
-                {"id": "ab3", "text": "conditions header", "role": "sectionHeading"}
-            ),
-            meta={"page": 1},
-        ),
-        Document(
-            content=json.dumps({"id": "ab2", "text": "paragraph 2", "role": None}),
+            content=json.dumps({"role": None, "text": "paragraph 2"}),
             meta={"page": 1},
         ),
         Document(
             content=json.dumps(
-                {"id": "ab4", "text": "condition 1", "role": "sectionHeading"}
+                {"role": "sectionHeading", "text": "Permit Conditions"}
             ),
             meta={"page": 1},
         ),
         Document(
-            content=json.dumps({"id": "ab5", "text": "condition 2", "role": None}),
+            content=json.dumps({"role": None, "text": "paragraph after header"}),
+            meta={"page": 1},
+        ),
+        Document(
+            content=json.dumps(
+                {"role": "sectionHeading", "text": "1. First condition"}
+            ),
+            meta={"page": 1},
+        ),
+        Document(
+            content=json.dumps({"role": None, "text": "2. Second condition"}),
             meta={"page": 1},
         ),
     ]
@@ -203,8 +203,57 @@ def test_filter_paragraphs_only_includes_paragraphs_in_conditions_section():
         result = filter_paragraphs(paragraphs)
 
     assert len(result) == 2
-    assert result[0].content["text"] == "condition 1"
-    assert result[1].content["text"] == "condition 2"
+    assert result[0].content["text"] == "1. First condition"
+    assert result[1].content["text"] == "2. Second condition"
+
+
+def test_filter_paragraphs_only_includes_paragraphs_in_conditions_section_no_conditions_header():
+    paragraphs = [
+        Document(
+            content=json.dumps({"role": None, "text": "paragraph 1"}),
+            meta={"page": 1},
+        ),
+        Document(
+            content=json.dumps({"role": None, "text": "paragraph 2"}),
+            meta={"page": 1},
+        ),
+    ]
+
+    for p in paragraphs:
+        if p.content:
+            p.content = json.loads(p.content)
+
+    with task_context(MockContext()):
+        result = filter_paragraphs(paragraphs)
+
+    assert len(result) == 2
+    assert result[0].content["text"] == "paragraph 1"
+    assert result[1].content["text"] == "paragraph 2"
+
+
+def test_filter_paragraphs_only_includes_paragraphs_in_conditions_section_header_only():
+    paragraphs = [
+        Document(
+            content=json.dumps({"role": None, "text": "paragraph 1"}),
+            meta={"page": 1},
+        ),
+        Document(
+            content=json.dumps(
+                {"role": "sectionHeading", "text": "Permit Conditions"}
+            ),
+            meta={"page": 1},
+        ),
+    ]
+
+    for p in paragraphs:
+        if p.content:
+            p.content = json.loads(p.content)
+
+    with task_context(MockContext()):
+        result = filter_paragraphs(paragraphs)
+
+    assert len(result) == 1
+    assert result[0].content["text"] == "Permit Conditions"
 
 
 def test_identify_bottom_of_first_page_header():
@@ -336,3 +385,40 @@ def test_filter_paragraphs_integration_multi_page():
     assert len(result) == 2
     assert result[0].content["text"] == "1. General Conditions"
     assert result[1].content["text"] == "This is the first condition."
+
+
+def test_filter_paragraphs_excludes_figure_paragraphs():
+    paragraphs = [
+        Document(
+            content=json.dumps({"role": None, "text": "This is a normal paragraph."}),
+            meta={"page": 1},
+        ),
+        Document(
+            content=json.dumps(
+                {"role": None, "text": ' Figure 1: Map of area 49° 5\' 30"'}
+            ),
+            meta={"page": 1},
+        ),
+        Document(
+            content=json.dumps({"role": None, "text": "Figure 2: Another map"}),
+            meta={"page": 1},
+        ),
+        Document(
+            content=json.dumps(
+                {"role": None, "text": "This is another normal paragraph."}
+            ),
+            meta={"page": 1},
+        ),
+    ]
+
+    for p in paragraphs:
+        if p.content:
+            p.content = json.loads(p.content)
+
+    with task_context(MockContext()):
+        result = filter_paragraphs(paragraphs)
+
+    assert len(result) == 3
+    assert result[0].content["text"] == "This is a normal paragraph."
+    assert result[1].content["text"] == "Figure 2: Another map"
+    assert result[2].content["text"] == "This is another normal paragraph."


### PR DESCRIPTION
## Objective 

[MDS-6511](https://bcmines.atlassian.net/browse/MDS-6511)

Updated logic to identify where conditions section start. This should fix an issue that popped up for some permits where extracted permit results include part of the preamble and table of contents. For those permits, the "role" of the preceding paragraph was incorrectly categorized as a "sectionHeading", and had the word "conditions" in it.

Still using some heuristics to try to identify this, but should now be a bit stricter and correctly identifies the section for those permits.

