### PR TITLE
[MDS-6633] Adding final app minespace edit toggle control in core

### DIFF
--- a/migrations/sql/V2025.09.16.10.06__add_editable_column_in_ams_final_application.sql
+++ b/migrations/sql/V2025.09.16.10.06__add_editable_column_in_ams_final_application.sql
@@ -1,0 +1,5 @@
+ALTER TABLE ams_final_application
+ADD COLUMN IF NOT EXISTS editable BOOLEAN NOT NULL DEFAULT TRUE;
+
+ALTER TABLE ams_final_application_version 
+ADD COLUMN IF NOT EXISTS editable BOOLEAN NOT NULL DEFAULT TRUE;

--- a/services/common/src/components/documents/ReplaceDocumentModal.tsx
+++ b/services/common/src/components/documents/ReplaceDocumentModal.tsx
@@ -91,12 +91,14 @@ const ReplaceDocumentModal: FC<ReplaceDocumentModalProps> = (props) => {
         })
       );
 
-      const newDocument = new MineDocument({
-        ...updatedDocument,
-        versions: [ConnectedVersion.data as IMineDocumentVersion, ...document.versions].reverse(),
-      });
+      if (ConnectedVersion) {
+        const newDocument = new MineDocument({
+          ...updatedDocument,
+          versions: [ConnectedVersion.data as IMineDocumentVersion, ...document.versions].reverse(),
+        });
 
-      props.handleSubmit(newDocument).then(() => dispatch(closeModal()));
+        props.handleSubmit(newDocument).then(() => dispatch(closeModal()));
+      }
     }
   };
 

--- a/services/common/src/components/project/EmaApplicationsTab.tsx
+++ b/services/common/src/components/project/EmaApplicationsTab.tsx
@@ -1,8 +1,9 @@
 import React, { useEffect, useState } from "react";
 import { useAppDispatch, useAppSelector } from "@mds/common/redux/rootState";
 import { useHistory, Link } from "react-router-dom";
