### PR TITLE
[MDS-6569] - Permit condition templates

### DIFF
--- a/services/common/src/components/permits/PermitConditionForm.tsx
+++ b/services/common/src/components/permits/PermitConditionForm.tsx
@@ -75,14 +75,14 @@ const PermitConditionForm: FC<PermitConditionFormProps> = ({
     const [isEditMode, setIsEditMode] = useState<boolean>(false);
     const { isFeatureEnabled } = useFeatureFlag();
     const permitConditionsValue = usePermitConditions();
-    const { loading, setLoading, standardConditionType, isNowEditor } = permitConditionsValue;
-    const editingAllowed = Boolean(standardConditionType) || isExtracted || isNowEditor;
+    const { loading, setLoading, isNowEditor, isStandardConditionEditor } = permitConditionsValue;
+    const editingAllowed = isStandardConditionEditor || isExtracted || isNowEditor;
     // the form fails to re-initialize when the category is changed, so concatenating it forces it to make a new one
     const formName = `${FORM.EDIT_PERMIT_CONDITION}_${condition.permit_condition_id}_${condition.condition_category_code}`;
     const editingFormDirty = useAppSelector(isDirty(editingFormName));
     const listItemFormDirty = useAppSelector(isDirty(FORM.EDIT_PERMIT_CONDITION));
     const conditionTags: IPermitConditionTag[] = useAppSelector(getPermitConditionTags);
-    const stepEditDisabled = Boolean(standardConditionType) || isNowEditor;
+    const stepEditDisabled = isStandardConditionEditor || isNowEditor;
     const showVariableConditionMenu = stepEditDisabled;
     const enablePermitConditionTags = isFeatureEnabled(Feature.PERMIT_CONDITION_TAGS);
     const conditionInputRef = useRef<TextAreaRef | null>(null);
@@ -141,7 +141,7 @@ const PermitConditionForm: FC<PermitConditionFormProps> = ({
             }
             : values;
         let resp;
-        if (standardConditionType) {
+        if (isStandardConditionEditor) {
             resp = await dispatch(updateStandardPermitCondition(values.standard_permit_condition_guid, values))
         } else {
             resp = await dispatch(
@@ -324,7 +324,7 @@ const PermitConditionForm: FC<PermitConditionFormProps> = ({
                 </Col>
                 <Col className="condition-column" {...editableProps}>
                     <Col className="condition-editor">
-                        {showVariableConditionMenu && <VariableConditionMenu inputRef={conditionInputRef} isManagementView={Boolean(standardConditionType)} conditionForm={editingFormName}/>}
+                        {showVariableConditionMenu && <VariableConditionMenu inputRef={conditionInputRef} isManagementView={isStandardConditionEditor} conditionForm={editingFormName}/>}
                         <Field
                             name="condition"
                             component={RenderAutoSizeField}

--- a/services/common/src/components/permits/PermitConditionLayer.tsx
+++ b/services/common/src/components/permits/PermitConditionLayer.tsx
@@ -52,13 +52,13 @@ const PermitConditionLayer: FC<PermitConditionLayerProps> = ({
   refreshData,
   categoryOptions,
 }) => {
-  const { loading, previousAmendment, permitGuid, standardConditionType, isNowEditor } = usePermitConditions();
+  const { loading, previousAmendment, permitGuid, standardConditionType, isNowEditor, isStandardConditionEditor } = usePermitConditions();
   const permitRequirements = useAppSelector(
     getReportRequirementsByCondition(permitGuid, permitAmendmentGuid, condition.permit_condition_id, isNowEditor)
   );
   const standardId = standardConditionType ? condition.permit_condition_id : undefined;
   const standardRequirements = useAppSelector(getStandardReportByCondition(standardId));
-  const requirements = standardConditionType ? standardRequirements : permitRequirements;
+  const requirements = isStandardConditionEditor ? standardRequirements : permitRequirements;
 
   const editingCondition = useMemo(
     () => editingFormName === `${FORM.EDIT_PERMIT_CONDITION}_${condition.permit_condition_id}_${condition.condition_category_code}`,
@@ -189,7 +189,7 @@ const PermitConditionLayer: FC<PermitConditionLayerProps> = ({
               />
             </div>
           )}
-          {!standardConditionType && !isNowEditor && <PermitConditionStatus
+          {!isStandardConditionEditor && !isNowEditor && <PermitConditionStatus
             condition={condition}
             previousCondition={matchingCondition}
             canEditPermitConditions={canEditPermitConditions}

--- a/services/common/src/components/permits/PermitConditionViewEdit.tsx
+++ b/services/common/src/components/permits/PermitConditionViewEdit.tsx
@@ -46,7 +46,6 @@ interface PermitConditionViewEditProps {
   setEditingFormName: (formName: string) => void;
   addingToCategoryCode: string;
   setAddingToCategoryCode: (categoryCode: string) => void;
-  typeCode?: string;
 }
 
 const PermitConditionViewEdit: FC<PermitConditionViewEditProps> = ({
@@ -61,7 +60,6 @@ const PermitConditionViewEdit: FC<PermitConditionViewEditProps> = ({
   setEditingFormName,
   addingToCategoryCode,
   setAddingToCategoryCode,
-  typeCode,
 }) => {
   const {
     mineGuid,
@@ -69,7 +67,7 @@ const PermitConditionViewEdit: FC<PermitConditionViewEditProps> = ({
     currentAmendment,
     loading,
     setLoading,
-    standardConditionType,
+    isStandardConditionEditor,
     isNowEditor,
     refreshData,
   } = usePermitConditions();
@@ -81,7 +79,7 @@ const PermitConditionViewEdit: FC<PermitConditionViewEditProps> = ({
   const defaultPermitConditionCategories = useAppSelector(getPermitConditionCategoryOptions);
 
   const conditionTags: IPermitConditionTag[] = useAppSelector(getPermitConditionTags);
-  const isStandardConditions = Boolean(standardConditionType);
+  const isStandardConditions = isStandardConditionEditor;
   const canAddConditions = isStandardConditions || isExtracted || isNowEditor;
   const areTagsEnabled = isFeatureEnabled(Feature.PERMIT_CONDITION_TAGS);
 
@@ -257,7 +255,7 @@ const PermitConditionViewEdit: FC<PermitConditionViewEditProps> = ({
                 >
                   Add Condition
                 </CoreButton>
-                {Boolean(typeCode) && (
+                {!isStandardConditionEditor && (
                   <CoreButton
                     type="primary"
                     loading={loading}
@@ -347,7 +345,6 @@ const PermitConditionViewEdit: FC<PermitConditionViewEditProps> = ({
                           <PermitTemplateConditionManager
                             permitAmendmentGuid={currentAmendment?.permit_amendment_guid}
                             category={category}
-                            typeCode={typeCode}
                             onInsert={() => refreshData()}
                             onClose={() => handleOpenTemplateManager(category)}
                           />

--- a/services/common/src/components/permits/PermitConditionViewEdit.tsx
+++ b/services/common/src/components/permits/PermitConditionViewEdit.tsx
@@ -123,6 +123,12 @@ const PermitConditionViewEdit: FC<PermitConditionViewEditProps> = ({
     [currentAmendment?.condition_categories, condWithoutConditionsText]
   );
 
+  useEffect(() => {
+    if (!userCanEdit) {
+      setAddingTemplateConditions(undefined);
+    }
+  }, [userCanEdit]);
+
   const canEditPermitConditions = (category: IPermitConditionCategory): boolean =>
     featureModifyConditions &&
     userCanEdit &&
@@ -147,17 +153,12 @@ const PermitConditionViewEdit: FC<PermitConditionViewEditProps> = ({
     setEditingFormName(FORM.EDIT_PERMIT_CONDITION);
   };
 
-  const handleRetrieveTemplates = (category) => {
+  const handleOpenTemplateManager = (category) => {
     if (addingTemplateConditions === category.condition_category_code) {
       setAddingTemplateConditions(undefined);
     } else {
       setAddingTemplateConditions(category.condition_category_code);
     }
-  };
-
-  const handleInsertTemplate = ({ category, condition }) => {
-    console.log("category", category);
-    console.log("condition", condition);
   };
 
   const handleUpdateConditionCategory = (category: IPermitConditionCategory) => {
@@ -256,14 +257,18 @@ const PermitConditionViewEdit: FC<PermitConditionViewEditProps> = ({
                 >
                   Add Condition
                 </CoreButton>
-                <CoreButton
-                  type="primary"
-                  loading={loading}
-                  disabled={Boolean(addingToCategoryCode) || Boolean(editingFormName)}
-                  onClick={() => handleRetrieveTemplates(category)}
-                >
-                  Retrieve Template Conditions
-                </CoreButton>
+                {Boolean(typeCode) && (
+                  <CoreButton
+                    type="primary"
+                    loading={loading}
+                    disabled={Boolean(addingToCategoryCode) || Boolean(editingFormName)}
+                    onClick={() => handleOpenTemplateManager(category)}
+                  >
+                    {addingTemplateConditions === category.condition_category_code
+                      ? "Close Template Conditions"
+                      : "Insert Template Conditions"}
+                  </CoreButton>
+                )}
               </Row>
             )}
           </Row>
@@ -340,9 +345,11 @@ const PermitConditionViewEdit: FC<PermitConditionViewEditProps> = ({
                         <Col span={12}>{renderCategory(category, idx)}</Col>
                         <Col span={12}>
                           <PermitTemplateConditionManager
+                            permitAmendmentGuid={currentAmendment?.permit_amendment_guid}
                             category={category}
                             typeCode={typeCode}
-                            onInsert={handleInsertTemplate}
+                            onInsert={() => refreshData()}
+                            onClose={() => handleOpenTemplateManager(category)}
                           />
                         </Col>
                       </Row>

--- a/services/common/src/components/permits/PermitConditionViewEdit.tsx
+++ b/services/common/src/components/permits/PermitConditionViewEdit.tsx
@@ -1,7 +1,13 @@
-import React, { FC, useEffect, useMemo } from "react";
+import React, { FC, useEffect, useMemo, useState } from "react";
 import { Col, Collapse, Row, Spin, Typography } from "antd";
 import LoadingOutlined from "@ant-design/icons/LoadingOutlined";
-import { IFormattedConditionCategory, IPermitCondition, IPermitConditionCategory, IPermitConditionTag, IStandardPermitCondition } from "@mds/common/interfaces";
+import {
+  IFormattedConditionCategory,
+  IPermitCondition,
+  IPermitConditionCategory,
+  IPermitConditionTag,
+  IStandardPermitCondition,
+} from "@mds/common/interfaces";
 import { useFeatureFlag } from "@mds/common/providers/featureFlags/useFeatureFlag";
 import { Feature } from "@mds/common/utils/featureFlag";
 import SubConditionForm from "./SubConditionForm";
@@ -10,295 +16,349 @@ import PermitConditionReviewAssignment from "./PermitConditionReviewAssignment";
 import CoreButton from "../common/CoreButton";
 import { EditPermitConditionCategoryInline } from "./PermitConditionCategory";
 import { useAppDispatch, useAppSelector } from "@mds/common/redux/rootState";
-import { deletePermitAmendmentConditionCategory, updatePermitAmendmentConditionCategory, updatePermitCondition, updateStandardPermitCondition } from "@mds/common/redux/actionCreators/permitActionCreator";
+import {
+  deletePermitAmendmentConditionCategory,
+  updatePermitAmendmentConditionCategory,
+  updatePermitCondition,
+  updateStandardPermitCondition,
+} from "@mds/common/redux/actionCreators/permitActionCreator";
 import { usePermitConditions } from "./PermitConditionsContext";
 import { createDropDownList } from "@mds/common/redux/utils/helpers";
 import { getPermitConditionCategoryOptions } from "@mds/common/redux/reducers/staticContentReducer";
 import { FORM } from "@mds/common/constants/forms";
-import { fetchPermitConditionTags, getPermitConditionTags } from "@mds/common/redux/slices/permitConditionTagSlice";
-import VariableConditionMenu from "./VariableConditionMenu";
+import {
+  fetchPermitConditionTags,
+  getPermitConditionTags,
+} from "@mds/common/redux/slices/permitConditionTagSlice";
+import PermitTemplateConditionManager from "@mds/common/components/permits/PermitTemplateConditionManager";
 
 const { Title } = Typography;
 
 interface PermitConditionViewEditProps {
-    isExtracted?: boolean;
-    userReviewCategoryCodes?: any[];
-    userCanEdit: boolean;
-    formattedCategories: IFormattedConditionCategory[];
-    collapseCategories?: boolean;
-    isExpanded?: boolean;
-    setSelectedCondition?: (condition: IPermitCondition) => void;
-    editingFormName: string;
-    setEditingFormName: (formName: string) => void;
-    addingToCategoryCode: string;
-    setAddingToCategoryCode: (categoryCode: string) => void;
+  isExtracted?: boolean;
+  userReviewCategoryCodes?: any[];
+  userCanEdit: boolean;
+  formattedCategories: IFormattedConditionCategory[];
+  collapseCategories?: boolean;
+  isExpanded?: boolean;
+  setSelectedCondition?: (condition: IPermitCondition) => void;
+  editingFormName: string;
+  setEditingFormName: (formName: string) => void;
+  addingToCategoryCode: string;
+  setAddingToCategoryCode: (categoryCode: string) => void;
+  typeCode?: string;
 }
 
 const PermitConditionViewEdit: FC<PermitConditionViewEditProps> = ({
-    userCanEdit,
-    formattedCategories,
-    isExtracted = false,
-    userReviewCategoryCodes = [],
-    collapseCategories = false,
-    isExpanded = true,
-    setSelectedCondition,
-    editingFormName,
-    setEditingFormName,
-    addingToCategoryCode,
-    setAddingToCategoryCode
+  userCanEdit,
+  formattedCategories,
+  isExtracted = false,
+  userReviewCategoryCodes = [],
+  collapseCategories = false,
+  isExpanded = true,
+  setSelectedCondition,
+  editingFormName,
+  setEditingFormName,
+  addingToCategoryCode,
+  setAddingToCategoryCode,
+  typeCode,
 }) => {
-    const {
+  const {
+    mineGuid,
+    permitGuid,
+    currentAmendment,
+    loading,
+    setLoading,
+    standardConditionType,
+    isNowEditor,
+    refreshData,
+  } = usePermitConditions();
+
+  const [addingTemplateConditions, setAddingTemplateConditions] = useState<string>();
+
+  const { isFeatureEnabled } = useFeatureFlag();
+  const dispatch = useAppDispatch();
+  const defaultPermitConditionCategories = useAppSelector(getPermitConditionCategoryOptions);
+
+  const conditionTags: IPermitConditionTag[] = useAppSelector(getPermitConditionTags);
+  const isStandardConditions = Boolean(standardConditionType);
+  const canAddConditions = isStandardConditions || isExtracted || isNowEditor;
+  const areTagsEnabled = isFeatureEnabled(Feature.PERMIT_CONDITION_TAGS);
+
+  const condWithoutConditionsText = defaultPermitConditionCategories?.map((cat) => {
+    return {
+      ...cat,
+      description: cat.description.replace("Conditions", "").trim(),
+    };
+  });
+
+  const featureModifyConditions = isFeatureEnabled(Feature.MODIFY_PERMIT_CONDITIONS);
+
+  useEffect(() => {
+    if (conditionTags?.length === 0 && areTagsEnabled) {
+      dispatch(fetchPermitConditionTags(undefined));
+    }
+  }, [conditionTags]);
+
+  const dropdownCategories = useMemo(
+    () =>
+      [
+        !isStandardConditions && {
+          groupName: "Custom Categories",
+          opt: createDropDownList(
+            currentAmendment?.condition_categories ?? [],
+            "description",
+            "condition_category_code"
+          ),
+        },
+        {
+          groupName: "Standard Categories",
+          opt: createDropDownList(
+            condWithoutConditionsText,
+            "description",
+            "condition_category_code"
+          ),
+        },
+      ].filter(Boolean),
+    [currentAmendment?.condition_categories, condWithoutConditionsText]
+  );
+
+  const canEditPermitConditions = (category: IPermitConditionCategory): boolean =>
+    featureModifyConditions &&
+    userCanEdit &&
+    (isStandardConditions ||
+      isNowEditor ||
+      userReviewCategoryCodes.includes(category.condition_category_code));
+
+  const refreshConditionData = async (closeForm = true) => {
+    await refreshData();
+    if (closeForm) {
+      setEditingFormName(null);
+    }
+  };
+
+  const handleAddCondition = async () => {
+    setAddingToCategoryCode(null);
+    await refreshConditionData();
+  };
+
+  const handleClickAddCondition = (category) => {
+    setAddingToCategoryCode(category.condition_category_code);
+    setEditingFormName(FORM.EDIT_PERMIT_CONDITION);
+  };
+
+  const handleRetrieveTemplates = (category) => {
+    if (addingTemplateConditions === category.condition_category_code) {
+      setAddingTemplateConditions(undefined);
+    } else {
+      setAddingTemplateConditions(category.condition_category_code);
+    }
+  };
+
+  const handleInsertTemplate = ({ category, condition }) => {
+    console.log("category", category);
+    console.log("condition", condition);
+  };
+
+  const handleUpdateConditionCategory = (category: IPermitConditionCategory) => {
+    setLoading(true);
+    dispatch(
+      updatePermitAmendmentConditionCategory(
         mineGuid,
         permitGuid,
-        currentAmendment,
-        loading,
-        setLoading,
-        standardConditionType,
-        isNowEditor,
-        refreshData,
-    } = usePermitConditions();
+        currentAmendment.permit_amendment_guid,
+        category
+      )
+    ).finally(() => setLoading(false));
+  };
 
-    const { isFeatureEnabled } = useFeatureFlag();
-    const dispatch = useAppDispatch();
-    const defaultPermitConditionCategories = useAppSelector(getPermitConditionCategoryOptions);
+  const handleDeleteConditionCategory = (category: IPermitConditionCategory) => {
+    setLoading(true);
+    dispatch(
+      deletePermitAmendmentConditionCategory(
+        mineGuid,
+        permitGuid,
+        currentAmendment?.permit_amendment_guid,
+        category.condition_category_code
+      )
+    ).finally(() => setLoading(false));
+  };
 
-    const conditionTags: IPermitConditionTag[] = useAppSelector(getPermitConditionTags);
-    const isStandardConditions = Boolean(standardConditionType);
-    const canAddConditions = isStandardConditions || isExtracted || isNowEditor;
-    const areTagsEnabled = isFeatureEnabled(Feature.PERMIT_CONDITION_TAGS);
+  const handleMoveCategory = (category: IPermitConditionCategory, newOrder: number) => {
+    const updatedCat = {
+      ...category,
+      display_order: newOrder,
+    };
 
-
-    const condWithoutConditionsText = defaultPermitConditionCategories?.map((cat) => {
-        return {
-            ...cat,
-            description: cat.description.replace("Conditions", "").trim(),
-        };
-    });
-
-    const featureModifyConditions = isFeatureEnabled(Feature.MODIFY_PERMIT_CONDITIONS);
-
-    useEffect(() => {
-        if (conditionTags?.length === 0 && areTagsEnabled) {
-            dispatch(fetchPermitConditionTags(undefined));
-        }
-    }, [conditionTags]);
-
-
-    const dropdownCategories = useMemo(
-        () => [
-            !isStandardConditions && {
-                groupName: "Custom Categories",
-                opt: createDropDownList(
-                    currentAmendment?.condition_categories ?? [],
-                    "description",
-                    "condition_category_code"
-                ),
-            },
-            {
-                groupName: "Standard Categories",
-                opt: createDropDownList(
-                    condWithoutConditionsText,
-                    "description",
-                    "condition_category_code"
-                ),
-            },
-        ].filter(Boolean),
-        [currentAmendment?.condition_categories, condWithoutConditionsText]
+    dispatch(
+      updatePermitAmendmentConditionCategory(
+        mineGuid,
+        permitGuid,
+        currentAmendment?.permit_amendment_guid,
+        updatedCat
+      )
     );
+  };
 
-    const canEditPermitConditions = (category: IPermitConditionCategory): boolean =>
-        featureModifyConditions &&
-        userCanEdit && (isStandardConditions || isNowEditor ||
-            userReviewCategoryCodes.includes(category.condition_category_code));
-
-    const refreshConditionData = async (closeForm = true) => {
-        await refreshData();
-        if (closeForm) {
-            setEditingFormName(null);
-        }
+  const handleMoveCondition = async (
+    condition: IPermitCondition | IStandardPermitCondition,
+    isMoveUp: boolean
+  ) => {
+    const newOrder = isMoveUp ? condition.display_order - 1 : condition.display_order + 1;
+    const updatedCond = {
+      ...condition,
+      display_order: newOrder,
     };
 
-    const handleAddCondition = async () => {
-        setAddingToCategoryCode(null);
-        await refreshConditionData();
-    };
-
-    const handleClickAddCondition = (category) => {
-        setAddingToCategoryCode(category.condition_category_code);
-        setEditingFormName(FORM.EDIT_PERMIT_CONDITION)
-    };
-
-    const handleUpdateConditionCategory = (category: IPermitConditionCategory) => {
-        setLoading(true);
-        dispatch(
-            updatePermitAmendmentConditionCategory(
-                mineGuid,
-                permitGuid,
-                currentAmendment.permit_amendment_guid,
-                category
-            )
-        ).finally(() => setLoading(false));
-    };
-
-    const handleDeleteConditionCategory = (category: IPermitConditionCategory) => {
-        setLoading(true);
-        dispatch(
-            deletePermitAmendmentConditionCategory(
-                mineGuid,
-                permitGuid,
-                currentAmendment?.permit_amendment_guid,
-                category.condition_category_code
-            )
-        ).finally(() => setLoading(false));
-    };
-
-    const handleMoveCategory = (category: IPermitConditionCategory, newOrder: number) => {
-        const updatedCat = {
-            ...category,
-            display_order: newOrder,
-        };
-
-        dispatch(
-            updatePermitAmendmentConditionCategory(
-                mineGuid,
-                permitGuid,
-                currentAmendment?.permit_amendment_guid,
-                updatedCat
-            )
-        );
-    };
-
-    const handleMoveCondition = async (condition: IPermitCondition | IStandardPermitCondition, isMoveUp: boolean) => {
-        const newOrder = isMoveUp ? condition.display_order - 1 : condition.display_order + 1;
-        const updatedCond = {
-            ...condition,
-            display_order: newOrder,
-        };
-
-        if ("standard_permit_condition_guid" in updatedCond) {
-            await dispatch(updateStandardPermitCondition(
-                updatedCond.standard_permit_condition_guid,
-                updatedCond
-            ));
-
-        } else {
-            await dispatch(
-                updatePermitCondition(
-                    updatedCond.permit_condition_guid,
-                    currentAmendment.permit_amendment_guid,
-                    updatedCond
-                )
-            );
-        }
-        await refreshConditionData();
-    };
-
-    const renderCategory = (category, idx) => {
-        return <div key={category.href} className="common-page-content">
-            <Col span={24}>
-                <Row justify="space-between">
-                    {!collapseCategories && <Title level={3} className="margin-none" id={category.href}>
-                        <EditPermitConditionCategoryInline
-                            canEdit={
-                                isExtracted && canEditPermitConditions(category.condition_category)
-                            }
-                            onDelete={handleDeleteConditionCategory}
-                            onChange={handleUpdateConditionCategory}
-                            moveUp={(cat) => handleMoveCategory(cat, idx - 1)}
-                            moveDown={(cat) => handleMoveCategory(cat, idx + 1)}
-                            currentPosition={idx}
-                            categoryCount={formattedCategories.length}
-                            category={category.condition_category}
-                            conditionCount={category?.conditions.length || 0}
-                        />
-                    </Title>}
-                    {canEditPermitConditions(category.condition_category) && canAddConditions && (
-                        <CoreButton
-                            type="primary"
-                            loading={loading}
-                            disabled={Boolean(addingToCategoryCode) || Boolean(editingFormName)}
-                            onClick={() => handleClickAddCondition(category)}
-                        >
-                            Add Condition
-                        </CoreButton>
-                    )}
-                </Row>
-                {featureModifyConditions && userCanEdit && !isStandardConditions && !isNowEditor && (
-                    <PermitConditionReviewAssignment category={category?.condition_category} />
-                )}
-            </Col>
-            {category.conditions.map((sc, idx) => (
-                <Col span={24} key={sc.permit_condition_id} className="fade-in">
-                    <PermitConditionLayer
-                        isExtracted={isExtracted}
-                        permitAmendmentGuid={currentAmendment?.permit_amendment_guid}
-                        condition={sc}
-                        isExpanded={isExpanded}
-                        handleMoveCondition={handleMoveCondition}
-                        currentPosition={idx}
-                        conditionCount={category.conditions.length}
-                        canEditPermitConditions={canEditPermitConditions(
-                            category.condition_category
-                        )}
-                        setEditingFormName={setEditingFormName}
-                        editingFormName={editingFormName ?? addingToCategoryCode}
-                        refreshData={refreshConditionData}
-                        conditionSelected={setSelectedCondition}
-                        categoryOptions={dropdownCategories}
-                    />
-                </Col>
-            ))}
-            {addingToCategoryCode === category.condition_category_code && (
-                <Col span={24}>
-                    <SubConditionForm
-                        conditionCategory={category}
-                        permitAmendmentGuid={currentAmendment?.permit_amendment_guid}
-                        handleCancel={() => { setAddingToCategoryCode(null); setEditingFormName(null); }}
-                        onSubmit={handleAddCondition}
-                        categoryOptions={dropdownCategories}
-                    />
-                </Col>
-            )}
-        </div>
+    if ("standard_permit_condition_guid" in updatedCond) {
+      await dispatch(
+        updateStandardPermitCondition(updatedCond.standard_permit_condition_guid, updatedCond)
+      );
+    } else {
+      await dispatch(
+        updatePermitCondition(
+          updatedCond.permit_condition_guid,
+          currentAmendment.permit_amendment_guid,
+          updatedCond
+        )
+      );
     }
+    await refreshConditionData();
+  };
 
+  const renderCategory = (category, idx) => {
     return (
-        <div>
-            <Row gutter={[16, 16]}>
-                {formattedCategories.map((category, idx) => {
-                    {
-                        if (collapseCategories) {
-                            return (
-                                <Col span={24} id={category.href} key={category.href}>
-                                    <Collapse
-                                        key={category.href}
-                                        className="light-header"
-                                    >
-                                        <Collapse.Panel
-                                            className="permit-conditions-collapse-panel"
-                                            forceRender
-                                            collapsible={loading ? "disabled" : undefined}
-                                            header={
-                                                <Row justify="space-between">
-                                                    <Col>
-                                                        {category.condition_category.step} {category.condition_category.description} ({category.conditions.length})
-                                                    </Col>
-                                                    {loading && <Col>
-                                                        <Spin indicator={<LoadingOutlined />} />
-                                                    </Col>}
-                                                </Row>
-                                            } key={category.href}>
-                                            {renderCategory(category, idx)}
-                                        </Collapse.Panel>
-                                    </Collapse>
-                                </Col>)
-                        }
-                        return renderCategory(category, idx)
-                    }
-                })}
-            </Row>
-        </div>
+      <div key={category.href} className="common-page-content">
+        <Col span={24}>
+          <Row justify="space-between">
+            {!collapseCategories && (
+              <Title level={3} className="margin-none" id={category.href}>
+                <EditPermitConditionCategoryInline
+                  canEdit={isExtracted && canEditPermitConditions(category.condition_category)}
+                  onDelete={handleDeleteConditionCategory}
+                  onChange={handleUpdateConditionCategory}
+                  moveUp={(cat) => handleMoveCategory(cat, idx - 1)}
+                  moveDown={(cat) => handleMoveCategory(cat, idx + 1)}
+                  currentPosition={idx}
+                  categoryCount={formattedCategories.length}
+                  category={category.condition_category}
+                  conditionCount={category?.conditions.length ?? 0}
+                />
+              </Title>
+            )}
+            {canEditPermitConditions(category.condition_category) && canAddConditions && (
+              <Row>
+                <CoreButton
+                  type="primary"
+                  loading={loading}
+                  disabled={Boolean(addingToCategoryCode) || Boolean(editingFormName)}
+                  onClick={() => handleClickAddCondition(category)}
+                >
+                  Add Condition
+                </CoreButton>
+                <CoreButton
+                  type="primary"
+                  loading={loading}
+                  disabled={Boolean(addingToCategoryCode) || Boolean(editingFormName)}
+                  onClick={() => handleRetrieveTemplates(category)}
+                >
+                  Retrieve Template Conditions
+                </CoreButton>
+              </Row>
+            )}
+          </Row>
+          {featureModifyConditions && userCanEdit && !isStandardConditions && !isNowEditor && (
+            <PermitConditionReviewAssignment category={category?.condition_category} />
+          )}
+        </Col>
+        {category.conditions.map((sc, idx) => (
+          <Col span={24} key={sc.permit_condition_id} className="fade-in">
+            <PermitConditionLayer
+              isExtracted={isExtracted}
+              permitAmendmentGuid={currentAmendment?.permit_amendment_guid}
+              condition={sc}
+              isExpanded={isExpanded}
+              handleMoveCondition={handleMoveCondition}
+              currentPosition={idx}
+              conditionCount={category.conditions.length}
+              canEditPermitConditions={canEditPermitConditions(category.condition_category)}
+              setEditingFormName={setEditingFormName}
+              editingFormName={editingFormName ?? addingToCategoryCode}
+              refreshData={refreshConditionData}
+              conditionSelected={setSelectedCondition}
+              categoryOptions={dropdownCategories}
+            />
+          </Col>
+        ))}
+        {addingToCategoryCode === category.condition_category_code && (
+          <Col span={24}>
+            <SubConditionForm
+              conditionCategory={category}
+              permitAmendmentGuid={currentAmendment?.permit_amendment_guid}
+              handleCancel={() => {
+                setAddingToCategoryCode(null);
+                setEditingFormName(null);
+              }}
+              onSubmit={handleAddCondition}
+              categoryOptions={dropdownCategories}
+            />
+          </Col>
+        )}
+      </div>
     );
+  };
+
+  return (
+    <div>
+      <Row gutter={[16, 16]}>
+        {formattedCategories.map((category, idx) => {
+          if (collapseCategories) {
+            return (
+              <Col span={24} id={category.href} key={category.href}>
+                <Collapse key={category.href} className="light-header">
+                  <Collapse.Panel
+                    className="permit-conditions-collapse-panel"
+                    forceRender
+                    collapsible={loading ? "disabled" : undefined}
+                    header={
+                      <Row justify="space-between">
+                        <Col>
+                          {category.condition_category.step}{" "}
+                          {category.condition_category.description} ({category.conditions.length})
+                        </Col>
+                        {loading && (
+                          <Col>
+                            <Spin indicator={<LoadingOutlined />} />
+                          </Col>
+                        )}
+                      </Row>
+                    }
+                    key={category.href}
+                  >
+                    {addingTemplateConditions === category.condition_category_code ? (
+                      <Row gutter={16}>
+                        <Col span={12}>{renderCategory(category, idx)}</Col>
+                        <Col span={12}>
+                          <PermitTemplateConditionManager
+                            category={category}
+                            typeCode={typeCode}
+                            onInsert={handleInsertTemplate}
+                          />
+                        </Col>
+                      </Row>
+                    ) : (
+                      renderCategory(category, idx)
+                    )}
+                  </Collapse.Panel>
+                </Collapse>
+              </Col>
+            );
+          }
+          return renderCategory(category, idx);
+        })}
+      </Row>
+    </div>
+  );
 };
 
 export default PermitConditionViewEdit;

--- a/services/common/src/components/permits/PermitConditionsContext.tsx
+++ b/services/common/src/components/permits/PermitConditionsContext.tsx
@@ -1,46 +1,52 @@
 import { IPermitAmendment } from "@mds/common/interfaces/permits";
-import React, { FC } from "react";
+import React, { FC, useMemo } from "react";
 
 interface PermitConditionsContextType {
-    mineGuid?: string;
-    permitGuid?: string;
-    latestAmendment?: IPermitAmendment;
-    previousAmendment?: IPermitAmendment;
-    currentAmendment?: IPermitAmendment;
-    standardConditionType?: string;
-    isNowEditor?: boolean;
-    loading: boolean;
-    setLoading: (loading: boolean) => void;
-    refreshData: () => Promise<any>;
+  mineGuid?: string;
+  permitGuid?: string;
+  latestAmendment?: IPermitAmendment;
+  previousAmendment?: IPermitAmendment;
+  currentAmendment?: IPermitAmendment;
+  standardConditionType?: string;
+  isStandardConditionEditor?: boolean;
+  isNowEditor?: boolean;
+  loading: boolean;
+  setLoading: (loading: boolean) => void;
+  refreshData: () => Promise<any>;
 }
 
-const PermitConditionsContext = React.createContext<PermitConditionsContextType | undefined>(undefined);
+const PermitConditionsContext = React.createContext<PermitConditionsContextType | undefined>(
+  undefined
+);
 
 export const usePermitConditions = () => {
-    const context = React.useContext(PermitConditionsContext);
-    if (!context) {
-        throw new Error('usePermitConditions must be used within a PermitConditionsProvider');
-    }
-    return context;
+  const context = React.useContext(PermitConditionsContext);
+  if (!context) {
+    throw new Error("usePermitConditions must be used within a PermitConditionsProvider");
+  }
+  return context;
 };
 
-
 export const PermitConditionsProvider: FC<{
-    children: React.ReactNode;
-    value: PermitConditionsContextType;
+  children: React.ReactNode;
+  value: PermitConditionsContextType;
 }> = ({ children, value }) => {
-    // undefined default value causes problems in permit condition form
-    const defaultValue = {
-        isNowEditor: false,
-    };
+  // undefined default value causes problems in permit condition form
+  const defaultValue = {
+    isNowEditor: false,
+    isStandardConditionEditor: false,
+  };
 
-    const contextValue = {
-        ...defaultValue,
-        ...value,
+  const contextValue = useMemo(() => {
+    return {
+      ...defaultValue,
+      ...value,
     };
-    return (
-        <PermitConditionsContext.Provider value={contextValue}>
-            {children}
-        </PermitConditionsContext.Provider>
-    );
+  }, [value]);
+
+  return (
+    <PermitConditionsContext.Provider value={contextValue}>
+      {children}
+    </PermitConditionsContext.Provider>
+  );
 };

--- a/services/common/src/components/permits/PermitTemplateConditionManager.tsx
+++ b/services/common/src/components/permits/PermitTemplateConditionManager.tsx
@@ -1,0 +1,148 @@
+import React, { FC, useEffect, useMemo } from "react";
+import { Collapse, Typography, Row, Col, Skeleton } from "antd";
+import { IFormattedConditionCategory, IStandardPermitCondition } from "@mds/common/interfaces";
+import { fetchStandardPermitConditions } from "@mds/common/redux/actionCreators/permitActionCreator";
+import { useAppDispatch, useAppSelector } from "@mds/common/redux/rootState";
+import { getStandardPermitConditionsFormatted } from "@mds/common/redux/selectors/permitSelectors";
+import {
+  fetchStandardReportRequirements,
+  getStandardReportRequirements,
+} from "@mds/common/redux/slices/mineReportPermitRequirementSlice";
+import { getIsFetching } from "@mds/common/redux/reducers/networkReducer";
+import { NetworkReducerTypes } from "@mds/common/constants/networkReducerTypes";
+import CoreButton from "@mds/common/components/common/CoreButton";
+
+interface PermitTemplateConditionManagerProps {
+  category: IFormattedConditionCategory;
+  typeCode: string;
+  onInsert: ({
+    category,
+    condition,
+  }: {
+    category: IFormattedConditionCategory;
+    condition: IStandardPermitCondition;
+  }) => void;
+}
+
+const PermitTemplateConditionManager: FC<PermitTemplateConditionManagerProps> = ({
+  category,
+  typeCode,
+  onInsert,
+}) => {
+  const dispatch = useAppDispatch();
+
+  const { categoriesWithConditions } = useAppSelector(getStandardPermitConditionsFormatted());
+  const reportRequirements = useAppSelector(getStandardReportRequirements);
+  const conditionsLoading = useAppSelector(
+    getIsFetching(NetworkReducerTypes.GET_PERMIT_CONDITIONS)
+  );
+  const conditionsLoaded =
+    categoriesWithConditions[0]?.conditions[0]?.notice_of_work_type === typeCode;
+
+  const templateConditions = useMemo(() => {
+    if (!reportRequirements) return [];
+    return (
+      categoriesWithConditions.find(
+        (cat) => cat.condition_category_code === category.condition_category_code
+      )?.conditions ?? []
+    );
+  }, [reportRequirements, categoriesWithConditions, category.condition_category_code]);
+
+  useEffect(() => {
+    if (!conditionsLoaded) {
+      dispatch(fetchStandardPermitConditions(typeCode)).then(() => {});
+    }
+  }, [typeCode]);
+
+  useEffect(() => {
+    if (!reportRequirements) {
+      dispatch(fetchStandardReportRequirements(undefined));
+    }
+  }, [reportRequirements]);
+
+  if (conditionsLoading) {
+    return <Skeleton active paragraph={{ rows: 4 }} />;
+  }
+
+  if (templateConditions?.length === 0) {
+    return (
+      <div>
+        <Typography.Title level={4}>Template Conditions</Typography.Title>
+        <Typography.Text>No template conditions available for this category.</Typography.Text>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <Typography.Title level={4}>Template Conditions</Typography.Title>
+      <Collapse className="template-conditions-collapse">
+        {templateConditions.map((condition: IStandardPermitCondition) => (
+          <Collapse.Panel
+            key={condition.standard_permit_condition_guid}
+            header={
+              <Row>
+                <Col flex="auto">
+                  <Typography.Text strong>
+                    {condition.condition.substring(0, 80)}
+                    {condition.condition.length > 80 ? "..." : ""}
+                  </Typography.Text>
+                </Col>
+                <Col>
+                  <CoreButton
+                    type="primary"
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      onInsert({
+                        category,
+                        condition,
+                      });
+                    }}
+                  >
+                    Insert Condition
+                  </CoreButton>
+                </Col>
+              </Row>
+            }
+          >
+            <Typography.Paragraph>{condition.condition}</Typography.Paragraph>
+
+            {condition.condition_type_code && (
+              <Row gutter={[8, 8]}>
+                <Col span={8}>
+                  <Typography.Text strong>Type:</Typography.Text>
+                </Col>
+                <Col span={16}>
+                  <Typography.Text>{condition.condition_type_code}</Typography.Text>
+                </Col>
+              </Row>
+            )}
+
+            {condition.sub_conditions && condition.sub_conditions.length > 0 && (
+              <>
+                <Typography.Text strong style={{ marginTop: "16px", display: "block" }}>
+                  Sub Conditions:
+                </Typography.Text>
+                <Collapse className="sub-conditions-collapse">
+                  {condition.sub_conditions.map((subCondition) => (
+                    <Collapse.Panel
+                      key={subCondition.standard_permit_condition_guid}
+                      header={
+                        subCondition.condition.substring(0, 80) +
+                        (subCondition.condition.length > 80 ? "..." : "")
+                      }
+                    >
+                      <Typography.Paragraph>{subCondition.condition}</Typography.Paragraph>
+                    </Collapse.Panel>
+                  ))}
+                </Collapse>
+              </>
+            )}
+          </Collapse.Panel>
+        ))}
+      </Collapse>
+    </div>
+  );
+};
+
+export default PermitTemplateConditionManager;

--- a/services/common/src/components/permits/PermitTemplateConditionManager.tsx
+++ b/services/common/src/components/permits/PermitTemplateConditionManager.tsx
@@ -1,38 +1,48 @@
 import React, { FC, useEffect, useMemo } from "react";
-import { Collapse, Typography, Row, Col, Skeleton } from "antd";
-import { IFormattedConditionCategory, IStandardPermitCondition } from "@mds/common/interfaces";
-import { fetchStandardPermitConditions } from "@mds/common/redux/actionCreators/permitActionCreator";
-import { useAppDispatch, useAppSelector } from "@mds/common/redux/rootState";
-import { getStandardPermitConditionsFormatted } from "@mds/common/redux/selectors/permitSelectors";
+import { Col, Collapse, Row, Skeleton, Typography } from "antd";
 import {
-  fetchStandardReportRequirements,
-  getStandardReportRequirements,
-} from "@mds/common/redux/slices/mineReportPermitRequirementSlice";
+  IFormattedConditionCategory,
+  IPermitCondition,
+  IStandardPermitCondition,
+} from "@mds/common/interfaces";
+import {
+  createPermitCondition,
+  fetchStandardPermitConditions,
+} from "@mds/common/redux/actionCreators/permitActionCreator";
+import { useAppDispatch, useAppSelector } from "@mds/common/redux/rootState";
+import {
+  getStandardPermitConditions,
+  getStandardPermitConditionsFormatted,
+} from "@mds/common/redux/selectors/permitSelectors";
 import { getIsFetching } from "@mds/common/redux/reducers/networkReducer";
 import { NetworkReducerTypes } from "@mds/common/constants/networkReducerTypes";
 import CoreButton from "@mds/common/components/common/CoreButton";
+import { LeftOutlined } from "@ant-design/icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faXmark } from "@fortawesome/pro-light-svg-icons";
+
+const { Text } = Typography;
 
 interface PermitTemplateConditionManagerProps {
   category: IFormattedConditionCategory;
   typeCode: string;
-  onInsert: ({
-    category,
-    condition,
-  }: {
-    category: IFormattedConditionCategory;
-    condition: IStandardPermitCondition;
-  }) => void;
+  onInsert: () => void;
+  onClose: () => void;
+  permitAmendmentGuid: string;
 }
 
 const PermitTemplateConditionManager: FC<PermitTemplateConditionManagerProps> = ({
   category,
   typeCode,
   onInsert,
+  permitAmendmentGuid,
+  onClose,
 }) => {
   const dispatch = useAppDispatch();
 
   const { categoriesWithConditions } = useAppSelector(getStandardPermitConditionsFormatted());
-  const reportRequirements = useAppSelector(getStandardReportRequirements);
+  const standardPermitConditions = useAppSelector(getStandardPermitConditions);
+
   const conditionsLoading = useAppSelector(
     getIsFetching(NetworkReducerTypes.GET_PERMIT_CONDITIONS)
   );
@@ -40,13 +50,13 @@ const PermitTemplateConditionManager: FC<PermitTemplateConditionManagerProps> = 
     categoriesWithConditions[0]?.conditions[0]?.notice_of_work_type === typeCode;
 
   const templateConditions = useMemo(() => {
-    if (!reportRequirements) return [];
+    if (!categoriesWithConditions) return [];
     return (
       categoriesWithConditions.find(
         (cat) => cat.condition_category_code === category.condition_category_code
       )?.conditions ?? []
     );
-  }, [reportRequirements, categoriesWithConditions, category.condition_category_code]);
+  }, [categoriesWithConditions, category.condition_category_code, standardPermitConditions]);
 
   useEffect(() => {
     if (!conditionsLoaded) {
@@ -54,11 +64,28 @@ const PermitTemplateConditionManager: FC<PermitTemplateConditionManagerProps> = 
     }
   }, [typeCode]);
 
-  useEffect(() => {
-    if (!reportRequirements) {
-      dispatch(fetchStandardReportRequirements(undefined));
-    }
-  }, [reportRequirements]);
+  const handleInsert = async (condition: IStandardPermitCondition) => {
+    const newCondition: IPermitCondition = {
+      condition_category_code: condition.condition_category_code,
+      condition_type_code: condition.condition_type_code,
+      display_order: category.conditions.length + 1,
+      condition: condition.condition,
+      sub_conditions: condition.sub_conditions,
+    } as unknown as IPermitCondition;
+    await dispatch(createPermitCondition(permitAmendmentGuid, newCondition));
+    onInsert();
+  };
+
+  const renderCloseButton = () => {
+    return (
+      <CoreButton
+        data-testid="close-template-manager-button"
+        type="primary"
+        onClick={onClose}
+        icon={<FontAwesomeIcon icon={faXmark} />}
+      />
+    );
+  };
 
   if (conditionsLoading) {
     return <Skeleton active paragraph={{ rows: 4 }} />;
@@ -69,19 +96,25 @@ const PermitTemplateConditionManager: FC<PermitTemplateConditionManagerProps> = 
       <div>
         <Typography.Title level={4}>Template Conditions</Typography.Title>
         <Typography.Text>No template conditions available for this category.</Typography.Text>
+        {renderCloseButton()}
       </div>
     );
   }
 
   return (
-    <div>
-      <Typography.Title level={4}>Template Conditions</Typography.Title>
-      <Collapse className="template-conditions-collapse">
+    <div data-testid="permit-condition-template-manager">
+      <Row wrap={false}>
+        <Col flex="auto">
+          <Typography.Title level={4}>Template Conditions</Typography.Title>
+        </Col>
+        <Col>{renderCloseButton()}</Col>
+      </Row>
+      <Collapse>
         {templateConditions.map((condition: IStandardPermitCondition) => (
           <Collapse.Panel
             key={condition.standard_permit_condition_guid}
             header={
-              <Row>
+              <Row wrap={false} data-testid="template-conditions-collapse">
                 <Col flex="auto">
                   <Typography.Text strong>
                     {condition.condition.substring(0, 80)}
@@ -90,13 +123,12 @@ const PermitTemplateConditionManager: FC<PermitTemplateConditionManagerProps> = 
                 </Col>
                 <Col>
                   <CoreButton
+                    data-testid="template-insert-button"
+                    icon={<LeftOutlined />}
                     type="primary"
                     onClick={(event) => {
                       event.stopPropagation();
-                      onInsert({
-                        category,
-                        condition,
-                      });
+                      handleInsert(condition);
                     }}
                   >
                     Insert Condition
@@ -107,29 +139,20 @@ const PermitTemplateConditionManager: FC<PermitTemplateConditionManagerProps> = 
           >
             <Typography.Paragraph>{condition.condition}</Typography.Paragraph>
 
-            {condition.condition_type_code && (
-              <Row gutter={[8, 8]}>
-                <Col span={8}>
-                  <Typography.Text strong>Type:</Typography.Text>
-                </Col>
-                <Col span={16}>
-                  <Typography.Text>{condition.condition_type_code}</Typography.Text>
-                </Col>
-              </Row>
-            )}
-
             {condition.sub_conditions && condition.sub_conditions.length > 0 && (
               <>
                 <Typography.Text strong style={{ marginTop: "16px", display: "block" }}>
                   Sub Conditions:
                 </Typography.Text>
-                <Collapse className="sub-conditions-collapse">
+                <Collapse>
                   {condition.sub_conditions.map((subCondition) => (
                     <Collapse.Panel
                       key={subCondition.standard_permit_condition_guid}
                       header={
-                        subCondition.condition.substring(0, 80) +
-                        (subCondition.condition.length > 80 ? "..." : "")
+                        <Text data-testid="sub-conditions-collapse">
+                          {subCondition.condition.substring(0, 80) +
+                            (subCondition.condition.length > 80 ? "..." : "")}
+                        </Text>
                       }
                     >
                       <Typography.Paragraph>{subCondition.condition}</Typography.Paragraph>

--- a/services/common/src/components/permits/PermitTemplateConditionManager.tsx
+++ b/services/common/src/components/permits/PermitTemplateConditionManager.tsx
@@ -1,14 +1,7 @@
-import React, { FC, useEffect, useMemo } from "react";
+import React, { FC, useEffect, useMemo, useState } from "react";
 import { Col, Collapse, Row, Skeleton, Typography } from "antd";
-import {
-  IFormattedConditionCategory,
-  IPermitCondition,
-  IStandardPermitCondition,
-} from "@mds/common/interfaces";
-import {
-  createPermitCondition,
-  fetchStandardPermitConditions,
-} from "@mds/common/redux/actionCreators/permitActionCreator";
+import { IFormattedConditionCategory, IStandardPermitCondition } from "@mds/common/interfaces";
+import { fetchStandardPermitConditions } from "@mds/common/redux/actionCreators/permitActionCreator";
 import { useAppDispatch, useAppSelector } from "@mds/common/redux/rootState";
 import {
   getStandardPermitConditions,
@@ -20,12 +13,13 @@ import CoreButton from "@mds/common/components/common/CoreButton";
 import { LeftOutlined } from "@ant-design/icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faXmark } from "@fortawesome/pro-light-svg-icons";
+import { postTemplateConditionToAmendment } from "@mds/common/redux/slices/permitConditionTemplateSlice";
+import { usePermitConditions } from "@mds/common/components/permits/PermitConditionsContext";
 
 const { Text } = Typography;
 
 interface PermitTemplateConditionManagerProps {
   category: IFormattedConditionCategory;
-  typeCode: string;
   onInsert: () => void;
   onClose: () => void;
   permitAmendmentGuid: string;
@@ -33,12 +27,16 @@ interface PermitTemplateConditionManagerProps {
 
 const PermitTemplateConditionManager: FC<PermitTemplateConditionManagerProps> = ({
   category,
-  typeCode,
   onInsert,
   permitAmendmentGuid,
   onClose,
 }) => {
   const dispatch = useAppDispatch();
+
+  const { standardConditionType } = usePermitConditions();
+
+  const [activeKeys, setActiveKeys] = useState<string[]>([]);
+  const [activeSubKeys, setActiveSubKeys] = useState<Record<string, string[]>>({});
 
   const { categoriesWithConditions } = useAppSelector(getStandardPermitConditionsFormatted());
   const standardPermitConditions = useAppSelector(getStandardPermitConditions);
@@ -46,8 +44,15 @@ const PermitTemplateConditionManager: FC<PermitTemplateConditionManagerProps> = 
   const conditionsLoading = useAppSelector(
     getIsFetching(NetworkReducerTypes.GET_PERMIT_CONDITIONS)
   );
+
+  useEffect(() => {
+    if (!conditionsLoaded) {
+      dispatch(fetchStandardPermitConditions(standardConditionType));
+    }
+  }, [standardConditionType]);
+
   const conditionsLoaded =
-    categoriesWithConditions[0]?.conditions[0]?.notice_of_work_type === typeCode;
+    categoriesWithConditions[0]?.conditions[0]?.notice_of_work_type === standardConditionType;
 
   const templateConditions = useMemo(() => {
     if (!categoriesWithConditions) return [];
@@ -58,21 +63,24 @@ const PermitTemplateConditionManager: FC<PermitTemplateConditionManagerProps> = 
     );
   }, [categoriesWithConditions, category.condition_category_code, standardPermitConditions]);
 
-  useEffect(() => {
-    if (!conditionsLoaded) {
-      dispatch(fetchStandardPermitConditions(typeCode)).then(() => {});
-    }
-  }, [typeCode]);
+  const handleCollapseChange = (keys: string | string[]) => {
+    setActiveKeys(Array.isArray(keys) ? keys : [keys]);
+  };
+
+  const handleSubCollapseChange = (parentKey: string) => (keys: string | string[]) => {
+    setActiveSubKeys({
+      ...activeSubKeys,
+      [parentKey]: Array.isArray(keys) ? keys : [keys],
+    });
+  };
 
   const handleInsert = async (condition: IStandardPermitCondition) => {
-    const newCondition: IPermitCondition = {
-      condition_category_code: condition.condition_category_code,
-      condition_type_code: condition.condition_type_code,
-      display_order: category.conditions.length + 1,
-      condition: condition.condition,
-      sub_conditions: condition.sub_conditions,
-    } as unknown as IPermitCondition;
-    await dispatch(createPermitCondition(permitAmendmentGuid, newCondition));
+    dispatch(
+      postTemplateConditionToAmendment({
+        permitAmendmentGuid,
+        standardPermitConditionGuid: condition.standard_permit_condition_guid,
+      })
+    );
     onInsert();
   };
 
@@ -101,6 +109,47 @@ const PermitTemplateConditionManager: FC<PermitTemplateConditionManagerProps> = 
     );
   }
 
+  const renderConditionText = (condition: IStandardPermitCondition, isExpanded: boolean) => {
+    if (isExpanded) return condition.condition;
+    return `${condition.condition.substring(0, 80)}${condition.condition.length > 80 ? "..." : ""}`;
+  };
+
+  const renderSubConditions = (
+    subConditions: IStandardPermitCondition[],
+    parentConditionKey: string
+  ) => {
+    return (
+      <>
+        <Typography.Text strong style={{ marginTop: "16px", display: "block" }}>
+          Sub Conditions:
+        </Typography.Text>
+        <Collapse
+          activeKey={activeSubKeys[parentConditionKey] || []}
+          onChange={handleSubCollapseChange(parentConditionKey)}
+        >
+          {subConditions.map((subCondition) => {
+            const subKey = subCondition.standard_permit_condition_guid;
+            const isSubExpanded = activeSubKeys[parentConditionKey]?.includes(subKey);
+
+            return (
+              <Collapse.Panel
+                key={subCondition.standard_permit_condition_guid}
+                header={
+                  <Text data-testid="sub-conditions-collapse">
+                    {renderConditionText(subCondition, isSubExpanded)}
+                  </Text>
+                }
+              >
+                {subCondition?.sub_conditions?.length > 0 &&
+                  renderSubConditions(subCondition.sub_conditions, subKey)}
+              </Collapse.Panel>
+            );
+          })}
+        </Collapse>
+      </>
+    );
+  };
+
   return (
     <div data-testid="permit-condition-template-manager">
       <Row wrap={false}>
@@ -109,60 +158,42 @@ const PermitTemplateConditionManager: FC<PermitTemplateConditionManagerProps> = 
         </Col>
         <Col>{renderCloseButton()}</Col>
       </Row>
-      <Collapse>
-        {templateConditions.map((condition: IStandardPermitCondition) => (
-          <Collapse.Panel
-            key={condition.standard_permit_condition_guid}
-            header={
-              <Row wrap={false} data-testid="template-conditions-collapse">
-                <Col flex="auto">
-                  <Typography.Text strong>
-                    {condition.condition.substring(0, 80)}
-                    {condition.condition.length > 80 ? "..." : ""}
-                  </Typography.Text>
-                </Col>
-                <Col>
-                  <CoreButton
-                    data-testid="template-insert-button"
-                    icon={<LeftOutlined />}
-                    type="primary"
-                    onClick={(event) => {
-                      event.stopPropagation();
-                      handleInsert(condition);
-                    }}
-                  >
-                    Insert Condition
-                  </CoreButton>
-                </Col>
-              </Row>
-            }
-          >
-            <Typography.Paragraph>{condition.condition}</Typography.Paragraph>
+      <Collapse activeKey={activeKeys} onChange={handleCollapseChange}>
+        {templateConditions.map((condition: IStandardPermitCondition) => {
+          const conditionKey = condition.standard_permit_condition_guid;
+          const isExpanded = activeKeys.includes(conditionKey);
 
-            {condition.sub_conditions && condition.sub_conditions.length > 0 && (
-              <>
-                <Typography.Text strong style={{ marginTop: "16px", display: "block" }}>
-                  Sub Conditions:
-                </Typography.Text>
-                <Collapse>
-                  {condition.sub_conditions.map((subCondition) => (
-                    <Collapse.Panel
-                      key={subCondition.standard_permit_condition_guid}
-                      header={
-                        <Text data-testid="sub-conditions-collapse">
-                          {subCondition.condition.substring(0, 80) +
-                            (subCondition.condition.length > 80 ? "..." : "")}
-                        </Text>
-                      }
+          return (
+            <Collapse.Panel
+              key={conditionKey}
+              header={
+                <Row wrap={false} data-testid="template-conditions-collapse" gutter={16}>
+                  <Col flex="auto">
+                    <Typography.Text strong>
+                      {renderConditionText(condition, isExpanded)}
+                    </Typography.Text>
+                  </Col>
+                  <Col>
+                    <CoreButton
+                      data-testid="template-insert-button"
+                      icon={<LeftOutlined />}
+                      type="primary"
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        handleInsert(condition);
+                      }}
                     >
-                      <Typography.Paragraph>{subCondition.condition}</Typography.Paragraph>
-                    </Collapse.Panel>
-                  ))}
-                </Collapse>
-              </>
-            )}
-          </Collapse.Panel>
-        ))}
+                      Insert
+                    </CoreButton>
+                  </Col>
+                </Row>
+              }
+            >
+              {condition?.sub_conditions?.length > 0 &&
+                renderSubConditions(condition.sub_conditions, conditionKey)}
+            </Collapse.Panel>
+          );
+        })}
       </Collapse>
     </div>
   );

--- a/services/common/src/components/permits/ReportPermitRequirementForm.tsx
+++ b/services/common/src/components/permits/ReportPermitRequirementForm.tsx
@@ -51,14 +51,14 @@ export const ReportPermitRequirementForm: FC<ReportPermitRequirementProps> = ({
 }) => {
   const formName = `${FORM.ADD_REPORT_TO_PERMIT_CONDITION}-${condition?.permit_condition_id ?? mineReportPermitRequirement?.mine_report_permit_requirement_id}`;
 
-  const { loading, currentAmendment, permitGuid, mineGuid, isNowEditor, standardConditionType } = usePermitConditions();
+  const { loading, currentAmendment, permitGuid, mineGuid, isNowEditor, isStandardConditionEditor } = usePermitConditions();
   const [selectedRequirement, setSelectedRequirement] = useState(mineReportPermitRequirement);
   const dispatch = useAppDispatch();
   const [isEditMode, setIsEditMode] = useState(isModal && canEditPermitConditions);
 
   const standardRequirements = useAppSelector(getStandardReportRequirements);
   const permitRequirements = useAppSelector(getMineReportPermitRequirementsByAmendment(permitGuid, currentAmendment?.permit_amendment_guid, isNowEditor));
-  const existingRequirements = Boolean(standardConditionType) ? standardRequirements : permitRequirements;
+  const existingRequirements = isStandardConditionEditor ? standardRequirements : permitRequirements;
 
   const hasExistingRequirements = existingRequirements?.length > 0;
   const existingRequirementsOptions = existingRequirements.map((r) => { return { label: r.report_name, value: r.mine_report_permit_requirement_id } });
@@ -69,7 +69,7 @@ export const ReportPermitRequirementForm: FC<ReportPermitRequirementProps> = ({
   const permitConditions = useAppSelector(getPermitConditionCategories(permitGuid, currentAmendment?.permit_amendment_guid));
   const standardConditions = useAppSelector(getStandardPermitConditionsFormatted());
 
-  const conditions = Boolean(standardConditionType)
+  const conditions = isStandardConditionEditor
     ? standardConditions
     : isNowEditor ? nowConditions : permitConditions;
 
@@ -274,7 +274,7 @@ export const ReportPermitRequirementForm: FC<ReportPermitRequirementProps> = ({
               disabled={loading || disableFields}
             />
           </Col>
-          <Col span={standardConditionType ? 24 : 12}>
+          <Col span={isStandardConditionEditor ? 24 : 12}>
             <Field
               name="due_date_period_months"
               label="Report Frequency"
@@ -290,7 +290,7 @@ export const ReportPermitRequirementForm: FC<ReportPermitRequirementProps> = ({
               disabled={loading || disableFields}
             />
           </Col>
-          {!standardConditionType &&
+          {!isStandardConditionEditor &&
             <Col md={12} sm={24}>
               <Field
                 name="initial_due_date"

--- a/services/common/src/components/permits/SubConditionForm.tsx
+++ b/services/common/src/components/permits/SubConditionForm.tsx
@@ -40,13 +40,13 @@ const SubConditionForm: FC<SubConditionFormProps> = ({
   onSubmit,
 }) => {
   const dispatch = useAppDispatch();
-  const { loading, setLoading, standardConditionType } = usePermitConditions();
+  const { loading, setLoading, standardConditionType, isStandardConditionEditor } = usePermitConditions();
   const formValues = useAppSelector(getFormValues(FORM.EDIT_PERMIT_CONDITION)) as IPermitCondition;
 
   const handleSubmit = async (values) => {
     setLoading(true);
     let resp;
-    if (permitAmendmentGuid && !standardConditionType) {
+    if (permitAmendmentGuid && !isStandardConditionEditor) {
       resp = await dispatch(createPermitCondition(permitAmendmentGuid, values));
     } else {
       resp = await dispatch(createStandardPermitCondition(standardConditionType, values));

--- a/services/common/src/constants/API.ts
+++ b/services/common/src/constants/API.ts
@@ -97,6 +97,8 @@ export const STANDARD_PERMIT_CONDITION = (permitConditionGuid) =>
 export const PERMIT_CONDITION_TAGS = () => `/mines/permits/condition-tags`;
 export const PERMIT_CONDITION_TAG = (tagGuid) =>
   `/mines/permits/condition-tags/${tagGuid}`;
+export const PERMIT_CONDITION_INSERT_TEMPLATE = (permitAmendmentGuid: string, standardPermitConditionGuid: string) =>
+  `/mines/permits/amendments/${permitAmendmentGuid}/standard_permit_conditions/${standardPermitConditionGuid}`;
 
 export const PERMIT_AMENDMENT_CONDITION_ASSIGN_REVIEWER = (params?: { permit_amendment_id: number }) =>
   `mines/permits/condition-category/assign-review-user?${queryString.stringify(params ?? {})}`;

--- a/services/common/src/redux/actionCreators/permitActionCreator.ts
+++ b/services/common/src/redux/actionCreators/permitActionCreator.ts
@@ -271,19 +271,6 @@ export const updatePermitAmendmentConditionCategory =
   (dispatch): Promise<IPermitCondition | IDispatchError> => {
     dispatch(request(NetworkReducerTypes.UPDATE_PERMIT_CONDITION_CATEGORY));
     dispatch(showLoading());
-    console.log(
-      "dispatching update permit condition category",
-      payload,
-      "with params: ",
-      mineGuid,
-      permitGuid,
-      permitAmdendmentGuid,
-      "and payload:"
-    );
-    console.log(
-      "endpoint",
-      `${ENVIRONMENT.apiUrl}${API.PERMIT_AMENDMENT_CONDITION_CATEGORIES(mineGuid, permitGuid, permitAmdendmentGuid)}/${payload.condition_category_code}`
-    );
     return CustomAxios()
       .put(
         `${ENVIRONMENT.apiUrl}${API.PERMIT_AMENDMENT_CONDITION_CATEGORIES(mineGuid, permitGuid, permitAmdendmentGuid)}/${payload.condition_category_code}`,

--- a/services/common/src/redux/actionCreators/permitActionCreator.ts
+++ b/services/common/src/redux/actionCreators/permitActionCreator.ts
@@ -23,99 +23,99 @@ import CustomAxios from "../customAxios";
 import { AxiosResponse } from "axios";
 import { AppThunk } from "@mds/common/interfaces/appThunk.type";
 
-export const createPermit = (
-  mineGuid: string,
-  payload: ICreatePermitPayload
-): AppThunk<Promise<AxiosResponse<IPermit>>> => (dispatch): Promise<AxiosResponse<IPermit>> => {
-  dispatch(request(NetworkReducerTypes.CREATE_PERMIT));
-  dispatch(showLoading("modal"));
-  return CustomAxios()
-    .post(ENVIRONMENT.apiUrl + API.PERMITS(mineGuid), payload, createRequestHeader())
-    .then((response: AxiosResponse<IPermit>) => {
-      notification.success({
-        message: "Successfully created a new permit",
-        duration: 10,
-      });
-      dispatch(success(NetworkReducerTypes.CREATE_PERMIT));
-      return response;
-    })
-    .catch(() => {
-      dispatch(error(NetworkReducerTypes.CREATE_PERMIT));
-    })
-    .finally(() => dispatch(hideLoading("modal")));
-};
+export const createPermit =
+  (mineGuid: string, payload: ICreatePermitPayload): AppThunk<Promise<AxiosResponse<IPermit>>> =>
+  (dispatch): Promise<AxiosResponse<IPermit>> => {
+    dispatch(request(NetworkReducerTypes.CREATE_PERMIT));
+    dispatch(showLoading("modal"));
+    return CustomAxios()
+      .post(ENVIRONMENT.apiUrl + API.PERMITS(mineGuid), payload, createRequestHeader())
+      .then((response: AxiosResponse<IPermit>) => {
+        notification.success({
+          message: "Successfully created a new permit",
+          duration: 10,
+        });
+        dispatch(success(NetworkReducerTypes.CREATE_PERMIT));
+        return response;
+      })
+      .catch(() => {
+        dispatch(error(NetworkReducerTypes.CREATE_PERMIT));
+      })
+      .finally(() => dispatch(hideLoading("modal")));
+  };
 
-export const fetchPermits = (mineGuid: string): AppThunk<Promise<void | IDispatchError>> => (
-  dispatch
-) => {
-  dispatch(request(NetworkReducerTypes.GET_PERMITS));
-  dispatch(showLoading("modal"));
-  return CustomAxios({ errorToastMessage: String.ERROR })
-    .get(ENVIRONMENT.apiUrl + API.PERMITS(mineGuid), createRequestHeader())
-    .then((response) => {
-      dispatch(success(NetworkReducerTypes.GET_PERMITS));
-      dispatch(permitActions.storePermits(response.data));
-    })
-    .catch(() => dispatch(error(NetworkReducerTypes.GET_PERMITS)))
-    .finally(() => dispatch(hideLoading("modal")));
-};
+export const fetchPermits =
+  (mineGuid: string): AppThunk<Promise<void | IDispatchError>> =>
+  (dispatch) => {
+    dispatch(request(NetworkReducerTypes.GET_PERMITS));
+    dispatch(showLoading("modal"));
+    return CustomAxios({ errorToastMessage: String.ERROR })
+      .get(ENVIRONMENT.apiUrl + API.PERMITS(mineGuid), createRequestHeader())
+      .then((response) => {
+        dispatch(success(NetworkReducerTypes.GET_PERMITS));
+        dispatch(permitActions.storePermits(response.data));
+      })
+      .catch(() => dispatch(error(NetworkReducerTypes.GET_PERMITS)))
+      .finally(() => dispatch(hideLoading("modal")));
+  };
 
-export const fetchDraftPermitByNOW = (
-  mineGuid: string,
-  nowApplicationGuid: string
-): AppThunk<Promise<AxiosResponse<IPermit[]>>> => (dispatch): Promise<AxiosResponse<IPermit[]>> => {
-  dispatch(request(NetworkReducerTypes.GET_PERMITS));
-  dispatch(showLoading());
-  return CustomAxios({ errorToastMessage: String.ERROR })
-    .get(
-      ENVIRONMENT.apiUrl + API.DRAFT_PERMITS(mineGuid, nowApplicationGuid),
-      createRequestHeader()
-    )
-    .then((response: AxiosResponse<IPermit[]>) => {
-      dispatch(success(NetworkReducerTypes.GET_PERMITS));
-      dispatch(permitActions.storeDraftPermits(response.data));
-      return response;
-    })
-    .catch(() => {
-      dispatch(error(NetworkReducerTypes.GET_PERMITS));
-    })
-    .finally(() => dispatch(hideLoading()));
-};
+export const fetchDraftPermitByNOW =
+  (mineGuid: string, nowApplicationGuid: string): AppThunk<Promise<AxiosResponse<IPermit[]>>> =>
+  (dispatch): Promise<AxiosResponse<IPermit[]>> => {
+    dispatch(request(NetworkReducerTypes.GET_PERMITS));
+    dispatch(showLoading());
+    return CustomAxios({ errorToastMessage: String.ERROR })
+      .get(
+        ENVIRONMENT.apiUrl + API.DRAFT_PERMITS(mineGuid, nowApplicationGuid),
+        createRequestHeader()
+      )
+      .then((response: AxiosResponse<IPermit[]>) => {
+        dispatch(success(NetworkReducerTypes.GET_PERMITS));
+        dispatch(permitActions.storeDraftPermits(response.data));
+        return response;
+      })
+      .catch(() => {
+        dispatch(error(NetworkReducerTypes.GET_PERMITS));
+      })
+      .finally(() => dispatch(hideLoading()));
+  };
 
-export const updatePermit = (
-  mineGuid: string,
-  permitGuid: string,
-  payload: IPermit
-): AppThunk<Promise<AxiosResponse<IPermit>>> => (dispatch): Promise<AxiosResponse<IPermit>> => {
-  dispatch(request(NetworkReducerTypes.UPDATE_PERMIT));
-  dispatch(showLoading());
-  return CustomAxios()
-    .put(
-      `${ENVIRONMENT.apiUrl}${API.PERMITS(mineGuid)}/${permitGuid}`,
-      payload,
-      createRequestHeader()
-    )
-    .then((response: AxiosResponse<IPermit>) => {
-      notification.success({
-        message: `Successfully updated permit`,
-        duration: 10,
-      });
-      dispatch(success(NetworkReducerTypes.UPDATE_PERMIT));
-      return response;
-    })
-    .catch(() => {
-      dispatch(error(NetworkReducerTypes.UPDATE_PERMIT));
-    })
-    .finally(() => dispatch(hideLoading()));
-};
+export const updatePermit =
+  (
+    mineGuid: string,
+    permitGuid: string,
+    payload: IPermit
+  ): AppThunk<Promise<AxiosResponse<IPermit>>> =>
+  (dispatch): Promise<AxiosResponse<IPermit>> => {
+    dispatch(request(NetworkReducerTypes.UPDATE_PERMIT));
+    dispatch(showLoading());
+    return CustomAxios()
+      .put(
+        `${ENVIRONMENT.apiUrl}${API.PERMITS(mineGuid)}/${permitGuid}`,
+        payload,
+        createRequestHeader()
+      )
+      .then((response: AxiosResponse<IPermit>) => {
+        notification.success({
+          message: `Successfully updated permit`,
+          duration: 10,
+        });
+        dispatch(success(NetworkReducerTypes.UPDATE_PERMIT));
+        return response;
+      })
+      .catch(() => {
+        dispatch(error(NetworkReducerTypes.UPDATE_PERMIT));
+      })
+      .finally(() => dispatch(hideLoading()));
+  };
 
-export const createPermitAmendment = (
-  mineGuid: string,
-  permitGuid: string,
-  payload: Partial<ICreatePermitAmendmentPayload>
-): AppThunk<Promise<AxiosResponse<IPermitAmendment>>> => (
-  dispatch
-): Promise<AxiosResponse<IPermitAmendment>> => {
+export const createPermitAmendment =
+  (
+    mineGuid: string,
+    permitGuid: string,
+    payload: Partial<ICreatePermitAmendmentPayload>
+  ): AppThunk<Promise<AxiosResponse<IPermitAmendment>>> =>
+  (dispatch): Promise<AxiosResponse<IPermitAmendment>> => {
     dispatch(request(NetworkReducerTypes.CREATE_PERMIT_AMENDMENT));
     dispatch(showLoading("modal"));
     return CustomAxios()
@@ -138,41 +138,43 @@ export const createPermitAmendment = (
       .finally(() => dispatch(hideLoading("modal")));
   };
 
-export const createPermitAmendmentVC = (
-  mineGuid: string,
-  permitGuid: string,
-  permitAmdendmentGuid: string
-): AppThunk<Promise<AxiosResponse<string>>> => (dispatch): Promise<AxiosResponse<string>> => {
-  dispatch(request(NetworkReducerTypes.PERMIT_AMENDMENT_VC));
-  dispatch(showLoading());
-  return CustomAxios()
-    .post(
-      `${ENVIRONMENT.apiUrl}${API.PERMIT_AMENDMENT_VC(mineGuid, permitGuid, permitAmdendmentGuid)}`,
-      {},
-      createRequestHeader()
-    )
-    .then((response: AxiosResponse<string>) => {
-      notification.success({
-        message: `Successfully Issued Permit Verifiable Credentials, Thanks Jason`,
-        duration: 10,
-      });
-      dispatch(success(NetworkReducerTypes.PERMIT_AMENDMENT_VC));
-      return response;
-    })
-    .catch(() => {
-      dispatch(error(NetworkReducerTypes.PERMIT_AMENDMENT_VC));
-    })
-    .finally(() => dispatch(hideLoading()));
-};
+export const createPermitAmendmentVC =
+  (
+    mineGuid: string,
+    permitGuid: string,
+    permitAmdendmentGuid: string
+  ): AppThunk<Promise<AxiosResponse<string>>> =>
+  (dispatch): Promise<AxiosResponse<string>> => {
+    dispatch(request(NetworkReducerTypes.PERMIT_AMENDMENT_VC));
+    dispatch(showLoading());
+    return CustomAxios()
+      .post(
+        `${ENVIRONMENT.apiUrl}${API.PERMIT_AMENDMENT_VC(mineGuid, permitGuid, permitAmdendmentGuid)}`,
+        {},
+        createRequestHeader()
+      )
+      .then((response: AxiosResponse<string>) => {
+        notification.success({
+          message: `Successfully Issued Permit Verifiable Credentials, Thanks Jason`,
+          duration: 10,
+        });
+        dispatch(success(NetworkReducerTypes.PERMIT_AMENDMENT_VC));
+        return response;
+      })
+      .catch(() => {
+        dispatch(error(NetworkReducerTypes.PERMIT_AMENDMENT_VC));
+      })
+      .finally(() => dispatch(hideLoading()));
+  };
 
-export const updatePermitAmendment = (
-  mineGuid: string,
-  permitGuid: string,
-  permitAmdendmentGuid: string,
-  payload: Partial<IUpdatePermitAmendmentPayload>
-): AppThunk<Promise<AxiosResponse<IPermitAmendment>>> => (
-  dispatch
-): Promise<AxiosResponse<IPermitAmendment>> => {
+export const updatePermitAmendment =
+  (
+    mineGuid: string,
+    permitGuid: string,
+    permitAmdendmentGuid: string,
+    payload: Partial<IUpdatePermitAmendmentPayload>
+  ): AppThunk<Promise<AxiosResponse<IPermitAmendment>>> =>
+  (dispatch): Promise<AxiosResponse<IPermitAmendment>> => {
     dispatch(request(NetworkReducerTypes.UPDATE_PERMIT_AMENDMENT));
     dispatch(showLoading());
     return CustomAxios()
@@ -199,14 +201,13 @@ export const updatePermitAmendment = (
       .finally(() => dispatch(hideLoading()));
   };
 
-
-export const fetchPermitAmendmentConditionCategories = (
-  mineGuid: string,
-  permitGuid: string,
-  permitAmdendmentGuid: string
-): AppThunk<Promise<IPermitCondition[] | IDispatchError>> => (
-  dispatch
-): Promise<IPermitCondition[] | IDispatchError> => {
+export const fetchPermitAmendmentConditionCategories =
+  (
+    mineGuid: string,
+    permitGuid: string,
+    permitAmdendmentGuid: string
+  ): AppThunk<Promise<IPermitCondition[] | IDispatchError>> =>
+  (dispatch): Promise<IPermitCondition[] | IDispatchError> => {
     dispatch(request(NetworkReducerTypes.GET_PERMIT_CONDITION_CATEGORIES));
     dispatch(showLoading());
     return CustomAxios()
@@ -215,25 +216,26 @@ export const fetchPermitAmendmentConditionCategories = (
         createRequestHeader()
       )
       .then((response: AxiosResponse<{ records: IPermitConditionCategory[] }>) => {
-        dispatch(permitActions.storeUpdatePermitConditionCategory({
-          condition_categories: response.data.records,
-          permitGuid
-        }));
+        dispatch(
+          permitActions.storeUpdatePermitConditionCategory({
+            condition_categories: response.data.records,
+            permitGuid,
+          })
+        );
         return response.data;
       })
       .catch(() => dispatch(error(NetworkReducerTypes.GET_PERMIT_CONDITION_CATEGORIES)))
       .finally(() => dispatch(hideLoading()));
   };
 
-
-export const createPermitAmendmentConditionCategory = (
-  mineGuid: string,
-  permitGuid: string,
-  permitAmdendmentGuid: string,
-  payload: IPermitConditionCategory
-): AppThunk<Promise<IPermitCondition | IDispatchError>> => (
-  dispatch
-): Promise<IPermitCondition | IDispatchError> => {
+export const createPermitAmendmentConditionCategory =
+  (
+    mineGuid: string,
+    permitGuid: string,
+    permitAmdendmentGuid: string,
+    payload: IPermitConditionCategory
+  ): AppThunk<Promise<IPermitCondition | IDispatchError>> =>
+  (dispatch): Promise<IPermitCondition | IDispatchError> => {
     dispatch(request(NetworkReducerTypes.CREATE_PERMIT_CONDITION_CATEGORY));
     dispatch(showLoading());
     return CustomAxios()
@@ -249,7 +251,9 @@ export const createPermitAmendmentConditionCategory = (
         });
 
         dispatch(success(NetworkReducerTypes.CREATE_PERMIT_CONDITION_CATEGORY));
-        dispatch(fetchPermitAmendmentConditionCategories(mineGuid, permitGuid, permitAmdendmentGuid));
+        dispatch(
+          fetchPermitAmendmentConditionCategories(mineGuid, permitGuid, permitAmdendmentGuid)
+        );
         dispatch(fetchPermits(mineGuid));
         return response.data;
       })
@@ -257,16 +261,29 @@ export const createPermitAmendmentConditionCategory = (
       .finally(() => dispatch(hideLoading()));
   };
 
-export const updatePermitAmendmentConditionCategory = (
-  mineGuid: string,
-  permitGuid: string,
-  permitAmdendmentGuid: string,
-  payload: IPermitConditionCategory
-): AppThunk<Promise<IPermitCondition | IDispatchError>> => (
-  dispatch
-): Promise<IPermitCondition | IDispatchError> => {
+export const updatePermitAmendmentConditionCategory =
+  (
+    mineGuid: string,
+    permitGuid: string,
+    permitAmdendmentGuid: string,
+    payload: IPermitConditionCategory
+  ): AppThunk<Promise<IPermitCondition | IDispatchError>> =>
+  (dispatch): Promise<IPermitCondition | IDispatchError> => {
     dispatch(request(NetworkReducerTypes.UPDATE_PERMIT_CONDITION_CATEGORY));
     dispatch(showLoading());
+    console.log(
+      "dispatching update permit condition category",
+      payload,
+      "with params: ",
+      mineGuid,
+      permitGuid,
+      permitAmdendmentGuid,
+      "and payload:"
+    );
+    console.log(
+      "endpoint",
+      `${ENVIRONMENT.apiUrl}${API.PERMIT_AMENDMENT_CONDITION_CATEGORIES(mineGuid, permitGuid, permitAmdendmentGuid)}/${payload.condition_category_code}`
+    );
     return CustomAxios()
       .put(
         `${ENVIRONMENT.apiUrl}${API.PERMIT_AMENDMENT_CONDITION_CATEGORIES(mineGuid, permitGuid, permitAmdendmentGuid)}/${payload.condition_category_code}`,
@@ -280,21 +297,23 @@ export const updatePermitAmendmentConditionCategory = (
         });
 
         dispatch(success(NetworkReducerTypes.UPDATE_PERMIT_CONDITION_CATEGORY));
-        dispatch(fetchPermitAmendmentConditionCategories(mineGuid, permitGuid, permitAmdendmentGuid));
+        dispatch(
+          fetchPermitAmendmentConditionCategories(mineGuid, permitGuid, permitAmdendmentGuid)
+        );
         return response.data;
       })
       .catch(() => dispatch(error(NetworkReducerTypes.UPDATE_PERMIT_CONDITION_CATEGORY)))
       .finally(() => dispatch(hideLoading()));
   };
 
-export const deletePermitAmendmentConditionCategory = (
-  mineGuid: string,
-  permitGuid: string,
-  permitAmdendmentGuid: string,
-  permitConditionCategoryCode: string,
-): AppThunk<Promise<IPermitCondition | IDispatchError>> => (
-  dispatch
-): Promise<IPermitCondition | IDispatchError> => {
+export const deletePermitAmendmentConditionCategory =
+  (
+    mineGuid: string,
+    permitGuid: string,
+    permitAmdendmentGuid: string,
+    permitConditionCategoryCode: string
+  ): AppThunk<Promise<IPermitCondition | IDispatchError>> =>
+  (dispatch): Promise<IPermitCondition | IDispatchError> => {
     dispatch(request(NetworkReducerTypes.DELETE_PERMIT_CONDITION_CATEGORY));
     dispatch(showLoading());
     return CustomAxios()
@@ -309,7 +328,9 @@ export const deletePermitAmendmentConditionCategory = (
         });
 
         dispatch(success(NetworkReducerTypes.DELETE_PERMIT_CONDITION_CATEGORY));
-        dispatch(fetchPermitAmendmentConditionCategories(mineGuid, permitGuid, permitAmdendmentGuid));
+        dispatch(
+          fetchPermitAmendmentConditionCategories(mineGuid, permitGuid, permitAmdendmentGuid)
+        );
         dispatch(fetchPermits(mineGuid));
         return response.data;
       })
@@ -317,138 +338,141 @@ export const deletePermitAmendmentConditionCategory = (
       .finally(() => dispatch(hideLoading()));
   };
 
-export const fetchPermitAmendment = (
-  mineGuid: string,
-  permitGuid: string,
-  permitAmdendmentGuid: string
-): AppThunk<Promise<IPermitAmendment>> => (dispatch): Promise<IPermitAmendment> => {
-  dispatch(request(NetworkReducerTypes.GET_PERMIT_AMENDMENT));
-  dispatch(showLoading());
-  return CustomAxios()
-    .get(
-      `${ENVIRONMENT.apiUrl}${API.PERMIT_AMENDMENT(mineGuid, permitGuid, permitAmdendmentGuid)}`,
-      createRequestHeader()
-    )
-    .then((response: AxiosResponse<IPermitAmendment>) => {
-      dispatch(success(NetworkReducerTypes.GET_PERMIT_AMENDMENT));
-      dispatch(permitActions.storePermitAmendment(response.data, permitGuid));
-      return response.data;
-    })
-    .catch(() => {
-      dispatch(error(NetworkReducerTypes.GET_PERMIT_AMENDMENT));
-    })
-    .finally(() => dispatch(hideLoading()));
-};
+export const fetchPermitAmendment =
+  (
+    mineGuid: string,
+    permitGuid: string,
+    permitAmdendmentGuid: string
+  ): AppThunk<Promise<IPermitAmendment>> =>
+  (dispatch): Promise<IPermitAmendment> => {
+    dispatch(request(NetworkReducerTypes.GET_PERMIT_AMENDMENT));
+    dispatch(showLoading());
+    return CustomAxios()
+      .get(
+        `${ENVIRONMENT.apiUrl}${API.PERMIT_AMENDMENT(mineGuid, permitGuid, permitAmdendmentGuid)}`,
+        createRequestHeader()
+      )
+      .then((response: AxiosResponse<IPermitAmendment>) => {
+        dispatch(success(NetworkReducerTypes.GET_PERMIT_AMENDMENT));
+        dispatch(permitActions.storePermitAmendment(response.data, permitGuid));
+        return response.data;
+      })
+      .catch(() => {
+        dispatch(error(NetworkReducerTypes.GET_PERMIT_AMENDMENT));
+      })
+      .finally(() => dispatch(hideLoading()));
+  };
 
-export const removePermitAmendmentDocument = (
-  mineGuid: string,
-  permitGuid: string,
-  permitAmdendmentGuid: string,
-  documentGuid: string
-): AppThunk<Promise<AxiosResponse<string>>> => (dispatch): Promise<AxiosResponse<string>> => {
-  dispatch(request(NetworkReducerTypes.UPDATE_PERMIT_AMENDMENT_DOCUMENT));
-  dispatch(showLoading());
-  return CustomAxios()
-    .delete(
-      `${ENVIRONMENT.apiUrl}${API.PERMIT_AMENDMENT_DOCUMENT(
-        mineGuid,
-        permitGuid,
-        permitAmdendmentGuid,
-        documentGuid
-      )}`,
-      createRequestHeader()
-    )
-    .then((response: AxiosResponse<string>) => {
-      notification.success({
-        message: `Successfully removed attached document`,
-        duration: 10,
-      });
-      dispatch(success(NetworkReducerTypes.UPDATE_PERMIT_AMENDMENT_DOCUMENT));
-      return response;
-    })
-    .catch(() => {
-      dispatch(error(NetworkReducerTypes.UPDATE_PERMIT_AMENDMENT_DOCUMENT));
-    })
-    .finally(() => dispatch(hideLoading()));
-};
+export const removePermitAmendmentDocument =
+  (
+    mineGuid: string,
+    permitGuid: string,
+    permitAmdendmentGuid: string,
+    documentGuid: string
+  ): AppThunk<Promise<AxiosResponse<string>>> =>
+  (dispatch): Promise<AxiosResponse<string>> => {
+    dispatch(request(NetworkReducerTypes.UPDATE_PERMIT_AMENDMENT_DOCUMENT));
+    dispatch(showLoading());
+    return CustomAxios()
+      .delete(
+        `${ENVIRONMENT.apiUrl}${API.PERMIT_AMENDMENT_DOCUMENT(
+          mineGuid,
+          permitGuid,
+          permitAmdendmentGuid,
+          documentGuid
+        )}`,
+        createRequestHeader()
+      )
+      .then((response: AxiosResponse<string>) => {
+        notification.success({
+          message: `Successfully removed attached document`,
+          duration: 10,
+        });
+        dispatch(success(NetworkReducerTypes.UPDATE_PERMIT_AMENDMENT_DOCUMENT));
+        return response;
+      })
+      .catch(() => {
+        dispatch(error(NetworkReducerTypes.UPDATE_PERMIT_AMENDMENT_DOCUMENT));
+      })
+      .finally(() => dispatch(hideLoading()));
+  };
 
-export const deletePermit = (
-  mineGuid: string,
-  permitGuid: string
-): AppThunk<Promise<AxiosResponse<string>>> => (dispatch): Promise<AxiosResponse<string>> => {
-  dispatch(request(NetworkReducerTypes.DELETE_PERMIT));
-  dispatch(showLoading());
-  return CustomAxios()
-    .delete(
-      `${ENVIRONMENT.apiUrl}${API.PERMIT_DELETE(mineGuid, permitGuid)}`,
-      createRequestHeader()
-    )
-    .then((response: AxiosResponse<string>) => {
-      notification.success({
-        message: "Successfully deleted permit and all related permit amendments and documents.",
-        duration: 10,
-      });
-      dispatch(success(NetworkReducerTypes.DELETE_PERMIT));
-      return response;
-    })
-    .catch(() => {
-      dispatch(error(NetworkReducerTypes.DELETE_PERMIT));
-    })
-    .finally(() => dispatch(hideLoading()));
-};
+export const deletePermit =
+  (mineGuid: string, permitGuid: string): AppThunk<Promise<AxiosResponse<string>>> =>
+  (dispatch): Promise<AxiosResponse<string>> => {
+    dispatch(request(NetworkReducerTypes.DELETE_PERMIT));
+    dispatch(showLoading());
+    return CustomAxios()
+      .delete(
+        `${ENVIRONMENT.apiUrl}${API.PERMIT_DELETE(mineGuid, permitGuid)}`,
+        createRequestHeader()
+      )
+      .then((response: AxiosResponse<string>) => {
+        notification.success({
+          message: "Successfully deleted permit and all related permit amendments and documents.",
+          duration: 10,
+        });
+        dispatch(success(NetworkReducerTypes.DELETE_PERMIT));
+        return response;
+      })
+      .catch(() => {
+        dispatch(error(NetworkReducerTypes.DELETE_PERMIT));
+      })
+      .finally(() => dispatch(hideLoading()));
+  };
 
-export const deletePermitAmendment = (
-  mineGuid: string,
-  permitGuid: string,
-  permitAmdendmentGuid: string
-): AppThunk<Promise<AxiosResponse<string>>> => (dispatch): Promise<AxiosResponse<string>> => {
-  dispatch(request(NetworkReducerTypes.DELETE_PERMIT_AMENDMENT));
-  dispatch(showLoading());
-  return CustomAxios()
-    .delete(
-      `${ENVIRONMENT.apiUrl}${API.PERMIT_AMENDMENT(mineGuid, permitGuid, permitAmdendmentGuid)}`,
-      createRequestHeader()
-    )
-    .then((response: AxiosResponse<string>) => {
-      notification.success({
-        message: "Successfully deleted permit amendment and all related documents.",
-        duration: 10,
-      });
-      dispatch(success(NetworkReducerTypes.DELETE_PERMIT_AMENDMENT));
-      return response;
-    })
-    .catch(() => {
-      dispatch(error(NetworkReducerTypes.DELETE_PERMIT_AMENDMENT));
-    })
-    .finally(() => dispatch(hideLoading()));
-};
+export const deletePermitAmendment =
+  (
+    mineGuid: string,
+    permitGuid: string,
+    permitAmdendmentGuid: string
+  ): AppThunk<Promise<AxiosResponse<string>>> =>
+  (dispatch): Promise<AxiosResponse<string>> => {
+    dispatch(request(NetworkReducerTypes.DELETE_PERMIT_AMENDMENT));
+    dispatch(showLoading());
+    return CustomAxios()
+      .delete(
+        `${ENVIRONMENT.apiUrl}${API.PERMIT_AMENDMENT(mineGuid, permitGuid, permitAmdendmentGuid)}`,
+        createRequestHeader()
+      )
+      .then((response: AxiosResponse<string>) => {
+        notification.success({
+          message: "Successfully deleted permit amendment and all related documents.",
+          duration: 10,
+        });
+        dispatch(success(NetworkReducerTypes.DELETE_PERMIT_AMENDMENT));
+        return response;
+      })
+      .catch(() => {
+        dispatch(error(NetworkReducerTypes.DELETE_PERMIT_AMENDMENT));
+      })
+      .finally(() => dispatch(hideLoading()));
+  };
 
-export const fetchPermitConditions = (
-  mineGuid: string,
-  permitGuid: string,
-  permitAmdendmentGuid: string
-): AppThunk => (dispatch) => {
-  dispatch(request(NetworkReducerTypes.GET_PERMIT_CONDITIONS));
-  dispatch(showLoading());
-  return CustomAxios()
-    .get(
-      `${ENVIRONMENT.apiUrl}${API.PERMIT_CONDITIONS(mineGuid, permitGuid, permitAmdendmentGuid)}`,
-      createRequestHeader()
-    )
-    .then((response) => {
-      dispatch(success(NetworkReducerTypes.GET_PERMIT_CONDITIONS));
-      dispatch(permitActions.storePermitConditions(response.data));
-    })
-    .catch(() => dispatch(error(NetworkReducerTypes.GET_PERMIT_CONDITIONS)))
-    .finally(() => dispatch(hideLoading()));
-};
+export const fetchPermitConditions =
+  (mineGuid: string, permitGuid: string, permitAmdendmentGuid: string): AppThunk =>
+  (dispatch) => {
+    dispatch(request(NetworkReducerTypes.GET_PERMIT_CONDITIONS));
+    dispatch(showLoading());
+    return CustomAxios()
+      .get(
+        `${ENVIRONMENT.apiUrl}${API.PERMIT_CONDITIONS(mineGuid, permitGuid, permitAmdendmentGuid)}`,
+        createRequestHeader()
+      )
+      .then((response) => {
+        dispatch(success(NetworkReducerTypes.GET_PERMIT_CONDITIONS));
+        dispatch(permitActions.storePermitConditions(response.data));
+      })
+      .catch(() => dispatch(error(NetworkReducerTypes.GET_PERMIT_CONDITIONS)))
+      .finally(() => dispatch(hideLoading()));
+  };
 
-export const createPermitCondition = (
-  permitAmdendmentGuid: string,
-  payload: IPermitCondition
-): AppThunk<Promise<IPermitCondition | IDispatchError>> => (
-  dispatch
-): Promise<IPermitCondition | IDispatchError> => {
+export const createPermitCondition =
+  (
+    permitAmdendmentGuid: string,
+    payload: IPermitCondition
+  ): AppThunk<Promise<IPermitCondition | IDispatchError>> =>
+  (dispatch): Promise<IPermitCondition | IDispatchError> => {
     dispatch(request(NetworkReducerTypes.CREATE_PERMIT_CONDITION));
     dispatch(showLoading());
     return CustomAxios()
@@ -469,12 +493,12 @@ export const createPermitCondition = (
       .finally(() => dispatch(hideLoading()));
   };
 
-export const deletePermitCondition = (
-  permitAmdendmentGuid: string,
-  permitConditionGuid: string
-): AppThunk<Promise<IPermitCondition | IDispatchError>> => (
-  dispatch
-): Promise<IPermitCondition | IDispatchError> => {
+export const deletePermitCondition =
+  (
+    permitAmdendmentGuid: string,
+    permitConditionGuid: string
+  ): AppThunk<Promise<IPermitCondition | IDispatchError>> =>
+  (dispatch): Promise<IPermitCondition | IDispatchError> => {
     dispatch(request(NetworkReducerTypes.DELETE_PERMIT_CONDITION));
     dispatch(showLoading("modal"));
     return CustomAxios()
@@ -499,17 +523,19 @@ export const deletePermitCondition = (
       .finally(() => dispatch(hideLoading("modal")));
   };
 
-export const setEditingConditionFlag = (payload: any): AppThunk => (dispatch) => {
-  dispatch(permitActions.storeEditingConditionFlag(payload));
-};
+export const setEditingConditionFlag =
+  (payload: any): AppThunk =>
+  (dispatch) => {
+    dispatch(permitActions.storeEditingConditionFlag(payload));
+  };
 
-export const updatePermitCondition = (
-  permitConditionGuid: string,
-  permitAmdendmentGuid: string,
-  payload: IPermitCondition
-): AppThunk<Promise<IPermitCondition | IDispatchError>> => (
-  dispatch
-): Promise<IPermitCondition | IDispatchError> => {
+export const updatePermitCondition =
+  (
+    permitConditionGuid: string,
+    permitAmdendmentGuid: string,
+    payload: IPermitCondition
+  ): AppThunk<Promise<IPermitCondition | IDispatchError>> =>
+  (dispatch): Promise<IPermitCondition | IDispatchError> => {
     dispatch(request(NetworkReducerTypes.UPDATE_PERMIT_CONDITION));
     dispatch(showLoading());
     return CustomAxios()
@@ -535,13 +561,13 @@ export const updatePermitCondition = (
       .finally(() => dispatch(hideLoading()));
   };
 
-export const patchPermitNumber = (
-  permitGuid: string,
-  mineGuid: string,
-  payload: { now_application_guid: string }
-): AppThunk<Promise<IPatchPermitNumber | IDispatchError>> => (
-  dispatch
-): Promise<IPatchPermitNumber | IDispatchError> => {
+export const patchPermitNumber =
+  (
+    permitGuid: string,
+    mineGuid: string,
+    payload: { now_application_guid: string }
+  ): AppThunk<Promise<IPatchPermitNumber | IDispatchError>> =>
+  (dispatch): Promise<IPatchPermitNumber | IDispatchError> => {
     dispatch(request(NetworkReducerTypes.PATCH_PERMIT));
     dispatch(showLoading("modal"));
     return CustomAxios()
@@ -562,13 +588,13 @@ export const patchPermitNumber = (
       .finally(() => dispatch(hideLoading("modal")));
   };
 
-export const patchPermitVCLocked = (
-  permitGuid: string,
-  mineGuid: string,
-  payload: { mines_act_permit_vc_locked: boolean }
-): AppThunk<Promise<IPatchPermitVCLocked | IDispatchError>> => (
-  dispatch
-): Promise<IPatchPermitVCLocked | IDispatchError> => {
+export const patchPermitVCLocked =
+  (
+    permitGuid: string,
+    mineGuid: string,
+    payload: { mines_act_permit_vc_locked: boolean }
+  ): AppThunk<Promise<IPatchPermitVCLocked | IDispatchError>> =>
+  (dispatch): Promise<IPatchPermitVCLocked | IDispatchError> => {
     dispatch(request(NetworkReducerTypes.PATCH_PERMIT));
     dispatch(showLoading("modal"));
     return CustomAxios()
@@ -590,28 +616,30 @@ export const patchPermitVCLocked = (
   };
 
 // standard permit conditions
-export const fetchStandardPermitConditions = (noticeOfWorkType: string): AppThunk<Promise<void>> => (dispatch) => {
-  dispatch(request(NetworkReducerTypes.GET_PERMIT_CONDITIONS));
-  dispatch(showLoading());
-  return CustomAxios()
-    .get(
-      `${ENVIRONMENT.apiUrl}${API.STANDARD_PERMIT_CONDITIONS(noticeOfWorkType)}`,
-      createRequestHeader()
-    )
-    .then((response) => {
-      dispatch(success(NetworkReducerTypes.GET_PERMIT_CONDITIONS));
-      dispatch(permitActions.storeStandardPermitConditions(response.data));
-    })
-    .catch(() => dispatch(error(NetworkReducerTypes.GET_PERMIT_CONDITIONS)))
-    .finally(() => dispatch(hideLoading()));
-};
+export const fetchStandardPermitConditions =
+  (noticeOfWorkType: string): AppThunk<Promise<void>> =>
+  (dispatch) => {
+    dispatch(request(NetworkReducerTypes.GET_PERMIT_CONDITIONS));
+    dispatch(showLoading());
+    return CustomAxios()
+      .get(
+        `${ENVIRONMENT.apiUrl}${API.STANDARD_PERMIT_CONDITIONS(noticeOfWorkType)}`,
+        createRequestHeader()
+      )
+      .then((response) => {
+        dispatch(success(NetworkReducerTypes.GET_PERMIT_CONDITIONS));
+        dispatch(permitActions.storeStandardPermitConditions(response.data));
+      })
+      .catch(() => dispatch(error(NetworkReducerTypes.GET_PERMIT_CONDITIONS)))
+      .finally(() => dispatch(hideLoading()));
+  };
 
-export const createStandardPermitCondition = (
-  type: string,
-  payload: IStandardPermitCondition
-): AppThunk<Promise<IStandardPermitCondition | IDispatchError>> => (
-  dispatch
-): Promise<IStandardPermitCondition | IDispatchError> => {
+export const createStandardPermitCondition =
+  (
+    type: string,
+    payload: IStandardPermitCondition
+  ): AppThunk<Promise<IStandardPermitCondition | IDispatchError>> =>
+  (dispatch): Promise<IStandardPermitCondition | IDispatchError> => {
     const newPayload = {
       ...payload,
       notice_of_work_type: type,
@@ -637,11 +665,9 @@ export const createStandardPermitCondition = (
       .finally(() => dispatch(hideLoading()));
   };
 
-export const deleteStandardPermitCondition = (
-  permitConditionGuid: string
-): AppThunk<Promise<IStandardPermitCondition | IDispatchError>> => (
-  dispatch
-): Promise<IStandardPermitCondition | IDispatchError> => {
+export const deleteStandardPermitCondition =
+  (permitConditionGuid: string): AppThunk<Promise<IStandardPermitCondition | IDispatchError>> =>
+  (dispatch): Promise<IStandardPermitCondition | IDispatchError> => {
     dispatch(request(NetworkReducerTypes.DELETE_PERMIT_CONDITION));
     dispatch(showLoading("modal"));
     return CustomAxios()
@@ -661,12 +687,12 @@ export const deleteStandardPermitCondition = (
       .finally(() => dispatch(hideLoading("modal")));
   };
 
-export const updateStandardPermitCondition = (
-  permitConditionGuid: string,
-  payload: IStandardPermitCondition
-): AppThunk<Promise<IStandardPermitCondition | IDispatchError>> => (
-  dispatch
-): Promise<IStandardPermitCondition | IDispatchError> => {
+export const updateStandardPermitCondition =
+  (
+    permitConditionGuid: string,
+    payload: IStandardPermitCondition
+  ): AppThunk<Promise<IStandardPermitCondition | IDispatchError>> =>
+  (dispatch): Promise<IStandardPermitCondition | IDispatchError> => {
     dispatch(request(NetworkReducerTypes.UPDATE_PERMIT_CONDITION));
     dispatch(showLoading());
     return CustomAxios()

--- a/services/common/src/redux/reducers/permitReducer.ts
+++ b/services/common/src/redux/reducers/permitReducer.ts
@@ -1,4 +1,9 @@
-import { IPermit, IPermitAmendment, IPermitCondition, IPermitConditionTag, IStandardPermitCondition } from "@mds/common/interfaces";
+import {
+  IPermit,
+  IPermitAmendment,
+  IPermitCondition,
+  IStandardPermitCondition,
+} from "@mds/common/interfaces";
 import * as actionTypes from "@mds/common/constants/actionTypes";
 import { PERMITS } from "@mds/common/constants/reducerTypes";
 import { RootState } from "@mds/common/redux/rootState";
@@ -28,24 +33,27 @@ const initialState = {
 export const permitReducer = (state: PermitState = initialState, action) => {
   switch (action.type) {
     case actionTypes.STORE_PERMITS:
-      const amendments: Record<string, IPermitAmendment> = action.payload.records.reduce((acc, permit) => {
-        const latestAmendment = permit.permit_amendments
-          .filter(a => a.permit_amendment_status_code !== 'DFT')[0];
+      const amendments: Record<string, IPermitAmendment> = action.payload.records.reduce(
+        (acc, permit) => {
+          const latestAmendment = permit.permit_amendments.filter(
+            (a) => a.permit_amendment_status_code !== "DFT"
+          )[0];
 
-        if (latestAmendment) {
-          acc[permit.permit_guid] = latestAmendment;
-        }
-        return acc;
-      }, {});
-
+          if (latestAmendment) {
+            acc[permit.permit_guid] = latestAmendment;
+          }
+          return acc;
+        },
+        {}
+      );
 
       return {
         ...state,
         permits: action.payload.records,
         latestPermitAmendments: {
-          ...(state.latestPermitAmendments),
-          ...amendments
-        }
+          ...state.latestPermitAmendments,
+          ...amendments,
+        },
       };
     case actionTypes.STORE_PERMIT_CONDITION_CATEGORY:
       const { permitGuid, condition_categories } = action.payload;
@@ -57,9 +65,9 @@ export const permitReducer = (state: PermitState = initialState, action) => {
           ...state.latestPermitAmendments,
           [permitGuid]: {
             ...permit,
-            condition_categories: [...condition_categories]
-          }
-        }
+            condition_categories: [...condition_categories],
+          },
+        },
       };
     case actionTypes.STORE_DRAFT_PERMITS:
       return {
@@ -80,7 +88,9 @@ export const permitReducer = (state: PermitState = initialState, action) => {
       // update the amendment in the permits state if it's there
       if (permit_index !== -1) {
         const newPermit = allPermits[permit_index];
-        const amendment_index = newPermit.permit_amendments.findIndex((a) => a.permit_amendment_guid === permit_amendment_guid);
+        const amendment_index = newPermit.permit_amendments.findIndex(
+          (a) => a.permit_amendment_guid === permit_amendment_guid
+        );
         newPermit.permit_amendments[amendment_index] = action.payload;
         allPermits[permit_index] = newPermit;
       }
@@ -91,11 +101,11 @@ export const permitReducer = (state: PermitState = initialState, action) => {
       return {
         ...state,
         permits: allPermits,
-        permitAmendments: { ...(state.permitAmendments), [permit_amendment_guid]: action.payload },
+        permitAmendments: { ...state.permitAmendments, [permit_amendment_guid]: action.payload },
         latestPermitAmendments: isInLatestAmendments
-          ? { ...(state.latestPermitAmendments), [permit_amendment_guid]: action.payload }
-          : state.latestPermitAmendments
-      }
+          ? { ...state.latestPermitAmendments, [permit_amendment_guid]: action.payload }
+          : state.latestPermitAmendments,
+      };
     case actionTypes.STORE_STANDARD_PERMIT_CONDITIONS:
       return {
         ...state,
@@ -122,8 +132,10 @@ const permitReducerObject = {
 
 export const getUnformattedPermits = (state: RootState): IPermit[] => state[PERMITS].permits;
 export const getDraftPermits = (state: RootState): IPermit[] => state[PERMITS].draftPermits;
-export const getLatestPermitAmendments = (state: RootState): IPermitAmendment[] => state[PERMITS].latestPermitAmendments;
-export const getPermitAmendments = (state: RootState): Record<string, IPermitAmendment> => state[PERMITS].permitAmendments;
+export const getLatestPermitAmendments = (state: RootState): IPermitAmendment[] =>
+  state[PERMITS].latestPermitAmendments;
+export const getPermitAmendments = (state: RootState): Record<string, IPermitAmendment> =>
+  state[PERMITS].permitAmendments;
 export const getPermitConditions = (state: RootState): IPermitCondition[] =>
   state[PERMITS].permitConditions;
 export const getStandardPermitConditions = (state: RootState): IStandardPermitCondition[] =>
@@ -132,6 +144,5 @@ export const getEditingConditionFlag = (state: RootState): boolean =>
   state[PERMITS].editingConditionFlag;
 export const getEditingPreambleFlag = (state: RootState): boolean =>
   state[PERMITS].editingPreambleFlag;
-
 
 export default permitReducerObject;

--- a/services/common/src/redux/slices/permitConditionTemplateSlice.spec.ts
+++ b/services/common/src/redux/slices/permitConditionTemplateSlice.spec.ts
@@ -1,0 +1,72 @@
+import {
+  postTemplateConditionToAmendment,
+  default as permitConditionTemplateReducer,
+  permitConditionTemplateReducerType,
+} from "./permitConditionTemplateSlice";
+import { configureStore } from "@reduxjs/toolkit";
+import CustomAxios from "../customAxios";
+import { notification } from "antd";
+
+jest.mock("../customAxios");
+jest.mock("antd", () => ({
+  notification: {
+    success: jest.fn(),
+  },
+}));
+
+describe("permitConditionTemplateSlice", () => {
+  let store;
+
+  beforeEach(() => {
+    store = configureStore({
+      reducer: {
+        [permitConditionTemplateReducerType]: permitConditionTemplateReducer,
+      },
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should post a template condition to amendment successfully", async () => {
+    const params = {
+      permitAmendmentGuid: "test-amendment-guid",
+      standardPermitConditionGuid: "test-condition-guid",
+    };
+
+    const mockResponse = {
+      message: "Permit conditions succesfully copied from standard permit conditions.",
+    };
+    (CustomAxios as jest.Mock).mockImplementation(() => ({
+      post: jest.fn().mockResolvedValue({ data: mockResponse }),
+    }));
+
+    await store.dispatch(postTemplateConditionToAmendment(params));
+
+    expect(notification.success).toHaveBeenCalledWith({
+      message: "Successfully inserted template condition.",
+      duration: 5,
+    });
+  });
+
+  it("should handle errors when posting a template condition", async () => {
+    const params = {
+      permitAmendmentGuid: "test-amendment-guid",
+      standardPermitConditionGuid: "test-condition-guid",
+    };
+
+    // Mock rejection
+    const mockError = new Error(
+      "Error"
+    );
+    (CustomAxios as jest.Mock).mockImplementation(() => ({
+      post: jest.fn().mockRejectedValue(mockError),
+    }));
+
+    await store.dispatch(postTemplateConditionToAmendment(params));
+
+    // Success notification should not be called on error
+    expect(notification.success).not.toHaveBeenCalled();
+  });
+});

--- a/services/common/src/redux/slices/permitConditionTemplateSlice.ts
+++ b/services/common/src/redux/slices/permitConditionTemplateSlice.ts
@@ -1,0 +1,49 @@
+import { createAppSlice, rejectHandler } from "@mds/common/redux/createAppSlice";
+import { createRequestHeader } from "@mds/common/redux/utils/RequestHeaders";
+import { PERMIT_CONDITION_INSERT_TEMPLATE } from "@mds/common/constants/API";
+import CustomAxios from "../customAxios";
+import { hideLoading, showLoading } from "react-redux-loading-bar";
+import { ENVIRONMENT } from "@mds/common/constants/environment";
+import { notification } from "antd";
+
+export const permitConditionTemplateReducerType = "permitConditionTemplateSlice";
+
+const permitConditionTemplateSlice = createAppSlice({
+  name: permitConditionTemplateReducerType,
+  initialState: {},
+  reducers: (create) => ({
+    postTemplateConditionToAmendment: create.asyncThunk(
+      async (
+        params: { permitAmendmentGuid: string; standardPermitConditionGuid: string },
+        thunkAPI
+      ) => {
+        const headers = createRequestHeader();
+        thunkAPI.dispatch(showLoading());
+        const response = await CustomAxios({
+          errorToastMessage: "default",
+        }).post(
+          `${ENVIRONMENT.apiUrl}${PERMIT_CONDITION_INSERT_TEMPLATE(params.permitAmendmentGuid, params.standardPermitConditionGuid)}`,
+          {},
+          headers
+        );
+        thunkAPI.dispatch(hideLoading());
+        return response.data;
+      },
+      {
+        fulfilled: () => {
+          notification.success({
+            message: "Successfully inserted template condition.",
+            duration: 5,
+          });
+        },
+        rejected: (state, action) => {
+          rejectHandler(action);
+        },
+      }
+    ),
+  }),
+});
+
+export const { postTemplateConditionToAmendment } = permitConditionTemplateSlice.actions;
+
+export default permitConditionTemplateSlice.reducer;

--- a/services/common/src/tests/handlers.ts
+++ b/services/common/src/tests/handlers.ts
@@ -13,6 +13,7 @@ import {
   PROJECT_SUMMARY_MINISTRY_COMMENTS,
   SEARCH_PERMIT_CONDITIONS_RESPONSE,
   AMS_ENVIRONMENT_AUTH_STATUS_RESPONSE,
+  STANDARD_PERMIT_CONDITIONS,
 } from "@mds/common/tests/mocks/dataMocks";
 import queryString from "query-string";
 import { SystemFlagEnum } from "../constants/enums";
@@ -54,10 +55,11 @@ const projectHandlers = [
     }
   ),
   http.post(
-    "/%3CAPI_URL%3E/projects/project-summary-environment-authorization-statuses", async () => {
+    "/%3CAPI_URL%3E/projects/project-summary-environment-authorization-statuses",
+    async () => {
       return HttpResponse.json(AMS_ENVIRONMENT_AUTH_STATUS_RESPONSE);
     }
-  )
+  ),
 ];
 
 const permitHandlers = [
@@ -128,8 +130,8 @@ const permitSearchHandlers = [
     const stream = new ReadableStream({
       start(controller) {
         const documentsAndFacets = {
-          documents: responseData.documents || [],
-          facets: responseData.facets || {},
+          documents: responseData.documents ?? [],
+          facets: responseData.facets ?? {},
         };
         controller.enqueue(
           encoder.encode(
@@ -139,7 +141,7 @@ const permitSearchHandlers = [
 
         controller.enqueue(encoder.encode(`event: ${SearchEventType.AI_START}\ndata: {}\n\n`));
 
-        const promptText = responseData.prompt?.answers?.[0] || "";
+        const promptText = responseData.prompt?.answers?.[0] ?? "";
         if (promptText) {
           controller.enqueue(
             encoder.encode(
@@ -214,6 +216,21 @@ const reviewAssignmentHandler = http.get(
   }
 );
 
+const permitConditionTemplateHandlers = [
+  http.get("/%3CAPI_URL%3E/mines/permits/standard-conditions/GEC", async () => {
+    return HttpResponse.json({ records: STANDARD_PERMIT_CONDITIONS });
+  }),
+  http.get("/%3CAPI_URL%3E/mines/reports/standard-permit-requirements", async () => {
+    return HttpResponse.json([]);
+  }),
+  http.post(
+    "/%3CAPI_URL%3E/mines/null/permits/null/amendments/permit-amendment-guid/conditions",
+    async () => {
+      return HttpResponse.json({});
+    }
+  ),
+];
+
 const commonHandlers = [
   ...mineHandlers,
   ...geoSpatialHandlers,
@@ -223,6 +240,7 @@ const commonHandlers = [
   ...permitSearchHandlers,
   complianceReportHandler,
   reviewAssignmentHandler,
+  ...permitConditionTemplateHandlers,
 ];
 
 export default commonHandlers;

--- a/services/common/src/tests/permits/PermitTemplateConditionManager.spec.tsx
+++ b/services/common/src/tests/permits/PermitTemplateConditionManager.spec.tsx
@@ -1,0 +1,160 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import { ReduxWrapper } from "@mds/common/tests/utils/ReduxWrapper";
+import * as MOCK from "@mds/common/tests/mocks/dataMocks";
+import PermitTemplateConditionManager from "@mds/common/components/permits/PermitTemplateConditionManager";
+import { PermitConditionsProvider } from "@mds/common/components/permits/PermitConditionsContext";
+import { PERMITS, STATIC_CONTENT } from "@mds/common/constants/reducerTypes";
+import userEvent from "@testing-library/user-event";
+
+const category = {
+  href: "GEC",
+  condition_category: {
+    description: "General Conditions",
+    step: "A.",
+  },
+  conditions: [],
+  condition_category_code: "GEC",
+  title: <p>"Geotechnical Conditions"</p>,
+  step: "1",
+  description: "General Conditions",
+};
+
+const initialState = {
+  [STATIC_CONTENT]: {
+    ...MOCK.BULK_STATIC_CONTENT_RESPONSE,
+  },
+  [PERMITS]: {
+    standardPermitConditions: MOCK.STANDARD_PERMIT_CONDITIONS,
+  },
+};
+
+const providerParams = {
+  mineGuid: "mineGuid",
+  permitGuid: "permitGuid",
+  latestAmendment: null,
+  previousAmendment: null,
+  currentAmendment: null,
+  loading: false,
+  setLoading: jest.fn(),
+  refreshData: jest.fn(),
+};
+
+describe("PermitTemplateConditionManager", () => {
+  it("renders the list of template conditions", async () => {
+    const { container, getByTestId, findByTestId } = render(
+      <ReduxWrapper initialState={initialState}>
+        <PermitConditionsProvider value={providerParams}>
+          <PermitTemplateConditionManager
+            category={category}
+            typeCode="GEC"
+            onInsert={jest.fn()}
+            onClose={jest.fn()}
+            permitAmendmentGuid="permit-amendment-guid"
+          />
+        </PermitConditionsProvider>
+      </ReduxWrapper>
+    );
+
+    const templateManager = await findByTestId("permit-condition-template-manager");
+    expect(templateManager).toMatchSnapshot();
+  });
+
+  it("shows message when no template conditions are available", () => {
+    const emptyState = {};
+
+    const { getByText } = render(
+      <ReduxWrapper initialState={emptyState}>
+        <PermitConditionsProvider value={providerParams}>
+          <PermitTemplateConditionManager
+            category={category}
+            typeCode="GEC"
+            onInsert={jest.fn()}
+            onClose={jest.fn()}
+            permitAmendmentGuid="permit-amendment-guid"
+          />
+        </PermitConditionsProvider>
+      </ReduxWrapper>
+    );
+
+    expect(getByText("No template conditions available for this category.")).toBeInTheDocument();
+  });
+
+  it("calls onClose when close button is clicked", async () => {
+    const onCloseMock = jest.fn();
+
+    const { findByTestId } = render(
+      <ReduxWrapper initialState={initialState}>
+        <PermitConditionsProvider value={providerParams}>
+          <PermitTemplateConditionManager
+            category={category}
+            typeCode="GEC"
+            onInsert={jest.fn()}
+            onClose={onCloseMock}
+            permitAmendmentGuid="permit-amendment-guid"
+          />
+        </PermitConditionsProvider>
+      </ReduxWrapper>
+    );
+
+    const user = userEvent.setup();
+    const templateConditions = await findByTestId("permit-condition-template-manager");
+    expect(templateConditions).toBeInTheDocument();
+
+    const closeButton = await findByTestId("close-template-manager-button");
+    await user.click(closeButton);
+
+    expect(onCloseMock).toHaveBeenCalled();
+  });
+
+  it("inserts a condition when Insert Condition button is clicked", async () => {
+    const onInsertMock = jest.fn();
+
+    const { findAllByTestId } = render(
+      <ReduxWrapper initialState={initialState}>
+        <PermitConditionsProvider value={providerParams}>
+          <PermitTemplateConditionManager
+            category={category}
+            typeCode="GEC"
+            onInsert={onInsertMock}
+            onClose={jest.fn()}
+            permitAmendmentGuid="permit-amendment-guid"
+          />
+        </PermitConditionsProvider>
+      </ReduxWrapper>
+    );
+
+    const user = userEvent.setup();
+
+    const insertButtons = await findAllByTestId("template-insert-button");
+    await user.click(insertButtons[0]);
+
+    expect(onInsertMock).toHaveBeenCalled();
+  });
+
+  it("renders sub-conditions when they exist", async () => {
+    const { findAllByTestId, findByText, queryByText } = render(
+      <ReduxWrapper initialState={initialState}>
+        <PermitConditionsProvider value={providerParams}>
+          <PermitTemplateConditionManager
+            category={category}
+            typeCode="GEC"
+            onInsert={jest.fn()}
+            onClose={jest.fn()}
+            permitAmendmentGuid="permit-amendment-guid"
+          />
+        </PermitConditionsProvider>
+      </ReduxWrapper>
+    );
+
+    const user = userEvent.setup();
+    const conditions = await findAllByTestId("template-conditions-collapse");
+
+    expect(queryByText(/Approved Activities:/)).not.toBeInTheDocument();
+
+    await user.click(conditions[0]);
+
+    expect(await findByText("Sub Conditions:")).toBeInTheDocument();
+    expect(await findByText(/Approved Activities:/)).toBeInTheDocument();
+  });
+});

--- a/services/common/src/tests/permits/PermitTemplateConditionManager.spec.tsx
+++ b/services/common/src/tests/permits/PermitTemplateConditionManager.spec.tsx
@@ -4,7 +4,7 @@ import { ReduxWrapper } from "@mds/common/tests/utils/ReduxWrapper";
 import * as MOCK from "@mds/common/tests/mocks/dataMocks";
 import PermitTemplateConditionManager from "@mds/common/components/permits/PermitTemplateConditionManager";
 import { PermitConditionsProvider } from "@mds/common/components/permits/PermitConditionsContext";
-import { PERMITS, STATIC_CONTENT } from "@mds/common/constants/reducerTypes";
+import { PERMITS } from "@mds/common/constants/reducerTypes";
 import userEvent from "@testing-library/user-event";
 
 const category = {
@@ -21,9 +21,6 @@ const category = {
 };
 
 const initialState = {
-  [STATIC_CONTENT]: {
-    ...MOCK.BULK_STATIC_CONTENT_RESPONSE,
-  },
   [PERMITS]: {
     standardPermitConditions: MOCK.STANDARD_PERMIT_CONDITIONS,
   },
@@ -32,6 +29,7 @@ const initialState = {
 const providerParams = {
   mineGuid: "mineGuid",
   permitGuid: "permitGuid",
+  standardConditionType: 'GEC',
   latestAmendment: null,
   previousAmendment: null,
   currentAmendment: null,
@@ -42,12 +40,11 @@ const providerParams = {
 
 describe("PermitTemplateConditionManager", () => {
   it("renders the list of template conditions", async () => {
-    const { container, getByTestId, findByTestId } = render(
+    const { findByTestId } = render(
       <ReduxWrapper initialState={initialState}>
         <PermitConditionsProvider value={providerParams}>
           <PermitTemplateConditionManager
             category={category}
-            typeCode="GEC"
             onInsert={jest.fn()}
             onClose={jest.fn()}
             permitAmendmentGuid="permit-amendment-guid"
@@ -68,7 +65,6 @@ describe("PermitTemplateConditionManager", () => {
         <PermitConditionsProvider value={providerParams}>
           <PermitTemplateConditionManager
             category={category}
-            typeCode="GEC"
             onInsert={jest.fn()}
             onClose={jest.fn()}
             permitAmendmentGuid="permit-amendment-guid"
@@ -88,7 +84,6 @@ describe("PermitTemplateConditionManager", () => {
         <PermitConditionsProvider value={providerParams}>
           <PermitTemplateConditionManager
             category={category}
-            typeCode="GEC"
             onInsert={jest.fn()}
             onClose={onCloseMock}
             permitAmendmentGuid="permit-amendment-guid"
@@ -115,7 +110,6 @@ describe("PermitTemplateConditionManager", () => {
         <PermitConditionsProvider value={providerParams}>
           <PermitTemplateConditionManager
             category={category}
-            typeCode="GEC"
             onInsert={onInsertMock}
             onClose={jest.fn()}
             permitAmendmentGuid="permit-amendment-guid"
@@ -138,7 +132,6 @@ describe("PermitTemplateConditionManager", () => {
         <PermitConditionsProvider value={providerParams}>
           <PermitTemplateConditionManager
             category={category}
-            typeCode="GEC"
             onInsert={jest.fn()}
             onClose={jest.fn()}
             permitAmendmentGuid="permit-amendment-guid"

--- a/services/common/src/tests/permits/SubConditionForm.spec.tsx
+++ b/services/common/src/tests/permits/SubConditionForm.spec.tsx
@@ -44,6 +44,7 @@ const providerParams = {
     currentAmendment: null,
     loading: false,
     setLoading: jest.fn(),
+    refreshData: jest.fn(),
 };
 
 describe("SubConditionForm", () => {

--- a/services/common/src/tests/permits/__snapshots__/PermitTemplateConditionManager.spec.tsx.snap
+++ b/services/common/src/tests/permits/__snapshots__/PermitTemplateConditionManager.spec.tsx.snap
@@ -85,22 +85,23 @@ exports[`PermitTemplateConditionManager renders the list of template conditions 
           <div
             class="ant-row ant-row-no-wrap"
             data-testid="template-conditions-collapse"
+            style="margin-left: -8px; margin-right: -8px;"
           >
             <div
               class="ant-col"
-              style="flex-basis: auto; min-width: 0;"
+              style="padding-left: 8px; padding-right: 8px; flex-basis: auto; min-width: 0;"
             >
               <span
                 class="ant-typography"
               >
                 <strong>
-                  Approval - This permit authorizes only the following mining activities as outlin
-                  ...
+                  Approval - This permit authorizes only the following mining activities as outlin...
                 </strong>
               </span>
             </div>
             <div
               class="ant-col"
+              style="padding-left: 8px; padding-right: 8px;"
             >
               <button
                 class="ant-btn ant-btn-primary core-btn core-btn-primary"
@@ -128,7 +129,7 @@ exports[`PermitTemplateConditionManager renders the list of template conditions 
                   </svg>
                 </span>
                 <span>
-                  Insert Condition
+                  Insert
                 </span>
               </button>
             </div>
@@ -175,22 +176,23 @@ exports[`PermitTemplateConditionManager renders the list of template conditions 
           <div
             class="ant-row ant-row-no-wrap"
             data-testid="template-conditions-collapse"
+            style="margin-left: -8px; margin-right: -8px;"
           >
             <div
               class="ant-col"
-              style="flex-basis: auto; min-width: 0;"
+              style="padding-left: 8px; padding-right: 8px; flex-basis: auto; min-width: 0;"
             >
               <span
                 class="ant-typography"
               >
                 <strong>
                   Definitions
-                  
                 </strong>
               </span>
             </div>
             <div
               class="ant-col"
+              style="padding-left: 8px; padding-right: 8px;"
             >
               <button
                 class="ant-btn ant-btn-primary core-btn core-btn-primary"
@@ -218,7 +220,7 @@ exports[`PermitTemplateConditionManager renders the list of template conditions 
                   </svg>
                 </span>
                 <span>
-                  Insert Condition
+                  Insert
                 </span>
               </button>
             </div>
@@ -265,22 +267,23 @@ exports[`PermitTemplateConditionManager renders the list of template conditions 
           <div
             class="ant-row ant-row-no-wrap"
             data-testid="template-conditions-collapse"
+            style="margin-left: -8px; margin-right: -8px;"
           >
             <div
               class="ant-col"
-              style="flex-basis: auto; min-width: 0;"
+              style="padding-left: 8px; padding-right: 8px; flex-basis: auto; min-width: 0;"
             >
               <span
                 class="ant-typography"
               >
                 <strong>
                   Documentation 
-                  
                 </strong>
               </span>
             </div>
             <div
               class="ant-col"
+              style="padding-left: 8px; padding-right: 8px;"
             >
               <button
                 class="ant-btn ant-btn-primary core-btn core-btn-primary"
@@ -308,7 +311,7 @@ exports[`PermitTemplateConditionManager renders the list of template conditions 
                   </svg>
                 </span>
                 <span>
-                  Insert Condition
+                  Insert
                 </span>
               </button>
             </div>
@@ -355,22 +358,23 @@ exports[`PermitTemplateConditionManager renders the list of template conditions 
           <div
             class="ant-row ant-row-no-wrap"
             data-testid="template-conditions-collapse"
+            style="margin-left: -8px; margin-right: -8px;"
           >
             <div
               class="ant-col"
-              style="flex-basis: auto; min-width: 0;"
+              style="padding-left: 8px; padding-right: 8px; flex-basis: auto; min-width: 0;"
             >
               <span
                 class="ant-typography"
               >
                 <strong>
                   Reports to be signed by a Qualified Professional:
-                  
                 </strong>
               </span>
             </div>
             <div
               class="ant-col"
+              style="padding-left: 8px; padding-right: 8px;"
             >
               <button
                 class="ant-btn ant-btn-primary core-btn core-btn-primary"
@@ -398,7 +402,7 @@ exports[`PermitTemplateConditionManager renders the list of template conditions 
                   </svg>
                 </span>
                 <span>
-                  Insert Condition
+                  Insert
                 </span>
               </button>
             </div>

--- a/services/common/src/tests/permits/__snapshots__/PermitTemplateConditionManager.spec.tsx.snap
+++ b/services/common/src/tests/permits/__snapshots__/PermitTemplateConditionManager.spec.tsx.snap
@@ -1,0 +1,411 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PermitTemplateConditionManager renders the list of template conditions 1`] = `
+<div
+  data-testid="permit-condition-template-manager"
+>
+  <div
+    class="ant-row ant-row-no-wrap"
+  >
+    <div
+      class="ant-col"
+      style="flex-basis: auto; min-width: 0;"
+    >
+      <h4
+        class="ant-typography"
+      >
+        Template Conditions
+      </h4>
+    </div>
+    <div
+      class="ant-col"
+    >
+      <button
+        class="ant-btn ant-btn-primary ant-btn-icon-only core-btn core-btn-primary"
+        data-testid="close-template-manager-button"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          class="svg-inline--fa fa-xmark "
+          data-icon="xmark"
+          data-prefix="fal"
+          focusable="false"
+          role="img"
+          viewBox="0 0 384 512"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M324.5 411.1c6.2 6.2 16.4 6.2 22.6 0s6.2-16.4 0-22.6L214.6 256 347.1 123.5c6.2-6.2 6.2-16.4 0-22.6s-16.4-6.2-22.6 0L192 233.4 59.5 100.9c-6.2-6.2-16.4-6.2-22.6 0s-6.2 16.4 0 22.6L169.4 256 36.9 388.5c-6.2 6.2-6.2 16.4 0 22.6s16.4 6.2 22.6 0L192 278.6 324.5 411.1z"
+            fill="currentColor"
+          />
+        </svg>
+      </button>
+    </div>
+  </div>
+  <div
+    class="ant-collapse ant-collapse-icon-position-start"
+  >
+    <div
+      class="ant-collapse-item"
+    >
+      <div
+        aria-disabled="false"
+        aria-expanded="false"
+        class="ant-collapse-header"
+        role="button"
+        tabindex="0"
+      >
+        <div
+          class="ant-collapse-expand-icon"
+        >
+          <span
+            aria-label="right"
+            class="anticon anticon-right ant-collapse-arrow"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="right"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+              />
+            </svg>
+          </span>
+        </div>
+        <span
+          class="ant-collapse-header-text"
+        >
+          <div
+            class="ant-row ant-row-no-wrap"
+            data-testid="template-conditions-collapse"
+          >
+            <div
+              class="ant-col"
+              style="flex-basis: auto; min-width: 0;"
+            >
+              <span
+                class="ant-typography"
+              >
+                <strong>
+                  Approval - This permit authorizes only the following mining activities as outlin
+                  ...
+                </strong>
+              </span>
+            </div>
+            <div
+              class="ant-col"
+            >
+              <button
+                class="ant-btn ant-btn-primary core-btn core-btn-primary"
+                data-testid="template-insert-button"
+                type="button"
+              >
+                <span
+                  aria-label="left"
+                  class="anticon anticon-left"
+                  role="img"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class=""
+                    data-icon="left"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M724 218.3V141c0-6.7-7.7-10.4-12.9-6.3L260.3 486.8a31.86 31.86 0 000 50.3l450.8 352.1c5.3 4.1 12.9.4 12.9-6.3v-77.3c0-4.9-2.3-9.6-6.1-12.6l-360-281 360-281.1c3.8-3 6.1-7.7 6.1-12.6z"
+                    />
+                  </svg>
+                </span>
+                <span>
+                  Insert Condition
+                </span>
+              </button>
+            </div>
+          </div>
+        </span>
+      </div>
+    </div>
+    <div
+      class="ant-collapse-item"
+    >
+      <div
+        aria-disabled="false"
+        aria-expanded="false"
+        class="ant-collapse-header"
+        role="button"
+        tabindex="0"
+      >
+        <div
+          class="ant-collapse-expand-icon"
+        >
+          <span
+            aria-label="right"
+            class="anticon anticon-right ant-collapse-arrow"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="right"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+              />
+            </svg>
+          </span>
+        </div>
+        <span
+          class="ant-collapse-header-text"
+        >
+          <div
+            class="ant-row ant-row-no-wrap"
+            data-testid="template-conditions-collapse"
+          >
+            <div
+              class="ant-col"
+              style="flex-basis: auto; min-width: 0;"
+            >
+              <span
+                class="ant-typography"
+              >
+                <strong>
+                  Definitions
+                  
+                </strong>
+              </span>
+            </div>
+            <div
+              class="ant-col"
+            >
+              <button
+                class="ant-btn ant-btn-primary core-btn core-btn-primary"
+                data-testid="template-insert-button"
+                type="button"
+              >
+                <span
+                  aria-label="left"
+                  class="anticon anticon-left"
+                  role="img"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class=""
+                    data-icon="left"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M724 218.3V141c0-6.7-7.7-10.4-12.9-6.3L260.3 486.8a31.86 31.86 0 000 50.3l450.8 352.1c5.3 4.1 12.9.4 12.9-6.3v-77.3c0-4.9-2.3-9.6-6.1-12.6l-360-281 360-281.1c3.8-3 6.1-7.7 6.1-12.6z"
+                    />
+                  </svg>
+                </span>
+                <span>
+                  Insert Condition
+                </span>
+              </button>
+            </div>
+          </div>
+        </span>
+      </div>
+    </div>
+    <div
+      class="ant-collapse-item"
+    >
+      <div
+        aria-disabled="false"
+        aria-expanded="false"
+        class="ant-collapse-header"
+        role="button"
+        tabindex="0"
+      >
+        <div
+          class="ant-collapse-expand-icon"
+        >
+          <span
+            aria-label="right"
+            class="anticon anticon-right ant-collapse-arrow"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="right"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+              />
+            </svg>
+          </span>
+        </div>
+        <span
+          class="ant-collapse-header-text"
+        >
+          <div
+            class="ant-row ant-row-no-wrap"
+            data-testid="template-conditions-collapse"
+          >
+            <div
+              class="ant-col"
+              style="flex-basis: auto; min-width: 0;"
+            >
+              <span
+                class="ant-typography"
+              >
+                <strong>
+                  Documentation 
+                  
+                </strong>
+              </span>
+            </div>
+            <div
+              class="ant-col"
+            >
+              <button
+                class="ant-btn ant-btn-primary core-btn core-btn-primary"
+                data-testid="template-insert-button"
+                type="button"
+              >
+                <span
+                  aria-label="left"
+                  class="anticon anticon-left"
+                  role="img"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class=""
+                    data-icon="left"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M724 218.3V141c0-6.7-7.7-10.4-12.9-6.3L260.3 486.8a31.86 31.86 0 000 50.3l450.8 352.1c5.3 4.1 12.9.4 12.9-6.3v-77.3c0-4.9-2.3-9.6-6.1-12.6l-360-281 360-281.1c3.8-3 6.1-7.7 6.1-12.6z"
+                    />
+                  </svg>
+                </span>
+                <span>
+                  Insert Condition
+                </span>
+              </button>
+            </div>
+          </div>
+        </span>
+      </div>
+    </div>
+    <div
+      class="ant-collapse-item"
+    >
+      <div
+        aria-disabled="false"
+        aria-expanded="false"
+        class="ant-collapse-header"
+        role="button"
+        tabindex="0"
+      >
+        <div
+          class="ant-collapse-expand-icon"
+        >
+          <span
+            aria-label="right"
+            class="anticon anticon-right ant-collapse-arrow"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="right"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+              />
+            </svg>
+          </span>
+        </div>
+        <span
+          class="ant-collapse-header-text"
+        >
+          <div
+            class="ant-row ant-row-no-wrap"
+            data-testid="template-conditions-collapse"
+          >
+            <div
+              class="ant-col"
+              style="flex-basis: auto; min-width: 0;"
+            >
+              <span
+                class="ant-typography"
+              >
+                <strong>
+                  Reports to be signed by a Qualified Professional:
+                  
+                </strong>
+              </span>
+            </div>
+            <div
+              class="ant-col"
+            >
+              <button
+                class="ant-btn ant-btn-primary core-btn core-btn-primary"
+                data-testid="template-insert-button"
+                type="button"
+              >
+                <span
+                  aria-label="left"
+                  class="anticon anticon-left"
+                  role="img"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class=""
+                    data-icon="left"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M724 218.3V141c0-6.7-7.7-10.4-12.9-6.3L260.3 486.8a31.86 31.86 0 000 50.3l450.8 352.1c5.3 4.1 12.9.4 12.9-6.3v-77.3c0-4.9-2.3-9.6-6.1-12.6l-360-281 360-281.1c3.8-3 6.1-7.7 6.1-12.6z"
+                    />
+                  </svg>
+                </span>
+                <span>
+                  Insert Condition
+                </span>
+              </button>
+            </div>
+          </div>
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/services/core-api/app/api/mines/namespace.py
+++ b/services/core-api/app/api/mines/namespace.py
@@ -111,6 +111,8 @@ from app.api.mines.permits.permit_conditions.resources.permit_condition_category
     PermitConditionCategoryResource,
 )
 from app.api.mines.permits.permit_conditions.resources.permit_condition_tag_resource import PermitConditionTagResource
+from app.api.mines.permits.permit_conditions.resources.permit_condition_template_resource import \
+    PermitConditionTemplateResource
 from app.api.mines.permits.permit_conditions.resources.permit_condition_type_resource import (
     PermitConditionTypeResource,
 )
@@ -350,6 +352,10 @@ api.add_resource(
 api.add_resource(
     PermitConditionsResource,
     '/<string:mine_guid>/permits/<string:permit_guid>/amendments/<string:permit_amendment_guid>/conditions/<string:permit_condition_guid>',
+)
+api.add_resource(
+    PermitConditionTemplateResource,
+    '/permits/amendments/<string:permit_amendment_guid>/standard_permit_conditions/<string:standard_permit_condition_guid>',
 )
 
 api.add_resource(ExplosivesPermitAmendmentResource,

--- a/services/core-api/app/api/mines/permits/permit_conditions/models/permit_conditions.py
+++ b/services/core-api/app/api/mines/permits/permit_conditions/models/permit_conditions.py
@@ -1,5 +1,7 @@
 from typing import Optional, List
 
+from werkzeug.exceptions import BadRequest
+
 from app.api.utils.field_template import FieldTemplate
 from app.api.utils.list_lettering_helpers import num_to_letter, num_to_roman
 from app.api.utils.models_mixins import AuditMixin, Base, SoftDeleteMixin
@@ -239,6 +241,10 @@ class PermitConditions(SoftDeleteMixin, AuditMixin, Base):
         report_requirements = StandardReportPermitRequirement.find_by_many_condition_ids(standard_condition_ids)
 
         for requirement in report_requirements:
+            existing_report_requirement = MineReportPermitRequirement.find_by_report_name(requirement.report_name, permit_amendment_id)
+            if existing_report_requirement:
+                raise BadRequest("A report requirement with the name provided already exists for this permit amendment.")
+
             mrpr = MineReportPermitRequirement(
                 report_name=requirement.report_name,
                 due_date_period_months=requirement.due_date_period_months,

--- a/services/core-api/app/api/mines/permits/permit_conditions/resources/permit_condition_template_resource.py
+++ b/services/core-api/app/api/mines/permits/permit_conditions/resources/permit_condition_template_resource.py
@@ -1,0 +1,32 @@
+from flask_restx import Resource
+from werkzeug.exceptions import BadRequest, NotFound
+
+from app.api.mines.permits.permit_conditions.resources.permit_conditions_resource import get_permit_amendment
+from app.extensions import api, db
+from app.api.mines.permits.permit_conditions.models import StandardPermitConditions, PermitConditions
+from app.api.utils.access_decorators import requires_role_edit_permit
+from app.api.utils.resources_mixins import UserMixin
+
+
+class PermitConditionTemplateResource(Resource, UserMixin):
+    @api.doc(description='Create a permit condition on the specified permit draft')
+    @requires_role_edit_permit
+    def post(self, permit_amendment_guid, standard_permit_condition_guid):
+        permit_amendment = get_permit_amendment(permit_amendment_guid)
+
+        if permit_amendment.is_generated_in_core and permit_amendment.permit_amendment_status_code != "DFT":
+            raise BadRequest('Permit Conditions cannot be edited if the permit was issued in Core and is no longer a draft.')
+
+        standard_permit_condition = StandardPermitConditions.find_by_standard_permit_condition_guid(standard_permit_condition_guid)
+        if not standard_permit_condition:
+            raise NotFound('No standard permit conditions found with that guid.')
+
+        PermitConditions.copy_from_standard([standard_permit_condition], permit_amendment.permit_amendment_id)
+        db.session.commit()
+        return (
+            {'message': 'Permit conditions successfully copied from standard permit conditions.'},
+            201,
+            {'Location': str(permit_amendment.permit_amendment_id)},
+        )
+
+

--- a/services/core-api/app/api/mines/permits/permit_conditions/resources/permit_conditions_resource.py
+++ b/services/core-api/app/api/mines/permits/permit_conditions/resources/permit_conditions_resource.py
@@ -70,31 +70,17 @@ class PermitConditionsListResource(Resource, UserMixin):
         return permit_condition, 201
 
     def _create_sub_conditions_recursively(self, sub_conditions, permit_amendment_id, parent_id, category_code):
-        """
-        Recursively create sub-conditions and their nested sub-conditions.
-
-        Args:
-            sub_conditions (list): List of sub-condition data dictionaries
-            permit_amendment_id (int): ID of the permit amendment
-            parent_id (int): ID of the parent condition
-            category_code (str): Category code of the parent condition
-        """
+        # Recursively create sub-conditions and their nested sub-conditions.
         for idx, sub_condition_data in enumerate(sub_conditions):
-            # Set the parent relationship and amendment ID
+
             sub_condition_data['permit_amendment_id'] = permit_amendment_id
             sub_condition_data['parent_permit_condition_id'] = parent_id
+            sub_condition_data['condition_category_code'] = sub_condition_data.get('condition_category_code', category_code)
+            sub_condition_data['display_order'] = sub_condition_data.get('display_order', idx + 1)
 
-            # Set the same category code as the parent
-            sub_condition_data['condition_category_code'] = category_code
-
-            # Set display order based on the index
-            sub_condition_data['display_order'] = idx + 1
-
-            # Get nested sub-conditions before loading the current one
             nested_sub_conditions = sub_condition_data.pop('sub_conditions', [])
 
             try:
-                # Load and validate the sub-condition
                 sub_condition = PermitConditions._schema().load(sub_condition_data)
                 sub_condition.save()
 

--- a/services/core-api/app/api/mines/permits/permit_conditions/resources/permit_conditions_resource.py
+++ b/services/core-api/app/api/mines/permits/permit_conditions/resources/permit_conditions_resource.py
@@ -30,15 +30,11 @@ class PermitConditionsListResource(Resource, UserMixin):
         if permit_amendment.is_generated_in_core and permit_amendment.permit_amendment_status_code != "DFT":
             raise BadRequest('Permit Conditions cannot be edited if the permit was issued in Core and is no longer a draft.')
 
-        # Extract data from the request
-        permit_condition_data = request.json['permit_condition']
-        permit_condition_data['permit_amendment_id'] = permit_amendment.permit_amendment_id
-
-        # Extract sub-conditions before loading the main condition
-        sub_conditions = permit_condition_data.pop('sub_conditions', [])
+        request.json['permit_condition'][
+            'permit_amendment_id'] = permit_amendment.permit_amendment_id
 
         try:
-            permit_condition = PermitConditions._schema().load(permit_condition_data)
+            permit_condition = PermitConditions._schema().load(request.json['permit_condition'])
 
             if not PermitConditionCategory.find_by_permit_condition_category_code(permit_condition.condition_category_code):
                 raise BadRequest('condition_category_code is invalid')
@@ -52,48 +48,9 @@ class PermitConditionsListResource(Resource, UserMixin):
 
         permit_condition.save()
 
-        # Process any sub-conditions if they exist
-        if sub_conditions:
-            try:
-                self._create_sub_conditions_recursively(
-                    sub_conditions,
-                    permit_amendment.permit_amendment_id,
-                    permit_condition.permit_condition_id,
-                    permit_condition.condition_category_code
-                )
-            except Exception as e:
-                db.session.rollback()
-                raise BadRequest(f"Error creating sub-conditions: {str(e)}")
-
         set_audit_metadata(permit_amendment)
 
         return permit_condition, 201
-
-    def _create_sub_conditions_recursively(self, sub_conditions, permit_amendment_id, parent_id, category_code):
-        # Recursively create sub-conditions and their nested sub-conditions.
-        for idx, sub_condition_data in enumerate(sub_conditions):
-
-            sub_condition_data['permit_amendment_id'] = permit_amendment_id
-            sub_condition_data['parent_permit_condition_id'] = parent_id
-            sub_condition_data['condition_category_code'] = sub_condition_data.get('condition_category_code', category_code)
-            sub_condition_data['display_order'] = sub_condition_data.get('display_order', idx + 1)
-
-            nested_sub_conditions = sub_condition_data.pop('sub_conditions', [])
-
-            try:
-                sub_condition = PermitConditions._schema().load(sub_condition_data)
-                sub_condition.save()
-
-                # If there are nested sub-conditions, process them recursively
-                if nested_sub_conditions:
-                    self._create_sub_conditions_recursively(
-                        nested_sub_conditions,
-                        permit_amendment_id,
-                        sub_condition.permit_condition_id,
-                        category_code
-                    )
-            except MarshmallowError as e:
-                raise BadRequest(f"Error creating sub-condition: {str(e)}")
 
     @api.doc(description='Get all permit conditions for a specific amendment')
     @requires_role_edit_permit
@@ -168,7 +125,7 @@ class PermitConditionsResource(Resource, UserMixin):
         if changed_category:
             condition.display_order = len(conditions) + 1
 
-         #Reset status unless status is being changed to complete
+        #Reset status unless status is being changed to complete
         if not ( changed_status and new_status_code == 'COM' ):
             if condition.top_level_parent_permit_condition_id is not None:
                 top_condition = PermitConditions.find_by_permit_condition_id(condition.top_level_parent_permit_condition_id)
@@ -213,7 +170,7 @@ class PermitConditionsResource(Resource, UserMixin):
 
         if permit_amendment.is_generated_in_core and permit_amendment.permit_amendment_status_code != "DFT":
             raise BadRequest('Permit Conditions cannot be edited if the permit was issued in Core and is no longer a draft.')
-            
+
         permit_condition = PermitConditions.find_by_permit_condition_guid(permit_condition_guid)
 
         if not permit_condition:

--- a/services/core-api/app/api/mines/permits/permit_conditions/resources/permit_conditions_resource.py
+++ b/services/core-api/app/api/mines/permits/permit_conditions/resources/permit_conditions_resource.py
@@ -30,11 +30,15 @@ class PermitConditionsListResource(Resource, UserMixin):
         if permit_amendment.is_generated_in_core and permit_amendment.permit_amendment_status_code != "DFT":
             raise BadRequest('Permit Conditions cannot be edited if the permit was issued in Core and is no longer a draft.')
 
-        request.json['permit_condition'][
-            'permit_amendment_id'] = permit_amendment.permit_amendment_id
+        # Extract data from the request
+        permit_condition_data = request.json['permit_condition']
+        permit_condition_data['permit_amendment_id'] = permit_amendment.permit_amendment_id
+
+        # Extract sub-conditions before loading the main condition
+        sub_conditions = permit_condition_data.pop('sub_conditions', [])
 
         try:
-            permit_condition = PermitConditions._schema().load(request.json['permit_condition'])
+            permit_condition = PermitConditions._schema().load(permit_condition_data)
 
             if not PermitConditionCategory.find_by_permit_condition_category_code(permit_condition.condition_category_code):
                 raise BadRequest('condition_category_code is invalid')
@@ -48,9 +52,62 @@ class PermitConditionsListResource(Resource, UserMixin):
 
         permit_condition.save()
 
+        # Process any sub-conditions if they exist
+        if sub_conditions:
+            try:
+                self._create_sub_conditions_recursively(
+                    sub_conditions,
+                    permit_amendment.permit_amendment_id,
+                    permit_condition.permit_condition_id,
+                    permit_condition.condition_category_code
+                )
+            except Exception as e:
+                db.session.rollback()
+                raise BadRequest(f"Error creating sub-conditions: {str(e)}")
+
         set_audit_metadata(permit_amendment)
 
         return permit_condition, 201
+
+    def _create_sub_conditions_recursively(self, sub_conditions, permit_amendment_id, parent_id, category_code):
+        """
+        Recursively create sub-conditions and their nested sub-conditions.
+
+        Args:
+            sub_conditions (list): List of sub-condition data dictionaries
+            permit_amendment_id (int): ID of the permit amendment
+            parent_id (int): ID of the parent condition
+            category_code (str): Category code of the parent condition
+        """
+        for idx, sub_condition_data in enumerate(sub_conditions):
+            # Set the parent relationship and amendment ID
+            sub_condition_data['permit_amendment_id'] = permit_amendment_id
+            sub_condition_data['parent_permit_condition_id'] = parent_id
+
+            # Set the same category code as the parent
+            sub_condition_data['condition_category_code'] = category_code
+
+            # Set display order based on the index
+            sub_condition_data['display_order'] = idx + 1
+
+            # Get nested sub-conditions before loading the current one
+            nested_sub_conditions = sub_condition_data.pop('sub_conditions', [])
+
+            try:
+                # Load and validate the sub-condition
+                sub_condition = PermitConditions._schema().load(sub_condition_data)
+                sub_condition.save()
+
+                # If there are nested sub-conditions, process them recursively
+                if nested_sub_conditions:
+                    self._create_sub_conditions_recursively(
+                        nested_sub_conditions,
+                        permit_amendment_id,
+                        sub_condition.permit_condition_id,
+                        category_code
+                    )
+            except MarshmallowError as e:
+                raise BadRequest(f"Error creating sub-condition: {str(e)}")
 
     @api.doc(description='Get all permit conditions for a specific amendment')
     @requires_role_edit_permit

--- a/services/core-api/tests/mines/permit/resources/test_permit_condition_resource.py
+++ b/services/core-api/tests/mines/permit/resources/test_permit_condition_resource.py
@@ -3,7 +3,6 @@ import json
 from app.api.mines.permits.permit_conditions.models.permit_conditions import PermitConditions
 from tests.factories import create_mine_and_permit
 
-
 # POST
 def test_get_permit_conditions_by_permit_amendment_by_guid(test_client, db_session, auth_headers):
     mine, permit = create_mine_and_permit()
@@ -26,52 +25,6 @@ def test_get_permit_conditions_by_permit_amendment_by_guid(test_client, db_sessi
     post_data = json.loads(post_resp.data.decode())
     assert post_resp.status_code == 201, post_resp.response
     assert str(post_data['permit_amendment_id']) == str(permit_amendment.permit_amendment_id)
-
-
-def test_post_permit_conditions_with_sub_conditions(test_client, db_session, auth_headers):
-    mine, permit = create_mine_and_permit()
-    permit_amendment = permit.permit_amendments[0]
-
-    data = {
-        "permit_condition": {
-            "condition": "test",
-            "condition_category_code": "GEC",
-            "parent_permit_condition_id": None,
-            "top_level_parent_permit_condition_id": None,
-            "display_order": 3,
-            "condition_type_code": "LIS",
-            "sub_conditions": [
-                {
-                    "condition": "Sub-condition 1",
-                    "condition_type_code": "LIS",
-                    "sub_conditions": [
-                        {
-                            "condition": "Nested sub-condition 1.1",
-                            "condition_type_code": "LIS",
-                        },
-                        {
-                            "condition": "Nested sub-condition 1.2",
-                            "condition_type_code": "LIS",
-                        }
-                    ]
-                },
-                {
-                    "condition": "Sub-condition 2",
-                    "condition_type_code": "LIS",
-                }
-            ]
-        }
-    }
-    post_resp = test_client.post(
-        f'/mines/{permit_amendment.mine_guid}/permits/{permit_amendment.permit_guid}/amendments/{permit_amendment.permit_amendment_guid}/conditions',
-        headers=auth_headers['full_auth_header'],
-        json=data)
-    post_data = json.loads(post_resp.data.decode())
-    assert post_resp.status_code == 201, post_resp.response
-    assert str(post_data['permit_amendment_id']) == str(permit_amendment.permit_amendment_id)
-    assert len(post_data['sub_conditions']) == 2
-    assert str(post_data['sub_conditions'][0]['condition']) == "Sub-condition 1"
-
 
 # DELETE
 def test_delete_permit_condition(test_client, db_session, auth_headers):

--- a/services/core-api/tests/mines/permit/resources/test_permit_condition_resource.py
+++ b/services/core-api/tests/mines/permit/resources/test_permit_condition_resource.py
@@ -1,10 +1,8 @@
-import json, pytest, uuid
-from datetime import datetime, timedelta
-from dateutil import parser
-from app.api.mines.permits.permit_conditions.models.permit_conditions import PermitConditions
-from app.api.mines.response_models import PermitCondition
+import json
 
+from app.api.mines.permits.permit_conditions.models.permit_conditions import PermitConditions
 from tests.factories import create_mine_and_permit
+
 
 # POST
 def test_get_permit_conditions_by_permit_amendment_by_guid(test_client, db_session, auth_headers):
@@ -29,6 +27,52 @@ def test_get_permit_conditions_by_permit_amendment_by_guid(test_client, db_sessi
     assert post_resp.status_code == 201, post_resp.response
     assert str(post_data['permit_amendment_id']) == str(permit_amendment.permit_amendment_id)
 
+
+def test_post_permit_conditions_with_sub_conditions(test_client, db_session, auth_headers):
+    mine, permit = create_mine_and_permit()
+    permit_amendment = permit.permit_amendments[0]
+
+    data = {
+        "permit_condition": {
+            "condition": "test",
+            "condition_category_code": "GEC",
+            "parent_permit_condition_id": None,
+            "top_level_parent_permit_condition_id": None,
+            "display_order": 3,
+            "condition_type_code": "LIS",
+            "sub_conditions": [
+                {
+                    "condition": "Sub-condition 1",
+                    "condition_type_code": "LIS",
+                    "sub_conditions": [
+                        {
+                            "condition": "Nested sub-condition 1.1",
+                            "condition_type_code": "LIS",
+                        },
+                        {
+                            "condition": "Nested sub-condition 1.2",
+                            "condition_type_code": "LIS",
+                        }
+                    ]
+                },
+                {
+                    "condition": "Sub-condition 2",
+                    "condition_type_code": "LIS",
+                }
+            ]
+        }
+    }
+    post_resp = test_client.post(
+        f'/mines/{permit_amendment.mine_guid}/permits/{permit_amendment.permit_guid}/amendments/{permit_amendment.permit_amendment_guid}/conditions',
+        headers=auth_headers['full_auth_header'],
+        json=data)
+    post_data = json.loads(post_resp.data.decode())
+    assert post_resp.status_code == 201, post_resp.response
+    assert str(post_data['permit_amendment_id']) == str(permit_amendment.permit_amendment_id)
+    assert len(post_data['sub_conditions']) == 2
+    assert str(post_data['sub_conditions'][0]['condition']) == "Sub-condition 1"
+
+
 # DELETE
 def test_delete_permit_condition(test_client, db_session, auth_headers):
     mine, permit = create_mine_and_permit()
@@ -46,6 +90,7 @@ def test_delete_permit_condition(test_client, db_session, auth_headers):
     # deleted items should be filtered out
     assert permit_amendment.conditions[0].deleted_ind != True
 
+
 # PUT
 def test_put_permit_condition(test_client, db_session, auth_headers):
     mine, permit = create_mine_and_permit()
@@ -53,13 +98,13 @@ def test_put_permit_condition(test_client, db_session, auth_headers):
     condition = permit_amendment.conditions[0]
 
     data = {
-            "permit_condition_guid": condition.permit_condition_guid,
-            "permit_amendment_id": condition.permit_amendment_id,
-            "condition_category_code": condition.condition_category_code,
-            "condition_type_code": condition.condition_type_code,
-            "condition": "edited",
-            "display_order": "2",
-        }
+        "permit_condition_guid": condition.permit_condition_guid,
+        "permit_amendment_id": condition.permit_amendment_id,
+        "condition_category_code": condition.condition_category_code,
+        "condition_type_code": condition.condition_type_code,
+        "condition": "edited",
+        "display_order": "2",
+    }
 
     put_resp = test_client.put(
         f'/mines/{permit_amendment.mine_guid}/permits/{permit_amendment.permit_guid}/amendments/{permit_amendment.permit_amendment_guid}/conditions/{condition.permit_condition_guid}',

--- a/services/core-api/tests/mines/permit/resources/test_permit_condition_template_resource.py
+++ b/services/core-api/tests/mines/permit/resources/test_permit_condition_template_resource.py
@@ -1,0 +1,59 @@
+import json
+import uuid
+
+from tests.factories import create_mine_and_permit, StandardPermitConditionsFactory, PermitAmendmentFactory
+from tests.now_application_factories import NOWApplicationIdentityFactory, NOWApplicationFactory
+
+
+def test_post_standard_permit_condition_to_permit_amendment(test_client, db_session, auth_headers):
+    mine, permit = create_mine_and_permit()
+    permit_amendment = permit.permit_amendments[0]
+    standard_permit_condition = StandardPermitConditionsFactory()
+
+    post_resp = test_client.post(
+        f'mines/permits/amendments/{permit_amendment.permit_amendment_guid}/standard_permit_conditions/{standard_permit_condition.standard_permit_condition_guid}',
+        headers=auth_headers['full_auth_header']
+    )
+    post_data = json.loads(post_resp.data.decode())
+    assert post_resp.status_code == 201, post_resp.response
+    assert str(post_data['message']) == 'Permit conditions successfully copied from standard permit conditions.'
+
+
+def test_post_standard_permit_condition_to_permit_amendment_not_found(test_client, db_session, auth_headers):
+    mine, permit = create_mine_and_permit()
+    permit_amendment = permit.permit_amendments[0]
+    non_existent_guid = str(uuid.uuid4())
+
+    post_resp = test_client.post(
+        f'mines/permits/amendments/{permit_amendment.permit_amendment_guid}/standard_permit_conditions/{non_existent_guid}',
+        headers=auth_headers['full_auth_header']
+    )
+    post_data = json.loads(post_resp.data.decode())
+    assert post_resp.status_code == 404, post_resp.response
+    assert str(post_data['message']) == '404 Not Found: No standard permit conditions found with that guid.'
+
+
+def test_post_standard_permit_condition_to_non_draft_permit_amendment(test_client, db_session, auth_headers):
+    mine, permit = create_mine_and_permit()
+    standard_permit_condition = StandardPermitConditionsFactory()
+
+    now_application_identity = NOWApplicationIdentityFactory(
+        now_application=NOWApplicationFactory(), mine=mine, now_number=str(mine.mine_no) + '-2023'
+    )
+
+    non_draft_amendment = PermitAmendmentFactory(
+        mine=mine,
+        permit=permit,
+        now_application_guid=now_application_identity.now_application_guid,
+        permit_amendment_status_code='ACT',
+        is_generated_in_core=True
+    )
+
+    post_resp = test_client.post(
+        f'mines/permits/amendments/{non_draft_amendment.permit_amendment_guid}/standard_permit_conditions/{standard_permit_condition.standard_permit_condition_guid}',
+        headers=auth_headers['full_auth_header']
+    )
+    post_data = json.loads(post_resp.data.decode())
+    assert post_resp.status_code == 400, post_resp.response
+    assert str(post_data[
+                   'message']) == '400 Bad Request: Permit Conditions cannot be edited if the permit was issued in Core and is no longer a draft.'

--- a/services/core-web/src/components/Forms/permits/GeneratePermitForm.tsx
+++ b/services/core-web/src/components/Forms/permits/GeneratePermitForm.tsx
@@ -92,6 +92,7 @@ export const GeneratePermitForm: FC<IGeneratedPermitFormProps> = (props) => {
     permitGuid: props.draftPermit.permit_guid,
     currentAmendment: props.draftPermitAmendment,
     isNowEditor: true,
+    standardConditionType: props.noticeOfWork.notice_of_work_type_code,
     loading,
     setLoading,
     refreshData: () =>
@@ -470,7 +471,6 @@ export const GeneratePermitForm: FC<IGeneratedPermitFormProps> = (props) => {
                 setEditingFormName={setEditingFormName}
                 addingToCategoryCode={addingToCategoryCode}
                 setAddingToCategoryCode={setAddingToCategoryCode}
-                typeCode={props.noticeOfWork.notice_of_work_type_code}
               />
             </PermitConditionsProvider>
           ) : (

--- a/services/core-web/src/components/Forms/permits/GeneratePermitForm.tsx
+++ b/services/core-web/src/components/Forms/permits/GeneratePermitForm.tsx
@@ -2,9 +2,17 @@ import React, { FC, useRef, useState } from "react";
 import { Field, getFormValues } from "@mds/common/components/forms/form";
 import { Button, Col, Row, Descriptions, Popconfirm } from "antd";
 import EditOutlined from "@ant-design/icons/EditOutlined";
-import { required, dateNotAfterOther, dateNotBeforeOther, maxLength } from "@mds/common/redux/utils/Validate";
+import {
+  required,
+  dateNotAfterOther,
+  dateNotBeforeOther,
+  maxLength,
+} from "@mds/common/redux/utils/Validate";
 import { resetForm, formatDate } from "@mds/common/redux/utils/helpers";
-import { getEditingPreambleFlag, getNowDraftConditionsFormatted } from "@mds/common/redux/selectors/permitSelectors";
+import {
+  getEditingPreambleFlag,
+  getNowDraftConditionsFormatted,
+} from "@mds/common/redux/selectors/permitSelectors";
 import * as FORM from "@/constants/forms";
 import { renderConfig } from "@/components/common/config";
 import VariableConditionMenuOld from "@/components/Forms/permits/conditions/VariableConditionMenuOld";
@@ -21,7 +29,14 @@ import AuthorizationWrapper from "@mds/common/wrappers/AuthorizationWrapper";
 import * as Permission from "@/constants/permissions";
 import FormWrapper from "@mds/common/components/forms/FormWrapper";
 import { useAppDispatch, useAppSelector } from "@mds/common/redux/rootState";
-import { IFormattedConditionCategory, INoWApplicationForm, INoWGeneratedPermit, IOption, IPermit, IPermitAmendment } from "@mds/common/interfaces";
+import {
+  IFormattedConditionCategory,
+  INoWApplicationForm,
+  INoWGeneratedPermit,
+  IOption,
+  IPermit,
+  IPermitAmendment,
+} from "@mds/common/interfaces";
 import { storeEditingPreambleFlag } from "@mds/common/redux/actions/permitActions";
 import { PermitConditionsProvider } from "@mds/common/components/permits/PermitConditionsContext";
 import PermitConditionViewEdit from "@mds/common/components/permits/PermitConditionViewEdit";
@@ -32,7 +47,6 @@ import { userHasRole } from "@mds/common/redux/selectors/authenticationSelectors
 import { USER_ROLES } from "@mds/common/constants/environment";
 import VariableConditionMenu from "@mds/common/components/permits/VariableConditionMenu";
 import { TextAreaRef } from "antd/lib/input/TextArea";
-
 
 interface IGeneratedPermitFormProps {
   isAmendment: boolean;
@@ -51,7 +65,8 @@ interface IGeneratedPermitFormProps {
 
 export const GeneratePermitForm: FC<IGeneratedPermitFormProps> = (props) => {
   const dispatch = useAppDispatch();
-  const formValues = (useAppSelector(getFormValues(FORM.GENERATE_PERMIT)) ?? {}) as INoWGeneratedPermit;
+  const formValues = (useAppSelector(getFormValues(FORM.GENERATE_PERMIT)) ??
+    {}) as INoWGeneratedPermit;
   const editingPreambleFlag = useAppSelector(getEditingPreambleFlag);
   const { isFeatureEnabled } = useFeatureFlag();
   const newEditorEnabled = isFeatureEnabled(Feature.NOW_PERMIT_CONDITIONS_EDITOR);
@@ -63,16 +78,14 @@ export const GeneratePermitForm: FC<IGeneratedPermitFormProps> = (props) => {
   const preambleInputRef = useRef<TextAreaRef | null>(null);
 
   const formattedCategories: IFormattedConditionCategory[] = categoriesWithConditions.map((cat) => {
-
     return {
       href: cat.condition_category_code,
       condition_category: { description: cat.description, step: cat.step },
       conditions: cat.conditions,
       condition_category_code: cat.condition_category_code,
       title: <span>{cat.description}</span>,
-    }
+    };
   });
-
 
   const conditionsProviderValue = {
     mineGuid: props.noticeOfWork.mine_guid,
@@ -81,7 +94,10 @@ export const GeneratePermitForm: FC<IGeneratedPermitFormProps> = (props) => {
     isNowEditor: true,
     loading,
     setLoading,
-    refreshData: () => dispatch(fetchDraftPermitByNOW(props.noticeOfWork.mine_guid, props.noticeOfWork.now_application_guid)),
+    refreshData: () =>
+      dispatch(
+        fetchDraftPermitByNOW(props.noticeOfWork.mine_guid, props.noticeOfWork.now_application_guid)
+      ),
   };
 
   return (
@@ -93,7 +109,7 @@ export const GeneratePermitForm: FC<IGeneratedPermitFormProps> = (props) => {
         onSubmitSuccess: resetForm(FORM.GENERATE_PERMIT),
         enableReinitialize: true,
       }}
-      onSubmit={() => { }}
+      onSubmit={() => {}}
     >
       {!props.draftPermitAmendment.has_permit_conditions && (
         <ScrollContentWrapper id="permit" title="Permit" isLoaded={props.isLoaded}>
@@ -312,7 +328,7 @@ export const GeneratePermitForm: FC<IGeneratedPermitFormProps> = (props) => {
           draftPermit={props.draftPermit}
         />
       </ScrollContentWrapper>
-      {editingPreambleFlag && !newEditorEnabled &&<VariableConditionMenuOld />}
+      {editingPreambleFlag && !newEditorEnabled && <VariableConditionMenuOld />}
       {props.draftPermitAmendment.has_permit_conditions && (
         <ScrollContentWrapper id="preamble" title="Preamble" isLoaded={props.isLoaded}>
           <>
@@ -380,17 +396,18 @@ export const GeneratePermitForm: FC<IGeneratedPermitFormProps> = (props) => {
             )}
             <br />
             <br />
-            <div
-              style={
-                editingPreambleFlag ? { backgroundColor: "#f3f0f0", padding: "20px" } : {}
-              }
-            >
+            <div style={editingPreambleFlag ? { backgroundColor: "#f3f0f0", padding: "20px" } : {}}>
               <Row gutter={32}>
                 <Col xs={48} md={24} className="condition-editor">
                   <Row className="ant-form-item-label">
                     <label htmlFor="preamble_text">Preamble Text</label>
                   </Row>
-                  {editingPreambleFlag && newEditorEnabled && <VariableConditionMenu conditionForm={editingFormName} inputRef={preambleInputRef} />}
+                  {editingPreambleFlag && newEditorEnabled && (
+                    <VariableConditionMenu
+                      conditionForm={editingFormName}
+                      inputRef={preambleInputRef}
+                    />
+                  )}
                   <Field
                     id="preamble_text"
                     name="preamble_text"
@@ -443,25 +460,28 @@ export const GeneratePermitForm: FC<IGeneratedPermitFormProps> = (props) => {
       )}
       {props.draftPermitAmendment.has_permit_conditions && (
         <ScrollContentWrapper id="conditions" title="Conditions" isLoaded={props.isLoaded}>
-          {newEditorEnabled ? <PermitConditionsProvider value={conditionsProviderValue}>
-            <PermitConditionViewEdit
-              userCanEdit={userCanEdit && !props.isViewMode}
-              formattedCategories={formattedCategories}
-              collapseCategories
-              editingFormName={editingFormName}
-              setEditingFormName={setEditingFormName}
-              addingToCategoryCode={addingToCategoryCode}
-              setAddingToCategoryCode={setAddingToCategoryCode}
-            />
-          </PermitConditionsProvider>
-            : <Conditions
+          {newEditorEnabled ? (
+            <PermitConditionsProvider value={conditionsProviderValue}>
+              <PermitConditionViewEdit
+                userCanEdit={userCanEdit && !props.isViewMode}
+                formattedCategories={formattedCategories}
+                collapseCategories
+                editingFormName={editingFormName}
+                setEditingFormName={setEditingFormName}
+                addingToCategoryCode={addingToCategoryCode}
+                setAddingToCategoryCode={setAddingToCategoryCode}
+                typeCode={props.noticeOfWork.notice_of_work_type_code}
+              />
+            </PermitConditionsProvider>
+          ) : (
+            <Conditions
               mineGuid={props.noticeOfWork.mine_guid}
               permitGuid={props.draftPermit.permit_guid}
               isViewMode={props.isViewMode}
               isSourcePermitGeneratedInCore={props.noticeOfWork.is_source_permit_generated_in_core}
               isNoWApplication={props.noticeOfWork.application_type_code === "NOW"}
             />
-          }
+          )}
         </ScrollContentWrapper>
       )}
       <ScrollContentWrapper id="maps" title="Maps">

--- a/services/core-web/src/components/Forms/permits/conditions/StandardPermitConditions.tsx
+++ b/services/core-web/src/components/Forms/permits/conditions/StandardPermitConditions.tsx
@@ -61,6 +61,7 @@ const StandardPermitConditions: FC<StandardPermitConditionsProps> = ({ type }) =
         loading: showLoading,
         setLoading: setIsLoading,
         standardConditionType: typeCode,
+        isStandardConditionEditor: true,
         refreshData: () => dispatch(fetchStandardPermitConditions(typeCode))
     };
 

--- a/services/core-web/src/components/Forms/permits/conditions/__snapshots__/StandardPermitConditions.spec.tsx.snap
+++ b/services/core-web/src/components/Forms/permits/conditions/__snapshots__/StandardPermitConditions.spec.tsx.snap
@@ -123,37 +123,41 @@ exports[`StandardPermitConditions renders properly 1`] = `
                     <div
                       class="ant-row ant-row-space-between"
                     >
-                      <button
-                        class="ant-btn ant-btn-primary ant-btn-loading core-btn core-btn-primary"
-                        type="button"
+                      <div
+                        class="ant-row"
                       >
-                        <span
-                          class="ant-btn-loading-icon"
+                        <button
+                          class="ant-btn ant-btn-primary ant-btn-loading core-btn core-btn-primary"
+                          type="button"
                         >
                           <span
-                            aria-label="loading"
-                            class="anticon anticon-loading anticon-spin"
-                            role="img"
+                            class="ant-btn-loading-icon"
                           >
-                            <svg
-                              aria-hidden="true"
-                              data-icon="loading"
-                              fill="currentColor"
-                              focusable="false"
-                              height="1em"
-                              viewBox="0 0 1024 1024"
-                              width="1em"
+                            <span
+                              aria-label="loading"
+                              class="anticon anticon-loading anticon-spin"
+                              role="img"
                             >
-                              <path
-                                d="M988 548c-19.9 0-36-16.1-36-36 0-59.4-11.6-117-34.6-171.3a440.45 440.45 0 00-94.3-139.9 437.71 437.71 0 00-139.9-94.3C629 83.6 571.4 72 512 72c-19.9 0-36-16.1-36-36s16.1-36 36-36c69.1 0 136.2 13.5 199.3 40.3C772.3 66 827 103 874 150c47 47 83.9 101.8 109.7 162.7 26.7 63.1 40.2 130.2 40.2 199.3.1 19.9-16 36-35.9 36z"
-                              />
-                            </svg>
+                              <svg
+                                aria-hidden="true"
+                                data-icon="loading"
+                                fill="currentColor"
+                                focusable="false"
+                                height="1em"
+                                viewBox="0 0 1024 1024"
+                                width="1em"
+                              >
+                                <path
+                                  d="M988 548c-19.9 0-36-16.1-36-36 0-59.4-11.6-117-34.6-171.3a440.45 440.45 0 00-94.3-139.9 437.71 437.71 0 00-139.9-94.3C629 83.6 571.4 72 512 72c-19.9 0-36-16.1-36-36s16.1-36 36-36c69.1 0 136.2 13.5 199.3 40.3C772.3 66 827 103 874 150c47 47 83.9 101.8 109.7 162.7 26.7 63.1 40.2 130.2 40.2 199.3.1 19.9-16 36-35.9 36z"
+                                />
+                              </svg>
+                            </span>
                           </span>
-                        </span>
-                        <span>
-                          Add Condition
-                        </span>
-                      </button>
+                          <span>
+                            Add Condition
+                          </span>
+                        </button>
+                      </div>
                     </div>
                   </div>
                   <div
@@ -1667,37 +1671,41 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                     <div
                       class="ant-row ant-row-space-between"
                     >
-                      <button
-                        class="ant-btn ant-btn-primary ant-btn-loading core-btn core-btn-primary"
-                        type="button"
+                      <div
+                        class="ant-row"
                       >
-                        <span
-                          class="ant-btn-loading-icon"
+                        <button
+                          class="ant-btn ant-btn-primary ant-btn-loading core-btn core-btn-primary"
+                          type="button"
                         >
                           <span
-                            aria-label="loading"
-                            class="anticon anticon-loading anticon-spin"
-                            role="img"
+                            class="ant-btn-loading-icon"
                           >
-                            <svg
-                              aria-hidden="true"
-                              data-icon="loading"
-                              fill="currentColor"
-                              focusable="false"
-                              height="1em"
-                              viewBox="0 0 1024 1024"
-                              width="1em"
+                            <span
+                              aria-label="loading"
+                              class="anticon anticon-loading anticon-spin"
+                              role="img"
                             >
-                              <path
-                                d="M988 548c-19.9 0-36-16.1-36-36 0-59.4-11.6-117-34.6-171.3a440.45 440.45 0 00-94.3-139.9 437.71 437.71 0 00-139.9-94.3C629 83.6 571.4 72 512 72c-19.9 0-36-16.1-36-36s16.1-36 36-36c69.1 0 136.2 13.5 199.3 40.3C772.3 66 827 103 874 150c47 47 83.9 101.8 109.7 162.7 26.7 63.1 40.2 130.2 40.2 199.3.1 19.9-16 36-35.9 36z"
-                              />
-                            </svg>
+                              <svg
+                                aria-hidden="true"
+                                data-icon="loading"
+                                fill="currentColor"
+                                focusable="false"
+                                height="1em"
+                                viewBox="0 0 1024 1024"
+                                width="1em"
+                              >
+                                <path
+                                  d="M988 548c-19.9 0-36-16.1-36-36 0-59.4-11.6-117-34.6-171.3a440.45 440.45 0 00-94.3-139.9 437.71 437.71 0 00-139.9-94.3C629 83.6 571.4 72 512 72c-19.9 0-36-16.1-36-36s16.1-36 36-36c69.1 0 136.2 13.5 199.3 40.3C772.3 66 827 103 874 150c47 47 83.9 101.8 109.7 162.7 26.7 63.1 40.2 130.2 40.2 199.3.1 19.9-16 36-35.9 36z"
+                                />
+                              </svg>
+                            </span>
                           </span>
-                        </span>
-                        <span>
-                          Add Condition
-                        </span>
-                      </button>
+                          <span>
+                            Add Condition
+                          </span>
+                        </button>
+                      </div>
                     </div>
                   </div>
                   <div
@@ -2882,37 +2890,41 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                     <div
                       class="ant-row ant-row-space-between"
                     >
-                      <button
-                        class="ant-btn ant-btn-primary ant-btn-loading core-btn core-btn-primary"
-                        type="button"
+                      <div
+                        class="ant-row"
                       >
-                        <span
-                          class="ant-btn-loading-icon"
+                        <button
+                          class="ant-btn ant-btn-primary ant-btn-loading core-btn core-btn-primary"
+                          type="button"
                         >
                           <span
-                            aria-label="loading"
-                            class="anticon anticon-loading anticon-spin"
-                            role="img"
+                            class="ant-btn-loading-icon"
                           >
-                            <svg
-                              aria-hidden="true"
-                              data-icon="loading"
-                              fill="currentColor"
-                              focusable="false"
-                              height="1em"
-                              viewBox="0 0 1024 1024"
-                              width="1em"
+                            <span
+                              aria-label="loading"
+                              class="anticon anticon-loading anticon-spin"
+                              role="img"
                             >
-                              <path
-                                d="M988 548c-19.9 0-36-16.1-36-36 0-59.4-11.6-117-34.6-171.3a440.45 440.45 0 00-94.3-139.9 437.71 437.71 0 00-139.9-94.3C629 83.6 571.4 72 512 72c-19.9 0-36-16.1-36-36s16.1-36 36-36c69.1 0 136.2 13.5 199.3 40.3C772.3 66 827 103 874 150c47 47 83.9 101.8 109.7 162.7 26.7 63.1 40.2 130.2 40.2 199.3.1 19.9-16 36-35.9 36z"
-                              />
-                            </svg>
+                              <svg
+                                aria-hidden="true"
+                                data-icon="loading"
+                                fill="currentColor"
+                                focusable="false"
+                                height="1em"
+                                viewBox="0 0 1024 1024"
+                                width="1em"
+                              >
+                                <path
+                                  d="M988 548c-19.9 0-36-16.1-36-36 0-59.4-11.6-117-34.6-171.3a440.45 440.45 0 00-94.3-139.9 437.71 437.71 0 00-139.9-94.3C629 83.6 571.4 72 512 72c-19.9 0-36-16.1-36-36s16.1-36 36-36c69.1 0 136.2 13.5 199.3 40.3C772.3 66 827 103 874 150c47 47 83.9 101.8 109.7 162.7 26.7 63.1 40.2 130.2 40.2 199.3.1 19.9-16 36-35.9 36z"
+                                />
+                              </svg>
+                            </span>
                           </span>
-                        </span>
-                        <span>
-                          Add Condition
-                        </span>
-                      </button>
+                          <span>
+                            Add Condition
+                          </span>
+                        </button>
+                      </div>
                     </div>
                   </div>
                   <div
@@ -3783,37 +3795,41 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                     <div
                       class="ant-row ant-row-space-between"
                     >
-                      <button
-                        class="ant-btn ant-btn-primary ant-btn-loading core-btn core-btn-primary"
-                        type="button"
+                      <div
+                        class="ant-row"
                       >
-                        <span
-                          class="ant-btn-loading-icon"
+                        <button
+                          class="ant-btn ant-btn-primary ant-btn-loading core-btn core-btn-primary"
+                          type="button"
                         >
                           <span
-                            aria-label="loading"
-                            class="anticon anticon-loading anticon-spin"
-                            role="img"
+                            class="ant-btn-loading-icon"
                           >
-                            <svg
-                              aria-hidden="true"
-                              data-icon="loading"
-                              fill="currentColor"
-                              focusable="false"
-                              height="1em"
-                              viewBox="0 0 1024 1024"
-                              width="1em"
+                            <span
+                              aria-label="loading"
+                              class="anticon anticon-loading anticon-spin"
+                              role="img"
                             >
-                              <path
-                                d="M988 548c-19.9 0-36-16.1-36-36 0-59.4-11.6-117-34.6-171.3a440.45 440.45 0 00-94.3-139.9 437.71 437.71 0 00-139.9-94.3C629 83.6 571.4 72 512 72c-19.9 0-36-16.1-36-36s16.1-36 36-36c69.1 0 136.2 13.5 199.3 40.3C772.3 66 827 103 874 150c47 47 83.9 101.8 109.7 162.7 26.7 63.1 40.2 130.2 40.2 199.3.1 19.9-16 36-35.9 36z"
-                              />
-                            </svg>
+                              <svg
+                                aria-hidden="true"
+                                data-icon="loading"
+                                fill="currentColor"
+                                focusable="false"
+                                height="1em"
+                                viewBox="0 0 1024 1024"
+                                width="1em"
+                              >
+                                <path
+                                  d="M988 548c-19.9 0-36-16.1-36-36 0-59.4-11.6-117-34.6-171.3a440.45 440.45 0 00-94.3-139.9 437.71 437.71 0 00-139.9-94.3C629 83.6 571.4 72 512 72c-19.9 0-36-16.1-36-36s16.1-36 36-36c69.1 0 136.2 13.5 199.3 40.3C772.3 66 827 103 874 150c47 47 83.9 101.8 109.7 162.7 26.7 63.1 40.2 130.2 40.2 199.3.1 19.9-16 36-35.9 36z"
+                                />
+                              </svg>
+                            </span>
                           </span>
-                        </span>
-                        <span>
-                          Add Condition
-                        </span>
-                      </button>
+                          <span>
+                            Add Condition
+                          </span>
+                        </button>
+                      </div>
                     </div>
                   </div>
                   <div
@@ -8644,37 +8660,41 @@ OR Activities must be conducted within the permit area illustrated by Figure # [
                     <div
                       class="ant-row ant-row-space-between"
                     >
-                      <button
-                        class="ant-btn ant-btn-primary ant-btn-loading core-btn core-btn-primary"
-                        type="button"
+                      <div
+                        class="ant-row"
                       >
-                        <span
-                          class="ant-btn-loading-icon"
+                        <button
+                          class="ant-btn ant-btn-primary ant-btn-loading core-btn core-btn-primary"
+                          type="button"
                         >
                           <span
-                            aria-label="loading"
-                            class="anticon anticon-loading anticon-spin"
-                            role="img"
+                            class="ant-btn-loading-icon"
                           >
-                            <svg
-                              aria-hidden="true"
-                              data-icon="loading"
-                              fill="currentColor"
-                              focusable="false"
-                              height="1em"
-                              viewBox="0 0 1024 1024"
-                              width="1em"
+                            <span
+                              aria-label="loading"
+                              class="anticon anticon-loading anticon-spin"
+                              role="img"
                             >
-                              <path
-                                d="M988 548c-19.9 0-36-16.1-36-36 0-59.4-11.6-117-34.6-171.3a440.45 440.45 0 00-94.3-139.9 437.71 437.71 0 00-139.9-94.3C629 83.6 571.4 72 512 72c-19.9 0-36-16.1-36-36s16.1-36 36-36c69.1 0 136.2 13.5 199.3 40.3C772.3 66 827 103 874 150c47 47 83.9 101.8 109.7 162.7 26.7 63.1 40.2 130.2 40.2 199.3.1 19.9-16 36-35.9 36z"
-                              />
-                            </svg>
+                              <svg
+                                aria-hidden="true"
+                                data-icon="loading"
+                                fill="currentColor"
+                                focusable="false"
+                                height="1em"
+                                viewBox="0 0 1024 1024"
+                                width="1em"
+                              >
+                                <path
+                                  d="M988 548c-19.9 0-36-16.1-36-36 0-59.4-11.6-117-34.6-171.3a440.45 440.45 0 00-94.3-139.9 437.71 437.71 0 00-139.9-94.3C629 83.6 571.4 72 512 72c-19.9 0-36-16.1-36-36s16.1-36 36-36c69.1 0 136.2 13.5 199.3 40.3C772.3 66 827 103 874 150c47 47 83.9 101.8 109.7 162.7 26.7 63.1 40.2 130.2 40.2 199.3.1 19.9-16 36-35.9 36z"
+                                />
+                              </svg>
+                            </span>
                           </span>
-                        </span>
-                        <span>
-                          Add Condition
-                        </span>
-                      </button>
+                          <span>
+                            Add Condition
+                          </span>
+                        </button>
+                      </div>
                     </div>
                   </div>
                   <div

--- a/services/core-web/src/components/admin/permitConditions/__snapshots__/AdminPermitConditionManagement.spec.tsx.snap
+++ b/services/core-web/src/components/admin/permitConditions/__snapshots__/AdminPermitConditionManagement.spec.tsx.snap
@@ -273,37 +273,41 @@ exports[`AdminPermitConditionManagement renders properly 1`] = `
                         <div
                           class="ant-row ant-row-space-between"
                         >
-                          <button
-                            class="ant-btn ant-btn-primary ant-btn-loading core-btn core-btn-primary"
-                            type="button"
+                          <div
+                            class="ant-row"
                           >
-                            <span
-                              class="ant-btn-loading-icon"
+                            <button
+                              class="ant-btn ant-btn-primary ant-btn-loading core-btn core-btn-primary"
+                              type="button"
                             >
                               <span
-                                aria-label="loading"
-                                class="anticon anticon-loading anticon-spin"
-                                role="img"
+                                class="ant-btn-loading-icon"
                               >
-                                <svg
-                                  aria-hidden="true"
-                                  data-icon="loading"
-                                  fill="currentColor"
-                                  focusable="false"
-                                  height="1em"
-                                  viewBox="0 0 1024 1024"
-                                  width="1em"
+                                <span
+                                  aria-label="loading"
+                                  class="anticon anticon-loading anticon-spin"
+                                  role="img"
                                 >
-                                  <path
-                                    d="M988 548c-19.9 0-36-16.1-36-36 0-59.4-11.6-117-34.6-171.3a440.45 440.45 0 00-94.3-139.9 437.71 437.71 0 00-139.9-94.3C629 83.6 571.4 72 512 72c-19.9 0-36-16.1-36-36s16.1-36 36-36c69.1 0 136.2 13.5 199.3 40.3C772.3 66 827 103 874 150c47 47 83.9 101.8 109.7 162.7 26.7 63.1 40.2 130.2 40.2 199.3.1 19.9-16 36-35.9 36z"
-                                  />
-                                </svg>
+                                  <svg
+                                    aria-hidden="true"
+                                    data-icon="loading"
+                                    fill="currentColor"
+                                    focusable="false"
+                                    height="1em"
+                                    viewBox="0 0 1024 1024"
+                                    width="1em"
+                                  >
+                                    <path
+                                      d="M988 548c-19.9 0-36-16.1-36-36 0-59.4-11.6-117-34.6-171.3a440.45 440.45 0 00-94.3-139.9 437.71 437.71 0 00-139.9-94.3C629 83.6 571.4 72 512 72c-19.9 0-36-16.1-36-36s16.1-36 36-36c69.1 0 136.2 13.5 199.3 40.3C772.3 66 827 103 874 150c47 47 83.9 101.8 109.7 162.7 26.7 63.1 40.2 130.2 40.2 199.3.1 19.9-16 36-35.9 36z"
+                                    />
+                                  </svg>
+                                </span>
                               </span>
-                            </span>
-                            <span>
-                              Add Condition
-                            </span>
-                          </button>
+                              <span>
+                                Add Condition
+                              </span>
+                            </button>
+                          </div>
                         </div>
                       </div>
                     </div>
@@ -418,37 +422,41 @@ exports[`AdminPermitConditionManagement renders properly 1`] = `
                         <div
                           class="ant-row ant-row-space-between"
                         >
-                          <button
-                            class="ant-btn ant-btn-primary ant-btn-loading core-btn core-btn-primary"
-                            type="button"
+                          <div
+                            class="ant-row"
                           >
-                            <span
-                              class="ant-btn-loading-icon"
+                            <button
+                              class="ant-btn ant-btn-primary ant-btn-loading core-btn core-btn-primary"
+                              type="button"
                             >
                               <span
-                                aria-label="loading"
-                                class="anticon anticon-loading anticon-spin"
-                                role="img"
+                                class="ant-btn-loading-icon"
                               >
-                                <svg
-                                  aria-hidden="true"
-                                  data-icon="loading"
-                                  fill="currentColor"
-                                  focusable="false"
-                                  height="1em"
-                                  viewBox="0 0 1024 1024"
-                                  width="1em"
+                                <span
+                                  aria-label="loading"
+                                  class="anticon anticon-loading anticon-spin"
+                                  role="img"
                                 >
-                                  <path
-                                    d="M988 548c-19.9 0-36-16.1-36-36 0-59.4-11.6-117-34.6-171.3a440.45 440.45 0 00-94.3-139.9 437.71 437.71 0 00-139.9-94.3C629 83.6 571.4 72 512 72c-19.9 0-36-16.1-36-36s16.1-36 36-36c69.1 0 136.2 13.5 199.3 40.3C772.3 66 827 103 874 150c47 47 83.9 101.8 109.7 162.7 26.7 63.1 40.2 130.2 40.2 199.3.1 19.9-16 36-35.9 36z"
-                                  />
-                                </svg>
+                                  <svg
+                                    aria-hidden="true"
+                                    data-icon="loading"
+                                    fill="currentColor"
+                                    focusable="false"
+                                    height="1em"
+                                    viewBox="0 0 1024 1024"
+                                    width="1em"
+                                  >
+                                    <path
+                                      d="M988 548c-19.9 0-36-16.1-36-36 0-59.4-11.6-117-34.6-171.3a440.45 440.45 0 00-94.3-139.9 437.71 437.71 0 00-139.9-94.3C629 83.6 571.4 72 512 72c-19.9 0-36-16.1-36-36s16.1-36 36-36c69.1 0 136.2 13.5 199.3 40.3C772.3 66 827 103 874 150c47 47 83.9 101.8 109.7 162.7 26.7 63.1 40.2 130.2 40.2 199.3.1 19.9-16 36-35.9 36z"
+                                    />
+                                  </svg>
+                                </span>
                               </span>
-                            </span>
-                            <span>
-                              Add Condition
-                            </span>
-                          </button>
+                              <span>
+                                Add Condition
+                              </span>
+                            </button>
+                          </div>
                         </div>
                       </div>
                     </div>
@@ -563,37 +571,41 @@ exports[`AdminPermitConditionManagement renders properly 1`] = `
                         <div
                           class="ant-row ant-row-space-between"
                         >
-                          <button
-                            class="ant-btn ant-btn-primary ant-btn-loading core-btn core-btn-primary"
-                            type="button"
+                          <div
+                            class="ant-row"
                           >
-                            <span
-                              class="ant-btn-loading-icon"
+                            <button
+                              class="ant-btn ant-btn-primary ant-btn-loading core-btn core-btn-primary"
+                              type="button"
                             >
                               <span
-                                aria-label="loading"
-                                class="anticon anticon-loading anticon-spin"
-                                role="img"
+                                class="ant-btn-loading-icon"
                               >
-                                <svg
-                                  aria-hidden="true"
-                                  data-icon="loading"
-                                  fill="currentColor"
-                                  focusable="false"
-                                  height="1em"
-                                  viewBox="0 0 1024 1024"
-                                  width="1em"
+                                <span
+                                  aria-label="loading"
+                                  class="anticon anticon-loading anticon-spin"
+                                  role="img"
                                 >
-                                  <path
-                                    d="M988 548c-19.9 0-36-16.1-36-36 0-59.4-11.6-117-34.6-171.3a440.45 440.45 0 00-94.3-139.9 437.71 437.71 0 00-139.9-94.3C629 83.6 571.4 72 512 72c-19.9 0-36-16.1-36-36s16.1-36 36-36c69.1 0 136.2 13.5 199.3 40.3C772.3 66 827 103 874 150c47 47 83.9 101.8 109.7 162.7 26.7 63.1 40.2 130.2 40.2 199.3.1 19.9-16 36-35.9 36z"
-                                  />
-                                </svg>
+                                  <svg
+                                    aria-hidden="true"
+                                    data-icon="loading"
+                                    fill="currentColor"
+                                    focusable="false"
+                                    height="1em"
+                                    viewBox="0 0 1024 1024"
+                                    width="1em"
+                                  >
+                                    <path
+                                      d="M988 548c-19.9 0-36-16.1-36-36 0-59.4-11.6-117-34.6-171.3a440.45 440.45 0 00-94.3-139.9 437.71 437.71 0 00-139.9-94.3C629 83.6 571.4 72 512 72c-19.9 0-36-16.1-36-36s16.1-36 36-36c69.1 0 136.2 13.5 199.3 40.3C772.3 66 827 103 874 150c47 47 83.9 101.8 109.7 162.7 26.7 63.1 40.2 130.2 40.2 199.3.1 19.9-16 36-35.9 36z"
+                                    />
+                                  </svg>
+                                </span>
                               </span>
-                            </span>
-                            <span>
-                              Add Condition
-                            </span>
-                          </button>
+                              <span>
+                                Add Condition
+                              </span>
+                            </button>
+                          </div>
                         </div>
                       </div>
                     </div>
@@ -708,37 +720,41 @@ exports[`AdminPermitConditionManagement renders properly 1`] = `
                         <div
                           class="ant-row ant-row-space-between"
                         >
-                          <button
-                            class="ant-btn ant-btn-primary ant-btn-loading core-btn core-btn-primary"
-                            type="button"
+                          <div
+                            class="ant-row"
                           >
-                            <span
-                              class="ant-btn-loading-icon"
+                            <button
+                              class="ant-btn ant-btn-primary ant-btn-loading core-btn core-btn-primary"
+                              type="button"
                             >
                               <span
-                                aria-label="loading"
-                                class="anticon anticon-loading anticon-spin"
-                                role="img"
+                                class="ant-btn-loading-icon"
                               >
-                                <svg
-                                  aria-hidden="true"
-                                  data-icon="loading"
-                                  fill="currentColor"
-                                  focusable="false"
-                                  height="1em"
-                                  viewBox="0 0 1024 1024"
-                                  width="1em"
+                                <span
+                                  aria-label="loading"
+                                  class="anticon anticon-loading anticon-spin"
+                                  role="img"
                                 >
-                                  <path
-                                    d="M988 548c-19.9 0-36-16.1-36-36 0-59.4-11.6-117-34.6-171.3a440.45 440.45 0 00-94.3-139.9 437.71 437.71 0 00-139.9-94.3C629 83.6 571.4 72 512 72c-19.9 0-36-16.1-36-36s16.1-36 36-36c69.1 0 136.2 13.5 199.3 40.3C772.3 66 827 103 874 150c47 47 83.9 101.8 109.7 162.7 26.7 63.1 40.2 130.2 40.2 199.3.1 19.9-16 36-35.9 36z"
-                                  />
-                                </svg>
+                                  <svg
+                                    aria-hidden="true"
+                                    data-icon="loading"
+                                    fill="currentColor"
+                                    focusable="false"
+                                    height="1em"
+                                    viewBox="0 0 1024 1024"
+                                    width="1em"
+                                  >
+                                    <path
+                                      d="M988 548c-19.9 0-36-16.1-36-36 0-59.4-11.6-117-34.6-171.3a440.45 440.45 0 00-94.3-139.9 437.71 437.71 0 00-139.9-94.3C629 83.6 571.4 72 512 72c-19.9 0-36-16.1-36-36s16.1-36 36-36c69.1 0 136.2 13.5 199.3 40.3C772.3 66 827 103 874 150c47 47 83.9 101.8 109.7 162.7 26.7 63.1 40.2 130.2 40.2 199.3.1 19.9-16 36-35.9 36z"
+                                    />
+                                  </svg>
+                                </span>
                               </span>
-                            </span>
-                            <span>
-                              Add Condition
-                            </span>
-                          </button>
+                              <span>
+                                Add Condition
+                              </span>
+                            </button>
+                          </div>
                         </div>
                       </div>
                     </div>
@@ -853,37 +869,41 @@ exports[`AdminPermitConditionManagement renders properly 1`] = `
                         <div
                           class="ant-row ant-row-space-between"
                         >
-                          <button
-                            class="ant-btn ant-btn-primary ant-btn-loading core-btn core-btn-primary"
-                            type="button"
+                          <div
+                            class="ant-row"
                           >
-                            <span
-                              class="ant-btn-loading-icon"
+                            <button
+                              class="ant-btn ant-btn-primary ant-btn-loading core-btn core-btn-primary"
+                              type="button"
                             >
                               <span
-                                aria-label="loading"
-                                class="anticon anticon-loading anticon-spin"
-                                role="img"
+                                class="ant-btn-loading-icon"
                               >
-                                <svg
-                                  aria-hidden="true"
-                                  data-icon="loading"
-                                  fill="currentColor"
-                                  focusable="false"
-                                  height="1em"
-                                  viewBox="0 0 1024 1024"
-                                  width="1em"
+                                <span
+                                  aria-label="loading"
+                                  class="anticon anticon-loading anticon-spin"
+                                  role="img"
                                 >
-                                  <path
-                                    d="M988 548c-19.9 0-36-16.1-36-36 0-59.4-11.6-117-34.6-171.3a440.45 440.45 0 00-94.3-139.9 437.71 437.71 0 00-139.9-94.3C629 83.6 571.4 72 512 72c-19.9 0-36-16.1-36-36s16.1-36 36-36c69.1 0 136.2 13.5 199.3 40.3C772.3 66 827 103 874 150c47 47 83.9 101.8 109.7 162.7 26.7 63.1 40.2 130.2 40.2 199.3.1 19.9-16 36-35.9 36z"
-                                  />
-                                </svg>
+                                  <svg
+                                    aria-hidden="true"
+                                    data-icon="loading"
+                                    fill="currentColor"
+                                    focusable="false"
+                                    height="1em"
+                                    viewBox="0 0 1024 1024"
+                                    width="1em"
+                                  >
+                                    <path
+                                      d="M988 548c-19.9 0-36-16.1-36-36 0-59.4-11.6-117-34.6-171.3a440.45 440.45 0 00-94.3-139.9 437.71 437.71 0 00-139.9-94.3C629 83.6 571.4 72 512 72c-19.9 0-36-16.1-36-36s16.1-36 36-36c69.1 0 136.2 13.5 199.3 40.3C772.3 66 827 103 874 150c47 47 83.9 101.8 109.7 162.7 26.7 63.1 40.2 130.2 40.2 199.3.1 19.9-16 36-35.9 36z"
+                                    />
+                                  </svg>
+                                </span>
                               </span>
-                            </span>
-                            <span>
-                              Add Condition
-                            </span>
-                          </button>
+                              <span>
+                                Add Condition
+                              </span>
+                            </button>
+                          </div>
                         </div>
                       </div>
                     </div>

--- a/services/core-web/src/components/mine/Projects/InformationRequirementsTableTab.tsx
+++ b/services/core-web/src/components/mine/Projects/InformationRequirementsTableTab.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from "react";
-import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router-dom";
 import { Tabs } from "antd";
 import { formatDate } from "@mds/common/redux/utils/helpers";
@@ -17,6 +16,7 @@ import {
 import ReviewInformationRequirementsTable from "@/components/mine/Projects/ReviewInformationRequirementsTable";
 import UpdateStatusForm from "@/components/Forms/MajorProject/UpdateStatusForm";
 import { FORM } from "@mds/common/constants/forms";
+import { useAppDispatch, useAppSelector } from "@mds/common/redux/rootState";
 
 const sideMenuOptions = [
   {
@@ -59,19 +59,18 @@ const sideMenuOptions = [
 
 const InformationRequirementsTableTab = () => {
   const { projectGuid } = useParams<{ projectGuid: string }>();
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
 
-  const project = useSelector(getProject);
-  const requirements = useSelector(getRequirements);
-  const informationRequirementsTable = useSelector(getInformationRequirementsTable);
-  const dropdownIRTStatusCodes = useSelector(getDropdownInformationRequirementsTableStatusCodes);
+  const project = useAppSelector(getProject);
+  const requirements = useAppSelector(getRequirements);
+  const informationRequirementsTable = useAppSelector(getInformationRequirementsTable);
+  const dropdownIRTStatusCodes = useAppSelector(getDropdownInformationRequirementsTableStatusCodes);
+
   const [isLoaded, setIsLoaded] = useState(false);
 
   const handleFetchData = () => {
-    dispatch(fetchProjectById(projectGuid))
-      // @ts-ignore
-      .then(() => dispatch(fetchRequirements()))
-      .catch(setIsLoaded(false));
+    dispatch(fetchProjectById(projectGuid));
+    dispatch(fetchRequirements());
   };
 
   useEffect(() => {
@@ -101,7 +100,7 @@ const InformationRequirementsTableTab = () => {
       updateInformationRequirementsTable({
         projectGuid,
         informationRequirementsTableGuid: informationRequirementsTable.irt_guid,
-        status_code: values.status_code
+        status_code: values.status_code,
       })
     );
     return handleFetchData();
@@ -151,4 +150,5 @@ const InformationRequirementsTableTab = () => {
     </div>
   );
 };
+
 export default InformationRequirementsTableTab;

--- a/services/core-web/src/components/noticeOfWork/applications/permitGeneration/__snapshots__/NOWPermitGeneration.spec.tsx.snap
+++ b/services/core-web/src/components/noticeOfWork/applications/permitGeneration/__snapshots__/NOWPermitGeneration.spec.tsx.snap
@@ -2832,14 +2832,26 @@ exports[`NOWPermitGeneration renders properly 1`] = `
                                       <div
                                         class="ant-row ant-row-space-between"
                                       >
-                                        <button
-                                          class="ant-btn ant-btn-primary core-btn core-btn-primary"
-                                          type="button"
+                                        <div
+                                          class="ant-row"
                                         >
-                                          <span>
-                                            Add Condition
-                                          </span>
-                                        </button>
+                                          <button
+                                            class="ant-btn ant-btn-primary core-btn core-btn-primary"
+                                            type="button"
+                                          >
+                                            <span>
+                                              Add Condition
+                                            </span>
+                                          </button>
+                                          <button
+                                            class="ant-btn ant-btn-primary core-btn core-btn-primary"
+                                            type="button"
+                                          >
+                                            <span>
+                                              Insert Template Conditions
+                                            </span>
+                                          </button>
+                                        </div>
                                       </div>
                                     </div>
                                   </div>
@@ -2924,14 +2936,26 @@ exports[`NOWPermitGeneration renders properly 1`] = `
                                       <div
                                         class="ant-row ant-row-space-between"
                                       >
-                                        <button
-                                          class="ant-btn ant-btn-primary core-btn core-btn-primary"
-                                          type="button"
+                                        <div
+                                          class="ant-row"
                                         >
-                                          <span>
-                                            Add Condition
-                                          </span>
-                                        </button>
+                                          <button
+                                            class="ant-btn ant-btn-primary core-btn core-btn-primary"
+                                            type="button"
+                                          >
+                                            <span>
+                                              Add Condition
+                                            </span>
+                                          </button>
+                                          <button
+                                            class="ant-btn ant-btn-primary core-btn core-btn-primary"
+                                            type="button"
+                                          >
+                                            <span>
+                                              Insert Template Conditions
+                                            </span>
+                                          </button>
+                                        </div>
                                       </div>
                                     </div>
                                     <div
@@ -3068,14 +3092,26 @@ exports[`NOWPermitGeneration renders properly 1`] = `
                                       <div
                                         class="ant-row ant-row-space-between"
                                       >
-                                        <button
-                                          class="ant-btn ant-btn-primary core-btn core-btn-primary"
-                                          type="button"
+                                        <div
+                                          class="ant-row"
                                         >
-                                          <span>
-                                            Add Condition
-                                          </span>
-                                        </button>
+                                          <button
+                                            class="ant-btn ant-btn-primary core-btn core-btn-primary"
+                                            type="button"
+                                          >
+                                            <span>
+                                              Add Condition
+                                            </span>
+                                          </button>
+                                          <button
+                                            class="ant-btn ant-btn-primary core-btn core-btn-primary"
+                                            type="button"
+                                          >
+                                            <span>
+                                              Insert Template Conditions
+                                            </span>
+                                          </button>
+                                        </div>
                                       </div>
                                     </div>
                                   </div>
@@ -3160,14 +3196,26 @@ exports[`NOWPermitGeneration renders properly 1`] = `
                                       <div
                                         class="ant-row ant-row-space-between"
                                       >
-                                        <button
-                                          class="ant-btn ant-btn-primary core-btn core-btn-primary"
-                                          type="button"
+                                        <div
+                                          class="ant-row"
                                         >
-                                          <span>
-                                            Add Condition
-                                          </span>
-                                        </button>
+                                          <button
+                                            class="ant-btn ant-btn-primary core-btn core-btn-primary"
+                                            type="button"
+                                          >
+                                            <span>
+                                              Add Condition
+                                            </span>
+                                          </button>
+                                          <button
+                                            class="ant-btn ant-btn-primary core-btn core-btn-primary"
+                                            type="button"
+                                          >
+                                            <span>
+                                              Insert Template Conditions
+                                            </span>
+                                          </button>
+                                        </div>
                                       </div>
                                     </div>
                                     <div
@@ -3788,14 +3836,26 @@ exports[`NOWPermitGeneration renders properly 1`] = `
                                       <div
                                         class="ant-row ant-row-space-between"
                                       >
-                                        <button
-                                          class="ant-btn ant-btn-primary core-btn core-btn-primary"
-                                          type="button"
+                                        <div
+                                          class="ant-row"
                                         >
-                                          <span>
-                                            Add Condition
-                                          </span>
-                                        </button>
+                                          <button
+                                            class="ant-btn ant-btn-primary core-btn core-btn-primary"
+                                            type="button"
+                                          >
+                                            <span>
+                                              Add Condition
+                                            </span>
+                                          </button>
+                                          <button
+                                            class="ant-btn ant-btn-primary core-btn core-btn-primary"
+                                            type="button"
+                                          >
+                                            <span>
+                                              Insert Template Conditions
+                                            </span>
+                                          </button>
+                                        </div>
                                       </div>
                                     </div>
                                     <div

--- a/services/core-web/src/tests/components/mine/Permit/__snapshots__/PermitConditions.spec.tsx.snap
+++ b/services/core-web/src/tests/components/mine/Permit/__snapshots__/PermitConditions.spec.tsx.snap
@@ -805,14 +805,18 @@ exports[`PermitConditions renders properly 1`] = `
                                         </span>
                                       </div>
                                     </h3>
-                                    <button
-                                      class="ant-btn ant-btn-primary core-btn core-btn-primary"
-                                      type="button"
+                                    <div
+                                      class="ant-row"
                                     >
-                                      <span>
-                                        Add Condition
-                                      </span>
-                                    </button>
+                                      <button
+                                        class="ant-btn ant-btn-primary core-btn core-btn-primary"
+                                        type="button"
+                                      >
+                                        <span>
+                                          Add Condition
+                                        </span>
+                                      </button>
+                                    </div>
                                   </div>
                                   <form
                                     class="ant-form ant-form-horizontal common-form common-form-PERMIT_CONDITION_REVIEW_ASSIGNMENT-HSC form-edit"

--- a/services/core-web/src/tests/components/mine/Permit/__snapshots__/PermitConditions.spec.tsx.snap
+++ b/services/core-web/src/tests/components/mine/Permit/__snapshots__/PermitConditions.spec.tsx.snap
@@ -816,6 +816,14 @@ exports[`PermitConditions renders properly 1`] = `
                                           Add Condition
                                         </span>
                                       </button>
+                                      <button
+                                        class="ant-btn ant-btn-primary core-btn core-btn-primary"
+                                        type="button"
+                                      >
+                                        <span>
+                                          Insert Template Conditions
+                                        </span>
+                                      </button>
                                     </div>
                                   </div>
                                   <form


### PR DESCRIPTION
## Objective 

Adding in the ability for a Core user to insert template conditions into a draft NOW template.

- When editing conditions on a draft permit there is now a button next to "Add Condition" that opens a template condition manager on the right side
- User can click on any of the top level template conditions and have it inserted at the bottom of the current category
- User can continue to add multiple template conditions and close the manager manually when they are done
- Inserted conditions can be edited in the same manner available for other conditions

[MDS-6569](https://bcmines.atlassian.net/browse/MDS-6569)

<img width="1457" height="847" alt="image" src="https://github.com/user-attachments/assets/984f1625-e374-48c3-b41e-802d7dc69573" />
