### PR TITLE
[MDS-6606] Standard Conditions Tags & Report Requirements

### DIFF
--- a/migrations/sql/V2025.07.30.13.20__add_standard_condition_tag_xref.sql
+++ b/migrations/sql/V2025.07.30.13.20__add_standard_condition_tag_xref.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS standard_permit_condition_tag_xref (
+    standard_permit_condition_tag_xref_guid   uuid DEFAULT gen_random_uuid() PRIMARY KEY,
+    permit_condition_tag_guid UUID NOT NULL,
+    standard_permit_condition_id INT NOT NULL,
+    create_user         VARCHAR(60) NOT NULL,
+    create_timestamp    timestamp with time zone DEFAULT now() NOT NULL,
+    update_user         VARCHAR(60) NOT NULL,
+    update_timestamp    timestamp with time zone DEFAULT now() NOT NULL,
+    deleted_ind         BOOLEAN DEFAULT false,
+    CONSTRAINT fk_standard_permit_condition
+        FOREIGN KEY (standard_permit_condition_id)
+            REFERENCES standard_permit_conditions (standard_permit_condition_id),
+    CONSTRAINT fk_permit_condition_tag
+        FOREIGN KEY (permit_condition_tag_guid)
+            REFERENCES permit_condition_tag (permit_condition_tag_guid)
+);

--- a/migrations/sql/V2025.07.30.14.02__standard_condition_report_req.sql
+++ b/migrations/sql/V2025.07.30.14.02__standard_condition_report_req.sql
@@ -1,0 +1,42 @@
+-- Add is_standard column with default false to mine_report_req_permit_condition_xref
+ALTER TABLE mine_report_req_permit_condition_xref
+    ADD COLUMN is_standard BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE mine_report_req_permit_condition_xref
+    ADD COLUMN standard_permit_condition_id INTEGER NULL REFERENCES standard_permit_conditions(standard_permit_condition_id);
+
+-- same additions for version table
+ALTER TABLE mine_report_req_permit_condition_xref_version
+    ADD COLUMN is_standard BOOLEAN DEFAULT FALSE;
+ALTER TABLE mine_report_req_permit_condition_xref_version
+    ADD COLUMN standard_permit_condition_id INTEGER;
+
+-- Drop NOT NULL constraint on permit_condition_ids
+ALTER TABLE mine_report_req_permit_condition_xref
+    ALTER COLUMN permit_condition_id DROP NOT NULL;
+
+-- Add a check constraint: at least one of permit_condition_id or standard_permit_condition_id must be present
+ALTER TABLE mine_report_req_permit_condition_xref
+    ADD CONSTRAINT mine_report_req_permit_condition_xref_condition_required
+    CHECK (
+        (is_standard = FALSE AND permit_condition_id IS NOT NULL)
+        OR (is_standard = TRUE AND  standard_permit_condition_id IS NOT NULL)
+    );
+
+-- Add is_standard column with default false
+ALTER TABLE mine_report_permit_requirement
+    ADD COLUMN is_standard BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- Drop NOT NULL constraint on permit_amendment_id
+ALTER TABLE mine_report_permit_requirement
+    ALTER COLUMN permit_amendment_id DROP NOT NULL;
+
+-- Add a check constraint: permit_amendment_id must be NOT NULL if is_standard is false
+ALTER TABLE mine_report_permit_requirement
+    ADD CONSTRAINT mine_report_permit_requirement_amendment_required_if_not_standard
+    CHECK (
+        (is_standard = TRUE AND permit_amendment_id IS NULL)
+        OR (is_standard = FALSE AND permit_amendment_id IS NOT NULL)
+    );
+
+ALTER TABLE mine_report_permit_requirement_version
+    ADD COLUMN is_standard BOOLEAN NOT NULL DEFAULT FALSE;

--- a/migrations/sql/V2025.07.30.14.02__standard_condition_report_req.sql
+++ b/migrations/sql/V2025.07.30.14.02__standard_condition_report_req.sql
@@ -40,3 +40,8 @@ ALTER TABLE mine_report_permit_requirement
 
 ALTER TABLE mine_report_permit_requirement_version
     ADD COLUMN is_standard BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- add unique index for standard report requirements: report_name must be unique where is_standard = True
+CREATE UNIQUE INDEX unique_standard_report_name_idx
+ON mine_report_permit_requirement (report_name)
+WHERE is_standard = TRUE AND report_name IS NOT NULL;

--- a/services/common/src/components/permits/PermitConditionForm.tsx
+++ b/services/common/src/components/permits/PermitConditionForm.tsx
@@ -328,7 +328,7 @@ const PermitConditionForm: FC<PermitConditionFormProps> = ({
                                             </Button>
                                         </Col>
                                     )}
