### PR TITLE
[MDS-6650] Fix Variable Condition Menu tooltip box

### DIFF
--- a/services/common/src/components/permits/VariableConditionMenu.tsx
+++ b/services/common/src/components/permits/VariableConditionMenu.tsx
@@ -126,7 +126,7 @@ const VariableConditionMenu: FC<VariableConditionMenuProps> = ({
           { key:"{regional_mine_inbox}", label: (
             <Space>
                 Regional Mine Inbox
-                <Tooltip title={"Defaults to the region associated with the Mine."} placement="right" mouseEnterDelay={0.3} getPopupContainer={triggerNode => triggerNode.parentNode as HTMLElement}>
+                <Tooltip title={"Defaults to the region associated with the Mine."} placement="right" mouseEnterDelay={0.3}>
                   <QuestionCircleOutlined className="icon-sm" />
                 </Tooltip>
             </Space>


### PR DESCRIPTION
## Objective 

[MDS-6650](https://bcmines.atlassian.net/browse/MDS-6650)

Remove getPopupContainer from the tooltip box which was preventing it from sizing correctly. An unnecessary holdover from when the menu was fixed positioned. 

<img width="892" height="142" alt="image" src="https://github.com/user-attachments/assets/34b578f6-5b32-453a-936c-6ab702d55f22" />

The getPopupContainer is still necessary on the dropdown in order for the snapshot/tests to work as otherwise the content is attached outside the element.
