### PR TITLE
[MDS-6657] Fix bug where variable inserted into the wrong form

### DIFF
--- a/services/common/src/components/permits/VariableConditionMenu.tsx
+++ b/services/common/src/components/permits/VariableConditionMenu.tsx
@@ -23,8 +23,7 @@ const VariableConditionMenu: FC<VariableConditionMenuProps> = ({
   inputRef
 }) => {
   const dispatch = useAppDispatch();
-  const conditionFormValues = useSelector(getFormValues(conditionForm)) as IConditionSection;
-  const generatePermitFormValues = useSelector(getFormValues(FORM.GENERATE_PERMIT)) as INoWGeneratedPermit;
+  const conditionFormValues = useSelector(getFormValues(conditionForm)) as IConditionSection | INoWGeneratedPermit;
   const reclamationSummary = useSelector(getNOWReclamationSummary);
   const activityTypeOptions = useSelector(getDropdownNoticeOfWorkActivityTypeOptions);
   const [open, setOpen] = useState(false);
@@ -34,16 +33,11 @@ const VariableConditionMenu: FC<VariableConditionMenuProps> = ({
     if (inputRef.current) {
       inputRef.current.focus();
     }
-    const isPreambleText = isEmpty(conditionFormValues);
-    const text = isPreambleText ? generatePermitFormValues.preamble_text ?? "" : conditionFormValues.condition ?? "";
+    const isPreambleText = "preamble_text" in conditionFormValues;
+    const text = isPreambleText ? conditionFormValues.preamble_text : conditionFormValues.condition ?? "";
     const pos = inputRef.current?.resizableTextArea?.textArea?.selectionStart ?? text.length;
     const newText = `${text.slice(0, pos)} ${event.key} ${text.slice(pos)}`.replace(/ {2,}/g, ' ');
-
-    if (!isPreambleText) {
-      await dispatch(change(conditionForm, "condition", newText));
-    } else {
-      await dispatch(change(FORM.GENERATE_PERMIT, "preamble_text", newText));
-    }
+    await dispatch(change(conditionForm, isPreambleText ? "preamble_text" : "condition", newText));
 
     if (inputRef.current) {
       const updatedCursorPos = newText.indexOf(event.key, pos) + event.key.length;

--- a/services/core-web/src/components/Forms/permits/GeneratePermitForm.tsx
+++ b/services/core-web/src/components/Forms/permits/GeneratePermitForm.tsx
@@ -390,7 +390,7 @@ export const GeneratePermitForm: FC<IGeneratedPermitFormProps> = (props) => {
                   <Row className="ant-form-item-label">
                     <label htmlFor="preamble_text">Preamble Text</label>
                   </Row>
-                  {editingPreambleFlag && newEditorEnabled && <VariableConditionMenu conditionForm={editingFormName} inputRef={preambleInputRef} />}
+                  {editingPreambleFlag && newEditorEnabled && <VariableConditionMenu conditionForm={FORM.GENERATE_PERMIT} inputRef={preambleInputRef} />}
                   <Field
                     id="preamble_text"
                     name="preamble_text"


### PR DESCRIPTION
## Objective 

[MDS-6657](https://bcmines.atlassian.net/browse/MDS-6657)

Fixed a bug spotted by Rebecca where if you are editing the preamble and a condition at the same time the menu may insert a variable meant for the preamble into a condition. 

Replaced using the currently editing form variable with FORM.GENERATE_PERMIT for the preamble to ensure it always goes to the correct place. Improved some of the logic in VariableConditionMenu too.
