### PR TITLE
[MDS-6605] Report Requirement bug

### DIFF
--- a/services/common/src/components/permits/ReportPermitRequirementForm.tsx
+++ b/services/common/src/components/permits/ReportPermitRequirementForm.tsx
@@ -85,7 +85,9 @@ export const ReportPermitRequirementForm: FC<ReportPermitRequirementProps> = ({
     const linked = condition_ids
       .map((id) => {
         return conditionMap[id];
-      }).sort((a, b) => a.stepPath.localeCompare(b.stepPath));
+      })
+      .filter(Boolean)
+      .sort((a, b) => a.stepPath.localeCompare(b.stepPath));
 
     return <ul>
       {linked.map((lc) => {

--- a/services/core-api/app/api/mines/reports/models/mine_report_permit_requirement.py
+++ b/services/core-api/app/api/mines/reports/models/mine_report_permit_requirement.py
@@ -81,6 +81,13 @@ class MineReportPermitRequirement(SoftDeleteMixin, AuditMixin, HistoryMixin, Bas
             return None
 
     @classmethod
+    def find_by_permit_condition_id(cls, id) -> Self | None:
+        xref = MineReportReqPermitConditionXref.find_by_permit_condition_id(id)
+        if xref:
+            return xref.mine_report_permit_requirement
+        return None
+    
+    @classmethod
     def find_by_report_name(cls, report_name, permit_amendment_id) -> Self:
         return cls.query.filter_by(report_name=report_name, permit_amendment_id=permit_amendment_id).one_or_none()
 

--- a/services/core-api/app/api/mines/reports/models/mine_report_permit_requirement.py
+++ b/services/core-api/app/api/mines/reports/models/mine_report_permit_requirement.py
@@ -79,13 +79,6 @@ class MineReportPermitRequirement(SoftDeleteMixin, AuditMixin, HistoryMixin, Bas
             return cls.query.filter_by(mine_report_permit_requirement_id=id, deleted_ind=False).first()
         except ValueError:
             return None
-        
-    @classmethod
-    def find_by_permit_condition_id(cls, id) -> Self | None:
-        xref = MineReportReqPermitConditionXref.find_by_permit_condition_id(id)
-        if xref:
-            return xref.mine_report_permit_requirement
-        return None
 
     @classmethod
     def find_by_report_name(cls, report_name, permit_amendment_id) -> Self:

--- a/services/core-api/app/api/mines/reports/models/mine_report_req_permit_condition_xref.py
+++ b/services/core-api/app/api/mines/reports/models/mine_report_req_permit_condition_xref.py
@@ -28,7 +28,7 @@ class MineReportReqPermitConditionXref(SoftDeleteMixin, AuditMixin, HistoryMixin
     mine_report_permit_requirement = db.relationship(
         'MineReportPermitRequirement',
         lazy='joined',
-        primaryjoin='MineReportReqPermitConditionXref.mine_report_permit_requirement_id == MineReportPermitRequirement.mine_report_permit_requirement_id',
+        primaryjoin='and_(MineReportReqPermitConditionXref.mine_report_permit_requirement_id == MineReportPermitRequirement.mine_report_permit_requirement_id, MineReportPermitRequirement.deleted_ind==False)',
     )
 
     def __repr__(self):
@@ -38,7 +38,10 @@ class MineReportReqPermitConditionXref(SoftDeleteMixin, AuditMixin, HistoryMixin
     def find_by_permit_condition_id(cls, id) -> Self | None:
         if id is None:
             return None
-        return cls.query.filter_by(permit_condition_id=id, deleted_ind=False).one_or_none()
+        xref = cls.query.filter_by(permit_condition_id=id, deleted_ind=False).one_or_none()
+        if xref is None or xref.mine_report_permit_requirement is None:
+            return None
+        return xref
     
     @classmethod
     def find_by_many_permit_condition_ids(cls, ids) -> Self:
@@ -80,7 +83,7 @@ class StandardReportReqPermitConditionXref(MineReportReqPermitConditionXref):
     mine_report_permit_requirement = db.relationship(
         'StandardReportPermitRequirement',
         lazy='joined',
-        primaryjoin='StandardReportReqPermitConditionXref.mine_report_permit_requirement_id == StandardReportPermitRequirement.mine_report_permit_requirement_id',
+        primaryjoin='and_(StandardReportReqPermitConditionXref.mine_report_permit_requirement_id == StandardReportPermitRequirement.mine_report_permit_requirement_id, StandardReportPermitRequirement.deleted_ind==False)',
     )
 
     @property
@@ -99,8 +102,13 @@ class StandardReportReqPermitConditionXref(MineReportReqPermitConditionXref):
         return cls.query.filter(cls.standard_permit_condition_id.in_(ids), cls.deleted_ind==False).all()
     
     @classmethod
-    def find_by_permit_condition_id(cls, id) -> Self:
-        return cls.query.filter_by(standard_permit_condition_id=id, deleted_ind=False).one_or_none()
+    def find_by_permit_condition_id(cls, id) -> Self | None:
+        if id is None:
+            return None
+        xref = cls.query.filter_by(standard_permit_condition_id=id, deleted_ind=False).one_or_none()
+        if xref is None or xref.mine_report_permit_requirement is None:
+            return None
+        return xref
     
     @classmethod
     def create(cls,

--- a/services/core-api/app/api/mines/reports/models/mine_report_req_permit_condition_xref.py
+++ b/services/core-api/app/api/mines/reports/models/mine_report_req_permit_condition_xref.py
@@ -38,10 +38,12 @@ class MineReportReqPermitConditionXref(SoftDeleteMixin, AuditMixin, HistoryMixin
     def find_by_permit_condition_id(cls, id) -> Self | None:
         if id is None:
             return None
-        xref = cls.query.filter_by(permit_condition_id=id, deleted_ind=False).one_or_none()
-        if xref is None or xref.mine_report_permit_requirement is None:
-            return None
-        return xref
+        return cls.query.join(cls.mine_report_permit_requirement).\
+            filter(
+                cls.permit_condition_id == id,
+                cls.deleted_ind == False,
+                cls.mine_report_permit_requirement.has(deleted_ind=False)
+            ).first()
     
     @classmethod
     def find_by_many_permit_condition_ids(cls, ids) -> Self:
@@ -105,10 +107,12 @@ class StandardReportReqPermitConditionXref(MineReportReqPermitConditionXref):
     def find_by_permit_condition_id(cls, id) -> Self | None:
         if id is None:
             return None
-        xref = cls.query.filter_by(standard_permit_condition_id=id, deleted_ind=False).one_or_none()
-        if xref is None or xref.mine_report_permit_requirement is None:
-            return None
-        return xref
+        return cls.query.join(cls.mine_report_permit_requirement).\
+            filter(
+                cls.standard_permit_condition_id == id,
+                cls.deleted_ind == False,
+                cls.mine_report_permit_requirement.has(deleted_ind=False)
+            ).first()
     
     @classmethod
     def create(cls,

--- a/services/core-api/tests/factories.py
+++ b/services/core-api/tests/factories.py
@@ -1903,7 +1903,6 @@ class MineReportPermitRequirementFactory(BaseFactory):
     ministry_recipient = factory.LazyFunction(
         lambda: [random.choice(list(OfficeDestination))]
     )
-    mine_report_permit_requirement_id = factory.LazyFunction(lambda: random.randint(1, 12))
     permit_amendment_id = factory.SelfAttribute('permit_amendment.permit_amendment_id')
 
 class StandardReportPermitRequirementFactory(BaseFactory):
@@ -1917,7 +1916,6 @@ class StandardReportPermitRequirementFactory(BaseFactory):
     ministry_recipient = factory.LazyFunction(
         lambda: [random.choice(list(OfficeDestination))]
     )
-    mine_report_permit_requirement_id = factory.LazyFunction(lambda: random.randint(1, 12))  
     report_name = factory.Faker('name')
 
 class MineReportReqPermitConditionXrefFactory(BaseFactory):


### PR DESCRIPTION
## Objective 
- filter out the requirement on the FE
   - reason for doing it on the FE: it runs into the error _before_ data is refreshed on the BE
- also there are errors from the one_or_none in find_by_permit_condition_id
   - deleted an unused function that calls it
   - made the join stricter in the xref table
   - made the function query filter out deleted reports, and made it a bit safer with .first rather than one_or_none so that at least it doesn't crash
      - there's examples in prod where conditions have 2 reports attached to them. 😬 

[MDS-6605](https://bcmines.atlassian.net/browse/MDS-6605)

_Why are you making this change? Provide a short explanation and/or screenshots_
