### PR TITLE
[MDS-6591] Bug fix - Add check for now_application

### DIFF
--- a/services/core-api/app/api/mines/permits/permit_amendment/models/permit_amendment.py
+++ b/services/core-api/app/api/mines/permits/permit_amendment/models/permit_amendment.py
@@ -150,14 +150,14 @@ class PermitAmendment(SoftDeleteMixin, AuditMixin, Base):
     @hybrid_property
     def now_application_documents(self):
         _now_app_docs = []
-        if self.now_application_identity:
+        if self.now_application_identity and self.now_application_identity.now_application:
             _now_app_docs = self.now_application_identity.now_application.documents
         return _now_app_docs
 
     @hybrid_property
     def imported_now_application_documents(self):
         _imported_now_app_docs = []
-        if self.now_application_identity:
+        if self.now_application_identity and self.now_application_identity.now_application:
             _imported_now_app_docs = self.now_application_identity.now_application.imported_submission_documents
         return _imported_now_app_docs
 


### PR DESCRIPTION
## Objective 

[MDS-6591](https://bcmines.atlassian.net/browse/MDS-6591)

Fix an error that can occur when a permit amendment has a now_guid but isn't linked to a now_application.