### PR TITLE
[MDS-6511] Fixed inconsistent highlighting of permit conditions

### DIFF
--- a/services/common/src/components/permits/PermitConditionLayer.tsx
+++ b/services/common/src/components/permits/PermitConditionLayer.tsx
@@ -81,8 +81,8 @@ const PermitConditionLayer: FC<PermitConditionLayerProps> = ({
   }, [isExpanded]);
 
   const handleSectionClick = (event) => {
+    event.stopPropagation();
     if (canEditPermitConditions) {
-      event.stopPropagation();
       setParentExpand();
     }
 


### PR DESCRIPTION
## Objective 

[MDS-6511](https://bcmines.atlassian.net/browse/MDS-6511)

Fixes an issue where highlighting of permit conditions in the pdf on click was pretty inconsistent, especially when not in an edit mode. 

Tracked it down to this little logic: When not in edit mode, the click event would bubble up to the top level condition, highlighting that condition instead of the one you actually clicked on.