### PR TITLE
[MDS-6634] Conflict between "Add Report Requirement" form and condition form

### DIFF
--- a/services/common/src/components/permits/PermitConditionForm.tsx
+++ b/services/common/src/components/permits/PermitConditionForm.tsx
@@ -47,7 +47,7 @@ interface PermitConditionFormProps {
     editingFormName: string;
     moveUp?: (condition: IPermitCondition | IStandardPermitCondition) => Promise<void>;
     moveDown?: (condition: IPermitCondition | IStandardPermitCondition) => Promise<void>;
-    refreshData: () => Promise<void>;
+    refreshData: (closeForm?: boolean) => Promise<void>;
     setIsAddingListItem: (isAdding: boolean) => void;
     isAddingListItem: boolean;
     categoryOptions?: IGroupedDropdownList[];
@@ -144,8 +144,7 @@ const PermitConditionForm: FC<PermitConditionFormProps> = ({
         }
         // @ts-ignore
         if (resp?.type !== ERROR) {
-            cancelEdit();
-            refreshData();
+            refreshData(false);
         }
         setLoading(false);
     };
@@ -188,7 +187,7 @@ const PermitConditionForm: FC<PermitConditionFormProps> = ({
 
     const handleOpenAddReportModal = (event, reportCondition: IPermitCondition | IStandardPermitCondition) => {
         event.stopPropagation();
-        dispatch(
+        const openReportModal = async () => await dispatch(
             openModal({
                 props: {
                     title: `Add Permit Required Report to Condition "${condition.stepPath}"`,
@@ -199,6 +198,15 @@ const PermitConditionForm: FC<PermitConditionFormProps> = ({
                 content: (props) => <PermitConditionsProvider value={permitConditionsValue}> <ReportPermitRequirementForm {...props} /> </PermitConditionsProvider>,
             })
         );
+        const formDirty = editingFormDirty || listItemFormDirty;
+
+        return formDirty ? Modal.confirm({
+            title: "Cancel editing condition?",
+            content: "Adding a report will cancel changes made to the condition",
+            onOk: openReportModal,
+            cancelText: "Edit Condition",
+            okText: "Add Report"
+        }) : openReportModal();
     };
 
     const editingEnabled = editingFormName !== formName && canEditPermitConditions && !loading;

--- a/services/common/src/components/permits/PermitConditionLayer.tsx
+++ b/services/common/src/components/permits/PermitConditionLayer.tsx
@@ -30,7 +30,7 @@ interface PermitConditionLayerProps {
   currentPosition: number;
   conditionCount: number;
   permitAmendmentGuid: string;
-  refreshData: () => Promise<void>;
+  refreshData: (closeForm?: boolean) => Promise<void>;
   conditionSelected?: (condition: IPermitCondition) => void;
   categoryOptions?: IGroupedDropdownList[];
 }

--- a/services/common/src/components/permits/PermitConditionStatus.tsx
+++ b/services/common/src/components/permits/PermitConditionStatus.tsx
@@ -19,7 +19,7 @@ interface PermitConditionStatusProps {
   isDisabled?: boolean;
   canEditPermitConditions?: boolean;
   permitAmendmentGuid: string;
-  refreshData: () => Promise<void>;
+  refreshData: (closeForm?: boolean) => Promise<void>;
 }
 
 export const PermitConditionStatus: FC<PermitConditionStatusProps> = ({

--- a/services/common/src/components/permits/PermitConditionViewEdit.tsx
+++ b/services/common/src/components/permits/PermitConditionViewEdit.tsx
@@ -110,10 +110,11 @@ const PermitConditionViewEdit: FC<PermitConditionViewEditProps> = ({
         userCanEdit && (isStandardConditions || isNowEditor ||
             userReviewCategoryCodes.includes(category.condition_category_code));
 
-    const refreshConditionData = async () => {
+    const refreshConditionData = async (closeForm = true) => {
         await refreshData();
-
-        setEditingFormName(null);
+        if (closeForm) {
+            setEditingFormName(null);
+        }
     };
 
     const handleAddCondition = async () => {

--- a/services/common/src/components/permits/ReportPermitRequirementForm.tsx
+++ b/services/common/src/components/permits/ReportPermitRequirementForm.tsx
@@ -39,7 +39,7 @@ interface ReportPermitRequirementProps {
   isModal?: boolean;
   mineReportPermitRequirement?: IMineReportPermitRequirement;
   canEditPermitConditions: boolean;
-  refreshData: () => Promise<void>;
+  refreshData: (closeForm?: boolean) => Promise<void>;
 }
 
 export const ReportPermitRequirementForm: FC<ReportPermitRequirementProps> = ({
@@ -136,7 +136,7 @@ export const ReportPermitRequirementForm: FC<ReportPermitRequirementProps> = ({
       resp = await dispatch(createMineReportPermitRequirement({ mineGuid, values }));
     }
     if (resp.payload) {
-      await refreshData();
+      // await refreshData(false);
       // this is for an edge case where an existing report is edited and so it has a form on the page
       // and it was not getting updated so not showing the correct conditions there.
       if (condition && values.mine_report_permit_requirement_id) {


### PR DESCRIPTION
## Objective 
- currently, adding a report requirement to a condition with unsaved changes will revert those changes
   - not just because the form closes, but also because of the refreshing data function (which is a whole can of worms)
-  as a solution, added a popconfirm when the condition form is dirty and the user clicks to add a report
- also, because users lose their place, not closing out the condition form after changes are saved
   - this is kind of an experiment to see if they like it better this way. Pretty easy to revert.
   - makes it easy for adding a report later,
   - and then they _can_ just click another condition to edit it if they like (they don't _have to_ click the X button to close editing if they're truly done)

[MDS-6634](https://bcmines.atlassian.net/browse/MDS-6634)

_Why are you making this change? Provide a short explanation and/or screenshots_
<img width="432" height="215" alt="image" src="https://github.com/user-attachments/assets/53657f5d-6e56-4527-a312-faed6384487c" />