-import { Row, Col, Typography, Button, Alert, Badge, List, Descriptions } from "antd";
-import { getSystemFlag } from "@mds/common/redux/selectors/authenticationSelectors";
+import { Row, Col, Typography, Button, Alert, Badge, List, Descriptions, Modal, Tooltip } from "antd";
+import FormOutlined from "@ant-design/icons/FormOutlined";
+import { getSystemFlag, userHasRole } from "@mds/common/redux/selectors/authenticationSelectors";
 import { getProject } from "@mds/common/redux/selectors/projectSelectors";
 import {
     fetchProjectSummaryEnvironmentAuthorizationStatuses,
@@ -23,6 +24,11 @@ import { Feature } from "@mds/common/utils";
 import ProjectContacts from "../projects/ProjectContacts";
 import { getProjectLeads } from "@mds/common/redux/selectors/partiesSelectors";
 import { getMinistryContactsByRegion } from "@mds/common/redux/selectors/minespaceSelector";
+import { fetchAmsFinalAppsByProjectSummary, updateAmsFinalAppMineSpaceEditability } from "@mds/common/redux/slices/amsFinalApplicationSlice";
+import { USER_ROLES } from "@mds/common/constants/environment";
+import CheckCircleOutlined from "@ant-design/icons/CheckCircleOutlined";
+import { COLOR } from "@mds/common/constants/styles";
+const { Paragraph } = Typography;
 
 const EmaApplicationsTab = () => {
     const dispatch = useAppDispatch();
@@ -31,13 +37,15 @@ const EmaApplicationsTab = () => {
     const projectLeads = useAppSelector(getProjectLeads);
     const history = useHistory();
     const [isLoaded, setIsLoaded] = useState(true);
-    const [emaAuths, setEmaAuths] = useState([]);
+    const [emaData, setEmaData] = useState([]);
     const systemFlag = useAppSelector(getSystemFlag);
     const { isFeatureEnabled } = useFeatureFlag();
     const amsFinalAppEnabled = isFeatureEnabled(Feature.AMS_FINAL_APPLICATION);
     const isCore = systemFlag === SystemFlagEnum.core;
     const authorizations = project?.project_summary?.authorizations;
     const hasMinesActApp = authorizations?.some(auth => auth.project_summary_authorization_type === "MINES_ACT_PERMIT");
+    const canEditMajorMineApplications = useAppSelector(userHasRole(USER_ROLES.role_edit_major_mine_applications));
+    const [editToggleLoading, setEditToggleLoading] = useState(false);
 
     const project_lead_contact =
         projectLeads?.filter((lead) => lead.party_guid.includes(project.project_lead_party_guid)) ?? [];
@@ -50,25 +58,79 @@ const EmaApplicationsTab = () => {
 
     const contactsAndProjectLead = [...project.contacts, project_lead_contact[0]];
 
-    useEffect(() => {
+    const fetchAmsData = async () => {
         const amsAuthorizations = authorizations?.filter(
             auth => auth.ams_tracking_number && auth.ams_tracking_number !== "0"
         );
         const amsTrackingNumbers = amsAuthorizations?.map(auth => auth.ams_tracking_number);
-        setIsLoaded(false);
-        dispatch(fetchProjectSummaryEnvironmentAuthorizationStatuses(amsTrackingNumbers)).then((statuses) => {
-            const emaAuthsData = amsAuthorizations.map(auth => {
-                const match = statuses.find(status => status?.ams_tracking_number === auth.ams_tracking_number);
-                return {
-                    ...auth,
-                    status: match?.status,
-                    ams_authorization_number: match?.ams_authorization_number,
-                }
-            })
-            setEmaAuths(emaAuthsData);
-            setIsLoaded(true);
+
+        const [statuses, finalApps] = await Promise.all([
+            dispatch(fetchProjectSummaryEnvironmentAuthorizationStatuses(amsTrackingNumbers)),
+            dispatch(fetchAmsFinalAppsByProjectSummary(project?.project_summary?.project_summary_guid)),
+        ]);
+
+        const emaMergedData = amsAuthorizations.map((auth) => {
+            const match = statuses.find(
+                (status) => status?.ams_tracking_number === auth.ams_tracking_number
+            );
+            return {
+                ...auth,
+                status: match?.status,
+                ams_authorization_number: match?.ams_authorization_number,
+                finalApp: finalApps?.payload?.records.find(
+                    (app) => app.project_summary_authorization_guid === auth.project_summary_authorization_guid) || null,
+            };
         });
+
+        setEmaData(emaMergedData);
+        setIsLoaded(true);
+        setEditToggleLoading(false);
+    };
+
+    useEffect(() => {
+        setIsLoaded(false);
+        fetchAmsData();
     }, [authorizations]);
+
+    const updateFinalAppMineSpaceEditability = async (emaRecord, canEdit) => {
+        const payload = {
+            projectSummaryGuid: emaRecord.project_summary_guid,
+            projectSummaryAuthorizationGuid: emaRecord.project_summary_authorization_guid,
+            application: { ...emaRecord.finalApp, editable: canEdit }
+        };
+
+        setEditToggleLoading(true);
+        dispatch(updateAmsFinalAppMineSpaceEditability(payload)).then(() => fetchAmsData());
+    };
+
+    const rendereMineSpaceFinalAppEditModal = (record, canEdit) => {
+        const iconColor = canEdit ? COLOR.successGreen : COLOR.yellow;
+        return Modal.confirm({
+            title: <b>Are you sure you want to change the file editability status for this application?</b>,
+            icon: <CheckCircleOutlined style={{ color: iconColor, fontSize: "26px" }} />,
+            content: (<div>
+                <Paragraph>
+                    Changing this setting will:
+                    <ul style={{ listStyleType: "disc" }}>
+                        {!canEdit
+                            ? <li>
+                                <b>Disable</b> file editting: Files will be locked and cannot be changed unless re-enabled.
+                            </li>
+                            : <li>
+                                <b>Enable</b> file editting: Users will be able to upload, replace, or modify files.
+                            </li>
+                        }
+                    </ul>
+
+                    This action affects all files associated with this final application project.
+                </Paragraph>
+            </div>),
+            width: 550,
+            okText: "Confirm Change",
+            cancelText: "Cancel",
+            onOk: () => updateFinalAppMineSpaceEditability(record, canEdit),
+        })
+    };
 
     return (
         <>
@@ -114,8 +176,10 @@ const EmaApplicationsTab = () => {
                             />}
                             <List
                                 itemLayout="vertical"
-                                dataSource={emaAuths}
+                                dataSource={emaData}
                                 renderItem={(item) => {
+                                    const finalApp = item.finalApp;
+                                    const editOptionText = finalApp?.editable ? "Disable" : "Enable";
                                     return <List.Item key={item.ams_tracking_number} className="grey-box margin-medium--top margin-medium--bottom">
                                         <Descriptions
                                             title={
@@ -136,6 +200,18 @@ const EmaApplicationsTab = () => {
                                             <Descriptions.Item label="Authorization Number">
                                                 {item.project_summary_permit_type[0] === "NEW" ? EMPTY_FIELD : item.ams_authorization_number}
                                             </Descriptions.Item>
+                                            {(isCore && canEditMajorMineApplications && finalApp)
+                                                ? <Descriptions.Item label="" style={{ float: "right", marginLeft: "auto" }}>
+                                                    <Tooltip title={`${editOptionText} File Editing`}>
+                                                        <Button
+                                                            className="ant-btn-ghost"
+                                                            onClick={() => rendereMineSpaceFinalAppEditModal(item, !finalApp.editable)}
+                                                            disabled={editToggleLoading}>
+                                                            <FormOutlined /> {editOptionText} Edits
+                                                        </Button>
+                                                    </Tooltip>
+                                                </Descriptions.Item>
+                                                : null}
                                         </Descriptions>
                                         {
                                             amsFinalAppEnabled && (
@@ -145,7 +221,10 @@ const EmaApplicationsTab = () => {
                                                         project.project_summary.project_summary_guid,
                                                         item.project_summary_authorization_guid
                                                     )
-                                                )} type="primary">
+                                                )}
+                                                    type="primary"
+                                                    disabled={editToggleLoading}
+                                                >
                                                     Manage Final Application
                                                 </Button>
                                             )

--- a/services/common/src/components/project/envApplication/EnvApplicationPage.tsx
+++ b/services/common/src/components/project/envApplication/EnvApplicationPage.tsx
@@ -15,8 +15,9 @@ import Loading from "../../common/Loading";
 import { getMineById } from "@mds/common/redux/selectors/mineSelectors";
 import { AMS_ENVIRONMENTAL_MANAGEMENT_ACT_TYPES_TEXT } from "@mds/common/constants/strings";
 import { Tag } from "antd";
-import { isProponent, userHasRole } from "@mds/common/redux/selectors/authenticationSelectors";
+import { isProponent, userHasRole, getSystemFlag } from "@mds/common/redux/selectors/authenticationSelectors";
 import { USER_ROLES } from "@mds/common/constants/environment";
+import { SystemFlagEnum } from "@mds/common/constants/enums";
 
 const EnvApplicationPage = () => {
     const { projectGuid, projectSummaryGuid, projectSummaryAuthorizationGuid, tab } = useParams<{
@@ -40,7 +41,9 @@ const EnvApplicationPage = () => {
     const trackingNumber = auth?.ams_tracking_number;
     const canEditMajorMineApplications = useAppSelector(userHasRole(USER_ROLES.role_edit_major_mine_applications));
     const isUserProponent = useAppSelector(isProponent);
-    const [isEditMode] = useState(canEditMajorMineApplications || isUserProponent);
+    const [isEditMode, setIsEditMode] = useState((canEditMajorMineApplications || isUserProponent));
+    const systemFlag = useAppSelector(getSystemFlag);
+    const isCore = systemFlag === SystemFlagEnum.core;
 
     const loaded = amsFinalAppLoaded && projectSummaryLoaded;
 
@@ -50,6 +53,12 @@ const EnvApplicationPage = () => {
         }
         dispatch(fetchAmsFinalApp({ projectSummaryGuid, projectSummaryAuthorizationGuid }));
     }, []);
+
+    useEffect(() => {
+        if (amsFinalApp && !isCore && !amsFinalApp.editable) {
+            setIsEditMode(false);
+        }
+    }, [amsFinalApp]);
 
     const handleSaveData = (values, _newActiveTab) => {
         const payload = {

--- a/services/common/src/components/projects/ProjectDocumentsTab.tsx
+++ b/services/common/src/components/projects/ProjectDocumentsTab.tsx
@@ -171,6 +171,7 @@ const ProjectDocumentsTab: FC<ProjectDocumentsTabProps> = ({ project }) => {
     const headingText = getAuthorizationHeader(auth);
     const infoText = formatUrlToUpperCaseString(headingText);
     const href = `application-${auth.ams_tracking_number}`;
+    const canChangeApplicationAmsFile = !isCore ? application.editable : canManageAmsFiles;
 
     return {
       href,
@@ -182,8 +183,8 @@ const ProjectDocumentsTab: FC<ProjectDocumentsTabProps> = ({ project }) => {
           titleLevel={5}
           infoText={infoText}
           key={application.ams_final_application_guid}
-          canArchive={canManageAmsFiles}
-          canReplace={canManageAmsFiles}
+          canArchive={canChangeApplicationAmsFile}
+          canReplace={canChangeApplicationAmsFile}
           onArchivedDocuments={refreshAmsApps}
           documents={application.documents.map(
             (d) =>

--- a/services/common/src/constants/API.ts
+++ b/services/common/src/constants/API.ts
@@ -183,6 +183,9 @@ export const PROJECT_SUMMARY_ENVIRONMENT_FINAL_APPLICATION_GET = (projectSummary
 export const PROJECT_SUMMARY_ENVIRONMENT_FINAL_APPLICATION = (projectSummaryGuid: string, project_summary_authorization_guid = "") =>
   `/projects/${projectSummaryGuid}/ams-final-application/${project_summary_authorization_guid}`;
 
+export const PROJECT_SUMMARY_ENVIRONMENT_FINAL_APPLICATION_MINESPACE_EDITABILITY = (projectSummaryGuid: string, project_summary_authorization_guid = "") =>
+  `/projects/${projectSummaryGuid}/ams-final-application/${project_summary_authorization_guid}/minespace-edit`;
+
 export const PROJECT_SUMMARY_ENVIRONMENT_FINAL_APPLICATION_DOCUMENTS = (projectSummaryGuid: string) =>
   `/projects/${projectSummaryGuid}/ams-final-application/documents`;
 

--- a/services/common/src/interfaces/projects/amsFinalApplication.interface.ts
+++ b/services/common/src/interfaces/projects/amsFinalApplication.interface.ts
@@ -23,4 +23,5 @@ export interface IAmsFinalApplication {
     pre_submitted_files: string[];
     submitted_timestamp?: string | null;
     documents: IAmsFinalApplicationDocument[];
+    editable: boolean;
 }

--- a/services/common/src/redux/slices/amsFinalApplicationSlice.ts
+++ b/services/common/src/redux/slices/amsFinalApplicationSlice.ts
@@ -91,6 +91,37 @@ const amsFinalAppSlice = createAppSlice({
                 }
             }
         ),
+        updateAmsFinalAppMineSpaceEditability: create.asyncThunk(
+            async (payload: {
+                projectSummaryGuid: string,
+                projectSummaryAuthorizationGuid: string,
+                application: Partial<IAmsFinalApplication>
+            }, thunkApi) => {
+                const headers = createRequestHeader();
+                thunkApi.dispatch(showLoading());
+                const { projectSummaryGuid, projectSummaryAuthorizationGuid, application } = payload;
+
+                let resp;
+                try {
+                    resp = await CustomAxios({
+                        successToastMessage: "Successfully updated application minespace editability",
+                    }).put(`${ENVIRONMENT.apiUrl}${API.PROJECT_SUMMARY_ENVIRONMENT_FINAL_APPLICATION_MINESPACE_EDITABILITY(projectSummaryGuid, projectSummaryAuthorizationGuid)}`,
+                        application, headers);
+                } finally {
+                    thunkApi.dispatch(hideLoading());
+                }
+                return resp.data;
+            },
+            {
+                fulfilled: (state: AmsFinalAppState, action) => {
+                    const newApplication = action.payload;
+                    state.amsFinalApplications[newApplication.project_summary_authorization_guid] = newApplication;
+                },
+                rejected: (state: AmsFinalAppState, action) => {
+                    rejectHandler(action)
+                }
+            }
+        ),
         fetchAmsFinalAppsByProjectSummary: create.asyncThunk(
             async (projectSummaryGuid: string, thunkApi) => {
                 const headers = createRequestHeader();
@@ -175,7 +206,7 @@ export const getAmsFinalAppsByProjectSummary = (projectSummaryGuid: string) =>
         return apps.filter((a) => a.project_summary_guid === projectSummaryGuid)
     });
 
-export const { fetchAmsFinalApp, fetchAmsFinalAppsByProjectSummary, createAmsFinalApp, updateAmsFinalApp } = amsFinalAppSlice.actions;
+export const { fetchAmsFinalApp, fetchAmsFinalAppsByProjectSummary, createAmsFinalApp, updateAmsFinalApp, updateAmsFinalAppMineSpaceEditability } = amsFinalAppSlice.actions;
 
 const amsFinalAppReducer = amsFinalAppSlice.reducer;
 export default amsFinalAppReducer;

--- a/services/common/src/tests/mocks/dataMocks.tsx
+++ b/services/common/src/tests/mocks/dataMocks.tsx
@@ -12764,6 +12764,7 @@ export const AMS_FINAL_APPLICATION: IAmsFinalApplication = {
     "LOC"
   ],
   "submitted_timestamp": "2025-06-25T20:11:48.890187+00:00",
+  "editable": true,
   "documents": [
     {
       "ams_final_application_document_xref_guid": "0886942c-0313-4199-9ed8-94bf9e69f230",

--- a/services/core-api/app/api/mines/documents/resources/mine_document_resource.py
+++ b/services/core-api/app/api/mines/documents/resources/mine_document_resource.py
@@ -12,7 +12,7 @@ from datetime import datetime
 from werkzeug.exceptions import BadRequest, NotFound
 
 from app.extensions import api
-from app.api.utils.access_decorators import EDIT_MAJOR_MINE_APPLICATIONS, MINE_ADMIN, requires_any_of, VIEW_ALL, MINESPACE_PROPONENT
+from app.api.utils.access_decorators import EDIT_MAJOR_MINE_APPLICATIONS, MINE_ADMIN, requires_any_of, VIEW_ALL, MINESPACE_PROPONENT, is_minespace_user
 from app.api.utils.resources_mixins import UserMixin
 
 from app.api.mines.documents.models.mine_document import MineDocument
@@ -23,6 +23,8 @@ from app.api.mines.response_models import ARCHIVE_MINE_DOCUMENT, MINE_DOCUMENT_M
 
 from app.api.services.document_manager_service import DocumentManagerService
 from app.api.projects.project.project_util import notify_file_updates
+from app.api.projects.ams_final_application.models.ams_final_application_document_xref import AmsFinalApplicationDocumentXref
+from app.api.projects.ams_final_application.models.ams_final_application import AmsFinalApplication
 
 class MineDocumentListResource(Resource, UserMixin):
     @api.doc(description='Returns list of documents associated with mines')
@@ -116,7 +118,15 @@ class MineDocumentArchiveResource(Resource, UserMixin):
             raise NotFound('Mine not found.')
 
         args = self.parser.parse_args()
-        mine_document_guids = args.get('mine_document_guids')
+        mine_document_guids = args.get('mine_document_guids', [])
+
+        if is_minespace_user():
+            ams_final_application_document_xref = AmsFinalApplicationDocumentXref.find_by_mine_document_guid(mine_document_guids[0])
+            if ams_final_application_document_xref:
+                ams_final_application_guid = ams_final_application_document_xref.ams_final_application_guid
+                ams_final_application = AmsFinalApplication.find_by_ams_final_application_guid(ams_final_application_guid)
+                if ams_final_application and not ams_final_application.editable:
+                        raise BadRequest("The following document(s) cannot currently be changed for this application")
 
         documents = MineDocument.find_by_mine_document_guid_many(mine_document_guids)
 

--- a/services/core-api/app/api/mines/documents/resources/mine_document_version_resource.py
+++ b/services/core-api/app/api/mines/documents/resources/mine_document_version_resource.py
@@ -11,7 +11,7 @@ from datetime import datetime
 from werkzeug.exceptions import BadRequest, NotFound
 
 from app.extensions import api
-from app.api.utils.access_decorators import EDIT_INFORMATION_REQUIREMENTS_TABLE, EDIT_MAJOR_MINE_APPLICATIONS, EDIT_PROJECT_DECISION_PACKAGES, EDIT_PROJECT_SUMMARIES, MINE_ADMIN, requires_any_of, VIEW_ALL, MINESPACE_PROPONENT
+from app.api.utils.access_decorators import EDIT_INFORMATION_REQUIREMENTS_TABLE, EDIT_MAJOR_MINE_APPLICATIONS, EDIT_PROJECT_DECISION_PACKAGES, EDIT_PROJECT_SUMMARIES, MINE_ADMIN, requires_any_of, VIEW_ALL, MINESPACE_PROPONENT, is_minespace_user
 from app.api.utils.resources_mixins import UserMixin
 
 from app.api.mines.documents.models.mine_document import MineDocument
@@ -19,6 +19,8 @@ from app.api.mines.mine.models.mine import Mine
 
 from app.api.mines.response_models import MINE_DOCUMENT_MODEL, MINE_DOCUMENT_VERSION_MODEL
 from app.api.services.document_manager_service import DocumentManagerService
+from app.api.projects.ams_final_application.models.ams_final_application_document_xref import AmsFinalApplicationDocumentXref
+from app.api.projects.ams_final_application.models.ams_final_application import AmsFinalApplication
 
 class MineDocumentVersionUploadResource(Resource, UserMixin):
 
@@ -44,6 +46,15 @@ class MineDocumentVersionUploadResource(Resource, UserMixin):
 
         if str(mine_document.mine_guid) != mine_guid:
             raise BadRequest('Mine document not attached to Mine')
+        
+        if is_minespace_user():
+            ams_final_application_document_xref = AmsFinalApplicationDocumentXref.find_by_mine_document_guid(mine_document_guid)
+            if ams_final_application_document_xref:
+                ams_final_application_guid = ams_final_application_document_xref.ams_final_application_guid
+                ams_final_application = AmsFinalApplication.find_by_ams_final_application_guid(ams_final_application_guid)
+                if ams_final_application and not ams_final_application.editable:
+                        raise BadRequest("The following document cannot currently be changed for this application")
+        
 
         if mine_document.is_archived:
             raise BadRequest('Cannot create new version of archived document')

--- a/services/core-api/app/api/projects/ams_final_application/models/ams_final_application.py
+++ b/services/core-api/app/api/projects/ams_final_application/models/ams_final_application.py
@@ -29,6 +29,7 @@ class AmsFinalApplication(HistoryMixin, SoftDeleteMixin, DraftMixin, AuditMixin,
         primaryjoin='and_(AmsFinalApplicationDocumentXref.ams_final_application_guid == AmsFinalApplication.ams_final_application_guid, AmsFinalApplicationDocumentXref.deleted_ind == False)'
     )
     project_summary_authorization = db.relationship("ProjectSummaryAuthorization", back_populates="ams_final_application")
+    editable = db.Column(db.Boolean, default=True)
 
     def __repr__(self):
         return f'{self.__class__.__name__} {self.ams_final_application_guid}'
@@ -48,6 +49,10 @@ class AmsFinalApplication(HistoryMixin, SoftDeleteMixin, DraftMixin, AuditMixin,
     @staticmethod
     def find_by_project_summary_guid(project_summary_guid):
         return AmsFinalApplication.query.join(AmsFinalApplication.project_summary_authorization).filter_by(project_summary_guid=project_summary_guid).all()
+    
+    @staticmethod
+    def find_by_ams_final_application_guid(ams_final_application_guid):
+        return AmsFinalApplication.query.filter_by(ams_final_application_guid=ams_final_application_guid).one_or_none()
 
     @classmethod
     def create(cls, 
@@ -55,13 +60,15 @@ class AmsFinalApplication(HistoryMixin, SoftDeleteMixin, DraftMixin, AuditMixin,
                submitter_name,
                is_agent=False,
                pre_submitted_files=None,
-               is_submitting=False
+               is_submitting=False,
+               editable=True,
                ):
         final_app = cls(
             project_summary_authorization_guid=project_summary_authorization_guid,
             submitter_name=submitter_name,
             is_agent=is_agent,
             pre_submitted_files=pre_submitted_files or [],
+            editable=editable,
         )
         if is_submitting:
             final_app.submitted_timestamp = datetime.now(timezone.utc)
@@ -75,7 +82,7 @@ class AmsFinalApplication(HistoryMixin, SoftDeleteMixin, DraftMixin, AuditMixin,
                documents=[],
                is_agent=False,
                pre_submitted_files=None,
-               is_submitting=False
+               is_submitting=False,
                ):
         self.submitter_name = submitter_name
         self.is_agent = is_agent
@@ -87,6 +94,11 @@ class AmsFinalApplication(HistoryMixin, SoftDeleteMixin, DraftMixin, AuditMixin,
             self.submit()
         else:
             self.save_draft()
+        return self
+    
+    def update_edit_toggle(self, editable= True):
+        self.editable = editable
+        self.save()
         return self
 
     def _update_documents(self, documents):  

--- a/services/core-api/app/api/projects/ams_final_application/resources/ams_final_application_resource.py
+++ b/services/core-api/app/api/projects/ams_final_application/resources/ams_final_application_resource.py
@@ -4,7 +4,7 @@ from werkzeug.exceptions import BadRequest, NotFound
 from app.api.utils.resources_mixins import UserMixin
 
 from app.extensions import api
-from app.api.utils.access_decorators import MINESPACE_PROPONENT, requires_any_of, VIEW_ALL, MINE_ADMIN, EDIT_MAJOR_MINE_APPLICATIONS
+from app.api.utils.access_decorators import MINESPACE_PROPONENT, requires_any_of, VIEW_ALL, MINE_ADMIN, EDIT_MAJOR_MINE_APPLICATIONS, is_minespace_user
 from app.api.projects.response_models import AMS_FINAL_APPLICATION_MODEL
 from app.api.projects.project_summary.models.project_summary import ProjectSummary
 from app.api.projects.project_summary.models.project_summary_authorization import ProjectSummaryAuthorization
@@ -71,6 +71,9 @@ class AmsFinalApplicationResource(Resource, UserMixin):
         final_app = AmsFinalApplication.find_by_authorization_guid(project_summary_authorization_guid)
         if not final_app:
             raise NotFound("AMS Final Application not found.")
+        if final_app.editable == False and is_minespace_user():
+            raise BadRequest("This Application cannot currently be editted in MineSpace.")
+
         submitter_name = data.get('submitter_name', None)
         documents = data.get('documents', [])
         is_agent = data.get('is_agent', False)
@@ -79,7 +82,27 @@ class AmsFinalApplicationResource(Resource, UserMixin):
         final_app = final_app.update(submitter_name, documents, is_agent, pre_submitted_files, is_submitting)
         return final_app, 200
 
-    
+class AmsFinalApplicationMineSpaceEditResource(Resource, UserMixin):
+    parser = CustomReqparser()
+    parser.add_argument('ams_final_application_guid', type=str, store_missing=False, required=False)
+    parser.add_argument('editable', type=bool, store_missing=False, required=True)
+
+    @requires_any_of([MINE_ADMIN, EDIT_MAJOR_MINE_APPLICATIONS ])
+    @api.expect(parser)
+    @api.marshal_with(AMS_FINAL_APPLICATION_MODEL, code=200)
+    def put(self, project_summary_guid, project_summary_authorization_guid):
+        data = self.parser.parse_args()
+        ams_final_application_guid = data.get('ams_final_application_guid')
+        if not ams_final_application_guid:
+            raise BadRequest("ams_final_application_guid is required for updating edit toggle.")
+        
+        final_app = AmsFinalApplication.find_by_authorization_guid(project_summary_authorization_guid)
+        if not final_app:
+            raise NotFound("AMS Final Application not found.")
+        
+        editable = data.get('editable', True)
+        final_app = final_app.update_edit_toggle(editable)
+        return final_app, 200
 
 class AmsFinalApplicationListResource(Resource, UserMixin):
     parser = CustomReqparser()

--- a/services/core-api/app/api/projects/ams_final_application/resources/ams_final_application_resource.py
+++ b/services/core-api/app/api/projects/ams_final_application/resources/ams_final_application_resource.py
@@ -1,18 +1,36 @@
+from app.api.mines.documents.models.mine_document import MineDocument
+from app.api.mines.mine.models.mine import Mine
+from app.api.projects.ams_final_application.models.ams_final_application import (
+    AmsFinalApplication,
+)
+from app.api.projects.project_summary.models.project_summary import ProjectSummary
+from app.api.projects.project_summary.models.project_summary_authorization import (
+    ProjectSummaryAuthorization,
+)
+from app.api.projects.response_models import AMS_FINAL_APPLICATION_MODEL
+from app.api.services.document_manager_service import DocumentManagerService
+from app.api.utils.access_decorators import (
+    EDIT_MAJOR_MINE_APPLICATIONS,
+    MINE_ADMIN,
+    MINESPACE_PROPONENT,
+    VIEW_ALL,
+    is_minespace_user,
+    requires_any_of,
+)
+from app.api.utils.custom_reqparser import CustomReqparser
+from app.api.utils.resources_mixins import UserMixin
+from app.extensions import api
 from flask import request
 from flask_restx import Resource
 from werkzeug.exceptions import BadRequest, NotFound
-from app.api.utils.resources_mixins import UserMixin
 
-from app.extensions import api
-from app.api.utils.access_decorators import MINESPACE_PROPONENT, requires_any_of, VIEW_ALL, MINE_ADMIN, EDIT_MAJOR_MINE_APPLICATIONS, is_minespace_user
-from app.api.projects.response_models import AMS_FINAL_APPLICATION_MODEL
-from app.api.projects.project_summary.models.project_summary import ProjectSummary
-from app.api.projects.project_summary.models.project_summary_authorization import ProjectSummaryAuthorization
-from app.api.projects.ams_final_application.models.ams_final_application import AmsFinalApplication
-from app.api.mines.documents.models.mine_document import MineDocument
-from app.api.mines.mine.models.mine import Mine
-from app.api.utils.custom_reqparser import CustomReqparser
-from app.api.services.document_manager_service import DocumentManagerService
+
+def check_mine_access(mine_guid):
+    mine = Mine.find_by_mine_guid(str(mine_guid))
+
+    if not mine:
+        raise NotFound('Mine not found')
+
 
 class AmsFinalApplicationDocumentResource(Resource, UserMixin):
 
@@ -45,6 +63,7 @@ class AmsFinalApplicationResource(Resource, UserMixin):
             raise BadRequest("No project summary authorization found")
         if project_summary_authorization.ams_tracking_number is None:
             raise BadRequest("Authorization must be successfully submitted before creating the final application.")
+        
 
     @requires_any_of([MINE_ADMIN, MINESPACE_PROPONENT, EDIT_MAJOR_MINE_APPLICATIONS])
     @api.expect(parser)
@@ -56,6 +75,9 @@ class AmsFinalApplicationResource(Resource, UserMixin):
         ams_final_application_guid = data.get('ams_final_application_guid')
         if ams_final_application_guid:
             raise BadRequest("ams_final_application_guid should not be provided when creating a new AMS Final Application. Use PUT to update an existing application.")
+        
+        check_mine_access(auth.project_summary.mine_guid)
+
         # Create new
         final_app = AmsFinalApplication.create(**data)
         return final_app, 201
@@ -73,6 +95,8 @@ class AmsFinalApplicationResource(Resource, UserMixin):
             raise NotFound("AMS Final Application not found.")
         if final_app.editable == False and is_minespace_user():
             raise BadRequest("This Application cannot currently be editted in MineSpace.")
+
+        check_mine_access(final_app.project_summary_authorization.project_summary.mine_guid)
 
         submitter_name = data.get('submitter_name', None)
         documents = data.get('documents', [])
@@ -114,10 +138,17 @@ class AmsFinalApplicationListResource(Resource, UserMixin):
     def get(self, project_summary_guid):
         data = self.parser.parse_args()
         project_summary_authorization_guid = data.get('project_summary_authorization_guid', None)
+
         if project_summary_authorization_guid is None:
             final_applications = AmsFinalApplication.find_by_project_summary_guid(project_summary_guid)
+            for fa in final_applications:
+                check_mine_access(fa.project_summary_authorization.project_summary.mine_guid)
+
             return final_applications
         final_application = AmsFinalApplication.find_by_authorization_guid(project_summary_authorization_guid)
+
+        
         if final_application is None:
             return []
+        check_mine_access(final_application.project_summary_authorization.project_summary.mine_guid)
         return [final_application]

--- a/services/core-api/app/api/projects/ams_final_application/resources/ams_final_application_resource.py
+++ b/services/core-api/app/api/projects/ams_final_application/resources/ams_final_application_resource.py
@@ -124,6 +124,8 @@ class AmsFinalApplicationMineSpaceEditResource(Resource, UserMixin):
         if not final_app:
             raise NotFound("AMS Final Application not found.")
         
+        check_mine_access(final_app.project_summary_authorization.project_summary.mine_guid)
+        
         editable = data.get('editable', True)
         final_app = final_app.update_edit_toggle(editable)
         return final_app, 200

--- a/services/core-api/app/api/projects/namespace.py
+++ b/services/core-api/app/api/projects/namespace.py
@@ -7,7 +7,7 @@ from app.api.projects.project_summary.resources.project_summary_list import Proj
 from app.api.projects.project_summary.resources.project_summary_document_types import ProjectSummaryDocumentTypeResource
 from app.api.projects.project_summary.resources.project_summary_ministry_comment import \
     ProjectSummaryMinistryCommentResource
-from app.api.projects.ams_final_application.resources.ams_final_application_resource import AmsFinalApplicationResource, AmsFinalApplicationListResource, AmsFinalApplicationDocumentResource
+from app.api.projects.ams_final_application.resources.ams_final_application_resource import AmsFinalApplicationResource, AmsFinalApplicationListResource, AmsFinalApplicationDocumentResource, AmsFinalApplicationMineSpaceEditResource
 from app.api.projects.project_summary.resources.project_summary_status_codes import ProjectSummaryStatusCodeResource
 from app.api.projects.project_summary.resources.project_summary_document_upload import ProjectSummaryDocumentUploadResource
 from app.api.projects.project_summary.resources.project_summary_uploaded_document import ProjectSummaryUploadedDocumentResource
@@ -69,6 +69,8 @@ api.add_resource(AmsFinalApplicationListResource,
                  '/<string:project_summary_guid>/ams-final-application')
 api.add_resource(AmsFinalApplicationDocumentResource, 
                  '/<string:project_summary_guid>/ams-final-application/documents')
+api.add_resource(AmsFinalApplicationMineSpaceEditResource,
+                 '/<string:project_summary_guid>/ams-final-application/<string:project_summary_authorization_guid>/minespace-edit')
 
 # Information Requirements Table (IRT)
 api.add_resource(InformationRequirementsTableDownloadResource,

--- a/services/core-api/app/api/projects/response_models.py
+++ b/services/core-api/app/api/projects/response_models.py
@@ -166,7 +166,8 @@ AMS_FINAL_APPLICATION_MODEL = api.model(
         'is_draft': fields.Boolean,
         'pre_submitted_files': fields.List(fields.String),
         'submitted_timestamp': fields.DateTime,
-        'documents': fields.List(fields.Nested(AMS_FINAL_APPLICATION_DOCUMENT_MODEL)), 
+        'documents': fields.List(fields.Nested(AMS_FINAL_APPLICATION_DOCUMENT_MODEL)),
+        'editable': fields.Boolean, 
     }
 )
 

--- a/services/core-api/tests/factories.py
+++ b/services/core-api/tests/factories.py
@@ -2006,6 +2006,7 @@ class AmsFinalApplicationFactory(BaseFactory):
     submitter_name = factory.Faker('name')
     is_agent = factory.Faker('boolean', chance_of_getting_true=30)
     pre_submitted_files = []
+    editable = True
 
     @factory.post_generation
     def documents(obj, create, extracted, **kwargs):

--- a/services/core-api/tests/projects/ams_final_application/resources/test_ams_final_application_resource.py
+++ b/services/core-api/tests/projects/ams_final_application/resources/test_ams_final_application_resource.py
@@ -39,6 +39,7 @@ def subscribe_minespace_user(db_session, project_summary, email='test-proponent@
 def _enable_real_user_mode():
     # Disable any test-mode short–circuiting so access decorators execute real logic
     User._test_mode = False
+    auth.apply_security = True
     auth.clear_cache()
 
 

--- a/services/core-api/tests/projects/ams_final_application/resources/test_ams_final_application_resource.py
+++ b/services/core-api/tests/projects/ams_final_application/resources/test_ams_final_application_resource.py
@@ -1,9 +1,350 @@
 import json
 import uuid
-from tests.factories import AmsFinalApplicationFactory, ProjectSummaryAmsAuthorizationFactory, ProjectSummaryFactory, ProjectFactory, MineFactory
+
+import pytest
+from app import auth
+from app.api.utils.include.user_info import User
+from tests.factories import (
+    AmsFinalApplicationFactory,
+    MineFactory,
+    MinespaceSubscriptionFactory,
+    MinespaceUserFactory,
+    ProjectFactory,
+    ProjectSummaryAmsAuthorizationFactory,
+    ProjectSummaryFactory,
+)
 from tests.status_code_gen import RandomAmsFinalApplicationDocumentTypeCode
 
-# test get by project summary guid
+# -----------------------------------------------------------------------------
+# Test utilities / helpers
+# -----------------------------------------------------------------------------
+
+def _staff_header(auth_headers):
+    return auth_headers['full_auth_header']
+
+
+def _proponent_header(auth_headers):
+    return auth_headers['proponent_only_auth_header']
+
+
+def subscribe_minespace_user(db_session, project_summary, email='test-proponent@bceid'):
+    """Create a MineSpace user and subscribe them to the mine of the given project summary."""
+    ms_user = MinespaceUserFactory(email_or_username=email)  # type: ignore[arg-type]
+    MinespaceSubscriptionFactory(mine=project_summary.project.mine, minespace_user=ms_user)  # type: ignore[arg-type]
+    db_session.commit()
+    auth.clear_cache()
+    return ms_user
+
+
+def _enable_real_user_mode():
+    # Disable any test-mode short–circuiting so access decorators execute real logic
+    User._test_mode = False
+    auth.clear_cache()
+
+
+# -----------------------------------------------------------------------------
+# Parameterized access control + functionality tests (staff vs proponent)
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("as_proponent", [False, True])
+def test_list_ams_final_apps_by_project_summary_guid(test_client, db_session, auth_headers, as_proponent):
+    project_summary = ProjectSummaryFactory()
+    # Create 3 authorizations + final apps
+    auths = [ProjectSummaryAmsAuthorizationFactory(project_summary=project_summary) for _ in range(3)]  # type: ignore[arg-type]
+    for a in auths:
+        AmsFinalApplicationFactory(project_summary_authorization=a)  # type: ignore[arg-type]
+
+    if as_proponent:
+        _enable_real_user_mode()
+        header = _proponent_header(auth_headers)
+        # Pre-subscription should hide existence => 404
+        pre_resp = test_client.get(
+            f"/projects/{project_summary.project_summary_guid}/ams-final-application",
+            headers=header,
+        )
+        assert pre_resp.status_code == 404
+        # Subscribe then succeed
+        subscribe_minespace_user(db_session, project_summary)
+        resp = test_client.get(
+            f"/projects/{project_summary.project_summary_guid}/ams-final-application",
+            headers=header,
+        )
+        data = json.loads(resp.data.decode())
+        assert resp.status_code == 200
+        assert len(data['records']) == 3
+    else:
+        header = _staff_header(auth_headers)
+        resp = test_client.get(
+            f"/projects/{project_summary.project_summary_guid}/ams-final-application",
+            headers=header,
+        )
+        data = json.loads(resp.data.decode())
+        assert resp.status_code == 200
+        assert len(data['records']) == 3
+
+
+@pytest.mark.parametrize("as_proponent", [False, True])
+def test_get_ams_final_apps_by_authorization_guid_filter(test_client, db_session, auth_headers, as_proponent):
+    project_summary = ProjectSummaryFactory()
+    target_auth = ProjectSummaryAmsAuthorizationFactory(project_summary=project_summary)  # type: ignore[arg-type]
+    other_auth = ProjectSummaryAmsAuthorizationFactory(project_summary=project_summary)  # type: ignore[arg-type]
+    final_app = AmsFinalApplicationFactory(project_summary_authorization=target_auth)  # type: ignore[arg-type]
+    AmsFinalApplicationFactory(project_summary_authorization=other_auth)  # type: ignore[arg-type]
+
+    if as_proponent:
+        _enable_real_user_mode()
+        header = _proponent_header(auth_headers)
+        pre_resp = test_client.get(
+            f"/projects/{project_summary.project_summary_guid}/ams-final-application?project_summary_authorization_guid={target_auth.project_summary_authorization_guid}",
+            headers=header,
+        )
+        assert pre_resp.status_code == 404
+        subscribe_minespace_user(db_session, project_summary)
+        resp = test_client.get(
+            f"/projects/{project_summary.project_summary_guid}/ams-final-application?project_summary_authorization_guid={target_auth.project_summary_authorization_guid}",
+            headers=header,
+        )
+        data = json.loads(resp.data.decode())
+        assert resp.status_code == 200
+        assert len(data['records']) == 1
+        assert data['records'][0]['ams_final_application_guid'] == str(final_app.ams_final_application_guid)
+    else:
+        header = _staff_header(auth_headers)
+        resp = test_client.get(
+            f"/projects/{project_summary.project_summary_guid}/ams-final-application?project_summary_authorization_guid={target_auth.project_summary_authorization_guid}",
+            headers=header,
+        )
+        data = json.loads(resp.data.decode())
+        assert resp.status_code == 200
+        assert len(data['records']) == 1
+        assert data['records'][0]['ams_final_application_guid'] == str(final_app.ams_final_application_guid)
+
+
+@pytest.mark.parametrize("as_proponent", [False, True])
+def test_create_ams_final_application(test_client, db_session, auth_headers, as_proponent):
+    project_summary = ProjectSummaryFactory()
+    authorization = ProjectSummaryAmsAuthorizationFactory(project_summary=project_summary, submit_success=True)  # type: ignore[arg-type]
+    post_data = {
+        'project_summary_authorization_guid': authorization.project_summary_authorization_guid,
+        'submitter_name': 'Submitter Name',
+        'is_agent': False,
+    }
+
+    if as_proponent:
+        _enable_real_user_mode()
+        header = _proponent_header(auth_headers)
+        pre_resp = test_client.post(
+            f"/projects/{project_summary.project_summary_guid}/ams-final-application/{authorization.project_summary_authorization_guid}",
+            headers=header,
+            json=post_data,
+        )
+        # Hidden before subscription
+        assert pre_resp.status_code == 404
+        subscribe_minespace_user(db_session, project_summary)
+        resp = test_client.post(
+            f"/projects/{project_summary.project_summary_guid}/ams-final-application/{authorization.project_summary_authorization_guid}",
+            headers=header,
+            json=post_data,
+        )
+        data = json.loads(resp.data.decode())
+        assert resp.status_code == 201
+        assert data['project_summary_authorization_guid'] == str(authorization.project_summary_authorization_guid)
+    else:
+        header = _staff_header(auth_headers)
+        resp = test_client.post(
+            f"/projects/{project_summary.project_summary_guid}/ams-final-application/{authorization.project_summary_authorization_guid}",
+            headers=header,
+            json=post_data,
+        )
+        data = json.loads(resp.data.decode())
+        assert resp.status_code == 201
+        assert data['project_summary_authorization_guid'] == str(authorization.project_summary_authorization_guid)
+
+
+@pytest.mark.parametrize("as_proponent", [False, True])
+def test_create_ams_final_application_unsubmitted_auth(test_client, db_session, auth_headers, as_proponent):
+    project_summary = ProjectSummaryFactory()
+    authorization = ProjectSummaryAmsAuthorizationFactory(project_summary=project_summary, submit_success=False)  # type: ignore[arg-type]
+    post_data = {
+        'project_summary_authorization_guid': authorization.project_summary_authorization_guid,
+        'submitter_name': 'Submitter Name',
+        'is_agent': False,
+    }
+    if as_proponent:
+        _enable_real_user_mode()
+        header = _proponent_header(auth_headers)
+        # Business rule triggers before need for subscription: expect 400
+        resp = test_client.post(
+            f"/projects/{project_summary.project_summary_guid}/ams-final-application/{authorization.project_summary_authorization_guid}",
+            headers=header,
+            json=post_data,
+        )
+        data = json.loads(resp.data.decode())
+        assert resp.status_code == 400
+        assert 'Authorization must be successfully submitted' in data['message']
+    else:
+        header = _staff_header(auth_headers)
+        resp = test_client.post(
+            f"/projects/{project_summary.project_summary_guid}/ams-final-application/{authorization.project_summary_authorization_guid}",
+            headers=header,
+            json=post_data,
+        )
+        data = json.loads(resp.data.decode())
+        assert resp.status_code == 400
+        assert 'Authorization must be successfully submitted' in data['message']
+
+
+@pytest.mark.parametrize("as_proponent", [False, True])
+def test_update_ams_final_application_add_documents(test_client, db_session, auth_headers, as_proponent):
+    # Need explicit mine/project to ensure subscription attaches correctly
+    mine = MineFactory(minimal=True)
+    project = ProjectFactory(mine=mine)
+    project_summary = ProjectSummaryFactory(project=project)
+    authorization = ProjectSummaryAmsAuthorizationFactory(project_summary=project_summary, submit_success=True)  # type: ignore[arg-type]
+
+    create_payload = {
+        'project_summary_authorization_guid': authorization.project_summary_authorization_guid,
+        'submitter_name': 'Submitter Name',
+        'is_agent': False,
+    }
+
+    header = _proponent_header(auth_headers) if as_proponent else _staff_header(auth_headers)
+    if as_proponent:
+        _enable_real_user_mode()
+        pre_create = test_client.post(
+            f"/projects/{project_summary.project_summary_guid}/ams-final-application/{authorization.project_summary_authorization_guid}",
+            headers=header,
+            json=create_payload,
+        )
+        assert pre_create.status_code == 404
+        subscribe_minespace_user(db_session, project_summary)
+
+    create_resp = test_client.post(
+        f"/projects/{project_summary.project_summary_guid}/ams-final-application/{authorization.project_summary_authorization_guid}",
+        headers=header,
+        json=create_payload,
+    )
+    assert create_resp.status_code == 201
+    final_app_guid = json.loads(create_resp.data.decode())['ams_final_application_guid']
+
+    doc_payload = [
+        {
+            'document_manager_guid': uuid.uuid4(),
+            'document_name': 'One.pdf',
+            'ams_final_application_document_type_code': RandomAmsFinalApplicationDocumentTypeCode(),
+        },
+        {
+            'document_manager_guid': uuid.uuid4(),
+            'document_name': 'Two.pdf',
+            'ams_final_application_document_type_code': RandomAmsFinalApplicationDocumentTypeCode(),
+        },
+    ]
+    put_payload = {
+        **create_payload,
+        'ams_final_application_guid': final_app_guid,
+        'documents': doc_payload,
+        'pre_submitted_files': ['LOC'],
+    }
+    put_resp = test_client.put(
+        f"/projects/{project_summary.project_summary_guid}/ams-final-application/{authorization.project_summary_authorization_guid}",
+        headers=header,
+        json=put_payload,
+    )
+    data = json.loads(put_resp.data.decode())
+    assert put_resp.status_code == 200
+    assert len(data['documents']) == 2
+
+
+@pytest.mark.parametrize("as_proponent", [False, True])
+def test_submit_ams_final_application(test_client, db_session, auth_headers, as_proponent):
+    final_app = AmsFinalApplicationFactory(is_submitted=False)
+    documents = [
+        {
+            'document_manager_guid': d.document_manager_guid,
+            'document_name': d.document_name,
+            'mine_document_guid': d.mine_document_guid,
+            'ams_final_application_document_type_code': d.ams_final_application_document_type_code,
+        }
+        for d in list(final_app.documents)
+    ]
+    put_payload = {
+        'ams_final_application_guid': final_app.ams_final_application_guid,
+        'project_summary_authorization_guid': final_app.project_summary_authorization_guid,
+        'submitter_name': final_app.submitter_name,
+        'is_agent': final_app.is_agent,
+        'pre_submitted_files': final_app.pre_submitted_files,
+        'documents': documents,
+        'is_submitting': True,
+    }
+
+    if as_proponent:
+        _enable_real_user_mode()
+        header = _proponent_header(auth_headers)
+        pre_resp = test_client.put(
+            f"/projects/{final_app.project_summary_authorization.project_summary_guid}/ams-final-application/{final_app.project_summary_authorization_guid}",
+            headers=header,
+            json=put_payload,
+        )
+        assert pre_resp.status_code == 404
+        subscribe_minespace_user(db_session, final_app.project_summary_authorization.project_summary)
+    else:
+        header = _staff_header(auth_headers)
+
+    resp = test_client.put(
+        f"/projects/{final_app.project_summary_authorization.project_summary_guid}/ams-final-application/{final_app.project_summary_authorization_guid}",
+        headers=header,
+        json=put_payload,
+    )
+    data = json.loads(resp.data.decode())
+    assert resp.status_code == 200
+    assert data['is_draft'] is False
+    assert data['submitted_timestamp'] is not None
+
+
+@pytest.mark.parametrize("as_proponent", [False, True])
+def test_update_ams_final_application_remove_documents(test_client, db_session, auth_headers, as_proponent):
+    final_app = AmsFinalApplicationFactory(is_submitted=False, documents=2)
+    put_payload = {
+        'ams_final_application_guid': final_app.ams_final_application_guid,
+        'project_summary_authorization_guid': final_app.project_summary_authorization_guid,
+        'submitter_name': final_app.submitter_name,
+        'is_agent': final_app.is_agent,
+        'pre_submitted_files': final_app.pre_submitted_files,
+        'documents': [
+            {
+                'ams_final_application_document_guid': str(final_app.documents[0].ams_final_application_document_xref_guid),
+                'document_manager_guid': str(final_app.documents[0].document_manager_guid),
+                'document_name': final_app.documents[0].document_name,
+                'mine_document_guid': str(final_app.documents[0].mine_document_guid),
+                'ams_final_application_document_type_code': final_app.documents[0].ams_final_application_document_type_code,
+            }
+        ],
+    }
+
+    if as_proponent:
+        _enable_real_user_mode()
+        header = _proponent_header(auth_headers)
+        pre_resp = test_client.put(
+            f"/projects/{final_app.project_summary_authorization.project_summary_guid}/ams-final-application/{final_app.project_summary_authorization_guid}",
+            headers=header,
+            json=put_payload,
+        )
+        assert pre_resp.status_code == 404
+        subscribe_minespace_user(db_session, final_app.project_summary_authorization.project_summary)
+    else:
+        header = _staff_header(auth_headers)
+
+    resp = test_client.put(
+        f"/projects/{final_app.project_summary_authorization.project_summary_guid}/ams-final-application/{final_app.project_summary_authorization_guid}",
+        headers=header,
+        json=put_payload,
+    )
+    data = json.loads(resp.data.decode())
+    assert resp.status_code == 200
+    assert len(data['documents']) == 1
+    assert data['documents'][0]['document_manager_guid'] == str(final_app.documents[0].document_manager_guid)
+
 def test_get_all_ams_final_apps_by_project_summary_guid(test_client, db_session, auth_headers):
     
     project_summary = ProjectSummaryFactory()
@@ -29,7 +370,6 @@ def test_get_all_ams_final_apps_by_project_summary_guid(test_client, db_session,
     assert get_data['records'][1]['ams_final_application_guid'] == str(final_app_2.ams_final_application_guid)
     assert get_data['records'][2]['ams_final_application_guid'] == str(final_app_3.ams_final_application_guid)
 
-# test get list (single record) by project summary authorization guid
 def test_get_ams_final_apps_by_project_summary_auth_guid(test_client, db_session, auth_headers):
     
     project_summary = ProjectSummaryFactory()
@@ -51,7 +391,6 @@ def test_get_ams_final_apps_by_project_summary_auth_guid(test_client, db_session
     assert len(get_data['records']) == 1
     assert get_data['records'][0]['ams_final_application_guid'] == str(final_app.ams_final_application_guid)
 
-# test create
 def test_post_ams_final_application(test_client, db_session, auth_headers):
     project_summary = ProjectSummaryFactory()
     auth = ProjectSummaryAmsAuthorizationFactory(project_summary=project_summary, submit_success=True)
@@ -77,7 +416,6 @@ def test_post_ams_final_application(test_client, db_session, auth_headers):
 
     
 
-# test add documents
 def test_put_ams_final_application_documents(test_client, db_session, auth_headers):
     mine = MineFactory(minimal=True)
     project = ProjectFactory(mine=mine)
@@ -199,7 +537,6 @@ def test_ams_final_app_unsubmitted_raises_error(test_client, db_session, auth_he
 def test_put_ams_final_remove_documents(test_client, db_session, auth_headers):
     final_app = AmsFinalApplicationFactory(is_submitted=False, documents=2)
 
-    # update to not include any of the documents- delete
     put_data = {
         'ams_final_application_guid': final_app.ams_final_application_guid,
         'project_summary_authorization_guid': final_app.project_summary_authorization_guid,
@@ -244,12 +581,6 @@ def test_put_ams_final_app_minespace_edit_toggle(test_client, db_session, auth_h
 
     put_data = {
         'ams_final_application_guid': final_app.ams_final_application_guid,
-        'project_summary_authorization_guid': final_app.project_summary_authorization_guid,
-        'submitter_name': final_app.submitter_name,
-        'is_agent': final_app.is_agent,
-        'pre_submitted_files': final_app.pre_submitted_files,
-        'documents': documents,
-        'is_submitting': True,
         'editable': False,
     }
 
@@ -262,3 +593,77 @@ def test_put_ams_final_app_minespace_edit_toggle(test_client, db_session, auth_h
 
     assert put_resp.status_code == 200
     assert put_resp_data['editable'] == False
+
+
+def test_minespace_edit_toggle_proponent_forbidden(test_client, db_session, auth_headers):
+    """Proponent should NOT be able to toggle edit flag (403 expected)."""
+    final_app = AmsFinalApplicationFactory(is_submitted=False)
+    _enable_real_user_mode()
+    header = _proponent_header(auth_headers)
+    # Subscribe so project/mine access passes before role check
+    subscribe_minespace_user(db_session, final_app.project_summary_authorization.project_summary)
+    put_data = {
+        'ams_final_application_guid': final_app.ams_final_application_guid,
+        'editable': False,
+    }
+    resp = test_client.put(
+        f"/projects/{final_app.project_summary_authorization.project_summary_guid}/ams-final-application/{final_app.project_summary_authorization_guid}/minespace-edit",
+        headers=header,
+        json=put_data,
+    )
+    assert resp.status_code == 403
+
+
+def test_proponent_cannot_update_when_editing_disabled(test_client, db_session, auth_headers):
+    """After editable is toggled off by staff, a proponent update attempt should fail with 400."""
+    # Create draft final application
+    final_app = AmsFinalApplicationFactory(is_submitted=False)
+
+    # Staff toggles editable to False
+    staff_header = _staff_header(auth_headers)
+    toggle_payload = {
+        'ams_final_application_guid': final_app.ams_final_application_guid,
+        'editable': False,
+    }
+    toggle_resp = test_client.put(
+        f"/projects/{final_app.project_summary_authorization.project_summary_guid}/ams-final-application/{final_app.project_summary_authorization_guid}/minespace-edit",
+        headers=staff_header,
+        json=toggle_payload,
+    )
+    assert toggle_resp.status_code == 200
+    toggle_data = json.loads(toggle_resp.data.decode())
+    assert toggle_data['editable'] is False
+
+    # Prepare proponent context
+    _enable_real_user_mode()
+    subscribe_minespace_user(db_session, final_app.project_summary_authorization.project_summary)
+    proponent_header = _proponent_header(auth_headers)
+
+    # Build an update payload (attempting normal PUT)
+    documents = [
+        {
+            'document_manager_guid': d.document_manager_guid,
+            'document_name': d.document_name,
+            'mine_document_guid': d.mine_document_guid,
+            'ams_final_application_document_type_code': d.ams_final_application_document_type_code,
+        }
+        for d in list(final_app.documents)
+    ]
+    update_payload = {
+        'ams_final_application_guid': final_app.ams_final_application_guid,
+        'project_summary_authorization_guid': final_app.project_summary_authorization_guid,
+        'submitter_name': final_app.submitter_name,
+        'is_agent': final_app.is_agent,
+        'pre_submitted_files': final_app.pre_submitted_files,
+        'documents': documents,
+        'is_submitting': False,
+    }
+
+    blocked_resp = test_client.put(
+        f"/projects/{final_app.project_summary_authorization.project_summary_guid}/ams-final-application/{final_app.project_summary_authorization_guid}",
+        headers=proponent_header,
+        json=update_payload,
+    )
+    blocked_data = json.loads(blocked_resp.data.decode())
+    assert blocked_resp.status_code == 400
+    assert 'cannot currently be editted' in blocked_data['message']

--- a/services/core-api/tests/projects/ams_final_application/resources/test_ams_final_application_resource.py
+++ b/services/core-api/tests/projects/ams_final_application/resources/test_ams_final_application_resource.py
@@ -228,3 +228,37 @@ def test_put_ams_final_remove_documents(test_client, db_session, auth_headers):
     assert put_resp_data['is_draft'] == True
     assert len(put_resp_data['documents']) == 1
     assert put_resp_data['documents'][0]['document_manager_guid'] == str(final_app.documents[0].document_manager_guid)
+
+def test_put_ams_final_app_minespace_edit_toggle(test_client, db_session, auth_headers):
+    final_app = AmsFinalApplicationFactory(is_submitted=False)
+
+    documents = [
+        {
+            'document_manager_guid': d.document_manager_guid,
+            'document_name': d.document_name,
+            'mine_document_guid': d.mine_document_guid,
+            'ams_final_application_document_type_code': d.ams_final_application_document_type_code
+        }
+        for d in list(final_app.documents)
+    ]
+
+    put_data = {
+        'ams_final_application_guid': final_app.ams_final_application_guid,
+        'project_summary_authorization_guid': final_app.project_summary_authorization_guid,
+        'submitter_name': final_app.submitter_name,
+        'is_agent': final_app.is_agent,
+        'pre_submitted_files': final_app.pre_submitted_files,
+        'documents': documents,
+        'is_submitting': True,
+        'editable': False,
+    }
+
+    put_resp = test_client.put(
+        f'/projects/{final_app.project_summary_authorization.project_summary_guid}/ams-final-application/{final_app.project_summary_authorization_guid}/minespace-edit',
+        headers=auth_headers['full_auth_header'], json=put_data
+    )
+
+    put_resp_data = json.loads(put_resp.data.decode())
+
+    assert put_resp.status_code == 200
+    assert put_resp_data['editable'] == False


### PR DESCRIPTION
## Objective 

[MDS-6633](https://bcmines.atlassian.net/browse/MDS-6633)

- Added in Core a button to toggle the MineSpace user's ability to edit a final application.
- Toggles for individual EMA final application
- Final Application submission form changed to view mode when application not editable
- Final application documents in the **All Documents** tab's **Env Application** section changed not to be replaceable or archive-able when not editable.
- Added backend check to see if in MineSpace a final application is editable during the new final application submission form and during the action of archiving and replacing files

<img width="1844" height="977" alt="image" src="https://github.com/user-attachments/assets/ede1b4a8-8dbe-4f85-bbf2-73eb66d165b5" />