-                                    {!standardConditionType && <Col>
+                                    <Col>
                                         <Button
                                             loading={loading}
                                             className="fa-icon-container btn-sm-padding"
@@ -341,7 +341,7 @@ const PermitConditionForm: FC<PermitConditionFormProps> = ({
                                                 ? "Report Added"
                                                 : "Add Report Requirement"}
                                         </Button>
-                                    </Col>}
+                                    </Col>
                                     {enablePermitConditionTags && conditionTags &&
                                         (<Col className="condition-tag-select">
                                             <Field

--- a/services/common/src/components/permits/PermitConditionForm.tsx
+++ b/services/common/src/components/permits/PermitConditionForm.tsx
@@ -78,8 +78,8 @@ const PermitConditionForm: FC<PermitConditionFormProps> = ({
     const editingFormDirty = useAppSelector(isDirty(editingFormName));
     const listItemFormDirty = useAppSelector(isDirty(FORM.EDIT_PERMIT_CONDITION));
     const conditionTags: IPermitConditionTag[] = useAppSelector(getPermitConditionTags);
-    const enablePermitConditionTags = isFeatureEnabled(Feature.PERMIT_CONDITION_TAGS) && !standardConditionType;
     const stepEditDisabled = Boolean(standardConditionType) || isNowEditor;
+    const enablePermitConditionTags = isFeatureEnabled(Feature.PERMIT_CONDITION_TAGS);
 
     const startEdit = () => {
         const handleEdit = () => {
@@ -342,7 +342,7 @@ const PermitConditionForm: FC<PermitConditionFormProps> = ({
                                                 : "Add Report Requirement"}
                                         </Button>
                                     </Col>}
-                                    {enablePermitConditionTags && conditionTags && !standardConditionType &&
+                                    {enablePermitConditionTags && conditionTags &&
                                         (<Col className="condition-tag-select">
                                             <Field
                                                 name="condition_tags"

--- a/services/common/src/components/permits/PermitConditionLayer.tsx
+++ b/services/common/src/components/permits/PermitConditionLayer.tsx
@@ -13,6 +13,7 @@ import { getReportRequirementsByCondition } from "@mds/common/redux/selectors/pe
 import { useAppSelector } from "@mds/common/redux/rootState";
 import { FORM } from "@mds/common/constants/forms";
 import { IStandardPermitCondition } from "@mds/common/interfaces";
+import { getStandardReportByCondition } from "@mds/common/redux/slices/mineReportPermitRequirementSlice";
 
 const { Title } = Typography;
 
@@ -52,9 +53,13 @@ const PermitConditionLayer: FC<PermitConditionLayerProps> = ({
   categoryOptions,
 }) => {
   const { loading, previousAmendment, permitGuid, standardConditionType, isNowEditor } = usePermitConditions();
-  const requirements = useAppSelector(
+  const permitRequirements = useAppSelector(
     getReportRequirementsByCondition(permitGuid, permitAmendmentGuid, condition.permit_condition_id, isNowEditor)
   );
+  const standardId = standardConditionType ? condition.permit_condition_id : undefined;
+  const standardRequirements = useAppSelector(getStandardReportByCondition(standardId));
+  const requirements = standardConditionType ? standardRequirements : permitRequirements;
+
   const editingCondition = useMemo(
     () => editingFormName === `${FORM.EDIT_PERMIT_CONDITION}_${condition.permit_condition_id}_${condition.condition_category_code}`,
     [condition.permit_condition_guid, editingFormName]

--- a/services/common/src/components/permits/PermitConditionViewEdit.tsx
+++ b/services/common/src/components/permits/PermitConditionViewEdit.tsx
@@ -64,7 +64,7 @@ const PermitConditionViewEdit: FC<PermitConditionViewEditProps> = ({
     const conditionTags: IPermitConditionTag[] = useAppSelector(getPermitConditionTags);
     const isStandardConditions = Boolean(standardConditionType);
     const canAddConditions = isStandardConditions || isExtracted || isNowEditor;
-    const areTagsEnabled = isFeatureEnabled(Feature.PERMIT_CONDITION_TAGS) && !isStandardConditions;
+    const areTagsEnabled = isFeatureEnabled(Feature.PERMIT_CONDITION_TAGS);
 
 
     const condWithoutConditionsText = defaultPermitConditionCategories?.map((cat) => {

--- a/services/common/src/components/permits/ReportPermitRequirementForm.tsx
+++ b/services/common/src/components/permits/ReportPermitRequirementForm.tsx
@@ -22,6 +22,7 @@ import { REPORT_FREQUENCY_HASH, REPORT_MINISTRY_RECIPIENT_HASH, REPORT_REGULATOR
 import {
   createMineReportPermitRequirement,
   deleteMineReportPermitRequirement,
+  getStandardReportRequirements,
   updateMineReportPermitRequirement,
 } from "@mds/common/redux/slices/mineReportPermitRequirementSlice";
 import { deleteConfirmWrapper } from "@mds/common/components/common/ActionMenu";
@@ -54,7 +55,10 @@ export const ReportPermitRequirementForm: FC<ReportPermitRequirementProps> = ({
   const [selectedRequirement, setSelectedRequirement] = useState(mineReportPermitRequirement);
   const dispatch = useAppDispatch();
   const [isEditMode, setIsEditMode] = useState(isModal && canEditPermitConditions);
-  const existingRequirements = useAppSelector(getMineReportPermitRequirementsByAmendment(permitGuid, currentAmendment.permit_amendment_guid, isNowEditor));
+
+  const standardRequirements = useAppSelector(getStandardReportRequirements);
+  const permitRequirements = useAppSelector(getMineReportPermitRequirementsByAmendment(permitGuid, currentAmendment?.permit_amendment_guid, isNowEditor));
+  const existingRequirements = Boolean(standardConditionType) ? standardRequirements : permitRequirements;
 
   const hasExistingRequirements = existingRequirements?.length > 0;
   const existingRequirementsOptions = existingRequirements.map((r) => { return { label: r.report_name, value: r.mine_report_permit_requirement_id } });

--- a/services/common/src/components/permits/ReportPermitRequirementForm.tsx
+++ b/services/common/src/components/permits/ReportPermitRequirementForm.tsx
@@ -26,7 +26,7 @@ import {
 } from "@mds/common/redux/slices/mineReportPermitRequirementSlice";
 import { deleteConfirmWrapper } from "@mds/common/components/common/ActionMenu";
 import { usePermitConditions } from "@mds/common/components/permits/PermitConditionsContext";
-import { getMineReportPermitRequirementsByAmendment, getNowDraftConditionsFormatted, getPermitConditionCategories } from "@mds/common/redux/selectors/permitSelectors";
+import { getMineReportPermitRequirementsByAmendment, getNowDraftConditionsFormatted, getPermitConditionCategories, getStandardPermitConditionsFormatted } from "@mds/common/redux/selectors/permitSelectors";
 import CoreButton from "../common/CoreButton";
 import RenderTreeSelect, { parseTreeValues } from "../forms/RenderTreeSelect";
 import RenderSubmitButton from "../forms/RenderSubmitButton";
@@ -49,18 +49,28 @@ export const ReportPermitRequirementForm: FC<ReportPermitRequirementProps> = ({
   refreshData,
 }) => {
   const formName = `${FORM.ADD_REPORT_TO_PERMIT_CONDITION}-${condition?.permit_condition_id ?? mineReportPermitRequirement?.mine_report_permit_requirement_id}`;
-  const { loading, currentAmendment, permitGuid, mineGuid, isNowEditor } = usePermitConditions();
+
+  const { loading, currentAmendment, permitGuid, mineGuid, isNowEditor, standardConditionType } = usePermitConditions();
   const [selectedRequirement, setSelectedRequirement] = useState(mineReportPermitRequirement);
   const dispatch = useAppDispatch();
   const [isEditMode, setIsEditMode] = useState(isModal && canEditPermitConditions);
   const existingRequirements = useAppSelector(getMineReportPermitRequirementsByAmendment(permitGuid, currentAmendment.permit_amendment_guid, isNowEditor));
+
   const hasExistingRequirements = existingRequirements?.length > 0;
   const existingRequirementsOptions = existingRequirements.map((r) => { return { label: r.report_name, value: r.mine_report_permit_requirement_id } });
   const disableFields = mineReportPermitRequirement?.mine_report_permit_requirement_id !== selectedRequirement?.mine_report_permit_requirement_id;
   const multipleConditions = selectedRequirement?.permit_condition_ids.length > 1;
-  const permitConditions = useAppSelector(getPermitConditionCategories(permitGuid, currentAmendment.permit_amendment_guid));
+
   const nowConditions = useAppSelector(getNowDraftConditionsFormatted);
-  const { conditionMap, categoriesWithConditions } = isNowEditor ? nowConditions : permitConditions;
+  const permitConditions = useAppSelector(getPermitConditionCategories(permitGuid, currentAmendment?.permit_amendment_guid));
+  const standardConditions = useAppSelector(getStandardPermitConditionsFormatted());
+
+  const conditions = Boolean(standardConditionType)
+    ? standardConditions
+    : isNowEditor ? nowConditions : permitConditions;
+
+  const { conditionMap, categoriesWithConditions } = conditions;
+
 
   const getLinkedConditionList = () => {
     if (!hasExistingRequirements || !selectedRequirement) {
@@ -258,7 +268,7 @@ export const ReportPermitRequirementForm: FC<ReportPermitRequirementProps> = ({
               disabled={loading || disableFields}
             />
           </Col>
-          <Col span={12}>
+          <Col span={standardConditionType ? 24 : 12}>
             <Field
               name="due_date_period_months"
               label="Report Frequency"
@@ -274,16 +284,17 @@ export const ReportPermitRequirementForm: FC<ReportPermitRequirementProps> = ({
               disabled={loading || disableFields}
             />
           </Col>
-          <Col md={12} sm={24}>
-            <Field
-              name="initial_due_date"
-              label="Initial Due Date"
-              placeholder="Select date"
-              formatViewDate
-              component={RenderDate}
-              disabled={loading || disableFields}
-            />
-          </Col>
+          {!standardConditionType &&
+            <Col md={12} sm={24}>
+              <Field
+                name="initial_due_date"
+                label="Initial Due Date"
+                placeholder="Select date"
+                formatViewDate
+                component={RenderDate}
+                disabled={loading || disableFields}
+              />
+            </Col>}
           <Col md={12} sm={24}>
             {!isModal && !isEditMode ? (
               <div>

--- a/services/common/src/constants/API.ts
+++ b/services/common/src/constants/API.ts
@@ -305,6 +305,7 @@ export const MINE_REPORT_CATEGORY = "/mines/reports/category-codes";
 export const MINE_REPORT_PERMIT_REQUIREMENT = (mineGuid) =>
   `/mines/${mineGuid}/reports/permit-requirements`;
 
+export const STANDARD_REPORT_PERMIT_REQUIREMENT = `/mines/reports/standard-permit-requirements`;
 // Compliance Codes
 export const COMPLIANCE_CODE_LIST = (params = {}) =>
   `/compliance/codes?${queryString.stringify(params)}`;

--- a/services/common/src/interfaces/permits/mineReportPermitRequirements.interface.ts
+++ b/services/common/src/interfaces/permits/mineReportPermitRequirements.interface.ts
@@ -6,5 +6,5 @@ export interface IMineReportPermitRequirement {
   permit_condition_ids: number[];
   due_date_period_months: number;
   initial_due_date: string;
-  permit_amendment_id: number;
+  permit_amendment_id?: number;
 }

--- a/services/common/src/interfaces/permits/standardPermitCondition.interface.ts
+++ b/services/common/src/interfaces/permits/standardPermitCondition.interface.ts
@@ -16,5 +16,5 @@ export interface IStandardPermitCondition {
   display_order: number;
   stepPath?: string;
   mineReportPermitRequirement?: IMineReportPermitRequirement;
-  condition_tags?: IPermitConditionTag[];
+  condition_tags: string[];
 }

--- a/services/common/src/redux/selectors/permitSelectors.ts
+++ b/services/common/src/redux/selectors/permitSelectors.ts
@@ -1,11 +1,12 @@
 import { createSelector } from "reselect";
 import { getNoticeOfWork } from "@mds/common/redux/selectors/noticeOfWorkSelectors";
 import * as permitReducer from "../reducers/permitReducer";
-import { IMineReportPermitRequirement, IPermitAmendment, IPermitCondition, IPermitConditionCategory } from "@mds/common/interfaces";
+import { IMineReportPermitRequirement, IPermitAmendment, IPermitCondition, IPermitConditionCategory, IStandardPermitCondition } from "@mds/common/interfaces";
 import { getPermitConditionCategoryOptions } from "./staticContentSelectors";
 import { uniqBy, memoize } from "lodash";
 import { formatPermitConditionStep } from "@mds/common/utils/helpers";
 import { RootState } from "../rootState";
+import { getStandardReportRequirements } from "../slices/mineReportPermitRequirementSlice";
 
 const draft = "DFT";
 
@@ -135,7 +136,7 @@ export const getMineReportPermitRequirementById = (permitGuid, reportId) =>
     }
   );
 
-const getSubConditionIds = (conditions: IPermitCondition[]) => {
+export const getSubConditionIds = (conditions: IPermitCondition[] | IStandardPermitCondition[]) => {
   if (!conditions?.length) {
     return [];
   }
@@ -278,8 +279,8 @@ export const getNowDraftConditionsFormatted =
   );
 
 export const getStandardPermitConditionsFormatted = () =>
-  createSelector([getStandardPermitConditions, getPermitConditionCategoryOptions],
-    (conditions, categories) => {
+  createSelector([getStandardPermitConditions, getPermitConditionCategoryOptions, getStandardReportRequirements],
+    (conditions, categories, reportRequirements) => {
       if (!conditions || !categories) {
         return {
           conditionMap: {},
@@ -293,7 +294,7 @@ export const getStandardPermitConditionsFormatted = () =>
         const catConditions = conditions.filter((c) =>
           c.condition_category_code === cat.condition_category_code
         );
-        const formattedConditions = catConditions.map((condition) => getStepPath(condition, cat, conditionMap));
+        const formattedConditions = catConditions.map((condition) => getStepPath(condition, cat, conditionMap, "", reportRequirements));
 
         return {
           ...cat,

--- a/services/common/src/redux/slices/mineReportPermitRequirementSlice.ts
+++ b/services/common/src/redux/slices/mineReportPermitRequirementSlice.ts
@@ -2,24 +2,48 @@ import { createAppSlice } from "@mds/common/redux/createAppSlice";
 import { hideLoading, showLoading } from "react-redux-loading-bar";
 import CustomAxios from "@mds/common/redux/customAxios";
 import { IMineReportPermitRequirement } from "@mds/common/interfaces";
-import { MINE_REPORT_PERMIT_REQUIREMENT } from "@mds/common/constants/API";
+import { MINE_REPORT_PERMIT_REQUIREMENT, STANDARD_REPORT_PERMIT_REQUIREMENT } from "@mds/common/constants/API";
 import { ENVIRONMENT } from "@mds/common/constants/environment";
+import { createSelector } from "@reduxjs/toolkit";
+import { getStandardPermitConditions, getSubConditionIds } from "../selectors/permitSelectors";
 
 const createRequestHeader = REQUEST_HEADER.createRequestHeader;
 export const mineReportPermitRequirementReducerType = "mineReportPermitRequirement";
 
-interface IMineReportPermitRequirementState { }
+interface IMineReportPermitRequirementState {
+  standardReportRequirements: IMineReportPermitRequirement[];
+}
 
-const initialState: IMineReportPermitRequirementState = {};
+const initialState: IMineReportPermitRequirementState = {
+  standardReportRequirements: undefined
+};
 
 const mineReportPermitRequirementSlice = createAppSlice({
   name: mineReportPermitRequirementReducerType,
   initialState,
   reducers: (create) => ({
+    fetchStandardReportRequirements: create.asyncThunk(
+      async (_, thunkApi) => {
+
+        const headers = createRequestHeader();
+
+        thunkApi.dispatch(showLoading());
+        const response = await CustomAxios({
+          errorToastMessage: "Error fetching standard report requirements"
+        }).get(`${ENVIRONMENT.apiUrl}${STANDARD_REPORT_PERMIT_REQUIREMENT}`, headers);
+
+        thunkApi.dispatch(hideLoading());
+        return response.data;
+      }, {
+      fulfilled: (state, action) => {
+        state.standardReportRequirements = action.payload.records;
+      }
+    }
+    ),
     createMineReportPermitRequirement: create.asyncThunk(
       async (
         payload: {
-          mineGuid: string;
+          mineGuid?: string;
           values: IMineReportPermitRequirement;
         },
         thunkApi
@@ -27,22 +51,33 @@ const mineReportPermitRequirementSlice = createAppSlice({
         const headers = createRequestHeader();
         thunkApi.dispatch(showLoading());
 
+        const url = payload.mineGuid
+          ? `${ENVIRONMENT.apiUrl}${MINE_REPORT_PERMIT_REQUIREMENT(payload.mineGuid)}`
+          : `${ENVIRONMENT.apiUrl}${STANDARD_REPORT_PERMIT_REQUIREMENT}`;
+
         const response = await CustomAxios({
           errorToastMessage: "default",
         }).post(
-          `${ENVIRONMENT.apiUrl}${MINE_REPORT_PERMIT_REQUIREMENT(payload.mineGuid)}`,
+          url,
           payload.values,
           headers
         );
 
         thunkApi.dispatch(hideLoading());
         return response.data;
+      }, {
+      fulfilled: (state, action) => {
+        if (!action.meta.arg.mineGuid) {
+          const newRequirement = action.payload;
+          state.standardReportRequirements = [...state.standardReportRequirements, newRequirement];
+        }
       }
+    }
     ),
     deleteMineReportPermitRequirement: create.asyncThunk(
       async (
         payload: {
-          mineGuid: string;
+          mineGuid?: string;
           mine_report_permit_requirement_id: number;
         },
         thunkApi
@@ -54,18 +89,31 @@ const mineReportPermitRequirementSlice = createAppSlice({
           successToastMessage: "Successfully deleted report requirement",
         };
         const { mineGuid, mine_report_permit_requirement_id } = payload;
+        const url = mineGuid
+          ? `${ENVIRONMENT.apiUrl}${MINE_REPORT_PERMIT_REQUIREMENT(mineGuid)}`
+          : `${ENVIRONMENT.apiUrl}${STANDARD_REPORT_PERMIT_REQUIREMENT}`;
+
         const response = await CustomAxios(messages).delete(
-          `${ENVIRONMENT.apiUrl}${MINE_REPORT_PERMIT_REQUIREMENT(mineGuid)}?mine_report_permit_requirement_id=${mine_report_permit_requirement_id}`,
+          `${url}?mine_report_permit_requirement_id=${mine_report_permit_requirement_id}`,
           headers
         );
 
         thunkApi.dispatch(hideLoading());
         return response.data;
       },
+      {
+        fulfilled: (state, action) => {
+          const { mineGuid, mine_report_permit_requirement_id } = action.meta.arg;
+          if (!mineGuid) {
+            state.standardReportRequirements = state.standardReportRequirements.filter((r) =>
+              r.mine_report_permit_requirement_id !== mine_report_permit_requirement_id);
+          }
+        }
+      }
     ),
     updateMineReportPermitRequirement: create.asyncThunk(
       async (payload: {
-        mineGuid: string;
+        mineGuid?: string;
         values: IMineReportPermitRequirement
       }, thunkApi) => {
         const headers = createRequestHeader();
@@ -76,18 +124,54 @@ const mineReportPermitRequirementSlice = createAppSlice({
         };
 
         const { mineGuid, values } = payload;
+        const url = mineGuid
+          ? `${ENVIRONMENT.apiUrl}${MINE_REPORT_PERMIT_REQUIREMENT(mineGuid)}`
+          : `${ENVIRONMENT.apiUrl}${STANDARD_REPORT_PERMIT_REQUIREMENT}`;
+
         const response = await CustomAxios(messages).put(
-          `${ENVIRONMENT.apiUrl}${MINE_REPORT_PERMIT_REQUIREMENT(mineGuid)}`,
+          url,
           values,
           headers,
         );
         thunkApi.dispatch(hideLoading());
         return response.data;
       },
+      {
+        fulfilled: (state, action) => {
+          const { mineGuid, values } = action.meta.arg;
+          const newRequirement = action.payload;
+          if (!mineGuid) {
+            state.standardReportRequirements = state.standardReportRequirements.map((r) =>
+              r.mine_report_permit_requirement_id === values.mine_report_permit_requirement_id
+                ? newRequirement
+                : r
+            );
+          }
+        }
+      }
     )
   }),
+  selectors: {
+    getStandardReportRequirements: (state: IMineReportPermitRequirementState) => state.standardReportRequirements
+  }
 });
 
-export const { createMineReportPermitRequirement, deleteMineReportPermitRequirement, updateMineReportPermitRequirement } = mineReportPermitRequirementSlice.actions;
+export const getStandardReportByCondition = (conditionId: number) =>
+  createSelector([getStandardReportRequirements, getStandardPermitConditions], (requirements, conditions) => {
+    if (!conditionId || !requirements || !(conditions?.length > 0)) {
+      return [];
+    }
+
+    const condition = conditions.find((c) => c.permit_condition_id === conditionId);
+    if (!condition) {
+      return [];
+    }
+    const allConditionIds = getSubConditionIds([condition]);
+    const reqByCondition = requirements.filter((r) => r.permit_condition_ids.some((id) => allConditionIds.includes(id)));
+    return reqByCondition;
+  });
+
+export const { getStandardReportRequirements } = mineReportPermitRequirementSlice.selectors;
+export const { createMineReportPermitRequirement, deleteMineReportPermitRequirement, fetchStandardReportRequirements, updateMineReportPermitRequirement } = mineReportPermitRequirementSlice.actions;
 export const mineReportPermitRequirementReducer = mineReportPermitRequirementSlice.reducer;
 export default mineReportPermitRequirementReducer;

--- a/services/common/src/tests/mocks/dataMocks.tsx
+++ b/services/common/src/tests/mocks/dataMocks.tsx
@@ -2022,6 +2022,7 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
     parent_standard_permit_condition_id: null,
     parent_permit_condition_id: null,
     condition_type_code: "SEC",
+    condition_tags: [],
     sub_conditions: [
       {
         standard_permit_condition_id: 420,
@@ -2033,6 +2034,7 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         parent_standard_permit_condition_id: 400,
         parent_permit_condition_id: 400,
         condition_type_code: "CON",
+        condition_tags: ["c0c31497-3f91-42d3-a13b-61eef85922f5"],
         sub_conditions: [
           {
             standard_permit_condition_id: 421,
@@ -2045,6 +2047,7 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             parent_permit_condition_id: 420,
             condition_type_code: "LIS",
             sub_conditions: [],
+            condition_tags: [],
             "step": "i.",
             "display_order": 1
           },
@@ -2060,7 +2063,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "LIS",
             sub_conditions: [],
             "step": "ii.",
-            "display_order": 2
+            "display_order": 2,
+            condition_tags: [],
           },
           {
             standard_permit_condition_id: 423,
@@ -2074,7 +2078,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "LIS",
             sub_conditions: [],
             "step": "iii.",
-            "display_order": 3
+            "display_order": 3,
+            condition_tags: [],
           },
           {
             standard_permit_condition_id: 424,
@@ -2088,7 +2093,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "LIS",
             sub_conditions: [],
             "step": "iv.",
-            "display_order": 4
+            "display_order": 4,
+            condition_tags: [],
           },
           {
             standard_permit_condition_id: 425,
@@ -2102,7 +2108,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "LIS",
             sub_conditions: [],
             "step": "v.",
-            "display_order": 5
+            "display_order": 5,
+            condition_tags: [],
           },
           {
             standard_permit_condition_id: 426,
@@ -2116,7 +2123,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "LIS",
             sub_conditions: [],
             "step": "vi.",
-            "display_order": 6
+            "display_order": 6,
+            condition_tags: [],
           },
           {
             standard_permit_condition_id: 427,
@@ -2130,7 +2138,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "LIS",
             sub_conditions: [],
             "step": "vii.",
-            "display_order": 7
+            "display_order": 7,
+            condition_tags: [],
           },
           {
             standard_permit_condition_id: 428,
@@ -2144,7 +2153,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "LIS",
             sub_conditions: [],
             "step": "viii.",
-            "display_order": 8
+            "display_order": 8,
+            condition_tags: [],
           }
         ],
         "step": "a.",
@@ -2160,6 +2170,7 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         parent_standard_permit_condition_id: 400,
         parent_permit_condition_id: 400,
         condition_type_code: "CON",
+        condition_tags: [],
         sub_conditions: [
           {
             standard_permit_condition_id: 430,
@@ -2173,7 +2184,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "LIS",
             sub_conditions: [],
             "step": "i.",
-            "display_order": 1
+            "display_order": 1,
+            condition_tags: [],
           }
         ],
         "step": "b.",
@@ -2191,7 +2203,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         condition_type_code: "CON",
         sub_conditions: [],
         "step": "c.",
-        "display_order": 3
+        "display_order": 3,
+        condition_tags: [],
       },
       {
         standard_permit_condition_id: 890,
@@ -2205,7 +2218,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         condition_type_code: "CON",
         sub_conditions: [],
         "step": "d.",
-        "display_order": 4
+        "display_order": 4,
+        condition_tags: [],
       },
       {
         standard_permit_condition_id: 432,
@@ -2219,7 +2233,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         condition_type_code: "CON",
         sub_conditions: [],
         "step": "e.",
-        "display_order": 5
+        "display_order": 5,
+        condition_tags: [],
       },
       {
         standard_permit_condition_id: 433,
@@ -2233,7 +2248,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         condition_type_code: "CON",
         sub_conditions: [],
         "step": "f.",
-        "display_order": 6
+        "display_order": 6,
+        condition_tags: [],
       },
       {
         standard_permit_condition_id: 434,
@@ -2247,7 +2263,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         condition_type_code: "CON",
         sub_conditions: [],
         "step": "g.",
-        "display_order": 7
+        "display_order": 7,
+        condition_tags: [],
       },
       {
         standard_permit_condition_id: 435,
@@ -2261,7 +2278,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         condition_type_code: "CON",
         sub_conditions: [],
         "step": "h.",
-        "display_order": 8
+        "display_order": 8,
+        condition_tags: [],
       },
       {
         standard_permit_condition_id: 436,
@@ -2275,7 +2293,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         condition_type_code: "CON",
         sub_conditions: [],
         "step": "i.",
-        "display_order": 9
+        "display_order": 9,
+        condition_tags: [],
       }
     ],
     "step": "1.",
@@ -2291,6 +2310,7 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
     parent_standard_permit_condition_id: null,
     parent_permit_condition_id: null,
     condition_type_code: "SEC",
+    condition_tags: [],
     sub_conditions: [
       {
         standard_permit_condition_id: 442,
@@ -2304,7 +2324,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         condition_type_code: "CON",
         sub_conditions: [],
         "step": "a.",
-        "display_order": 1
+        "display_order": 1,
+        condition_tags: [],
       }
     ],
     "step": "1.",
@@ -2320,6 +2341,7 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
     parent_standard_permit_condition_id: null,
     parent_permit_condition_id: null,
     condition_type_code: "SEC",
+    condition_tags: [],
     sub_conditions: [
       {
         standard_permit_condition_id: 540,
@@ -2333,7 +2355,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         condition_type_code: "CON",
         sub_conditions: [],
         "step": "a.",
-        "display_order": 1
+        "display_order": 1,
+        condition_tags: [],
       },
       {
         standard_permit_condition_id: 541,
@@ -2345,6 +2368,7 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         parent_standard_permit_condition_id: 415,
         parent_permit_condition_id: 415,
         condition_type_code: "CON",
+        condition_tags: [],
         sub_conditions: [
           {
             standard_permit_condition_id: 542,
@@ -2358,7 +2382,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "LIS",
             sub_conditions: [],
             "step": "i.",
-            "display_order": 1
+            "display_order": 1,
+            condition_tags: [],
           },
           {
             standard_permit_condition_id: 543,
@@ -2372,7 +2397,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "LIS",
             sub_conditions: [],
             "step": "ii.",
-            "display_order": 2
+            "display_order": 2,
+            condition_tags: [],
           }
         ],
         "step": "b.",
@@ -2392,6 +2418,7 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
     parent_standard_permit_condition_id: null,
     parent_permit_condition_id: null,
     condition_type_code: "SEC",
+    condition_tags: [],
     sub_conditions: [
       {
         standard_permit_condition_id: 452,
@@ -2405,7 +2432,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         condition_type_code: "CON",
         sub_conditions: [],
         "step": "a.",
-        "display_order": 1
+        "display_order": 1,
+        condition_tags: [],
       },
       {
         standard_permit_condition_id: 453,
@@ -2417,6 +2445,7 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         parent_standard_permit_condition_id: 406,
         parent_permit_condition_id: 406,
         condition_type_code: "CON",
+        condition_tags: [],
         sub_conditions: [
           {
             standard_permit_condition_id: 454,
@@ -2430,7 +2459,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "LIS",
             sub_conditions: [],
             "step": "i.",
-            "display_order": 1
+            "display_order": 1,
+            condition_tags: [],
           },
           {
             standard_permit_condition_id: 455,
@@ -2444,7 +2474,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "LIS",
             sub_conditions: [],
             "step": "ii.",
-            "display_order": 2
+            "display_order": 2,
+            condition_tags: [],
           }
         ],
         "step": "b.",
@@ -2464,6 +2495,7 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
     parent_standard_permit_condition_id: null,
     parent_permit_condition_id: null,
     condition_type_code: "SEC",
+    condition_tags: [],
     sub_conditions: [
       {
         standard_permit_condition_id: 459,
@@ -2477,7 +2509,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         condition_type_code: "CON",
         sub_conditions: [],
         "step": "a.",
-        "display_order": 1
+        "display_order": 1,
+        condition_tags: [],
       },
       {
         standard_permit_condition_id: 460,
@@ -2491,7 +2524,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         condition_type_code: "CON",
         sub_conditions: [],
         "step": "b.",
-        "display_order": 2
+        "display_order": 2,
+        condition_tags: [],
       },
       {
         standard_permit_condition_id: 461,
@@ -2505,7 +2539,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         condition_type_code: "CON",
         sub_conditions: [],
         "step": "c.",
-        "display_order": 3
+        "display_order": 3,
+        condition_tags: [],
       },
       {
         standard_permit_condition_id: 462,
@@ -2519,7 +2554,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         condition_type_code: "CON",
         sub_conditions: [],
         "step": "d.",
-        "display_order": 4
+        "display_order": 4,
+        condition_tags: [],
       },
       {
         standard_permit_condition_id: 463,
@@ -2531,6 +2567,7 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         parent_standard_permit_condition_id: 410,
         parent_permit_condition_id: 410,
         condition_type_code: "CON",
+        condition_tags: [],
         sub_conditions: [
           {
             standard_permit_condition_id: 891,
@@ -2544,7 +2581,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "LIS",
             sub_conditions: [],
             "step": "i.",
-            "display_order": 1
+            "display_order": 1,
+            condition_tags: [],
           },
           {
             standard_permit_condition_id: 892,
@@ -2558,7 +2596,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "LIS",
             sub_conditions: [],
             "step": "ii.",
-            "display_order": 2
+            "display_order": 2,
+            condition_tags: [],
           }
         ],
         "step": "e.",
@@ -2578,6 +2617,7 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
     parent_standard_permit_condition_id: null,
     parent_permit_condition_id: null,
     condition_type_code: "SEC",
+    condition_tags: [],
     sub_conditions: [
       {
         standard_permit_condition_id: 465,
@@ -2591,7 +2631,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         condition_type_code: "CON",
         sub_conditions: [],
         "step": "a.",
-        "display_order": 1
+        "display_order": 1,
+        condition_tags: [],
       },
       {
         standard_permit_condition_id: 466,
@@ -2605,7 +2646,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         condition_type_code: "CON",
         sub_conditions: [],
         "step": "b.",
-        "display_order": 2
+        "display_order": 2,
+        condition_tags: [],
       },
       {
         standard_permit_condition_id: 467,
@@ -2619,7 +2661,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         condition_type_code: "CON",
         sub_conditions: [],
         "step": "c.",
-        "display_order": 3
+        "display_order": 3,
+        condition_tags: [],
       },
       {
         standard_permit_condition_id: 468,
@@ -2633,7 +2676,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         condition_type_code: "CON",
         sub_conditions: [],
         "step": "d.",
-        "display_order": 4
+        "display_order": 4,
+        condition_tags: [],
       },
       {
         standard_permit_condition_id: 469,
@@ -2647,7 +2691,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         condition_type_code: "CON",
         sub_conditions: [],
         "step": "e.",
-        "display_order": 5
+        "display_order": 5,
+        condition_tags: [],
       },
       {
         standard_permit_condition_id: 470,
@@ -2661,7 +2706,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         condition_type_code: "CON",
         sub_conditions: [],
         "step": "f.",
-        "display_order": 6
+        "display_order": 6,
+        condition_tags: [],
       },
       {
         standard_permit_condition_id: 471,
@@ -2675,7 +2721,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         condition_type_code: "CON",
         sub_conditions: [],
         "step": "g.",
-        "display_order": 7
+        "display_order": 7,
+        condition_tags: [],
       },
       {
         standard_permit_condition_id: 472,
@@ -2687,6 +2734,7 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         parent_standard_permit_condition_id: 411,
         parent_permit_condition_id: 411,
         condition_type_code: "CON",
+        condition_tags: [],
         sub_conditions: [
           {
             standard_permit_condition_id: 473,
@@ -2700,7 +2748,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "LIS",
             sub_conditions: [],
             "step": "i.",
-            "display_order": 1
+            "display_order": 1,
+            condition_tags: [],
           }
         ],
         "step": "h.",
@@ -2716,6 +2765,7 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         parent_standard_permit_condition_id: 411,
         parent_permit_condition_id: 411,
         condition_type_code: "CON",
+        condition_tags: [],
         sub_conditions: [
           {
             standard_permit_condition_id: 475,
@@ -2729,7 +2779,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "LIS",
             sub_conditions: [],
             "step": "i.",
-            "display_order": 1
+            "display_order": 1,
+            condition_tags: [],
           }
         ],
         "step": "i.",
@@ -2749,6 +2800,7 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
     parent_standard_permit_condition_id: null,
     parent_permit_condition_id: null,
     condition_type_code: "SEC",
+    condition_tags: [],
     sub_conditions: [
       {
         standard_permit_condition_id: 544,
@@ -2762,7 +2814,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         condition_type_code: "CON",
         sub_conditions: [],
         "step": "a.",
-        "display_order": 1
+        "display_order": 1,
+        condition_tags: [],
       },
       {
         standard_permit_condition_id: 545,
@@ -2776,7 +2829,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         condition_type_code: "CON",
         sub_conditions: [],
         "step": "b.",
-        "display_order": 2
+        "display_order": 2,
+        condition_tags: [],
       }
     ],
     "step": "2.",
@@ -2792,6 +2846,7 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
     parent_standard_permit_condition_id: null,
     parent_permit_condition_id: null,
     condition_type_code: "SEC",
+    condition_tags: [],
     sub_conditions: [
       {
         standard_permit_condition_id: 443,
@@ -2805,7 +2860,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         condition_type_code: "CON",
         sub_conditions: [],
         "step": "a.",
-        "display_order": 1
+        "display_order": 1,
+        condition_tags: [],
       }
     ],
     "step": "2.",
@@ -2821,6 +2877,7 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
     parent_standard_permit_condition_id: null,
     parent_permit_condition_id: null,
     condition_type_code: "SEC",
+    condition_tags: [],
     sub_conditions: [
       {
         standard_permit_condition_id: 456,
@@ -2834,7 +2891,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         condition_type_code: "CON",
         sub_conditions: [],
         "step": "a.",
-        "display_order": 1
+        "display_order": 1,
+        condition_tags: [],
       }
     ],
     "step": "2.",
@@ -2850,6 +2908,7 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
     parent_standard_permit_condition_id: null,
     parent_permit_condition_id: null,
     condition_type_code: "SEC",
+    condition_tags: [],
     sub_conditions: [
       {
         standard_permit_condition_id: 419,
@@ -2863,7 +2922,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         condition_type_code: "CON",
         sub_conditions: [],
         "step": "a.",
-        "display_order": 1
+        "display_order": 1,
+        condition_tags: [],
       }
     ],
     "step": "2.",
@@ -2879,6 +2939,7 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
     parent_standard_permit_condition_id: null,
     parent_permit_condition_id: null,
     condition_type_code: "SEC",
+    condition_tags: [],
     sub_conditions: [
       {
         standard_permit_condition_id: 457,
@@ -2892,7 +2953,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         condition_type_code: "CON",
         sub_conditions: [],
         "step": "a.",
-        "display_order": 1
+        "display_order": 1,
+        condition_tags: [],
       },
       {
         standard_permit_condition_id: 458,
@@ -2906,7 +2968,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         condition_type_code: "CON",
         sub_conditions: [],
         "step": "b.",
-        "display_order": 2
+        "display_order": 2,
+        condition_tags: [],
       }
     ],
     "step": "3.",
@@ -2922,6 +2985,7 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
     parent_standard_permit_condition_id: null,
     parent_permit_condition_id: null,
     condition_type_code: "SEC",
+    condition_tags: [],
     sub_conditions: [
       {
         standard_permit_condition_id: 476,
@@ -2935,7 +2999,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         condition_type_code: "CON",
         sub_conditions: [],
         "step": "a.",
-        "display_order": 1
+        "display_order": 1,
+        condition_tags: [],
       },
       {
         standard_permit_condition_id: 477,
@@ -2949,7 +3014,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         condition_type_code: "CON",
         sub_conditions: [],
         "step": "b.",
-        "display_order": 2
+        "display_order": 2,
+        condition_tags: [],
       },
       {
         standard_permit_condition_id: 478,
@@ -2963,7 +3029,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         condition_type_code: "CON",
         sub_conditions: [],
         "step": "c.",
-        "display_order": 3
+        "display_order": 3,
+        condition_tags: [],
       },
       {
         standard_permit_condition_id: 479,
@@ -2977,7 +3044,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         condition_type_code: "CON",
         sub_conditions: [],
         "step": "d.",
-        "display_order": 4
+        "display_order": 4,
+        condition_tags: [],
       },
       {
         standard_permit_condition_id: 480,
@@ -2991,7 +3059,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         condition_type_code: "CON",
         sub_conditions: [],
         "step": "e.",
-        "display_order": 5
+        "display_order": 5,
+        condition_tags: [],
       }
     ],
     "step": "3.",
@@ -3007,6 +3076,7 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
     parent_standard_permit_condition_id: null,
     parent_permit_condition_id: null,
     condition_type_code: "SEC",
+    condition_tags: [],
     sub_conditions: [
       {
         standard_permit_condition_id: 934,
@@ -3020,7 +3090,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         condition_type_code: "CON",
         sub_conditions: [],
         "step": "a.",
-        "display_order": 1
+        "display_order": 1,
+        condition_tags: [],
       },
       {
         standard_permit_condition_id: 437,
@@ -3032,6 +3103,7 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         parent_standard_permit_condition_id: 401,
         parent_permit_condition_id: 401,
         condition_type_code: "CON",
+        condition_tags: [],
         sub_conditions: [
           {
             standard_permit_condition_id: 438,
@@ -3045,7 +3117,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "LIS",
             sub_conditions: [],
             "step": "i.",
-            "display_order": 1
+            "display_order": 1,
+            condition_tags: [],
           },
           {
             standard_permit_condition_id: 563,
@@ -3059,7 +3132,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "LIS",
             sub_conditions: [],
             "step": "ii.",
-            "display_order": 2
+            "display_order": 2,
+            condition_tags: [],
           }
         ],
         "step": "b.",
@@ -3077,7 +3151,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         condition_type_code: "CON",
         sub_conditions: [],
         "step": "c.",
-        "display_order": 3
+        "display_order": 3,
+        condition_tags: [],
       },
       {
         standard_permit_condition_id: 440,
@@ -3091,7 +3166,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         condition_type_code: "CON",
         sub_conditions: [],
         "step": "d.",
-        "display_order": 4
+        "display_order": 4,
+        condition_tags: [],
       }
     ],
     "step": "3.",
@@ -3107,6 +3183,7 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
     parent_standard_permit_condition_id: null,
     parent_permit_condition_id: null,
     condition_type_code: "SEC",
+    condition_tags: [],
     sub_conditions: [
       {
         standard_permit_condition_id: 546,
@@ -3120,7 +3197,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         condition_type_code: "CON",
         sub_conditions: [],
         "step": "a.",
-        "display_order": 1
+        "display_order": 1,
+        condition_tags: [],
       },
       {
         standard_permit_condition_id: 547,
@@ -3132,6 +3210,7 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         parent_standard_permit_condition_id: 417,
         parent_permit_condition_id: 417,
         condition_type_code: "CON",
+        condition_tags: [],
         sub_conditions: [
           {
             standard_permit_condition_id: 905,
@@ -3145,7 +3224,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "LIS",
             sub_conditions: [],
             "step": "i.",
-            "display_order": 1
+            "display_order": 1,
+            condition_tags: [],
           },
           {
             standard_permit_condition_id: 906,
@@ -3159,7 +3239,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "LIS",
             sub_conditions: [],
             "step": "ii.",
-            "display_order": 2
+            "display_order": 2,
+            condition_tags: [],
           },
           {
             standard_permit_condition_id: 907,
@@ -3173,7 +3254,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "LIS",
             sub_conditions: [],
             "step": "iii.",
-            "display_order": 3
+            "display_order": 3,
+            condition_tags: [],
           },
           {
             standard_permit_condition_id: 908,
@@ -3187,7 +3269,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "LIS",
             sub_conditions: [],
             "step": "iv.",
-            "display_order": 4
+            "display_order": 4,
+            condition_tags: [],
           }
         ],
         "step": "b.",
@@ -3203,6 +3286,7 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         parent_standard_permit_condition_id: 417,
         parent_permit_condition_id: 417,
         condition_type_code: "CON",
+        condition_tags: [],
         sub_conditions: [
           {
             standard_permit_condition_id: 552,
@@ -3216,7 +3300,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "LIS",
             sub_conditions: [],
             "step": "i.",
-            "display_order": 1
+            "display_order": 1,
+            condition_tags: [],
           },
           {
             standard_permit_condition_id: 553,
@@ -3228,6 +3313,7 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             parent_standard_permit_condition_id: 551,
             parent_permit_condition_id: 551,
             condition_type_code: "LIS",
+            condition_tags: [],
             sub_conditions: [
               {
                 standard_permit_condition_id: 554,
@@ -3241,7 +3327,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
                 condition_type_code: "LIS",
                 sub_conditions: [],
                 "step": "1.",
-                "display_order": 1
+                "display_order": 1,
+                condition_tags: [],
               },
               {
                 standard_permit_condition_id: 555,
@@ -3255,7 +3342,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
                 condition_type_code: "LIS",
                 sub_conditions: [],
                 "step": "2.",
-                "display_order": 2
+                "display_order": 2,
+                condition_tags: [],
               },
               {
                 standard_permit_condition_id: 556,
@@ -3269,7 +3357,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
                 condition_type_code: "LIS",
                 sub_conditions: [],
                 "step": "3.",
-                "display_order": 3
+                "display_order": 3,
+                condition_tags: [],
               },
               {
                 standard_permit_condition_id: 557,
@@ -3283,7 +3372,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
                 condition_type_code: "LIS",
                 sub_conditions: [],
                 "step": "4.",
-                "display_order": 4
+                "display_order": 4,
+                condition_tags: [],
               },
               {
                 standard_permit_condition_id: 558,
@@ -3297,7 +3387,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
                 condition_type_code: "LIS",
                 sub_conditions: [],
                 "step": "5.",
-                "display_order": 5
+                "display_order": 5,
+                condition_tags: [],
               }
             ],
             "step": "ii.",
@@ -3317,6 +3408,7 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         parent_standard_permit_condition_id: 417,
         parent_permit_condition_id: 417,
         condition_type_code: "CON",
+        condition_tags: [],
         sub_conditions: [
           {
             standard_permit_condition_id: 910,
@@ -3330,7 +3422,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "LIS",
             sub_conditions: [],
             "step": "i.",
-            "display_order": 1
+            "display_order": 1,
+            condition_tags: [],
           },
           {
             standard_permit_condition_id: 911,
@@ -3344,7 +3437,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "LIS",
             sub_conditions: [],
             "step": "ii.",
-            "display_order": 2
+            "display_order": 2,
+            condition_tags: [],
           },
           {
             standard_permit_condition_id: 912,
@@ -3358,7 +3452,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "LIS",
             sub_conditions: [],
             "step": "iii.",
-            "display_order": 3
+            "display_order": 3,
+            condition_tags: [],
           }
         ],
         "step": "d.",
@@ -3378,6 +3473,7 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
     parent_standard_permit_condition_id: null,
     parent_permit_condition_id: null,
     condition_type_code: "SEC",
+    condition_tags: [],
     sub_conditions: [
       {
         standard_permit_condition_id: 565,
@@ -3391,7 +3487,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         condition_type_code: "CON",
         sub_conditions: [],
         "step": "a.",
-        "display_order": 1
+        "display_order": 1,
+        condition_tags: [],
       },
       {
         standard_permit_condition_id: 566,
@@ -3405,7 +3502,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         condition_type_code: "CON",
         sub_conditions: [],
         "step": "b.",
-        "display_order": 2
+        "display_order": 2,
+        condition_tags: [],
       },
       {
         standard_permit_condition_id: 567,
@@ -3419,7 +3517,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         condition_type_code: "CON",
         sub_conditions: [],
         "step": "c.",
-        "display_order": 3
+        "display_order": 3,
+        condition_tags: [],
       },
       {
         standard_permit_condition_id: 568,
@@ -3433,7 +3532,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         condition_type_code: "CON",
         sub_conditions: [],
         "step": "d.",
-        "display_order": 4
+        "display_order": 4,
+        condition_tags: [],
       },
       {
         standard_permit_condition_id: 569,
@@ -3447,7 +3547,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         condition_type_code: "CON",
         sub_conditions: [],
         "step": "e.",
-        "display_order": 5
+        "display_order": 5,
+        condition_tags: [],
       },
       {
         standard_permit_condition_id: 570,
@@ -3461,7 +3562,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         condition_type_code: "CON",
         sub_conditions: [],
         "step": "f.",
-        "display_order": 6
+        "display_order": 6,
+        condition_tags: [],
       },
       {
         standard_permit_condition_id: 571,
@@ -3475,7 +3577,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         condition_type_code: "CON",
         sub_conditions: [],
         "step": "g.",
-        "display_order": 7
+        "display_order": 7,
+        condition_tags: [],
       },
       {
         standard_permit_condition_id: 572,
@@ -3489,7 +3592,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         condition_type_code: "CON",
         sub_conditions: [],
         "step": "h.",
-        "display_order": 8
+        "display_order": 8,
+        condition_tags: [],
       },
       {
         standard_permit_condition_id: 573,
@@ -3503,7 +3607,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         condition_type_code: "CON",
         sub_conditions: [],
         "step": "i.",
-        "display_order": 9
+        "display_order": 9,
+        condition_tags: [],
       },
       {
         standard_permit_condition_id: 574,
@@ -3517,7 +3622,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         condition_type_code: "CON",
         sub_conditions: [],
         "step": "j.",
-        "display_order": 10
+        "display_order": 10,
+        condition_tags: [],
       },
       {
         standard_permit_condition_id: 575,
@@ -3531,7 +3637,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         condition_type_code: "CON",
         sub_conditions: [],
         "step": "k.",
-        "display_order": 11
+        "display_order": 11,
+        condition_tags: [],
       },
       {
         standard_permit_condition_id: 576,
@@ -3543,6 +3650,7 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         parent_standard_permit_condition_id: 564,
         parent_permit_condition_id: 564,
         condition_type_code: "CON",
+        condition_tags: [],
         sub_conditions: [
           {
             standard_permit_condition_id: 577,
@@ -3556,7 +3664,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "LIS",
             sub_conditions: [],
             "step": "i.",
-            "display_order": 1
+            "display_order": 1,
+            condition_tags: [],
           },
           {
             standard_permit_condition_id: 578,
@@ -3570,7 +3679,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "LIS",
             sub_conditions: [],
             "step": "ii.",
-            "display_order": 2
+            "display_order": 2,
+            condition_tags: [],
           },
           {
             standard_permit_condition_id: 579,
@@ -3584,7 +3694,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "LIS",
             sub_conditions: [],
             "step": "iii.",
-            "display_order": 3
+            "display_order": 3,
+            condition_tags: [],
           },
           {
             standard_permit_condition_id: 580,
@@ -3598,7 +3709,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "LIS",
             sub_conditions: [],
             "step": "iv.",
-            "display_order": 4
+            "display_order": 4,
+            condition_tags: [],
           },
           {
             standard_permit_condition_id: 581,
@@ -3612,7 +3724,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "LIS",
             sub_conditions: [],
             "step": "v.",
-            "display_order": 5
+            "display_order": 5,
+            condition_tags: [],
           },
           {
             standard_permit_condition_id: 582,
@@ -3626,7 +3739,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "LIS",
             sub_conditions: [],
             "step": "vi.",
-            "display_order": 6
+            "display_order": 6,
+            condition_tags: [],
           }
         ],
         "step": "l.",
@@ -3646,6 +3760,7 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
     parent_standard_permit_condition_id: null,
     parent_permit_condition_id: null,
     condition_type_code: "SEC",
+    condition_tags: [],
     sub_conditions: [
       {
         standard_permit_condition_id: 559,
@@ -3657,6 +3772,7 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         parent_standard_permit_condition_id: 418,
         parent_permit_condition_id: 418,
         condition_type_code: "CON",
+        condition_tags: [],
         sub_conditions: [
           {
             standard_permit_condition_id: 560,
@@ -3670,7 +3786,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "LIS",
             sub_conditions: [],
             "step": "i.",
-            "display_order": 1
+            "display_order": 1,
+            condition_tags: [],
           },
           {
             standard_permit_condition_id: 561,
@@ -3684,7 +3801,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "LIS",
             sub_conditions: [],
             "step": "ii.",
-            "display_order": 2
+            "display_order": 2,
+            condition_tags: [],
           }
         ],
         "step": "a.",
@@ -3704,6 +3822,7 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
     parent_standard_permit_condition_id: null,
     parent_permit_condition_id: null,
     condition_type_code: "SEC",
+    condition_tags: [],
     sub_conditions: [
       {
         standard_permit_condition_id: 441,
@@ -3717,7 +3836,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         condition_type_code: "CON",
         sub_conditions: [],
         "step": "a.",
-        "display_order": 1
+        "display_order": 1,
+        condition_tags: [],
       }
     ],
     "step": "4.",
@@ -3733,6 +3853,7 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
     parent_standard_permit_condition_id: null,
     parent_permit_condition_id: null,
     condition_type_code: "SEC",
+    condition_tags: [],
     sub_conditions: [
       {
         standard_permit_condition_id: 482,
@@ -3744,6 +3865,7 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         parent_standard_permit_condition_id: 413,
         parent_permit_condition_id: 413,
         condition_type_code: "SEC",
+        condition_tags: [],
         sub_conditions: [
           {
             standard_permit_condition_id: 483,
@@ -3757,7 +3879,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "CON",
             sub_conditions: [],
             "step": "i.",
-            "display_order": 1
+            "display_order": 1,
+            condition_tags: [],
           },
           {
             standard_permit_condition_id: 484,
@@ -3769,6 +3892,7 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             parent_standard_permit_condition_id: 482,
             parent_permit_condition_id: 482,
             condition_type_code: "CON",
+            condition_tags: [],
             sub_conditions: [
               {
                 standard_permit_condition_id: 485,
@@ -3782,7 +3906,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
                 condition_type_code: "LIS",
                 sub_conditions: [],
                 "step": "1.",
-                "display_order": 1
+                "display_order": 1,
+                condition_tags: [],
               },
               {
                 standard_permit_condition_id: 486,
@@ -3796,7 +3921,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
                 condition_type_code: "LIS",
                 sub_conditions: [],
                 "step": "2.",
-                "display_order": 2
+                "display_order": 2,
+                condition_tags: [],
               },
               {
                 standard_permit_condition_id: 487,
@@ -3810,7 +3936,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
                 condition_type_code: "LIS",
                 sub_conditions: [],
                 "step": "3.",
-                "display_order": 3
+                "display_order": 3,
+                condition_tags: [],
               },
               {
                 standard_permit_condition_id: 488,
@@ -3824,7 +3951,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
                 condition_type_code: "LIS",
                 sub_conditions: [],
                 "step": "4.",
-                "display_order": 4
+                "display_order": 4,
+                condition_tags: [],
               },
               {
                 standard_permit_condition_id: 489,
@@ -3838,7 +3966,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
                 condition_type_code: "LIS",
                 sub_conditions: [],
                 "step": "5.",
-                "display_order": 5
+                "display_order": 5,
+                condition_tags: [],
               }
             ],
             "step": "ii.",
@@ -3858,6 +3987,7 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         parent_standard_permit_condition_id: 413,
         parent_permit_condition_id: 413,
         condition_type_code: "SEC",
+        condition_tags: [],
         sub_conditions: [
           {
             standard_permit_condition_id: 491,
@@ -3871,7 +4001,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "CON",
             sub_conditions: [],
             "step": "i.",
-            "display_order": 1
+            "display_order": 1,
+            condition_tags: [],
           },
           {
             standard_permit_condition_id: 492,
@@ -3885,7 +4016,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "CON",
             sub_conditions: [],
             "step": "ii.",
-            "display_order": 2
+            "display_order": 2,
+            condition_tags: [],
           },
           {
             standard_permit_condition_id: 493,
@@ -3899,7 +4031,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "CON",
             sub_conditions: [],
             "step": "iii.",
-            "display_order": 3
+            "display_order": 3,
+            condition_tags: [],
           },
           {
             standard_permit_condition_id: 494,
@@ -3913,7 +4046,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "CON",
             sub_conditions: [],
             "step": "iv.",
-            "display_order": 4
+            "display_order": 4,
+            condition_tags: [],
           },
           {
             standard_permit_condition_id: 495,
@@ -3927,7 +4061,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "CON",
             sub_conditions: [],
             "step": "v.",
-            "display_order": 5
+            "display_order": 5,
+            condition_tags: [],
           },
           {
             standard_permit_condition_id: 496,
@@ -3941,7 +4076,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "CON",
             sub_conditions: [],
             "step": "vi.",
-            "display_order": 6
+            "display_order": 6,
+            condition_tags: [],
           },
           {
             standard_permit_condition_id: 497,
@@ -3955,7 +4091,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "CON",
             sub_conditions: [],
             "step": "vii.",
-            "display_order": 7
+            "display_order": 7,
+            condition_tags: [],
           },
           {
             standard_permit_condition_id: 498,
@@ -3969,7 +4106,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "CON",
             sub_conditions: [],
             "step": "viii.",
-            "display_order": 8
+            "display_order": 8,
+            condition_tags: [],
           },
           {
             standard_permit_condition_id: 500,
@@ -3983,7 +4121,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "CON",
             sub_conditions: [],
             "step": "x.",
-            "display_order": 10
+            "display_order": 10,
+            condition_tags: [],
           },
           {
             standard_permit_condition_id: 501,
@@ -3997,7 +4136,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "CON",
             sub_conditions: [],
             "step": "xi.",
-            "display_order": 11
+            "display_order": 11,
+            condition_tags: [],
           }
         ],
         "step": "b.",
@@ -4013,6 +4153,7 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         parent_standard_permit_condition_id: 413,
         parent_permit_condition_id: 413,
         condition_type_code: "SEC",
+        condition_tags: [],
         sub_conditions: [
           {
             standard_permit_condition_id: 503,
@@ -4026,7 +4167,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "CON",
             sub_conditions: [],
             "step": "i.",
-            "display_order": 1
+            "display_order": 1,
+            condition_tags: [],
           },
           {
             standard_permit_condition_id: 504,
@@ -4040,7 +4182,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "CON",
             sub_conditions: [],
             "step": "ii.",
-            "display_order": 2
+            "display_order": 2,
+            condition_tags: [],
           },
           {
             standard_permit_condition_id: 505,
@@ -4054,7 +4197,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "CON",
             sub_conditions: [],
             "step": "iii.",
-            "display_order": 3
+            "display_order": 3,
+            condition_tags: [],
           },
           {
             standard_permit_condition_id: 506,
@@ -4068,7 +4212,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "CON",
             sub_conditions: [],
             "step": "iv.",
-            "display_order": 4
+            "display_order": 4,
+            condition_tags: [],
           },
           {
             standard_permit_condition_id: 507,
@@ -4082,7 +4227,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "CON",
             sub_conditions: [],
             "step": "v.",
-            "display_order": 5
+            "display_order": 5,
+            condition_tags: [],
           },
           {
             standard_permit_condition_id: 508,
@@ -4096,7 +4242,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "CON",
             sub_conditions: [],
             "step": "vi.",
-            "display_order": 6
+            "display_order": 6,
+            condition_tags: [],
           },
           {
             standard_permit_condition_id: 509,
@@ -4110,7 +4257,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "CON",
             sub_conditions: [],
             "step": "vii.",
-            "display_order": 7
+            "display_order": 7,
+            condition_tags: [],
           }
         ],
         "step": "c.",
@@ -4126,6 +4274,7 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         parent_standard_permit_condition_id: 413,
         parent_permit_condition_id: 413,
         condition_type_code: "SEC",
+        condition_tags: [],
         sub_conditions: [
           {
             standard_permit_condition_id: 511,
@@ -4139,7 +4288,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "CON",
             sub_conditions: [],
             "step": "i.",
-            "display_order": 1
+            "display_order": 1,
+            condition_tags: [],
           },
           {
             standard_permit_condition_id: 512,
@@ -4153,7 +4303,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "CON",
             sub_conditions: [],
             "step": "ii.",
-            "display_order": 2
+            "display_order": 2,
+            condition_tags: [],
           },
           {
             standard_permit_condition_id: 513,
@@ -4167,7 +4318,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "CON",
             sub_conditions: [],
             "step": "iii.",
-            "display_order": 3
+            "display_order": 3,
+            condition_tags: [],
           },
           {
             standard_permit_condition_id: 514,
@@ -4181,7 +4333,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "CON",
             sub_conditions: [],
             "step": "iv.",
-            "display_order": 4
+            "display_order": 4,
+            condition_tags: [],
           },
           {
             standard_permit_condition_id: 515,
@@ -4195,7 +4348,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "CON",
             sub_conditions: [],
             "step": "v.",
-            "display_order": 5
+            "display_order": 5,
+            condition_tags: [],
           },
           {
             standard_permit_condition_id: 516,
@@ -4209,7 +4363,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "CON",
             sub_conditions: [],
             "step": "vi.",
-            "display_order": 6
+            "display_order": 6,
+            condition_tags: [],
           },
           {
             standard_permit_condition_id: 517,
@@ -4223,7 +4378,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "CON",
             sub_conditions: [],
             "step": "vii.",
-            "display_order": 7
+            "display_order": 7,
+            condition_tags: [],
           }
         ],
         "step": "d.",
@@ -4239,6 +4395,7 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         parent_standard_permit_condition_id: 413,
         parent_permit_condition_id: 413,
         condition_type_code: "SEC",
+        condition_tags: [],
         sub_conditions: [
           {
             standard_permit_condition_id: 519,
@@ -4252,7 +4409,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "CON",
             sub_conditions: [],
             "step": "i.",
-            "display_order": 1
+            "display_order": 1,
+            condition_tags: [],
           }
         ],
         "step": "e.",
@@ -4268,6 +4426,7 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         parent_standard_permit_condition_id: 413,
         parent_permit_condition_id: 413,
         condition_type_code: "SEC",
+        condition_tags: [],
         sub_conditions: [
           {
             standard_permit_condition_id: 521,
@@ -4281,7 +4440,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "CON",
             sub_conditions: [],
             "step": "i.",
-            "display_order": 1
+            "display_order": 1,
+            condition_tags: [],
           },
           {
             standard_permit_condition_id: 522,
@@ -4295,7 +4455,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "CON",
             sub_conditions: [],
             "step": "ii.",
-            "display_order": 2
+            "display_order": 2,
+            condition_tags: [],
           },
           {
             standard_permit_condition_id: 523,
@@ -4309,7 +4470,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "CON",
             sub_conditions: [],
             "step": "iii.",
-            "display_order": 3
+            "display_order": 3,
+            condition_tags: [],
           }
         ],
         "step": "f.",
@@ -4325,6 +4487,7 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         parent_standard_permit_condition_id: 413,
         parent_permit_condition_id: 413,
         condition_type_code: "SEC",
+        condition_tags: [],
         sub_conditions: [
           {
             standard_permit_condition_id: 525,
@@ -4338,7 +4501,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "CON",
             sub_conditions: [],
             "step": "i.",
-            "display_order": 1
+            "display_order": 1,
+            condition_tags: [],
           },
           {
             standard_permit_condition_id: 526,
@@ -4352,7 +4516,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "CON",
             sub_conditions: [],
             "step": "ii.",
-            "display_order": 2
+            "display_order": 2,
+            condition_tags: [],
           },
           {
             standard_permit_condition_id: 527,
@@ -4366,7 +4531,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "CON",
             sub_conditions: [],
             "step": "iii.",
-            "display_order": 3
+            "display_order": 3,
+            condition_tags: [],
           }
         ],
         "step": "g.",
@@ -4382,6 +4548,7 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         parent_standard_permit_condition_id: 413,
         parent_permit_condition_id: 413,
         condition_type_code: "SEC",
+        condition_tags: [],
         sub_conditions: [
           {
             standard_permit_condition_id: 529,
@@ -4395,7 +4562,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "CON",
             sub_conditions: [],
             "step": "i.",
-            "display_order": 1
+            "display_order": 1,
+            condition_tags: [],
           },
           {
             standard_permit_condition_id: 530,
@@ -4409,7 +4577,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "CON",
             sub_conditions: [],
             "step": "ii.",
-            "display_order": 2
+            "display_order": 2,
+            condition_tags: [],
           },
           {
             standard_permit_condition_id: 531,
@@ -4423,7 +4592,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "CON",
             sub_conditions: [],
             "step": "iii.",
-            "display_order": 3
+            "display_order": 3,
+            condition_tags: [],
           },
           {
             standard_permit_condition_id: 532,
@@ -4437,7 +4607,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "CON",
             sub_conditions: [],
             "step": "iv.",
-            "display_order": 4
+            "display_order": 4,
+            condition_tags: [],
           },
           {
             standard_permit_condition_id: 533,
@@ -4451,7 +4622,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "CON",
             sub_conditions: [],
             "step": "v.",
-            "display_order": 5
+            "display_order": 5,
+            condition_tags: [],
           },
           {
             standard_permit_condition_id: 534,
@@ -4465,7 +4637,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "CON",
             sub_conditions: [],
             "step": "vi.",
-            "display_order": 6
+            "display_order": 6,
+            condition_tags: [],
           }
         ],
         "step": "h.",
@@ -4481,6 +4654,7 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         parent_standard_permit_condition_id: 413,
         parent_permit_condition_id: 413,
         condition_type_code: "SEC",
+        condition_tags: [],
         sub_conditions: [
           {
             standard_permit_condition_id: 894,
@@ -4494,7 +4668,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "CON",
             sub_conditions: [],
             "step": "i.",
-            "display_order": 1
+            "display_order": 1,
+            condition_tags: [],
           },
           {
             standard_permit_condition_id: 895,
@@ -4508,7 +4683,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "CON",
             sub_conditions: [],
             "step": "ii.",
-            "display_order": 2
+            "display_order": 2,
+            condition_tags: [],
           },
           {
             standard_permit_condition_id: 896,
@@ -4522,7 +4698,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "CON",
             sub_conditions: [],
             "step": "iii.",
-            "display_order": 3
+            "display_order": 3,
+            condition_tags: [],
           },
           {
             standard_permit_condition_id: 897,
@@ -4534,6 +4711,7 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             parent_standard_permit_condition_id: 893,
             parent_permit_condition_id: 893,
             condition_type_code: "CON",
+            condition_tags: [],
             sub_conditions: [
               {
                 standard_permit_condition_id: 898,
@@ -4547,7 +4725,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
                 condition_type_code: "LIS",
                 sub_conditions: [],
                 "step": "1.",
-                "display_order": 1
+                "display_order": 1,
+                condition_tags: [],
               },
               {
                 standard_permit_condition_id: 899,
@@ -4561,7 +4740,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
                 condition_type_code: "LIS",
                 sub_conditions: [],
                 "step": "2.",
-                "display_order": 2
+                "display_order": 2,
+                condition_tags: [],
               }
             ],
             "step": "iv.",
@@ -4579,7 +4759,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "CON",
             sub_conditions: [],
             "step": "v.",
-            "display_order": 5
+            "display_order": 5,
+            condition_tags: [],
           },
           {
             standard_permit_condition_id: 901,
@@ -4593,7 +4774,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "CON",
             sub_conditions: [],
             "step": "vi.",
-            "display_order": 6
+            "display_order": 6,
+            condition_tags: [],
           },
           {
             standard_permit_condition_id: 902,
@@ -4607,7 +4789,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "CON",
             sub_conditions: [],
             "step": "vii.",
-            "display_order": 7
+            "display_order": 7,
+            condition_tags: [],
           },
           {
             standard_permit_condition_id: 903,
@@ -4621,7 +4804,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "CON",
             sub_conditions: [],
             "step": "viii.",
-            "display_order": 8
+            "display_order": 8,
+            condition_tags: [],
           },
           {
             standard_permit_condition_id: 904,
@@ -4635,7 +4819,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "CON",
             sub_conditions: [],
             "step": "ix.",
-            "display_order": 9
+            "display_order": 9,
+            condition_tags: [],
           }
         ],
         "step": "i.",
@@ -4657,7 +4842,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
     condition_type_code: "SEC",
     sub_conditions: [],
     "step": "4.",
-    "display_order": 4
+    "display_order": 4,
+    condition_tags: [],
   },
   {
     standard_permit_condition_id: 414,
@@ -4669,6 +4855,7 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
     parent_standard_permit_condition_id: null,
     parent_permit_condition_id: null,
     condition_type_code: "SEC",
+    condition_tags: [],
     sub_conditions: [
       {
         standard_permit_condition_id: 535,
@@ -4682,7 +4869,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         condition_type_code: "CON",
         sub_conditions: [],
         "step": "a.",
-        "display_order": 1
+        "display_order": 1,
+        condition_tags: [],
       },
       {
         standard_permit_condition_id: 536,
@@ -4696,7 +4884,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         condition_type_code: "CON",
         sub_conditions: [],
         "step": "b.",
-        "display_order": 2
+        "display_order": 2,
+        condition_tags: [],
       },
       {
         standard_permit_condition_id: 537,
@@ -4710,7 +4899,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         condition_type_code: "CON",
         sub_conditions: [],
         "step": "c.",
-        "display_order": 3
+        "display_order": 3,
+        condition_tags: [],
       },
       {
         standard_permit_condition_id: 538,
@@ -4724,7 +4914,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         condition_type_code: "CON",
         sub_conditions: [],
         "step": "d.",
-        "display_order": 4
+        "display_order": 4,
+        condition_tags: [],
       },
       {
         standard_permit_condition_id: 539,
@@ -4738,7 +4929,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         condition_type_code: "CON",
         sub_conditions: [],
         "step": "e.",
-        "display_order": 5
+        "display_order": 5,
+        condition_tags: [],
       }
     ],
     "step": "5.",
@@ -4754,6 +4946,7 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
     parent_standard_permit_condition_id: null,
     parent_permit_condition_id: null,
     condition_type_code: "SEC",
+    condition_tags: [],
     sub_conditions: [
       {
         standard_permit_condition_id: 814,
@@ -4765,6 +4958,7 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         parent_standard_permit_condition_id: 802,
         parent_permit_condition_id: 802,
         condition_type_code: "SEC",
+        condition_tags: [],
         sub_conditions: [
           {
             standard_permit_condition_id: 838,
@@ -4778,7 +4972,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "CON",
             sub_conditions: [],
             "step": "i.",
-            "display_order": 1
+            "display_order": 1,
+            condition_tags: [],
           }
         ],
         "step": "a.",
@@ -4794,6 +4989,7 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         parent_standard_permit_condition_id: 802,
         parent_permit_condition_id: 802,
         condition_type_code: "SEC",
+        condition_tags: [],
         sub_conditions: [
           {
             standard_permit_condition_id: 842,
@@ -4807,7 +5003,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "CON",
             sub_conditions: [],
             "step": "i.",
-            "display_order": 1
+            "display_order": 1,
+            condition_tags: [],
           }
         ],
         "step": "b.",
@@ -4827,6 +5024,7 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
     parent_standard_permit_condition_id: null,
     parent_permit_condition_id: null,
     condition_type_code: "SEC",
+    condition_tags: [],
     sub_conditions: [
       {
         standard_permit_condition_id: 830,
@@ -4838,6 +5036,7 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         parent_standard_permit_condition_id: 810,
         parent_permit_condition_id: 810,
         condition_type_code: "SEC",
+        condition_tags: [],
         sub_conditions: [
           {
             standard_permit_condition_id: 854,
@@ -4851,7 +5050,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "CON",
             sub_conditions: [],
             "step": "i.",
-            "display_order": 1
+            "display_order": 1,
+            condition_tags: [],
           }
         ],
         "step": "a.",
@@ -4867,6 +5067,7 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         parent_standard_permit_condition_id: 810,
         parent_permit_condition_id: 810,
         condition_type_code: "SEC",
+        condition_tags: [],
         sub_conditions: [
           {
             standard_permit_condition_id: 858,
@@ -4880,7 +5081,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "CON",
             sub_conditions: [],
             "step": "i.",
-            "display_order": 1
+            "display_order": 1,
+            condition_tags: [],
           }
         ],
         "step": "b.",
@@ -4900,6 +5102,7 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
     parent_standard_permit_condition_id: null,
     parent_permit_condition_id: null,
     condition_type_code: "SEC",
+    condition_tags: [],
     sub_conditions: [
       {
         standard_permit_condition_id: 822,
@@ -4911,6 +5114,7 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         parent_standard_permit_condition_id: 806,
         parent_permit_condition_id: 806,
         condition_type_code: "SEC",
+        condition_tags: [],
         sub_conditions: [
           {
             standard_permit_condition_id: 846,
@@ -4924,7 +5128,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "CON",
             sub_conditions: [],
             "step": "i.",
-            "display_order": 1
+            "display_order": 1,
+            condition_tags: [],
           }
         ],
         "step": "a.",
@@ -4940,6 +5145,7 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
         parent_standard_permit_condition_id: 806,
         parent_permit_condition_id: 806,
         condition_type_code: "SEC",
+        condition_tags: [],
         sub_conditions: [
           {
             standard_permit_condition_id: 850,
@@ -4953,7 +5159,8 @@ export const STANDARD_PERMIT_CONDITIONS: IStandardPermitCondition[] = [
             condition_type_code: "CON",
             sub_conditions: [],
             "step": "i.",
-            "display_order": 1
+            "display_order": 1,
+            condition_tags: [],
           }
         ],
         "step": "b.",

--- a/services/core-api/app/api/mines/namespace.py
+++ b/services/core-api/app/api/mines/namespace.py
@@ -151,7 +151,10 @@ from app.api.mines.reports.resources.mine_report_due_date_type_resource import (
     MineReportDueDateTypeResource,
 )
 from app.api.mines.reports.resources.mine_report_permit_requirement import (
-    MineReportPermitRequirementResource,
+    MineReportPermitRequirementResource
+)
+from app.api.mines.permits.permit_conditions.resources.standard_report_permit_requirement_resource import (
+    StandardReportPermitRequirementResource
 )
 from app.api.mines.reports.resources.mine_report_submission_resource import (
     ReportSubmissionResource,
@@ -280,6 +283,8 @@ api.add_resource(
     '/<string:mine_guid>/reports/documents',
 )
 api.add_resource(MineReportPermitRequirementResource, '/<string:mine_guid>/reports/permit-requirements')
+api.add_resource(StandardReportPermitRequirementResource, '/reports/standard-permit-requirements')
+
 api.add_resource(MineReportDueDateTypeResource, '/reports/due-date-types')
 
 api.add_resource(PermitResource, '/<string:mine_guid>/permits/<string:permit_guid>')

--- a/services/core-api/app/api/mines/permits/permit/resources/permit.py
+++ b/services/core-api/app/api/mines/permits/permit/resources/permit.py
@@ -229,11 +229,7 @@ class PermitListResource(Resource, UserMixin):
 
                 standard_conditions = StandardPermitConditions.find_by_notice_of_work_type_code(
                     now_type)
-                for condition in standard_conditions:
-                    PermitConditions.create(condition.condition_category_code,
-                                            condition.condition_type_code,
-                                            amendment.permit_amendment_id, condition.condition,
-                                            condition.display_order, condition.sub_conditions)
+                PermitConditions.copy_from_standard(standard_conditions, amendment.permit_amendment_id)
                 db.session.commit()
 
         for newFile in uploadedFiles:

--- a/services/core-api/app/api/mines/permits/permit_amendment/resources/permit_amendment.py
+++ b/services/core-api/app/api/mines/permits/permit_amendment/resources/permit_amendment.py
@@ -214,11 +214,8 @@ class PermitAmendmentListResource(Resource, UserMixin):
                 now_type = application_identity.now_application.notice_of_work_type_code
                 standard_conditions = StandardPermitConditions.find_by_notice_of_work_type_code(
                     now_type)
-                for condition in standard_conditions:
-                    PermitConditions.create(condition.condition_category_code,
-                                            condition.condition_type_code,
-                                            new_pa.permit_amendment_id, condition.condition,
-                                            condition.display_order, condition.sub_conditions)
+
+                PermitConditions.copy_from_standard(standard_conditions, new_pa.permit_amendment_id)
 
             if application_identity.now_application:
                 if populate_with_conditions:

--- a/services/core-api/app/api/mines/permits/permit_conditions/models/permit_condition_tag_xref.py
+++ b/services/core-api/app/api/mines/permits/permit_conditions/models/permit_condition_tag_xref.py
@@ -27,5 +27,5 @@ class PermitConditionTagXref(SoftDeleteMixin, AuditMixin, Base):
         ).first()
 
     @classmethod
-    def deleteAllByGuid(cls, permit_condition_tag_guid):
+    def delete_all_by_guid(cls, permit_condition_tag_guid):
         return PermitConditionTagXref.query.filter_by(permit_condition_tag_guid=uuid.UUID(permit_condition_tag_guid)).delete()

--- a/services/core-api/app/api/mines/permits/permit_conditions/models/permit_conditions.py
+++ b/services/core-api/app/api/mines/permits/permit_conditions/models/permit_conditions.py
@@ -1,11 +1,10 @@
-from typing import Optional
+from typing import Optional, List
 
 from app.api.utils.field_template import FieldTemplate
 from app.api.utils.list_lettering_helpers import num_to_letter, num_to_roman
 from app.api.utils.models_mixins import AuditMixin, Base, SoftDeleteMixin
-from app.api.mines.reports.models.mine_report_req_permit_condition_xref import MineReportReqPermitConditionXref
-from app.api.mines.reports.models.mine_report_permit_requirement import MineReportPermitRequirement
-from app.api.mines.permits.permit_conditions.models.permit_condition_tag import PermitConditionTag
+from app.api.mines.permits.permit_conditions.models.permit_condition_tag_xref import PermitConditionTagXref
+from app.api.mines.permits.permit_conditions.models.standard_permit_conditions import StandardPermitConditions
 from app.extensions import db
 from marshmallow import fields
 from sqlalchemy.dialects.postgresql import JSONB, UUID
@@ -169,6 +168,92 @@ class PermitConditions(SoftDeleteMixin, AuditMixin, Base):
             self.permit_condition_guid,
             self.display_order,
         )
+    
+    def update_condition_tags(self, new_tags):
+        old_tags = self.condition_tags
+        if old_tags != new_tags:
+
+            # Remove tags
+            for tag in old_tags:
+                if tag not in new_tags:
+                    xref = PermitConditionTagXref.find_by_guid_and_condition_id(tag, self.permit_condition_id)
+                    if xref:
+                        xref.delete(True)
+                    
+            # Add new tags
+            for tag in new_tags:
+                if tag not in old_tags:
+                    #Check if xref already exists
+                    deleted_xref = PermitConditionTagXref.find_by_guid_and_condition_id(tag, self.permit_condition_id)
+
+                    if(deleted_xref):
+                        deleted_xref.deleted_ind = False
+                        deleted_xref.save()
+                    else:
+                        xref = PermitConditionTagXref(
+                            permit_condition_tag_guid=tag,
+                            permit_condition_id=self.permit_condition_id
+                        )
+                        xref.save()
+
+    @classmethod
+    def _copy_from_standard_recursive(cls, standard_condition: StandardPermitConditions, permit_amendment_id, parent_condition=None):
+        from app.api.mines.reports.models.mine_report_req_permit_condition_xref import MineReportReqPermitConditionXref, StandardReportReqPermitConditionXref
+        from app.api.mines.reports.models.mine_report_permit_requirement import (
+            MineReportPermitRequirement
+        )
+        permit_condition = cls(
+            condition_category_code=standard_condition.condition_category_code,
+            condition_type_code=standard_condition.condition_type_code,
+            permit_amendment_id=permit_amendment_id,
+            condition=standard_condition.condition,
+            display_order=standard_condition.display_order,
+            parent=parent_condition,
+        )
+
+        permit_condition.save(commit=False)
+        permit_condition.update_condition_tags(standard_condition.condition_tags)
+        # and the xrefs here
+        xref = StandardReportReqPermitConditionXref.find_by_permit_condition_id(standard_condition.standard_permit_condition_id)
+        if xref is not None:
+            report_name = xref.mine_report_permit_requirement.report_name
+            report_requirement = MineReportPermitRequirement.find_by_report_name(report_name, permit_amendment_id)
+            mrpr = MineReportReqPermitConditionXref.create(
+                mine_report_permit_requirement=report_requirement,
+                permit_condition_id=permit_condition.permit_condition_id
+            )
+            mrpr.save(commit=True)
+
+
+        for condition in standard_condition.sub_conditions:
+            PermitConditions._copy_from_standard_recursive(condition, permit_amendment_id, permit_condition)
+    
+    @classmethod
+    def copy_from_standard(cls, standard_conditions: List[StandardPermitConditions], permit_amendment_id):
+        # the import is in the functions because otherwise it creates a circular reference
+        from app.api.mines.reports.models.mine_report_permit_requirement import (
+            StandardReportPermitRequirement, MineReportPermitRequirement
+        )
+        from app.api.mines.reports.models.mine_report_req_permit_condition_xref import MineReportReqPermitConditionXref, StandardReportReqPermitConditionXref
+
+        standard_condition_ids = []
+        for condition in standard_conditions:
+            standard_condition_ids.extend(condition.get_all_sub_condition_ids())
+
+        report_requirements = StandardReportPermitRequirement.find_by_many_condition_ids(standard_condition_ids)
+
+        for requirement in report_requirements:
+            mrpr = MineReportPermitRequirement(
+                report_name=requirement.report_name,
+                due_date_period_months=requirement.due_date_period_months,
+                cim_or_cpo=requirement.cim_or_cpo,
+                ministry_recipient=requirement.ministry_recipient,
+                permit_amendment_id=permit_amendment_id
+            )
+            mrpr.save(commit=True)
+        
+        for condition in standard_conditions:
+            PermitConditions._copy_from_standard_recursive(condition, permit_amendment_id)
 
     @classmethod
     def create(

--- a/services/core-api/app/api/mines/permits/permit_conditions/models/permit_conditions.py
+++ b/services/core-api/app/api/mines/permits/permit_conditions/models/permit_conditions.py
@@ -171,30 +171,26 @@ class PermitConditions(SoftDeleteMixin, AuditMixin, Base):
     
     def update_condition_tags(self, new_tags):
         old_tags = self.condition_tags
-        if old_tags != new_tags:
+        tags_to_remove = [tag for tag in old_tags if tag not in new_tags]
+        tags_to_add = [tag for tag in new_tags if tag not in old_tags]
 
-            # Remove tags
-            for tag in old_tags:
-                if tag not in new_tags:
-                    xref = PermitConditionTagXref.find_by_guid_and_condition_id(tag, self.permit_condition_id)
-                    if xref:
-                        xref.delete(True)
-                    
-            # Add new tags
-            for tag in new_tags:
-                if tag not in old_tags:
-                    #Check if xref already exists
-                    deleted_xref = PermitConditionTagXref.find_by_guid_and_condition_id(tag, self.permit_condition_id)
+        for t in tags_to_remove:
+            xref = PermitConditionTagXref.find_by_guid_and_condition_id(t, self.permit_condition_id)
+            if xref:
+                xref.delete(True)
+        
+        for t in tags_to_add:
+            deleted_xref = PermitConditionTagXref.find_by_guid_and_condition_id(t, self.permit_condition_id)
 
-                    if(deleted_xref):
-                        deleted_xref.deleted_ind = False
-                        deleted_xref.save()
-                    else:
-                        xref = PermitConditionTagXref(
-                            permit_condition_tag_guid=tag,
-                            permit_condition_id=self.permit_condition_id
-                        )
-                        xref.save()
+            if(deleted_xref):
+                deleted_xref.deleted_ind = False
+                deleted_xref.save()
+            else:
+                xref = PermitConditionTagXref(
+                    permit_condition_tag_guid=t,
+                    permit_condition_id=self.permit_condition_id
+                )
+                xref.save()
 
     @classmethod
     def _copy_from_standard_recursive(cls, standard_condition: StandardPermitConditions, permit_amendment_id, parent_condition=None):

--- a/services/core-api/app/api/mines/permits/permit_conditions/models/standard_permit_condition_tag_xref.py
+++ b/services/core-api/app/api/mines/permits/permit_conditions/models/standard_permit_condition_tag_xref.py
@@ -1,0 +1,31 @@
+import uuid
+from sqlalchemy.dialects.postgresql import UUID
+from app.extensions import db
+from sqlalchemy.schema import FetchedValue
+
+from app.api.utils.models_mixins import AuditMixin, Base, SoftDeleteMixin
+
+
+class StandardPermitConditionTagXref(SoftDeleteMixin, AuditMixin, Base):
+    __tablename__ = 'standard_permit_condition_tag_xref'
+    standard_permit_condition_tag_xref_guid = db.Column(UUID(as_uuid=True), server_default=FetchedValue(), primary_key=True)
+    permit_condition_tag_guid = db.Column(UUID(as_uuid=True), db.ForeignKey('permit_condition_tag.permit_condition_tag_guid'), nullable=False)
+    standard_permit_condition_id = db.Column(db.Integer, db.ForeignKey('standard_permit_conditions.standard_permit_condition_id'), nullable=False)
+
+    standard_permit_condition = db.relationship(
+        'StandardPermitConditions',
+        back_populates='condition_tag_xrefs'
+    )
+
+    permit_condition_tag = db.relationship('PermitConditionTag', backref=db.backref('standard_tag_xrefs', lazy='dynamic'))
+
+    @classmethod
+    def find_by_guid_and_condition_id(cls, tag_guid, condition_id):
+        return StandardPermitConditionTagXref.query.filter_by(
+            permit_condition_tag_guid=uuid.UUID(tag_guid),
+            standard_permit_condition_id=condition_id
+        ).first()
+
+    @classmethod
+    def delete_all_by_guid(cls, permit_condition_tag_guid):
+        return StandardPermitConditionTagXref.query.filter_by(permit_condition_tag_guid=uuid.UUID(permit_condition_tag_guid)).delete()

--- a/services/core-api/app/api/mines/permits/permit_conditions/models/standard_permit_conditions.py
+++ b/services/core-api/app/api/mines/permits/permit_conditions/models/standard_permit_conditions.py
@@ -96,6 +96,12 @@ class StandardPermitConditions(SoftDeleteMixin, AuditMixin, Base):
         return cls.query.filter_by(
             standard_permit_condition_guid=standard_permit_condition_guid, deleted_ind=False).first()
 
+    @classmethod
+    def find_many_by_permit_condition_ids(cls, ids):
+        return cls.query.filter(
+            cls.standard_permit_condition_id.in_(ids)
+        ).filter_by(deleted_ind=False).all()
+
 
     @classmethod
     def find_by_standard_permit_condition_id(cls, standard_permit_condition_id):

--- a/services/core-api/app/api/mines/permits/permit_conditions/models/standard_permit_conditions.py
+++ b/services/core-api/app/api/mines/permits/permit_conditions/models/standard_permit_conditions.py
@@ -7,7 +7,6 @@ from sqlalchemy.schema import FetchedValue
 from app.extensions import db
 from app.api.utils.models_mixins import SoftDeleteMixin, AuditMixin, Base
 from app.api.utils.list_lettering_helpers import num_to_letter, num_to_roman
-from app.api.mines.permits.permit_conditions.models.permit_condition_tag import PermitConditionTag
 from app.api.mines.permits.permit_conditions.models.standard_permit_condition_tag_xref import StandardPermitConditionTagXref
 
 class StandardPermitConditions(SoftDeleteMixin, AuditMixin, Base):
@@ -102,13 +101,22 @@ class StandardPermitConditions(SoftDeleteMixin, AuditMixin, Base):
             cls.standard_permit_condition_id.in_(ids)
         ).filter_by(deleted_ind=False).all()
 
-
+    def get_all_sub_condition_ids(self):
+        ids = [self.standard_permit_condition_id]
+        def collect_ids(condition):
+            for sub in condition.sub_conditions:
+                ids.append(sub.standard_permit_condition_id)
+                collect_ids(sub)
+        collect_ids(self)
+        return ids
+    
     @classmethod
     def find_by_standard_permit_condition_id(cls, standard_permit_condition_id):
         return cls.query.filter_by(
             standard_permit_condition_id=standard_permit_condition_id, deleted_ind=False).first()
     
-    def update_condition_tags(self, old_tags, new_tags):
+    def update_condition_tags(self, new_tags):
+        old_tags = self.condition_tags
         if old_tags != new_tags:
 
             # Remove tags

--- a/services/core-api/app/api/mines/permits/permit_conditions/models/standard_permit_conditions.py
+++ b/services/core-api/app/api/mines/permits/permit_conditions/models/standard_permit_conditions.py
@@ -117,27 +117,24 @@ class StandardPermitConditions(SoftDeleteMixin, AuditMixin, Base):
     
     def update_condition_tags(self, new_tags):
         old_tags = self.condition_tags
-        if old_tags != new_tags:
 
-            # Remove tags
-            for tag in old_tags:
-                if tag not in new_tags:
-                    xref = StandardPermitConditionTagXref.find_by_guid_and_condition_id(tag,self.standard_permit_condition_id)
-                    if xref:
-                        xref.delete(True)
-                    
-            # Add new tags
-            for tag in new_tags:
-                if tag not in old_tags:
-                    #Check if xref already exists
-                    deleted_xref = StandardPermitConditionTagXref.find_by_guid_and_condition_id(tag,self.standard_permit_condition_id)
+        tags_to_remove = [tag for tag in old_tags if tag not in new_tags]
+        tags_to_add = [tag for tag in new_tags if tag not in old_tags]
 
-                    if(deleted_xref):
-                        deleted_xref.deleted_ind = False
-                        deleted_xref.save()
-                    else:
-                        xref = StandardPermitConditionTagXref(
-                            permit_condition_tag_guid=tag,
-                            standard_permit_condition_id=self.standard_permit_condition_id
-                        )
-                        xref.save()
+        for t in tags_to_remove:
+            xref = StandardPermitConditionTagXref.find_by_guid_and_condition_id(t, self.standard_permit_condition_id)
+            if xref:
+                xref.delete(True)
+        
+        for t in tags_to_add:
+            deleted_xref = StandardPermitConditionTagXref.find_by_guid_and_condition_id(t, self.standard_permit_condition_id)
+
+            if(deleted_xref):
+                deleted_xref.deleted_ind = False
+                deleted_xref.save()
+            else:
+                xref = StandardPermitConditionTagXref(
+                    permit_condition_tag_guid=t,
+                    standard_permit_condition_id=self.standard_permit_condition_id
+                )
+                xref.save()

--- a/services/core-api/app/api/mines/permits/permit_conditions/models/standard_permit_conditions.py
+++ b/services/core-api/app/api/mines/permits/permit_conditions/models/standard_permit_conditions.py
@@ -7,7 +7,8 @@ from sqlalchemy.schema import FetchedValue
 from app.extensions import db
 from app.api.utils.models_mixins import SoftDeleteMixin, AuditMixin, Base
 from app.api.utils.list_lettering_helpers import num_to_letter, num_to_roman
-
+from app.api.mines.permits.permit_conditions.models.permit_condition_tag import PermitConditionTag
+from app.api.mines.permits.permit_conditions.models.standard_permit_condition_tag_xref import StandardPermitConditionTagXref
 
 class StandardPermitConditions(SoftDeleteMixin, AuditMixin, Base):
     __tablename__ = 'standard_permit_conditions'
@@ -34,11 +35,22 @@ class StandardPermitConditions(SoftDeleteMixin, AuditMixin, Base):
         order_by='asc(StandardPermitConditions.display_order)',
         backref=backref('parent', remote_side=[standard_permit_condition_id]))
 
+    condition_tag_xrefs = db.relationship(
+        "StandardPermitConditionTagXref",
+        back_populates="standard_permit_condition",
+        lazy="joined",
+        primaryjoin="and_(StandardPermitConditions.standard_permit_condition_id==StandardPermitConditionTagXref.standard_permit_condition_id,StandardPermitConditionTagXref.deleted_ind==False)",
+    )
+
     def __repr__(self):
         return f'{self.__class__.__name__} {self.standard_permit_condition_id}, {self.standard_permit_condition_guid}'
 
     def __str__(self):
         return f'{self.__class__.__name__} standard_permit_condition_id: {self.standard_permit_condition_id}, standard_permit_condition_guid: {self.standard_permit_condition_guid}, condition: {self.condition}, condition_category_code: {self.condition_category_code}, condition_type_code: {self.condition_type_code}, notice_of_work_type: {self.notice_of_work_type}, parent_standard_permit_condition_id: {self.parent_standard_permit_condition_id}, display_order: {self.display_order}, all_sub_conditions: {self.all_sub_conditions}'
+
+    @hybrid_property
+    def condition_tags(self):
+        return [ str(tag_xref.permit_condition_tag_guid) for tag_xref in self.condition_tag_xrefs if tag_xref.permit_condition_tag and not tag_xref.permit_condition_tag.deleted_ind]
 
     @hybrid_property
     def sub_conditions(self):
@@ -89,3 +101,29 @@ class StandardPermitConditions(SoftDeleteMixin, AuditMixin, Base):
     def find_by_standard_permit_condition_id(cls, standard_permit_condition_id):
         return cls.query.filter_by(
             standard_permit_condition_id=standard_permit_condition_id, deleted_ind=False).first()
+    
+    def update_condition_tags(self, old_tags, new_tags):
+        if old_tags != new_tags:
+
+            # Remove tags
+            for tag in old_tags:
+                if tag not in new_tags:
+                    xref = StandardPermitConditionTagXref.find_by_guid_and_condition_id(tag,self.standard_permit_condition_id)
+                    if xref:
+                        xref.delete(True)
+                    
+            # Add new tags
+            for tag in new_tags:
+                if tag not in old_tags:
+                    #Check if xref already exists
+                    deleted_xref = StandardPermitConditionTagXref.find_by_guid_and_condition_id(tag,self.standard_permit_condition_id)
+
+                    if(deleted_xref):
+                        deleted_xref.deleted_ind = False
+                        deleted_xref.save()
+                    else:
+                        xref = StandardPermitConditionTagXref(
+                            permit_condition_tag_guid=tag,
+                            standard_permit_condition_id=self.standard_permit_condition_id
+                        )
+                        xref.save()

--- a/services/core-api/app/api/mines/permits/permit_conditions/resources/permit_condition_tag_resource.py
+++ b/services/core-api/app/api/mines/permits/permit_conditions/resources/permit_condition_tag_resource.py
@@ -26,7 +26,7 @@ class PermitConditionTagResource(Resource, UserMixin):
         if not tag:
             raise BadRequest(f"Permit condition tag with ID {permit_condition_tag_guid} not found.")
         tag.delete(True)
-        PermitConditionTagXref.deleteAllByGuid(permit_condition_tag_guid)
+        PermitConditionTagXref.delete_all_by_guid(permit_condition_tag_guid)
         return {'message': 'Permit condition tag deleted successfully.'}, 204
     
     @requires_role_mine_admin

--- a/services/core-api/app/api/mines/permits/permit_conditions/resources/permit_conditions_resource.py
+++ b/services/core-api/app/api/mines/permits/permit_conditions/resources/permit_conditions_resource.py
@@ -95,7 +95,7 @@ class PermitConditionsResource(Resource, UserMixin):
         old_condition = PermitConditions.find_by_permit_condition_guid(permit_condition_guid)
         old_display_order = old_condition.display_order
         old_category_code = old_condition.condition_category_code
-        old_tags = old_condition.condition_tags;
+        old_tags = old_condition.condition_tags
         new_category_code = request_data.get("condition_category_code", None)
         if not PermitConditionCategory.find_by_permit_condition_category_code(new_category_code):
             raise BadRequest('condition_category_code is invalid')

--- a/services/core-api/app/api/mines/permits/permit_conditions/resources/permit_conditions_resource.py
+++ b/services/core-api/app/api/mines/permits/permit_conditions/resources/permit_conditions_resource.py
@@ -5,7 +5,6 @@ from werkzeug.exceptions import BadRequest, NotFound, InternalServerError
 from marshmallow.exceptions import MarshmallowError
 from datetime import datetime, timezone
 
-from app.api.mines.permits.permit_conditions.models.permit_condition_tag_xref import PermitConditionTagXref
 from app.api.mines.permits.permit_conditions.tasks import export_and_index_permit_amendments
 from app.api.mines.reports.models.mine_report_req_permit_condition_xref import MineReportReqPermitConditionXref
 from app.extensions import api, jwt, db
@@ -95,7 +94,6 @@ class PermitConditionsResource(Resource, UserMixin):
         old_condition = PermitConditions.find_by_permit_condition_guid(permit_condition_guid)
         old_display_order = old_condition.display_order
         old_category_code = old_condition.condition_category_code
-        old_tags = old_condition.condition_tags
         new_category_code = request_data.get("condition_category_code", None)
         if not PermitConditionCategory.find_by_permit_condition_category_code(new_category_code):
             raise BadRequest('condition_category_code is invalid')
@@ -152,7 +150,7 @@ class PermitConditionsResource(Resource, UserMixin):
 
         set_audit_metadata(permit_amendment, False)
 
-        update_condition_tags(old_tags, new_tags, condition)
+        condition.update_condition_tags(new_tags)
 
         db.session.commit()
 
@@ -219,29 +217,3 @@ def set_audit_metadata(permit_amendment, commit=True):
     permit_amendment.permit_conditions_last_updated_by = User().get_user_username()
     permit_amendment.permit_conditions_last_updated_date = datetime.now(timezone.utc)
     permit_amendment.save(commit=commit)
-
-def update_condition_tags(old_tags, new_tags, condition):
-    if old_tags != new_tags:
-
-        # Remove tags
-        for tag in old_tags:
-            if tag not in new_tags:
-                xref = PermitConditionTagXref.find_by_guid_and_condition_id(tag,condition.permit_condition_id)
-                if xref:
-                    xref.delete(True)
-                
-        # Add new tags
-        for tag in new_tags:
-            if tag not in old_tags:
-                #Check if xref already exists
-                deleted_xref = PermitConditionTagXref.find_by_guid_and_condition_id(tag,condition.permit_condition_id)
-
-                if(deleted_xref):
-                    deleted_xref.deleted_ind = False
-                    deleted_xref.save()
-                else:
-                    xref = PermitConditionTagXref(
-                        permit_condition_tag_guid=tag,
-                        permit_condition_id=condition.permit_condition_id
-                    )
-                    xref.save()

--- a/services/core-api/app/api/mines/permits/permit_conditions/resources/standard_permit_conditions_resource.py
+++ b/services/core-api/app/api/mines/permits/permit_conditions/resources/standard_permit_conditions_resource.py
@@ -5,21 +5,25 @@ from marshmallow.exceptions import MarshmallowError
 
 from app.extensions import api, db
 from app.api.mines.response_models import STANDARD_PERMIT_CONDITION_MODEL
-from app.api.mines.permits.permit_conditions.models import StandardPermitConditions
+from app.api.mines.permits.permit_conditions.models import StandardPermitConditions, StandardPermitConditionTagXref
 from app.api.utils.access_decorators import requires_role_edit_standard_permit_conditions
 from app.api.utils.resources_mixins import UserMixin
 
 
-class StandardPermitConditionsResource(Resource, UserMixin):
+class StandardPermitConditionsResource(Resource, UserMixin):    
     @api.doc(description='Update a standard permit condition')
     @requires_role_edit_standard_permit_conditions
     @api.expect(STANDARD_PERMIT_CONDITION_MODEL)
     @api.marshal_with(STANDARD_PERMIT_CONDITION_MODEL, code=200)
     def put(self, standard_permit_condition_guid):
+
+        request_data = request.json
+
         old_display_order = None
         old_condition = StandardPermitConditions.find_by_standard_permit_condition_guid(
             standard_permit_condition_guid)
-
+        old_tags = old_condition.condition_tags
+        new_tags = request_data.get("condition_tags", [])
         if old_condition:
             old_display_order = old_condition.display_order
 
@@ -31,6 +35,8 @@ class StandardPermitConditionsResource(Resource, UserMixin):
                     standard_permit_condition_guid))
         except MarshmallowError as e:
             raise BadRequest(e)
+        
+        condition.update_condition_tags(old_tags, new_tags)
 
         conditions = []
         if condition.parent_standard_permit_condition_id is not None:

--- a/services/core-api/app/api/mines/permits/permit_conditions/resources/standard_permit_conditions_resource.py
+++ b/services/core-api/app/api/mines/permits/permit_conditions/resources/standard_permit_conditions_resource.py
@@ -5,7 +5,7 @@ from marshmallow.exceptions import MarshmallowError
 
 from app.extensions import api, db
 from app.api.mines.response_models import STANDARD_PERMIT_CONDITION_MODEL
-from app.api.mines.permits.permit_conditions.models import StandardPermitConditions, StandardPermitConditionTagXref
+from app.api.mines.permits.permit_conditions.models import StandardPermitConditions
 from app.api.utils.access_decorators import requires_role_edit_standard_permit_conditions
 from app.api.utils.resources_mixins import UserMixin
 
@@ -22,7 +22,6 @@ class StandardPermitConditionsResource(Resource, UserMixin):
         old_display_order = None
         old_condition = StandardPermitConditions.find_by_standard_permit_condition_guid(
             standard_permit_condition_guid)
-        old_tags = old_condition.condition_tags
         new_tags = request_data.get("condition_tags", [])
         if old_condition:
             old_display_order = old_condition.display_order
@@ -36,7 +35,7 @@ class StandardPermitConditionsResource(Resource, UserMixin):
         except MarshmallowError as e:
             raise BadRequest(e)
         
-        condition.update_condition_tags(old_tags, new_tags)
+        condition.update_condition_tags(new_tags)
 
         conditions = []
         if condition.parent_standard_permit_condition_id is not None:

--- a/services/core-api/app/api/mines/permits/permit_conditions/resources/standard_report_permit_requirement_resource.py
+++ b/services/core-api/app/api/mines/permits/permit_conditions/resources/standard_report_permit_requirement_resource.py
@@ -1,0 +1,128 @@
+from datetime import datetime
+
+from app.api.mines.mine.models.mine import Mine
+from app.api.mines.permits.permit_amendment.models.permit_amendment import (
+    PermitAmendment,
+)
+from app.api.mines.permits.permit_conditions.models import PermitConditions
+from app.api.mines.permits.permit_conditions.models.standard_permit_conditions import StandardPermitConditions
+from app.api.mines.reports.models.mine_report_permit_requirement import (
+    CimOrCpo,
+    StandardReportPermitRequirement,
+)
+from app.api.mines.response_models import MINE_REPORT_PERMIT_REQUIREMENT
+from app.api.utils.access_decorators import requires_any_of, requires_role_edit_standard_permit_conditions, VIEW_ALL, MINESPACE_PROPONENT
+from app.api.utils.custom_reqparser import CustomReqparser
+from app.api.utils.resources_mixins import UserMixin
+from app.extensions import api
+from flask import current_app
+from flask_restx import Resource
+from werkzeug.exceptions import BadRequest, NotFound
+from flask_restx import reqparse
+from sqlalchemy.exc import IntegrityError
+
+class StandardReportPermitRequirementResource(Resource, UserMixin):
+    parser = CustomReqparser()
+
+    parser.add_argument("mine_report_permit_requirement_id", type=int, location="json")
+    parser.add_argument("due_date_period_months", type=int, location="json")
+    parser.add_argument("cim_or_cpo", type=str, location="json")
+    parser.add_argument("ministry_recipient", type=list, location="json")
+    parser.add_argument("permit_condition_ids", type=list, location="json")
+    parser.add_argument("report_name", type=str, location="json")
+
+    @api.expect(parser)
+    @api.doc(description="Creates a new report requirement for standard/template conditions")
+    @api.marshal_with(MINE_REPORT_PERMIT_REQUIREMENT, code=201)
+    @requires_role_edit_standard_permit_conditions
+    def post(self):
+        data = self.parser.parse_args()
+
+        permit_condition_ids = data.get("permit_condition_ids")
+        permit_conditions = StandardPermitConditions.find_many_by_permit_condition_ids(permit_condition_ids)
+
+        if not permit_conditions:
+            raise NotFound("Standard Permit Conditions not found")
+        
+        cim_or_cpo = data.get("cim_or_cpo")
+        cim_or_cpo = None if cim_or_cpo == "None" else CimOrCpo(cim_or_cpo)
+
+        try:
+            standard_report_permit_requirement = StandardReportPermitRequirement.create(
+                report_name=data.get("report_name"),
+                due_date_period_months=data.get("due_date_period_months"),
+                cim_or_cpo=cim_or_cpo,
+                ministry_recipient=data.get("ministry_recipient"),
+                permit_condition_ids=permit_condition_ids
+            )
+        except IntegrityError as e:
+            current_app.logger.info(e)
+
+        return standard_report_permit_requirement, 201
+    
+    @api.expect(parser)
+    @api.doc(description="Update a standard report requirement")
+    @api.marshal_with(MINE_REPORT_PERMIT_REQUIREMENT, code=200)
+    @requires_role_edit_standard_permit_conditions
+    def put(self):
+        data = self.parser.parse_args()
+
+        mine_report_permit_requirement_id = data.get("mine_report_permit_requirement_id", None)
+        report_requirement = StandardReportPermitRequirement.find_by_mine_report_permit_requirement_id(mine_report_permit_requirement_id)
+        if not report_requirement:
+            raise NotFound(f"Report requirement with id {mine_report_permit_requirement_id} not found.")
+
+        permit_condition_ids = data.get("permit_condition_ids")
+
+        if not permit_condition_ids or len(permit_condition_ids) == 0:
+            raise BadRequest("Report requirement must be associated with one or more standard permit conditions.")
+        
+        permit_conditions = StandardPermitConditions.find_many_by_permit_condition_ids(permit_condition_ids
+                                                                               )
+        if len(permit_conditions) != len(permit_condition_ids):
+            not_found_ids = [x.permit_condition_id for x in permit_conditions if x.permit_condition_id not in permit_condition_ids]
+            current_app.logger.info(f"Standard conditions with the following ids were not found: {', '.join(map(str, not_found_ids))}")
+            raise BadRequest(f"{len(not_found_ids)} standard conditions were not found")
+            
+        cim_or_cpo = data.get("cim_or_cpo")
+        data['cim_or_cpo'] = None if cim_or_cpo == "None" else CimOrCpo(cim_or_cpo)
+
+        try:
+            report_requirement.update(**data)
+        except IntegrityError as e:
+            current_app.logger.info(e)
+            raise BadRequest(self.unique_report_error_message)
+        return report_requirement
+        
+
+    @api.doc(description="Return all standard report requirements")
+    @api.marshal_with(MINE_REPORT_PERMIT_REQUIREMENT, code=200, envelope="records")
+    @requires_any_of([VIEW_ALL, MINESPACE_PROPONENT])
+    def get(self):
+        records = StandardReportPermitRequirement.get_all()
+        return records
+    
+    @api.doc(description='Delete a standard report permit requirement')
+    @api.response(204, "Successfully deleted report requirement.")
+    @requires_role_edit_standard_permit_conditions
+    def delete(self):
+        parser = reqparse.RequestParser()
+        parser.add_argument(
+            'mine_report_permit_requirement_id',
+            type=int,
+            location='args',
+            required=True,
+            help='Standard report permit requirement id to help identify report requirement'
+        )
+        args = parser.parse_args()
+        mine_report_permit_requirement_id = args.get('mine_report_permit_requirement_id')
+
+        report_requirement = StandardReportPermitRequirement.find_by_mine_report_permit_requirement_id(
+            mine_report_permit_requirement_id
+            )
+        if not report_requirement:
+            raise NotFound(f"Report requirement with id {mine_report_permit_requirement_id} not found")
+
+
+        report_requirement.delete()
+        current_app.logger.info(f'Deleting {report_requirement}')

--- a/services/core-api/app/api/mines/permits/permit_conditions/resources/standard_report_permit_requirement_resource.py
+++ b/services/core-api/app/api/mines/permits/permit_conditions/resources/standard_report_permit_requirement_resource.py
@@ -22,6 +22,8 @@ from flask_restx import reqparse
 from sqlalchemy.exc import IntegrityError
 
 class StandardReportPermitRequirementResource(Resource, UserMixin):
+    unique_report_error_message = "Report name must be unique"
+
     parser = CustomReqparser()
 
     parser.add_argument("mine_report_permit_requirement_id", type=int, location="json")
@@ -45,7 +47,7 @@ class StandardReportPermitRequirementResource(Resource, UserMixin):
             raise NotFound("Standard Permit Conditions not found")
         
         cim_or_cpo = data.get("cim_or_cpo")
-        cim_or_cpo = None if cim_or_cpo == "None" else CimOrCpo(cim_or_cpo)
+        cim_or_cpo = None if cim_or_cpo == "NONE" else CimOrCpo(cim_or_cpo)
 
         try:
             standard_report_permit_requirement = StandardReportPermitRequirement.create(
@@ -57,6 +59,7 @@ class StandardReportPermitRequirementResource(Resource, UserMixin):
             )
         except IntegrityError as e:
             current_app.logger.info(e)
+            raise BadRequest(self.unique_report_error_message)
 
         return standard_report_permit_requirement, 201
     
@@ -85,13 +88,14 @@ class StandardReportPermitRequirementResource(Resource, UserMixin):
             raise BadRequest(f"{len(not_found_ids)} standard conditions were not found")
             
         cim_or_cpo = data.get("cim_or_cpo")
-        data['cim_or_cpo'] = None if cim_or_cpo == "None" else CimOrCpo(cim_or_cpo)
+        data['cim_or_cpo'] = None if cim_or_cpo == "NONE" else CimOrCpo(cim_or_cpo)
 
         try:
             report_requirement.update(**data)
         except IntegrityError as e:
             current_app.logger.info(e)
             raise BadRequest(self.unique_report_error_message)
+        
         return report_requirement
         
 
@@ -123,6 +127,6 @@ class StandardReportPermitRequirementResource(Resource, UserMixin):
         if not report_requirement:
             raise NotFound(f"Report requirement with id {mine_report_permit_requirement_id} not found")
 
-
-        report_requirement.delete()
         current_app.logger.info(f'Deleting {report_requirement}')
+        report_requirement.delete()        
+        return None, 204

--- a/services/core-api/app/api/mines/reports/models/mine_report_permit_requirement.py
+++ b/services/core-api/app/api/mines/reports/models/mine_report_permit_requirement.py
@@ -92,7 +92,7 @@ class MineReportPermitRequirement(SoftDeleteMixin, AuditMixin, HistoryMixin, Bas
         return cls.query.filter_by(report_name=report_name, permit_amendment_id=permit_amendment_id).one_or_none()
 
     @classmethod
-    def get_all(cls) -> list[Self]:
+    def get_all(cls) -> list[Self] | None:
         try:
             return cls.query.all()
         except ValueError:

--- a/services/core-api/app/api/mines/reports/models/mine_report_permit_requirement.py
+++ b/services/core-api/app/api/mines/reports/models/mine_report_permit_requirement.py
@@ -1,6 +1,6 @@
 from datetime import date
 from enum import Enum
-from typing import Optional, Self
+from typing import Optional, Self, List
 
 from app.api.utils.models_mixins import AuditMixin, Base, SoftDeleteMixin, HistoryMixin
 from app.extensions import db
@@ -74,7 +74,7 @@ class MineReportPermitRequirement(SoftDeleteMixin, AuditMixin, HistoryMixin, Bas
         return '<MineReportPermitRequirement %r>' % self.mine_report_permit_requirement_id
 
     @classmethod
-    def find_by_mine_report_permit_requirement_id(cls, id) -> "MineReportPermitRequirement":
+    def find_by_mine_report_permit_requirement_id(cls, id) -> Self | None:
         try:
             return cls.query.filter_by(mine_report_permit_requirement_id=id, deleted_ind=False).first()
         except ValueError:
@@ -88,21 +88,18 @@ class MineReportPermitRequirement(SoftDeleteMixin, AuditMixin, HistoryMixin, Bas
         return None
 
     @classmethod
-    def find_by_report_name(cls, report_name) -> "MineReportPermitRequirement":
-        try:
-            return cls.query.filter_by(report_name=report_name).all()
-        except ValueError:
-            return None
+    def find_by_report_name(cls, report_name, permit_amendment_id) -> Self:
+        return cls.query.filter_by(report_name=report_name, permit_amendment_id=permit_amendment_id).one_or_none()
 
     @classmethod
-    def get_all(cls) -> list["MineReportPermitRequirement"]:
+    def get_all(cls) -> list[Self]:
         try:
             return cls.query.all()
         except ValueError:
             return None
         
 
-    def update_permit_conditions(self, new_permit_condition_ids) -> "MineReportPermitRequirement":
+    def update_permit_conditions(self, new_permit_condition_ids) -> None:
         current_condition_ids = self.permit_condition_ids
         
         to_add = [c for c in new_permit_condition_ids if c not in current_condition_ids]
@@ -138,7 +135,7 @@ class MineReportPermitRequirement(SoftDeleteMixin, AuditMixin, HistoryMixin, Bas
                cim_or_cpo: Optional[CimOrCpo],
                ministry_recipient: Optional[list[OfficeDestination]],
                permit_condition_ids: list[int],
-               permit_amendment_id: int) -> "MineReportPermitRequirement":
+               permit_amendment_id: int) -> Self:
 
         mine_report_permit_requirement = cls(
             report_name=report_name,
@@ -180,7 +177,7 @@ class StandardReportPermitRequirement(MineReportPermitRequirement):
         backref=backref('mine_report_permit_requirements', lazy='joined')
     )
 
-    def update_permit_conditions(self, new_permit_condition_ids) -> "StandardReportPermitRequirement":
+    def update_permit_conditions(self, new_permit_condition_ids) -> None:
         current_condition_ids = self.permit_condition_ids
         
         to_add = [c for c in new_permit_condition_ids if c not in current_condition_ids]
@@ -198,13 +195,19 @@ class StandardReportPermitRequirement(MineReportPermitRequirement):
             self.mine_report_req_permit_conditions.append(xref)
 
     @classmethod
+    def find_by_many_condition_ids(cls, ids) -> List[Self]:
+        xrefs = StandardReportReqPermitConditionXref.find_by_many_permit_condition_ids(ids)
+        requirements = [xref.mine_report_permit_requirement for xref in xrefs if xref.mine_report_permit_requirement]
+        return list(set(requirements))
+
+    @classmethod
     def create(cls,
                report_name: Optional[str],
                due_date_period_months: int,
                cim_or_cpo: Optional[CimOrCpo],
                ministry_recipient: Optional[list[OfficeDestination]],
                permit_condition_ids: list[int]
-               ) -> "StandardReportPermitRequirement":
+               ) -> Self:
 
         standard_report_permit_requirement = cls(
             report_name=report_name,

--- a/services/core-api/app/api/mines/reports/models/mine_report_permit_requirement.py
+++ b/services/core-api/app/api/mines/reports/models/mine_report_permit_requirement.py
@@ -8,7 +8,7 @@ from sqlalchemy.dialects.postgresql import ARRAY
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.schema import FetchedValue
 from sqlalchemy.orm import backref
-from app.api.mines.reports.models.mine_report_req_permit_condition_xref import MineReportReqPermitConditionXref
+from app.api.mines.reports.models.mine_report_req_permit_condition_xref import MineReportReqPermitConditionXref, StandardReportReqPermitConditionXref
 
 class CimOrCpo(str, Enum):
     CIM = "CIM"
@@ -42,6 +42,14 @@ class MineReportPermitRequirement(SoftDeleteMixin, AuditMixin, HistoryMixin, Bas
     ministry_recipient: Optional[list[OfficeDestination]] = db.Column(
         ARRAY(db.Enum(OfficeDestination, name='ministry_recipient_type')), nullable=True)
     permit_amendment_id: int = db.Column(db.Integer, db.ForeignKey('permit_amendment.permit_amendment_id'))
+    is_standard: bool = db.Column(db.Boolean, nullable=False, server_default='false')
+
+    # creates a filter for the class so that all results returned by the cls.query have is_standard=False
+    __mapper_args__ = {
+        "polymorphic_on": is_standard,
+        "polymorphic_identity": False,
+    }
+
     mine_report_req_permit_conditions: list[MineReportReqPermitConditionXref] = db.relationship(
         MineReportReqPermitConditionXref,
         overlaps="mine_report_permit_requirement",
@@ -113,7 +121,7 @@ class MineReportPermitRequirement(SoftDeleteMixin, AuditMixin, HistoryMixin, Bas
     
     def update(self, **kwargs):
         for key, value in kwargs.items():
-            if key in ['mine_report_permit_requirement_id', 'permit_amendment_id', 'permit_condition_ids']:
+            if key in ['mine_report_permit_requirement_id', 'permit_amendment_id', 'permit_condition_ids', 'is_standard']:
                 continue     # non-editable fields from put or should be handled separately
             setattr(self, key, value)
         
@@ -150,3 +158,67 @@ class MineReportPermitRequirement(SoftDeleteMixin, AuditMixin, HistoryMixin, Bas
 
         mine_report_permit_requirement.save(commit=True)
         return mine_report_permit_requirement
+
+
+class StandardReportPermitRequirement(MineReportPermitRequirement):
+    # creates the opposite filter for the class so cls.query all results have is_standard=true
+    __mapper_args__ = {
+        "polymorphic_identity": True,
+    }
+
+    mine_report_req_permit_conditions: list[StandardReportReqPermitConditionXref] = db.relationship(
+        StandardReportReqPermitConditionXref,
+        overlaps="mine_report_permit_requirement",
+        lazy='joined',
+        primaryjoin='and_(StandardReportPermitRequirement.mine_report_permit_requirement_id == StandardReportReqPermitConditionXref.mine_report_permit_requirement_id, StandardReportReqPermitConditionXref.deleted_ind==False)',
+    )
+    permit_conditions = db.relationship(
+        'StandardPermitConditions',
+        secondary='mine_report_req_permit_condition_xref',
+        secondaryjoin='and_(StandardReportReqPermitConditionXref.standard_permit_condition_id == StandardPermitConditions.standard_permit_condition_id, StandardReportReqPermitConditionXref.deleted_ind==False)',
+        lazy='joined',
+        backref=backref('mine_report_permit_requirements', lazy='joined')
+    )
+
+    def update_permit_conditions(self, new_permit_condition_ids) -> "StandardReportPermitRequirement":
+        current_condition_ids = self.permit_condition_ids
+        
+        to_add = [c for c in new_permit_condition_ids if c not in current_condition_ids]
+        to_delete = [x for x in self.mine_report_req_permit_conditions if x.permit_condition_id not in new_permit_condition_ids]
+        
+        for xref in to_delete:
+            xref.delete()
+
+        for permit_condition_id in to_add:
+            xref = StandardReportReqPermitConditionXref.create(
+                mine_report_permit_requirement=self,
+                permit_condition_id=permit_condition_id
+            )
+
+            self.mine_report_req_permit_conditions.append(xref)
+
+    @classmethod
+    def create(cls,
+               report_name: Optional[str],
+               due_date_period_months: int,
+               cim_or_cpo: Optional[CimOrCpo],
+               ministry_recipient: Optional[list[OfficeDestination]],
+               permit_condition_ids: list[int]
+               ) -> "StandardReportPermitRequirement":
+
+        standard_report_permit_requirement = cls(
+            report_name=report_name,
+            due_date_period_months=due_date_period_months,\
+            cim_or_cpo=cim_or_cpo,
+            ministry_recipient=ministry_recipient,
+        )
+        for permit_condition_id in permit_condition_ids:
+            xref = StandardReportReqPermitConditionXref.create(
+                mine_report_permit_requirement=standard_report_permit_requirement,
+                permit_condition_id=permit_condition_id
+            )
+
+            standard_report_permit_requirement.mine_report_req_permit_conditions.append(xref)
+
+        standard_report_permit_requirement.save(commit=True)
+        return standard_report_permit_requirement

--- a/services/core-api/app/api/mines/reports/models/mine_report_req_permit_condition_xref.py
+++ b/services/core-api/app/api/mines/reports/models/mine_report_req_permit_condition_xref.py
@@ -72,7 +72,6 @@ class StandardReportReqPermitConditionXref(MineReportReqPermitConditionXref):
         "polymorphic_identity": True,
     }
 
-    # TODO: this needs a FK constraint
     standard_permit_condition_id = db.Column(
         db.Integer, db.ForeignKey('standard_permit_conditions.standard_permit_condition_id'), nullable=True)
     

--- a/services/core-api/app/api/mines/reports/models/mine_report_req_permit_condition_xref.py
+++ b/services/core-api/app/api/mines/reports/models/mine_report_req_permit_condition_xref.py
@@ -16,7 +16,15 @@ class MineReportReqPermitConditionXref(SoftDeleteMixin, AuditMixin, HistoryMixin
     mine_report_permit_requirement_id = db.Column(
         db.Integer, db.ForeignKey('mine_report_permit_requirement.mine_report_permit_requirement_id'))
     permit_condition_id = db.Column(
-        db.Integer, db.ForeignKey('permit_conditions.permit_condition_id'))
+        db.Integer, db.ForeignKey('permit_conditions.permit_condition_id'), nullable=True)
+
+    # Use polymorphic_on to distinguish between standard and non-standard xrefs
+    is_standard = db.Column(db.Boolean, nullable=False, server_default='false')
+    __mapper_args__ = {
+        "polymorphic_on": is_standard,
+        "polymorphic_identity": False,
+    }
+
     mine_report_permit_requirement = db.relationship(
         'MineReportPermitRequirement',
         lazy='joined',
@@ -53,3 +61,40 @@ class MineReportReqPermitConditionXref(SoftDeleteMixin, AuditMixin, HistoryMixin
             xref.delete(commit=commit)
 
         db.session.commit()
+
+# Subclass for standard report xrefs (is_standard=True, standard_permit_condition_id)
+class StandardReportReqPermitConditionXref(MineReportReqPermitConditionXref):
+    __mapper_args__ = {
+        "polymorphic_identity": True,
+    }
+
+    # TODO: this needs a FK constraint
+    standard_permit_condition_id = db.Column(
+        db.Integer, db.ForeignKey('standard_permit_conditions.standard_permit_condition_id'), nullable=True)
+    
+    mine_report_permit_requirement = db.relationship(
+        'StandardReportPermitRequirement',
+        lazy='joined',
+        primaryjoin='StandardReportReqPermitConditionXref.mine_report_permit_requirement_id == StandardReportPermitRequirement.mine_report_permit_requirement_id',
+    )
+
+    @property
+    def permit_condition_id(self):
+        return self.standard_permit_condition_id
+
+    @permit_condition_id.setter
+    def permit_condition_id(self, value):
+        self.standard_permit_condition_id = value
+
+    def __repr__(self):
+        return f'<StandardReportReqPermitConditionXref {self.mine_report_req_permit_condition_xref_guid}>'
+    
+    @classmethod
+    def create(cls,
+               mine_report_permit_requirement,
+               permit_condition_id):
+        standard_report_req_permit_condition_xref = cls(
+            mine_report_permit_requirement=mine_report_permit_requirement,
+            standard_permit_condition_id=permit_condition_id,    
+        )
+        return standard_report_req_permit_condition_xref

--- a/services/core-api/app/api/mines/reports/models/mine_report_req_permit_condition_xref.py
+++ b/services/core-api/app/api/mines/reports/models/mine_report_req_permit_condition_xref.py
@@ -39,6 +39,10 @@ class MineReportReqPermitConditionXref(SoftDeleteMixin, AuditMixin, HistoryMixin
         return cls.query.filter_by(permit_condition_id=id, deleted_ind=False).one_or_none()
     
     @classmethod
+    def find_by_many_permit_condition_ids(cls, ids) -> Self:
+        return cls.query.filter(cls.permit_condition_id.in_(ids), cls.deleted_ind==False).all()
+    
+    @classmethod
     def create(cls,
                mine_report_permit_requirement,
                permit_condition_id):
@@ -88,6 +92,14 @@ class StandardReportReqPermitConditionXref(MineReportReqPermitConditionXref):
 
     def __repr__(self):
         return f'<StandardReportReqPermitConditionXref {self.mine_report_req_permit_condition_xref_guid}>'
+
+    @classmethod
+    def find_by_many_permit_condition_ids(cls, ids) -> Self:
+        return cls.query.filter(cls.standard_permit_condition_id.in_(ids), cls.deleted_ind==False).all()
+    
+    @classmethod
+    def find_by_permit_condition_id(cls, id) -> Self:
+        return cls.query.filter_by(standard_permit_condition_id=id, deleted_ind=False).one_or_none()
     
     @classmethod
     def create(cls,

--- a/services/core-api/app/api/mines/response_models.py
+++ b/services/core-api/app/api/mines/response_models.py
@@ -994,7 +994,9 @@ STANDARD_PERMIT_CONDITION_MODEL = api.model(
         'condition_type_code': fields.String,
         'sub_conditions': fields.List(StandardPermitCondition),
         'step': fields.String,
-        'display_order': fields.Integer
+        'display_order': fields.Integer,
+        'condition_tags': fields.List(fields.String)
+        
     })
 
 GOVERNMENT_AGENCY_TYPE_MODEL = api.model(

--- a/services/core-api/app/api/mines/response_models.py
+++ b/services/core-api/app/api/mines/response_models.py
@@ -258,7 +258,8 @@ MINE_REPORT_PERMIT_REQUIREMENT = api.model(
         'cim_or_cpo': fields.String(enum=[e.value for e in CimOrCpo], attribute='cim_or_cpo.name'),
         'ministry_recipient': fields.List(fields.String(enum=[e.value for e in OfficeDestination])),
         'permit_condition_ids': fields.List(fields.Integer),
-        'permit_amendment_id': fields.Integer
+        'permit_amendment_id': fields.Integer,
+        'is_standard': fields.Boolean,
     }
 )
 

--- a/services/core-api/tests/auth/test_expected_auth.py
+++ b/services/core-api/tests/auth/test_expected_auth.py
@@ -77,6 +77,9 @@ from app.api.mines.region.resources.region import MineRegionResource
 from app.api.mines.reports.resources.mine_report_permit_requirement import (
     MineReportPermitRequirementResource,
 )
+from app.api.mines.permits.permit_conditions.resources.standard_report_permit_requirement_resource import (
+    StandardReportPermitRequirementResource
+)
 from app.api.mines.reports.resources.mine_reports import (
     MineReportListResource,
     MineReportResource,
@@ -220,6 +223,10 @@ from app.api.utils.access_decorators import (
      (MineReportListResource, "get", [VIEW_ALL, MINESPACE_PROPONENT]),
      (MineReportListResource, "post", [EDIT_REPORT, MINESPACE_PROPONENT]),
      (MineReportPermitRequirementResource, "post", [EDIT_REPORT]),
+     (StandardReportPermitRequirementResource, "post", [EDIT_STANDARD_PERMIT_CONDITIONS]),
+     (StandardReportPermitRequirementResource, "put", [EDIT_STANDARD_PERMIT_CONDITIONS]),
+     (StandardReportPermitRequirementResource, "delete", [EDIT_STANDARD_PERMIT_CONDITIONS]),
+     (StandardReportPermitRequirementResource, "get", [VIEW_ALL, MINESPACE_PROPONENT]),
      (MineStatusXrefListResource, "get", [VIEW_ALL]),
      (MineTailingsStorageFacilityListResource, "get", [VIEW_ALL]),
      (MineTailingsStorageFacilityListResource, "post", [MINESPACE_PROPONENT, EDIT_TSF]),

--- a/services/core-api/tests/factories.py
+++ b/services/core-api/tests/factories.py
@@ -7,6 +7,7 @@ import factory
 import factory.fuzzy
 from app.api.activity.models.activity_notification import ActivityNotification
 from app.api.mines.permits.permit_conditions.models.permit_condition_tag import PermitConditionTag
+from app.api.mines.permits.permit_conditions.models.standard_permit_condition_tag_xref import StandardPermitConditionTagXref
 from app.api.projects.ams_final_application.models.ams_final_application import AmsFinalApplication
 from app.api.projects.ams_final_application.models.ams_final_application_document_xref import AmsFinalApplicationDocumentXref
 from app.api.constants import PERMIT_LINKED_CONTACT_TYPES, TSF_ALLOWED_CONTACT_TYPES
@@ -57,10 +58,12 @@ from app.api.mines.reports.models.mine_report_definition_compliance_article_xref
 from app.api.mines.reports.models.mine_report_permit_requirement import (
     CimOrCpo,
     MineReportPermitRequirement,
+    StandardReportPermitRequirement,
     OfficeDestination,
 )
 from app.api.mines.reports.models.mine_report_req_permit_condition_xref import (
     MineReportReqPermitConditionXref,
+    StandardReportReqPermitConditionXref,
 )
 from app.api.mines.reports.models.mine_report_submission import MineReportSubmission
 from app.api.mines.status.models.mine_status import MineStatus
@@ -1145,6 +1148,18 @@ class PermitConditionTagFactory(BaseFactory):
     description = factory.Faker('text', max_nb_chars=20)
     deleted_ind = False
 
+class StandardPermitConditionTagXrefFactory(BaseFactory):
+    class Meta:
+        model = StandardPermitConditionTagXref
+
+    class Params:
+        permit_condition_tag = factory.SubFactory(PermitConditionTagFactory)
+        standard_permit_condition = factory.SubFactory(StandardPermitConditions)
+    
+    standard_permit_condition_tag_xref_guid = GUID
+    permit_condition_tag_guid = factory.SelfAttribute('permit_condition_tag.permit_condition_tag_guid')
+    standard_permit_condition_id = factory.SelfAttribute('standard_permit_condition.standard_permit_condition_id')
+
 class PermitAmendmentFactory(BaseFactory):
 
     class Meta:
@@ -1891,6 +1906,19 @@ class MineReportPermitRequirementFactory(BaseFactory):
     mine_report_permit_requirement_id = factory.LazyFunction(lambda: random.randint(1, 12))
     permit_amendment_id = factory.SelfAttribute('permit_amendment.permit_amendment_id')
 
+class StandardReportPermitRequirementFactory(BaseFactory):
+    class Meta:
+        model = StandardReportPermitRequirement
+
+    due_date_period_months = factory.LazyFunction(lambda: random.randint(1, 12))
+    active_ind = factory.LazyFunction(lambda: random.choice([True, False]))
+    deleted_ind = False
+    cim_or_cpo = factory.LazyFunction(lambda: random.choice(list(CimOrCpo)))
+    ministry_recipient = factory.LazyFunction(
+        lambda: [random.choice(list(OfficeDestination))]
+    )
+    mine_report_permit_requirement_id = factory.LazyFunction(lambda: random.randint(1, 12))  
+    report_name = factory.Faker('name')
 
 class MineReportReqPermitConditionXrefFactory(BaseFactory):
     class Meta:
@@ -1903,6 +1931,17 @@ class MineReportReqPermitConditionXrefFactory(BaseFactory):
     permit_condition_id = factory.SelfAttribute('permit_condition.permit_condition_id')
     mine_report_permit_requirement_id = factory.SelfAttribute('mine_report_permit_requirement.mine_report_permit_requirement_id')
 
+class StandardReportReqConditionXrefFactory(BaseFactory):
+    class Meta:
+        model = StandardReportReqPermitConditionXref
+
+    class Params:
+        permit_condition = factory.SubFactory(PermitConditionsFactory)
+        mine_report_permit_requirement = factory.SubFactory(StandardReportPermitRequirementFactory)
+
+    standard_permit_condition_id = factory.SelfAttribute('permit_condition.permit_condition_id')
+    permit_condition_id = factory.SelfAttribute('permit_condition.permit_condition_id')
+    mine_report_permit_requirement_id = factory.SelfAttribute('mine_report_permit_requirement.mine_report_permit_requirement_id')
 
 class PermitExtractionTaskFactory(BaseFactory):
     class Meta:

--- a/services/core-api/tests/mines/permit/models/test_copy_permit_conditions.py
+++ b/services/core-api/tests/mines/permit/models/test_copy_permit_conditions.py
@@ -1,0 +1,105 @@
+from app.api.mines.permits.permit_conditions.models.standard_permit_conditions import StandardPermitConditions
+from app.api.mines.permits.permit_conditions.models.permit_conditions import PermitConditions
+from app.api.mines.reports.models.mine_report_permit_requirement import MineReportPermitRequirement
+from tests.factories import (
+    PermitAmendmentFactory, 
+    StandardPermitConditionsFactory, 
+    PermitConditionTagFactory, 
+    StandardPermitConditionTagXrefFactory,
+    StandardReportPermitRequirementFactory, 
+    StandardReportReqConditionXrefFactory, 
+    create_mine_and_permit,
+)
+
+def test_copy_permit_conditions_from_standard(db_session):
+    mine, permit = create_mine_and_permit(num_permit_amendments=1)
+    permit_amendment = PermitAmendmentFactory(conditions=0, mine=mine, permit=permit)
+
+    standard_permit_conditions = StandardPermitConditionsFactory.create_batch(size=3)
+    for i, c in enumerate(standard_permit_conditions):
+        sub = StandardPermitConditions(
+            condition=f"condition text {i}",
+            condition_category_code=c.condition_category_code,
+            condition_type_code="LIS",
+            notice_of_work_type=c.notice_of_work_type,
+            parent_standard_permit_condition_id=c.standard_permit_condition_id,
+            display_order=i + 1,            
+        )
+        sub.save(commit=True)
+
+    # tags + tag xrefs for standard conditions
+    tag1 = PermitConditionTagFactory()
+    tag2 = PermitConditionTagFactory()
+
+    StandardPermitConditionTagXrefFactory(
+        permit_condition_tag=tag1,
+        standard_permit_condition=standard_permit_conditions[0]
+    )
+    StandardPermitConditionTagXrefFactory(
+        permit_condition_tag=tag2,
+        standard_permit_condition=standard_permit_conditions[2].sub_conditions[0]
+    )
+
+    # report requirements + condition xrefs for standard conditions
+    # has 1 condition
+    req1 = StandardReportPermitRequirementFactory()
+    # has 2 conditions
+    req2 = StandardReportPermitRequirementFactory()
+
+    StandardReportReqConditionXrefFactory(
+        permit_condition=standard_permit_conditions[0],
+        mine_report_permit_requirement=req1
+    )
+    StandardReportReqConditionXrefFactory(
+        permit_condition=standard_permit_conditions[1],
+        mine_report_permit_requirement=req2
+    )
+    StandardReportReqConditionXrefFactory(
+        permit_condition=standard_permit_conditions[2].sub_conditions[0],
+        mine_report_permit_requirement=req2
+    )
+    
+    # copy over standard conditions to permit amendment
+    PermitConditions.copy_from_standard(standard_permit_conditions, permit_amendment.permit_amendment_id)
+
+    # check conditions were copied correctly
+    assert len(permit_amendment.conditions) == len(standard_permit_conditions)
+    for spc in standard_permit_conditions:
+        matching_conditions = [c for c in permit_amendment.conditions if c.condition == spc.condition]
+        assert len(matching_conditions) == 1
+        copied_condition = matching_conditions[0]
+        assert copied_condition.condition_category_code == spc.condition_category_code
+        assert copied_condition.display_order == spc.display_order
+        assert len(copied_condition.sub_conditions) == len(spc.sub_conditions)
+
+        spc_sub = spc.sub_conditions[0]
+        copied_sub = copied_condition.sub_conditions[0]
+        assert copied_sub.condition == spc_sub.condition
+        assert copied_sub.condition_category_code == spc_sub.condition_category_code
+        assert copied_sub.display_order == spc_sub.display_order
+
+        # check tags were copied correctly
+        assert len(spc.condition_tags) == len(copied_condition.condition_tags)
+        if (len(spc.condition_tags) > 0):
+            assert spc.condition_tags[0] == copied_condition.condition_tags[0]
+        # check tags on sub_conditions copy as well
+        assert len(spc_sub.condition_tags) == len(copied_sub.condition_tags)
+        if (len(spc_sub.condition_tags) > 0):
+            assert spc_sub.condition_tags[0] == copied_sub.condition_tags[0]
+
+    # check report req were copied correctly
+    copied_report_req_1 = MineReportPermitRequirement.find_by_report_name(req1.report_name, permit_amendment.permit_amendment_id)
+    copied_report_req_2 = MineReportPermitRequirement.find_by_report_name(req2.report_name, permit_amendment.permit_amendment_id)
+
+    assert copied_report_req_1 is not None
+    assert copied_report_req_2 is not None
+
+    assert copied_report_req_1.due_date_period_months == req1.due_date_period_months
+    assert copied_report_req_1.cim_or_cpo == req1.cim_or_cpo
+    assert copied_report_req_1.ministry_recipient == req1.ministry_recipient
+    assert len(copied_report_req_1.permit_conditions) == 1
+
+    assert len(copied_report_req_2.permit_conditions) == 2
+    expected_condition_ids = [permit_amendment.conditions[1].permit_condition_id, permit_amendment.conditions[2].sub_conditions[0].permit_condition_id]
+    assert copied_report_req_2.permit_conditions[0].permit_condition_id in expected_condition_ids
+    assert copied_report_req_2.permit_conditions[1].permit_condition_id in expected_condition_ids

--- a/services/core-api/tests/mines/permit/resources/test_standard_permit_condition_resource.py
+++ b/services/core-api/tests/mines/permit/resources/test_standard_permit_condition_resource.py
@@ -61,18 +61,6 @@ def test_put_standard_permit(test_client, db_session, auth_headers):
 
     assert put_resp.status_code == 200
 
-
-def test_put_standard_permit(test_client, db_session, auth_headers):
-    standard_permit_condition = StandardPermitConditionsFactory()
-
-    put_resp = test_client.put(
-        f'/mines/permits/standard-conditions/{uuid.uuid4()}',
-        headers=auth_headers['full_auth_header'],
-        json=STD_PERMIT_CONDITIONS_DATA)
-
-    assert put_resp.status_code == 200
-
-
 def test_delete_standard_permit(test_client, db_session, auth_headers):
     standard_permit_condition = StandardPermitConditionsFactory()
 

--- a/services/core-api/tests/mines/permit/resources/test_standard_permit_condition_resource.py
+++ b/services/core-api/tests/mines/permit/resources/test_standard_permit_condition_resource.py
@@ -1,9 +1,7 @@
 import json
 import uuid
 
-from flask import current_app
-from app.api.mines.permits.permit_conditions.models.standard_permit_conditions import StandardPermitConditions
-from tests.factories import StandardPermitConditionsFactory
+from tests.factories import StandardPermitConditionsFactory, PermitConditionTagFactory, StandardPermitConditionTagXrefFactory
 
 NOTICE_OF_WORK_TYPE ='SAG'
 
@@ -83,3 +81,26 @@ def test_delete_not_found_standard_permit(test_client, db_session, auth_headers)
 
     assert 'No standard permit condition found with that guid.' in del_data['message']
     assert del_resp.status_code == 400
+
+def test_standard_permit_condition_tags(test_client, db_session, auth_headers):
+    standard_permit_condition = StandardPermitConditionsFactory()
+    tag = PermitConditionTagFactory()
+    StandardPermitConditionTagXrefFactory(
+        permit_condition_tag=tag,
+        standard_permit_condition=standard_permit_condition
+    )
+
+    new_tag = PermitConditionTagFactory()
+
+    put_json = STD_PERMIT_CONDITIONS_DATA | {
+        "condition_tags": [new_tag.permit_condition_tag_guid]
+    }
+    put_resp = test_client.put(
+        f'/mines/permits/standard-conditions/{standard_permit_condition.standard_permit_condition_guid}',
+        headers=auth_headers['full_auth_header'],
+        json=put_json)
+
+    assert put_resp.status_code == 200
+    put_data = json.loads(put_resp.data.decode())
+    assert len(put_data['condition_tags']) == 1
+    assert put_data['condition_tags'][0] == str(new_tag.permit_condition_tag_guid)

--- a/services/core-api/tests/mines/permit/resources/test_standard_report_permit_requirement_resource.py
+++ b/services/core-api/tests/mines/permit/resources/test_standard_report_permit_requirement_resource.py
@@ -1,0 +1,120 @@
+import json
+from tests.factories import StandardPermitConditionsFactory, StandardReportPermitRequirementFactory, StandardReportReqConditionXrefFactory
+
+def test_post_standard_report_permit_requirement(test_client, db_session, auth_headers):
+    standard_condition = StandardPermitConditionsFactory()
+
+    submission_data = {
+        'due_date_period_months': 6,
+        'cim_or_cpo': 'CIM',
+        'ministry_recipient': ['HS'],
+        'permit_condition_ids': [standard_condition.standard_permit_condition_id],
+        'report_name': "Test Report"
+    }
+
+    post_resp = test_client.post(
+        '/mines/reports/standard-permit-requirements',
+        headers=auth_headers['full_auth_header'],
+        json=submission_data
+    )
+    post_data = json.loads(post_resp.data.decode())
+
+    assert post_resp.status_code == 201
+
+    for key, value in submission_data.items():
+        assert post_data[key] == value, f'mismatch with {key}, expected {value}, got {str(post_data[key])}'
+
+    assert post_data['is_standard'] == True
+    assert post_data['permit_amendment_id'] is None
+    assert post_data['mine_report_permit_requirement_id'] is not None
+
+def test_update_standard_report_requirement(test_client, db_session, auth_headers):
+    # Create initial standard report requirement and xref using factories
+    standard_condition = StandardPermitConditionsFactory()
+    report_req = StandardReportPermitRequirementFactory(
+        due_date_period_months=6,
+        cim_or_cpo='CIM',
+        ministry_recipient=['HS'],
+        report_name="Test Report Update"
+    )
+    StandardReportReqConditionXrefFactory(
+        permit_condition=standard_condition,
+        mine_report_permit_requirement=report_req
+    )
+    db_session.commit()
+
+    # Update the report requirement
+    update_data = {
+        'mine_report_permit_requirement_id': report_req.mine_report_permit_requirement_id,
+        'due_date_period_months': 12,
+        'cim_or_cpo': 'CPO',
+        'ministry_recipient': ['MMO'],
+        'permit_condition_ids': [standard_condition.standard_permit_condition_id],
+        'report_name': "Test Report Update"
+    }
+    put_resp = test_client.put(
+        '/mines/reports/standard-permit-requirements',
+        headers=auth_headers['full_auth_header'],
+        json=update_data
+    )
+    put_data = json.loads(put_resp.data.decode())
+    assert put_resp.status_code == 200
+    assert put_data['due_date_period_months'] == 12
+    assert put_data['cim_or_cpo'] == 'CPO'
+    assert put_data['ministry_recipient'] == ['MMO']
+    assert put_data['permit_condition_ids'] == [standard_condition.standard_permit_condition_id]
+    assert put_data['report_name'] == "Test Report Update"
+
+def test_delete_standard_report_requirement(test_client, db_session, auth_headers):
+    # Create initial standard report requirement and xref using factories
+    standard_condition = StandardPermitConditionsFactory()
+    report_req = StandardReportPermitRequirementFactory(
+        due_date_period_months=6,
+        cim_or_cpo='CIM',
+        ministry_recipient=['HS'],
+        report_name="Test Report Delete"
+    )
+    StandardReportReqConditionXrefFactory(
+        permit_condition=standard_condition,
+        mine_report_permit_requirement=report_req
+    )
+    db_session.commit()
+
+    # Delete the report requirement
+    delete_resp = test_client.delete(
+        f"/mines/reports/standard-permit-requirements?mine_report_permit_requirement_id={report_req.mine_report_permit_requirement_id}",
+        headers=auth_headers['full_auth_header'],
+    )
+    assert delete_resp.status_code == 204
+
+def test_post_duplicate_standard_report_requirement_bad_request(test_client, db_session, auth_headers):
+    # Create initial standard report requirement and xref using factories
+    standard_condition = StandardPermitConditionsFactory()
+    report_req = StandardReportPermitRequirementFactory(
+        due_date_period_months=6,
+        cim_or_cpo='CIM',
+        ministry_recipient=['HS'],
+        report_name="DUPLICATE_STANDARD_REPORT_NAME_TEST"
+    )
+    StandardReportReqConditionXrefFactory(
+        permit_condition=standard_condition,
+        mine_report_permit_requirement=report_req
+    )
+    db_session.commit()
+
+    # Attempt to create duplicate via POST
+    submission_data = {
+        'due_date_period_months': 6,
+        'cim_or_cpo': 'CIM',
+        'ministry_recipient': ['HS'],
+        'permit_condition_ids': [standard_condition.standard_permit_condition_id],
+        'report_name': "DUPLICATE_STANDARD_REPORT_NAME_TEST"
+    }
+    post_resp_2 = test_client.post(
+        '/mines/reports/standard-permit-requirements',
+        headers=auth_headers['full_auth_header'],
+        json=submission_data
+    )
+    assert post_resp_2.status_code == 400
+    data = json.loads(post_resp_2.data.decode())
+    assert "Report name must be unique" in data.get("message", "")

--- a/services/core-web/src/components/Forms/permits/conditions/StandardPermitConditions.tsx
+++ b/services/core-web/src/components/Forms/permits/conditions/StandardPermitConditions.tsx
@@ -7,8 +7,7 @@ import { fetchStandardPermitConditions } from "@mds/common/redux/actionCreators/
 import { getIsFetching } from "@mds/common/redux/reducers/networkReducer";
 import { useAppDispatch, useAppSelector } from "@mds/common/redux/rootState";
 import { getStandardPermitConditionsFormatted } from "@mds/common/redux/selectors/permitSelectors";
-import { IFormattedConditionCategory, IPermitConditionTag } from "@mds/common/interfaces";
-import { fetchPermitConditionTags, getPermitConditionTags } from "@mds/common/redux/slices/permitConditionTagSlice";
+import { IFormattedConditionCategory } from "@mds/common/interfaces";
 import { fetchStandardReportRequirements, getStandardReportRequirements } from "@mds/common/redux/slices/mineReportPermitRequirementSlice";
 
 
@@ -40,17 +39,8 @@ const StandardPermitConditions: FC<StandardPermitConditionsProps> = ({ type }) =
     const [isLoading, setIsLoading] = useState(false);
     const [editingFormName, setEditingFormName] = useState<string>();
     const [addingToCategoryCode, setAddingToCategoryCode] = useState<string>();
-    // TODO: won't be necessary after NoW editor merge
-    const conditionTags: IPermitConditionTag[] = useAppSelector(getPermitConditionTags);
 
     const showLoading = conditionsLoading || isLoading;
-
-    // TODO: remove
-    useEffect(() => {
-        if (conditionTags?.length === 0) {
-            dispatch(fetchPermitConditionTags(undefined));
-        }
-    }, [conditionTags]);
 
     useEffect(() => {
         if (!reportRequirements) {

--- a/services/core-web/src/components/Forms/permits/conditions/StandardPermitConditions.tsx
+++ b/services/core-web/src/components/Forms/permits/conditions/StandardPermitConditions.tsx
@@ -9,6 +9,7 @@ import { useAppDispatch, useAppSelector } from "@mds/common/redux/rootState";
 import { getStandardPermitConditionsFormatted } from "@mds/common/redux/selectors/permitSelectors";
 import { IFormattedConditionCategory, IPermitConditionTag } from "@mds/common/interfaces";
 import { fetchPermitConditionTags, getPermitConditionTags } from "@mds/common/redux/slices/permitConditionTagSlice";
+import { fetchStandardReportRequirements, getStandardReportRequirements } from "@mds/common/redux/slices/mineReportPermitRequirementSlice";
 
 
 interface StandardPermitConditionsProps {
@@ -35,6 +36,7 @@ const StandardPermitConditions: FC<StandardPermitConditionsProps> = ({ type }) =
     const { categoriesWithConditions } = useAppSelector(getStandardPermitConditionsFormatted());
     const conditionsLoading = useAppSelector(getIsFetching(NetworkReducerTypes.GET_PERMIT_CONDITIONS));
     const conditionsLoaded = categoriesWithConditions[0]?.conditions[0]?.notice_of_work_type === typeCode;
+    const reportRequirements = useAppSelector(getStandardReportRequirements);
     const [isLoading, setIsLoading] = useState(false);
     const [editingFormName, setEditingFormName] = useState<string>();
     const [addingToCategoryCode, setAddingToCategoryCode] = useState<string>();
@@ -49,6 +51,12 @@ const StandardPermitConditions: FC<StandardPermitConditionsProps> = ({ type }) =
             dispatch(fetchPermitConditionTags(undefined));
         }
     }, [conditionTags]);
+
+    useEffect(() => {
+        if (!reportRequirements) {
+            dispatch(fetchStandardReportRequirements(undefined))
+        }
+    }, [reportRequirements]);
 
     useEffect(() => {
         if (!conditionsLoaded) {

--- a/services/core-web/src/components/Forms/permits/conditions/StandardPermitConditions.tsx
+++ b/services/core-web/src/components/Forms/permits/conditions/StandardPermitConditions.tsx
@@ -7,7 +7,8 @@ import { fetchStandardPermitConditions } from "@mds/common/redux/actionCreators/
 import { getIsFetching } from "@mds/common/redux/reducers/networkReducer";
 import { useAppDispatch, useAppSelector } from "@mds/common/redux/rootState";
 import { getStandardPermitConditionsFormatted } from "@mds/common/redux/selectors/permitSelectors";
-import { IFormattedConditionCategory } from "@mds/common/interfaces";
+import { IFormattedConditionCategory, IPermitConditionTag } from "@mds/common/interfaces";
+import { fetchPermitConditionTags, getPermitConditionTags } from "@mds/common/redux/slices/permitConditionTagSlice";
 
 
 interface StandardPermitConditionsProps {
@@ -37,9 +38,17 @@ const StandardPermitConditions: FC<StandardPermitConditionsProps> = ({ type }) =
     const [isLoading, setIsLoading] = useState(false);
     const [editingFormName, setEditingFormName] = useState<string>();
     const [addingToCategoryCode, setAddingToCategoryCode] = useState<string>();
+    // TODO: won't be necessary after NoW editor merge
+    const conditionTags: IPermitConditionTag[] = useAppSelector(getPermitConditionTags);
 
     const showLoading = conditionsLoading || isLoading;
 
+    // TODO: remove
+    useEffect(() => {
+        if (conditionTags?.length === 0) {
+            dispatch(fetchPermitConditionTags(undefined));
+        }
+    }, [conditionTags]);
 
     useEffect(() => {
         if (!conditionsLoaded) {

--- a/services/core-web/src/components/Forms/permits/conditions/__snapshots__/StandardPermitConditions.spec.tsx.snap
+++ b/services/core-web/src/components/Forms/permits/conditions/__snapshots__/StandardPermitConditions.spec.tsx.snap
@@ -192,6 +192,9 @@ exports[`StandardPermitConditions renders properly 1`] = `
                               </div>
                             </div>
                           </div>
+                          <div
+                            class="ant-row"
+                          />
                         </div>
                         <div>
                           <div
@@ -226,6 +229,9 @@ exports[`StandardPermitConditions renders properly 1`] = `
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                               <div>
                                 <div
@@ -260,6 +266,9 @@ exports[`StandardPermitConditions renders properly 1`] = `
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -297,6 +306,9 @@ exports[`StandardPermitConditions renders properly 1`] = `
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -334,6 +346,9 @@ exports[`StandardPermitConditions renders properly 1`] = `
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -371,6 +386,9 @@ exports[`StandardPermitConditions renders properly 1`] = `
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -408,6 +426,9 @@ exports[`StandardPermitConditions renders properly 1`] = `
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -445,6 +466,9 @@ exports[`StandardPermitConditions renders properly 1`] = `
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -482,6 +506,9 @@ exports[`StandardPermitConditions renders properly 1`] = `
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -519,6 +546,9 @@ exports[`StandardPermitConditions renders properly 1`] = `
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -559,6 +589,9 @@ exports[`StandardPermitConditions renders properly 1`] = `
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                               <div>
                                 <div
@@ -593,6 +626,9 @@ exports[`StandardPermitConditions renders properly 1`] = `
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -634,6 +670,9 @@ OR Activities must be conducted as outlined in [Document X].
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                             </div>
                           </div>
@@ -673,6 +712,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                             </div>
                           </div>
@@ -710,6 +752,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                             </div>
                           </div>
@@ -747,6 +792,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                             </div>
                           </div>
@@ -784,6 +832,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                             </div>
                           </div>
@@ -821,6 +872,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                             </div>
                           </div>
@@ -858,6 +912,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                             </div>
                           </div>
@@ -902,6 +959,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                               </div>
                             </div>
                           </div>
+                          <div
+                            class="ant-row"
+                          />
                         </div>
                         <div>
                           <div
@@ -936,6 +996,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                             </div>
                           </div>
@@ -980,6 +1043,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                               </div>
                             </div>
                           </div>
+                          <div
+                            class="ant-row"
+                          />
                         </div>
                         <div>
                           <div
@@ -1014,6 +1080,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                             </div>
                           </div>
@@ -1051,6 +1120,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                               <div>
                                 <div
@@ -1085,6 +1157,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -1122,6 +1197,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -1162,6 +1240,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                             </div>
                           </div>
@@ -1199,6 +1280,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                             </div>
                           </div>
@@ -1243,6 +1327,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                               </div>
                             </div>
                           </div>
+                          <div
+                            class="ant-row"
+                          />
                         </div>
                         <div>
                           <div
@@ -1277,6 +1364,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                             </div>
                           </div>
@@ -1466,6 +1556,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                               </div>
                             </div>
                           </div>
+                          <div
+                            class="ant-row"
+                          />
                         </div>
                         <div>
                           <div
@@ -1500,6 +1593,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                             </div>
                           </div>
@@ -1544,6 +1640,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                               </div>
                             </div>
                           </div>
+                          <div
+                            class="ant-row"
+                          />
                         </div>
                         <div>
                           <div
@@ -1578,6 +1677,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                             </div>
                           </div>
@@ -1622,6 +1724,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                               </div>
                             </div>
                           </div>
+                          <div
+                            class="ant-row"
+                          />
                         </div>
                         <div>
                           <div
@@ -1656,6 +1761,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                             </div>
                           </div>
@@ -1693,6 +1801,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                             </div>
                           </div>
@@ -1730,6 +1841,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                             </div>
                           </div>
@@ -1767,6 +1881,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                             </div>
                           </div>
@@ -1804,6 +1921,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                             </div>
                           </div>
@@ -1841,6 +1961,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                             </div>
                           </div>
@@ -1878,6 +2001,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                             </div>
                           </div>
@@ -1915,6 +2041,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                             </div>
                           </div>
@@ -1952,6 +2081,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                             </div>
                           </div>
@@ -1989,6 +2121,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                             </div>
                           </div>
@@ -2026,6 +2161,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                             </div>
                           </div>
@@ -2063,6 +2201,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                               <div>
                                 <div
@@ -2097,6 +2238,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -2134,6 +2278,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -2171,6 +2318,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -2208,6 +2358,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -2245,6 +2398,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -2282,6 +2438,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -2474,6 +2633,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                               </div>
                             </div>
                           </div>
+                          <div
+                            class="ant-row"
+                          />
                         </div>
                         <div>
                           <div
@@ -2508,6 +2670,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                             </div>
                           </div>
@@ -2545,6 +2710,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                               <div>
                                 <div
@@ -2579,6 +2747,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -2616,6 +2787,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -2663,6 +2837,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                               </div>
                             </div>
                           </div>
+                          <div
+                            class="ant-row"
+                          />
                         </div>
                         <div>
                           <div
@@ -2697,6 +2874,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                             </div>
                           </div>
@@ -2741,6 +2921,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                               </div>
                             </div>
                           </div>
+                          <div
+                            class="ant-row"
+                          />
                         </div>
                         <div>
                           <div
@@ -2775,6 +2958,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                             </div>
                           </div>
@@ -2812,6 +2998,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                             </div>
                           </div>
@@ -2856,6 +3045,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                               </div>
                             </div>
                           </div>
+                          <div
+                            class="ant-row"
+                          />
                         </div>
                       </div>
                       <div />
@@ -2897,6 +3089,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                               </div>
                             </div>
                           </div>
+                          <div
+                            class="ant-row"
+                          />
                         </div>
                         <div>
                           <div
@@ -2931,6 +3126,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                               <div>
                                 <div
@@ -2965,6 +3163,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -3005,6 +3206,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                               <div>
                                 <div
@@ -3039,6 +3243,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -3231,6 +3438,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                               </div>
                             </div>
                           </div>
+                          <div
+                            class="ant-row"
+                          />
                         </div>
                         <div>
                           <div
@@ -3265,6 +3475,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                             </div>
                           </div>
@@ -3302,6 +3515,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                             </div>
                           </div>
@@ -3339,6 +3555,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                             </div>
                           </div>
@@ -3376,6 +3595,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                             </div>
                           </div>
@@ -3413,6 +3635,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                               <div>
                                 <div
@@ -3447,6 +3672,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -3484,6 +3712,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -3531,6 +3762,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                               </div>
                             </div>
                           </div>
+                          <div
+                            class="ant-row"
+                          />
                         </div>
                         <div>
                           <div
@@ -3565,6 +3799,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                             </div>
                           </div>
@@ -3602,6 +3839,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                             </div>
                           </div>
@@ -3639,6 +3879,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                             </div>
                           </div>
@@ -3676,6 +3919,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                             </div>
                           </div>
@@ -3713,6 +3959,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                             </div>
                           </div>
@@ -3750,6 +3999,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                             </div>
                           </div>
@@ -3787,6 +4039,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                             </div>
                           </div>
@@ -3824,6 +4079,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                               <div>
                                 <div
@@ -3858,6 +4116,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -3898,6 +4159,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                               <div>
                                 <div
@@ -3932,6 +4196,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -3979,6 +4246,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                               </div>
                             </div>
                           </div>
+                          <div
+                            class="ant-row"
+                          />
                         </div>
                         <div>
                           <div
@@ -4013,6 +4283,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                             </div>
                           </div>
@@ -4050,6 +4323,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                             </div>
                           </div>
@@ -4087,6 +4363,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                             </div>
                           </div>
@@ -4124,6 +4403,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                             </div>
                           </div>
@@ -4161,6 +4443,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                             </div>
                           </div>
@@ -4205,6 +4490,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                               </div>
                             </div>
                           </div>
+                          <div
+                            class="ant-row"
+                          />
                         </div>
                         <div>
                           <div
@@ -4239,6 +4527,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                               <div>
                                 <div
@@ -4273,6 +4564,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -4310,6 +4604,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                     <div>
                                       <div
@@ -4344,6 +4641,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                                 </div>
                                               </div>
                                             </div>
+                                            <div
+                                              class="ant-row"
+                                            />
                                           </div>
                                         </div>
                                       </div>
@@ -4381,6 +4681,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                                 </div>
                                               </div>
                                             </div>
+                                            <div
+                                              class="ant-row"
+                                            />
                                           </div>
                                         </div>
                                       </div>
@@ -4418,6 +4721,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                                 </div>
                                               </div>
                                             </div>
+                                            <div
+                                              class="ant-row"
+                                            />
                                           </div>
                                         </div>
                                       </div>
@@ -4455,6 +4761,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                                 </div>
                                               </div>
                                             </div>
+                                            <div
+                                              class="ant-row"
+                                            />
                                           </div>
                                         </div>
                                       </div>
@@ -4492,6 +4801,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                                 </div>
                                               </div>
                                             </div>
+                                            <div
+                                              class="ant-row"
+                                            />
                                           </div>
                                         </div>
                                       </div>
@@ -4535,6 +4847,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                               <div>
                                 <div
@@ -4569,6 +4884,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -4606,6 +4924,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -4643,6 +4964,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -4680,6 +5004,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -4717,6 +5044,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -4754,6 +5084,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -4791,6 +5124,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -4828,6 +5164,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -4865,6 +5204,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -4902,6 +5244,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -4942,6 +5287,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                               <div>
                                 <div
@@ -4976,6 +5324,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -5013,6 +5364,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -5050,6 +5404,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -5087,6 +5444,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -5124,6 +5484,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -5161,6 +5524,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -5198,6 +5564,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -5238,6 +5607,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                               <div>
                                 <div
@@ -5272,6 +5644,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -5309,6 +5684,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -5346,6 +5724,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -5383,6 +5764,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -5420,6 +5804,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -5457,6 +5844,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -5494,6 +5884,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -5534,6 +5927,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                               <div>
                                 <div
@@ -5568,6 +5964,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -5608,6 +6007,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                               <div>
                                 <div
@@ -5642,6 +6044,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -5679,6 +6084,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -5716,6 +6124,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -5756,6 +6167,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                               <div>
                                 <div
@@ -5790,6 +6204,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -5827,6 +6244,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -5864,6 +6284,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -5904,6 +6327,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                               <div>
                                 <div
@@ -5938,6 +6364,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -5975,6 +6404,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -6012,6 +6444,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -6049,6 +6484,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -6086,6 +6524,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -6123,6 +6564,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -6163,6 +6607,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                               <div>
                                 <div
@@ -6197,6 +6644,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -6234,6 +6684,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -6271,6 +6724,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -6308,6 +6764,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                     <div>
                                       <div
@@ -6342,6 +6801,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                                 </div>
                                               </div>
                                             </div>
+                                            <div
+                                              class="ant-row"
+                                            />
                                           </div>
                                         </div>
                                       </div>
@@ -6379,6 +6841,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                                 </div>
                                               </div>
                                             </div>
+                                            <div
+                                              class="ant-row"
+                                            />
                                           </div>
                                         </div>
                                       </div>
@@ -6419,6 +6884,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -6456,6 +6924,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -6493,6 +6964,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -6530,6 +7004,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -6567,6 +7044,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -6614,6 +7094,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                               </div>
                             </div>
                           </div>
+                          <div
+                            class="ant-row"
+                          />
                         </div>
                         <div>
                           <div
@@ -6648,6 +7131,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                             </div>
                           </div>
@@ -6685,6 +7171,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                             </div>
                           </div>
@@ -6722,6 +7211,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                             </div>
                           </div>
@@ -6759,6 +7251,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                             </div>
                           </div>
@@ -6796,6 +7291,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                             </div>
                           </div>
@@ -6840,6 +7338,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                               </div>
                             </div>
                           </div>
+                          <div
+                            class="ant-row"
+                          />
                         </div>
                         <div>
                           <div
@@ -6874,6 +7375,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                               <div>
                                 <div
@@ -6908,6 +7412,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -6948,6 +7455,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                               <div>
                                 <div
@@ -6982,6 +7492,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -7174,6 +7687,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                               </div>
                             </div>
                           </div>
+                          <div
+                            class="ant-row"
+                          />
                         </div>
                         <div>
                           <div
@@ -7208,6 +7724,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                             </div>
                           </div>
@@ -7245,6 +7764,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                               <div>
                                 <div
@@ -7279,6 +7801,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -7316,6 +7841,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -7363,6 +7891,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                               </div>
                             </div>
                           </div>
+                          <div
+                            class="ant-row"
+                          />
                         </div>
                         <div>
                           <div
@@ -7397,6 +7928,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                             </div>
                           </div>
@@ -7434,6 +7968,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                             </div>
                           </div>
@@ -7478,6 +8015,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                               </div>
                             </div>
                           </div>
+                          <div
+                            class="ant-row"
+                          />
                         </div>
                         <div>
                           <div
@@ -7512,6 +8052,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                             </div>
                           </div>
@@ -7549,6 +8092,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                               <div>
                                 <div
@@ -7583,6 +8129,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -7620,6 +8169,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -7657,6 +8209,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -7694,6 +8249,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -7734,6 +8292,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                               <div>
                                 <div
@@ -7768,6 +8329,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -7805,6 +8369,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                     <div>
                                       <div
@@ -7839,6 +8406,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                                 </div>
                                               </div>
                                             </div>
+                                            <div
+                                              class="ant-row"
+                                            />
                                           </div>
                                         </div>
                                       </div>
@@ -7876,6 +8446,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                                 </div>
                                               </div>
                                             </div>
+                                            <div
+                                              class="ant-row"
+                                            />
                                           </div>
                                         </div>
                                       </div>
@@ -7913,6 +8486,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                                 </div>
                                               </div>
                                             </div>
+                                            <div
+                                              class="ant-row"
+                                            />
                                           </div>
                                         </div>
                                       </div>
@@ -7950,6 +8526,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                                 </div>
                                               </div>
                                             </div>
+                                            <div
+                                              class="ant-row"
+                                            />
                                           </div>
                                         </div>
                                       </div>
@@ -7987,6 +8566,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                                 </div>
                                               </div>
                                             </div>
+                                            <div
+                                              class="ant-row"
+                                            />
                                           </div>
                                         </div>
                                       </div>
@@ -8030,6 +8612,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                               <div>
                                 <div
@@ -8064,6 +8649,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -8101,6 +8689,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -8138,6 +8729,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -8185,6 +8779,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                               </div>
                             </div>
                           </div>
+                          <div
+                            class="ant-row"
+                          />
                         </div>
                         <div>
                           <div
@@ -8219,6 +8816,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                               <div>
                                 <div
@@ -8253,6 +8853,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -8290,6 +8893,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -8337,6 +8943,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                               </div>
                             </div>
                           </div>
+                          <div
+                            class="ant-row"
+                          />
                         </div>
                         <div>
                           <div
@@ -8371,6 +8980,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                               <div>
                                 <div
@@ -8405,6 +9017,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>
@@ -8445,6 +9060,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                     </div>
                                   </div>
                                 </div>
+                                <div
+                                  class="ant-row"
+                                />
                               </div>
                               <div>
                                 <div
@@ -8479,6 +9097,9 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                                           </div>
                                         </div>
                                       </div>
+                                      <div
+                                        class="ant-row"
+                                      />
                                     </div>
                                   </div>
                                 </div>

--- a/services/core-web/src/components/admin/permitConditions/PermitConditionsNavigation.tsx
+++ b/services/core-web/src/components/admin/permitConditions/PermitConditionsNavigation.tsx
@@ -57,13 +57,13 @@ const PermitConditionsNavigation: FC<AdminNavigationProps> = (props) => {
     id: ifActiveButton("tag-management"),
     icon: <DownOutlined />,
     children: [{
-        key: "tag-management",
-        label: (
-          <Link to={routes.ADMIN_PERMIT_CONDITION_TAG_MANAGEMENT.route}>
-            Manage Tags
-          </Link>
-        )
-      }
+      key: "manage-tags",
+      label: (
+        <Link to={routes.ADMIN_PERMIT_CONDITION_TAG_MANAGEMENT.route}>
+          Manage Tags
+        </Link>
+      )
+    }
     ]
   }
 


### PR DESCRIPTION
## Objective 
1. make it so admin users can add tags & report requirements to the standard conditions
2. and then when the standard conditions are copied over to a NoW when a draft permit is started, those tags & report requirements are also copied over

[MDS-6606](https://bcmines.atlassian.net/browse/MDS-6606)
