### PR TITLE
[MDS-6614] Extraction failing

### DIFF
--- a/services/core-api/app/api/mines/reports/models/mine_report_req_permit_condition_xref.py
+++ b/services/core-api/app/api/mines/reports/models/mine_report_req_permit_condition_xref.py
@@ -27,7 +27,9 @@ class MineReportReqPermitConditionXref(SoftDeleteMixin, AuditMixin, HistoryMixin
         return f'<MineReportReqPermitConditionXref {self.mine_report_req_permit_condition_xref_guid}>'
     
     @classmethod
-    def find_by_permit_condition_id(cls, id) -> Self:
+    def find_by_permit_condition_id(cls, id) -> Self | None:
+        if id is None:
+            return None
         return cls.query.filter_by(permit_condition_id=id, deleted_ind=False).one_or_none()
     
     @classmethod


### PR DESCRIPTION
## Objective 
- locally at least, the extraction was failing because of None being passed into the function and returning multiple rows
- hard to say what's happening in other environments
- still failed locally after switching to branch where records with permit_condition_id=None were being excluded from query, so change should probably go into effect

[MDS-6614](https://bcmines.atlassian.net/browse/MDS-6614)

_Why are you making this change? Provide a short explanation and/or screenshots_
