### PR TITLE
[FIX] Make text wrap normal

### DIFF
--- a/services/minespace-web/src/styles/components/Tables.scss
+++ b/services/minespace-web/src/styles/components/Tables.scss
@@ -97,6 +97,7 @@
 .ant-table-tbody>tr>td.ant-table-cell {
   vertical-align: middle;
   padding: 15px 8px 15px 16px;
+  overflow-wrap: normal;
 
   button {
     margin-top: 0;


### PR DESCRIPTION
## Objective 
- little fix for overflow-wrap, which was being set (I think it was the generated file) to "break-word".
- note that we have a "wrapped-text" class and that this change doesn't take precedence over that rule (which I think is generally added to lists of file names and sets `word-break: normal` and `overflow-wrap: anywhere`)

_Why are you making this change? Provide a short explanation and/or screenshots_
Problem:
<img width="1455" height="496" alt="image" src="https://github.com/user-attachments/assets/a9043d09-1fa5-43f0-9fa3-c09bdfe12fba" />
After fix:
<img width="1442" height="516" alt="image" src="https://github.com/user-attachments/assets/a2b087b9-6194-4364-a8d1-fc8fd41422f3" />
(sometimes the status will be on 2 rows with it breaking between the dot and the word but I thought that was no big deal)