### PR TITLE
[MDS-6659] Fix keycloak error on hot reload

### DIFF
--- a/services/common/src/keycloak.tsx
+++ b/services/common/src/keycloak.tsx
@@ -1,12 +1,7 @@
 import Keycloak from "keycloak-js";
 import { KEYCLOAK } from "@mds/common/constants/environment";
 
-let kc: Keycloak;
-const getKeycloak = () => {
-  kc = kc ?? new Keycloak(KEYCLOAK);
-  return kc;
-};
-
+const keycloak = new Keycloak(KEYCLOAK);
 export const keycloakInitConfig = {
   pkceMethod: KEYCLOAK.pkceMethod,
   idpHint: KEYCLOAK.idir_idpHint,
@@ -17,5 +12,4 @@ export const keycloakInitConfig = {
     }silent-check-sso.html`,
 };
 
-const keycloak = getKeycloak();
 export default keycloak;


### PR DESCRIPTION
## Objective 

[MDS-6659](https://bcmines.atlassian.net/browse/MDS-6659)

Keycloak throws an error when a webpack rebuild/ hot reload happens in development. Removing the singleton appears to stop this error being thrown, however there was an original reason we added this which I have been unable to replicate so this requires some testing before merging! (Maybe apply this change locally and leave it for a bit)

The alternative fix will be to attach the singleton to the window.