### PR TITLE
[MDS-6580] Bug fix, variable condition menu showing in incorrect places

### DIFF
--- a/services/common/src/components/permits/PermitConditionForm.tsx
+++ b/services/common/src/components/permits/PermitConditionForm.tsx
@@ -322,7 +322,7 @@ const PermitConditionForm: FC<PermitConditionFormProps> = ({
                 </Col>
                 <Col className="condition-column" {...editableProps}>
                     <Col className="condition-editor">
-                        <VariableConditionMenu inputRef={conditionInputRef} isManagementView={Boolean(standardConditionType)} conditionForm={editingFormName}/>
+                        {stepEditDisabled && <VariableConditionMenu inputRef={conditionInputRef} isManagementView={Boolean(standardConditionType)} conditionForm={editingFormName}/>}
                         <Field
                             name="condition"
                             component={RenderAutoSizeField}

--- a/services/common/src/components/permits/PermitConditionForm.tsx
+++ b/services/common/src/components/permits/PermitConditionForm.tsx
@@ -83,6 +83,7 @@ const PermitConditionForm: FC<PermitConditionFormProps> = ({
     const listItemFormDirty = useAppSelector(isDirty(FORM.EDIT_PERMIT_CONDITION));
     const conditionTags: IPermitConditionTag[] = useAppSelector(getPermitConditionTags);
     const stepEditDisabled = Boolean(standardConditionType) || isNowEditor;
+    const showVariableConditionMenu = stepEditDisabled;
     const enablePermitConditionTags = isFeatureEnabled(Feature.PERMIT_CONDITION_TAGS);
     const conditionInputRef = useRef<TextAreaRef | null>(null);
 
@@ -322,7 +323,7 @@ const PermitConditionForm: FC<PermitConditionFormProps> = ({
                 </Col>
                 <Col className="condition-column" {...editableProps}>
                     <Col className="condition-editor">
-                        {stepEditDisabled && <VariableConditionMenu inputRef={conditionInputRef} isManagementView={Boolean(standardConditionType)} conditionForm={editingFormName}/>}
+                        {showVariableConditionMenu && <VariableConditionMenu inputRef={conditionInputRef} isManagementView={Boolean(standardConditionType)} conditionForm={editingFormName}/>}
                         <Field
                             name="condition"
                             component={RenderAutoSizeField}

--- a/services/common/src/tests/permits/__snapshots__/PermitConditionForm.spec.tsx.snap
+++ b/services/common/src/tests/permits/__snapshots__/PermitConditionForm.spec.tsx.snap
@@ -64,42 +64,6 @@ exports[`PermitConditionForm renders properly in edit mode 1`] = `
           class="ant-col condition-editor"
         >
           <div
-            class="ant-row condition-editor-toolbar"
-          >
-            <button
-              class="ant-btn ant-btn-default ant-dropdown-trigger"
-              type="button"
-            >
-              <span>
-                Condition Data Variables
-              </span>
-              <span
-                aria-label="question-circle"
-                class="anticon anticon-question-circle icon-sm"
-                role="img"
-                style="margin-left: 8px;"
-              >
-                <svg
-                  aria-hidden="true"
-                  class=""
-                  data-icon="question-circle"
-                  fill="currentColor"
-                  focusable="false"
-                  height="1em"
-                  viewBox="64 64 896 896"
-                  width="1em"
-                >
-                  <path
-                    d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
-                  />
-                  <path
-                    d="M623.6 316.7C593.6 290.4 554 276 512 276s-81.6 14.5-111.6 40.7C369.2 344 352 380.7 352 420v7.6c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V420c0-44.1 43.1-80 96-80s96 35.9 96 80c0 31.1-22 59.6-56.1 72.7-21.2 8.1-39.2 22.3-52.1 40.9-13.1 19-19.9 41.8-19.9 64.9V620c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8v-22.7a48.3 48.3 0 0130.9-44.8c59-22.7 97.1-74.7 97.1-132.5.1-39.3-17.1-76-48.3-103.3zM472 732a40 40 0 1080 0 40 40 0 10-80 0z"
-                  />
-                </svg>
-              </span>
-            </button>
-          </div>
-          <div
             class="ant-form-item ant-form-item-with-help"
           >
             <div


### PR DESCRIPTION
## Objective 

[MDS-6580](https://bcmines.atlassian.net/browse/MDS-6580)

Bug fix, don't show Variable Condition menu unless it's on the Now editor or StandardConditionEditor.

Open to renaming the stepEditDisabled variable to something better! 