### PR TITLE
[MDS-6684] - Incident Validation Error Message

### DIFF
--- a/services/common/src/redux/utils/Validate.ts
+++ b/services/common/src/redux/utils/Validate.ts
@@ -279,7 +279,8 @@ export const dateNotBeforeStrictOther = memoize(
   (other: string, otherLabel?: string) => (value: string) =>
     value && other && moment(value).isBefore(other)
       ? `Date cannot be before ${otherLabel ? `${otherLabel} - ` : ""}${moment(other).format("YYYY-MM-DD HH:mm Z z")}`
-      : undefined
+      : undefined,
+  (other, otherLabel) => `${other}_${otherLabel}`
 );
 
 export const timeNotBeforeOther = memoize(

--- a/services/common/src/redux/utils/Validate.ts
+++ b/services/common/src/redux/utils/Validate.ts
@@ -156,11 +156,11 @@ export const spatialDocumentBundle = (files: any[]) => {
 export const notnone = (value) => (value === "None" ? "Please select an item" : undefined);
 
 export const maxLength = memoize((max) => (value) =>
-  value && value.length > max ? `Must be ${max} characters or less` : undefined
+    value && value.length > max ? `Must be ${max} characters or less` : undefined
 );
 
 export const minLength = memoize((min) => (value) =>
-  value && value.length < min ? `Must be ${min} characters or more` : undefined
+    value && value.length < min ? `Must be ${min} characters or more` : undefined
 );
 
 export const exactLength = memoize((min) => (value) =>
@@ -203,7 +203,6 @@ export const lonNegative = (value) =>
 export const phoneNumber = (value) =>
   value && !Validate.checkPhone(value) ? "Invalid phone number e.g. xxx-xxx-xxxx" : undefined;
 
-
 export const postalCodeWithCountry = memoize((address_type_code = "CAN") => (value) => {
   const code_type = address_type_code === "USA" ? "zip code" : "postal code";
   if (!["CAN", "USA"].includes(address_type_code)) {
@@ -224,9 +223,9 @@ export const currency = (value) =>
   value && !Validate.checkCurrency(value) ? "Invalid dollar amount" : undefined;
 
 export const validateStartDate = memoize((previousStartDate) => (value) =>
-  value <= previousStartDate
-    ? "New manager's start date cannot be on or before the previous manager's start date."
-    : undefined
+    value <= previousStartDate
+      ? "New manager's start date cannot be on or before the previous manager's start date."
+      : undefined
 );
 
 export const alertStartDateNotBeforeHistoric = memoize((mineAlerts) => (value) => {
@@ -245,9 +244,9 @@ export const max = memoize((maxValue) => (value) =>
 );
 
 export const alertNotInFutureIfCurrentActive = memoize((mineAlert) => (value) =>
-  value && mineAlert.start_date && new Date(value) >= new Date()
-    ? "Start date cannot be in the future if there is a current active alert.  Please update or remove current alert first"
-    : undefined
+    value && mineAlert.start_date && new Date(value) >= new Date()
+      ? "Start date cannot be in the future if there is a current active alert.  Please update or remove current alert first"
+      : undefined
 );
 
 export const dateNotInFuture = (value) =>
@@ -267,39 +266,42 @@ export const dateInFuture = (value) =>
 
 // NOTE: modified from version in CORE- change from <= to <
 export const dateNotBeforeOther = memoize((other: string, otherLabel?: string) => (value: string) => {
-  const invalid = value && other && value < other;
-  if (!invalid) {
-    return undefined;
-  }
-  const otherFormattedDate = moment(other).format("ddd MMM D YYYY");
-  const otherDateText = otherLabel ? `${otherLabel} (${otherFormattedDate})` : otherFormattedDate;
+    const invalid = value && other && value < other;
+    if (!invalid) {
+      return undefined;
+    }
+    const otherFormattedDate = moment(other).format("ddd MMM D YYYY");
+    const otherDateText = otherLabel ? `${otherLabel} (${otherFormattedDate})` : otherFormattedDate;
   return `Date cannot be before ${otherDateText}`
 }, (other, otherLabel) => `${other}_${otherLabel}`);
 
-export const dateNotBeforeStrictOther = memoize((other) => (value) =>
-  value && other && moment(value).isBefore(other) ? `Date cannot be before ${other}` : undefined
+export const dateNotBeforeStrictOther = memoize(
+  (other: string, otherLabel?: string) => (value: string) =>
+    value && other && moment(value).isBefore(other)
+      ? `Date cannot be before ${otherLabel ? `${otherLabel} - ` : ""}${moment(other).format("YYYY-MM-DD HH:mm Z z")}`
+      : undefined
 );
 
 export const timeNotBeforeOther = memoize(
   (comparableDate, baseDate, baseTime) => (comparableTime) =>
     baseTime &&
-      baseDate &&
-      comparableDate &&
-      comparableTime &&
-      baseDate === comparableDate &&
-      comparableTime < baseTime
+    baseDate &&
+    comparableDate &&
+    comparableTime &&
+    baseDate === comparableDate &&
+    comparableTime < baseTime
       ? `Time cannot be before ${baseTime.format("H:mm")} hrs.`
       : undefined
 );
 
 // NOTE: modified from version in CORE- change from >= to >
 export const dateNotAfterOther = memoize((other: string, otherLabel?: string) => (value: string) => {
-  const invalid = value && other && value > other;
-  if (!invalid) {
-    return undefined;
-  }
-  const otherFormattedDate = moment(other).format("ddd MMM D YYYY");
-  const otherDateText = otherLabel ? `${otherLabel} (${otherFormattedDate})` : otherFormattedDate;
+    const invalid = value && other && value > other;
+    if (!invalid) {
+      return undefined;
+    }
+    const otherFormattedDate = moment(other).format("ddd MMM D YYYY");
+    const otherDateText = otherLabel ? `${otherLabel} (${otherFormattedDate})` : otherFormattedDate;
 
   return `Date cannot be after ${otherDateText}`
 }, (other, otherLabel) => `${other}_${otherLabel}`);
@@ -308,9 +310,9 @@ export const yearNotInFuture = (value) =>
   value && value > new Date().getFullYear() ? "Year cannot be in the future" : undefined;
 
 export const validateIncidentDate = memoize((reportedDate) => (value) =>
-  value <= reportedDate
-    ? "Incident date and time cannot occur before reporting occurence."
-    : undefined
+    value <= reportedDate
+      ? "Incident date and time cannot occur before reporting occurence."
+      : undefined
 );
 
 export const decimalPlaces = memoize((places) => (value) => {
@@ -401,7 +403,7 @@ export const validateIfApplicationTypeCorrespondsToPermitNumber = (
       Strings.APPLICATION_TYPES_BY_PERMIT_PREFIX[permit.permit_prefix].includes(applicationType)
       ? undefined
       : `The ${isAdminAmendment ? "Type of Administrative Amendment" : "Type of Notice of Work"
-      } does not match to the selected permit.`;
+        } does not match to the selected permit.`;
   }
   return undefined;
 };

--- a/services/core-web/src/components/Forms/incidents/IncidentFormInitialReport.tsx
+++ b/services/core-web/src/components/Forms/incidents/IncidentFormInitialReport.tsx
@@ -150,7 +150,7 @@ const IncidentFormInitialReport: FC<IncidentFormInitialReportProps> = ({
                   placeholder="Please select date"
                   validate={[
                     dateNotInFutureTZ,
-                    dateNotBeforeStrictOther(formValues.incident_timestamp),
+                    dateNotBeforeStrictOther(formValues.incident_timestamp, 'Incident date & time'),
                   ]}
                 />
               </Col>
@@ -200,7 +200,7 @@ const IncidentFormInitialReport: FC<IncidentFormInitialReportProps> = ({
                   validate={[
                     required,
                     dateNotInFutureTZ,
-                    dateNotBeforeStrictOther(formValues.incident_timestamp),
+                    dateNotBeforeStrictOther(formValues.incident_timestamp, 'Incident date & time'),
                   ]}
                 />
               </Col>
@@ -251,7 +251,7 @@ const IncidentFormInitialReport: FC<IncidentFormInitialReportProps> = ({
                 timezone={formValues.incident_timezone}
                 validate={[
                   dateNotInFutureTZ,
-                  dateNotBeforeStrictOther(formValues.incident_timestamp),
+                  dateNotBeforeStrictOther(formValues.incident_timestamp, 'Incident date & time'),
                 ]}
                 disabled={!isEditMode}
               />

--- a/services/core-web/src/components/Forms/incidents/IncidentFormMinistryFollowup.tsx
+++ b/services/core-web/src/components/Forms/incidents/IncidentFormMinistryFollowup.tsx
@@ -11,7 +11,8 @@ import { renderConfig } from "@/components/common/config";
 import RenderDateTimeTz from "@mds/common/components/forms/RenderDateTimeTz";
 import { normalizeDatetime } from "@mds/common/redux/utils/helpers";
 import {
-  required, requiredRadioButton,
+  required,
+  requiredRadioButton,
   dateNotBeforeStrictOther,
   dateNotInFutureTZ,
   requiredList,
@@ -34,7 +35,9 @@ const IncidentFormMinistryFollowup: FC<IncidentFormMinistryFollowupProps> = ({
   dangerousOccurenceSubparagraphOptions,
   inspectorOptions,
 }) => {
-  const formValues = useSelector((state) => getFormValues(ADD_EDIT_INCIDENT)(state)) as IMineIncident;
+  const formValues = useSelector((state) =>
+    getFormValues(ADD_EDIT_INCIDENT)(state)
+  ) as IMineIncident;
 
   const filteredFollowUpActions = incidentFollowUpActionOptions.filter(
     (act) => act.mine_incident_followup_investigation_type !== INCIDENT_FOLLOWUP_ACTIONS.unknown
@@ -98,20 +101,20 @@ const IncidentFormMinistryFollowup: FC<IncidentFormMinistryFollowupProps> = ({
             )}
           {formValues?.determination_type_code ===
             INCIDENT_DETERMINATION_TYPES.dangerousOccurance && (
-              <Col xs={24} md={12}>
-                <Field
-                  label="Which section(s) of the code apply to this dangerous occurrence?"
-                  id="dangerous_occurrence_subparagraph_ids"
-                  name="dangerous_occurrence_subparagraph_ids"
-                  placeholder="Please choose one or more..."
-                  component={renderConfig.MULTI_SELECT}
-                  data={dangerousOccurenceSubparagraphOptions}
-                  required
-                  validate={[requiredList]}
-                  disabled={!isEditMode}
-                />
-              </Col>
-            )}
+            <Col xs={24} md={12}>
+              <Field
+                label="Which section(s) of the code apply to this dangerous occurrence?"
+                id="dangerous_occurrence_subparagraph_ids"
+                name="dangerous_occurrence_subparagraph_ids"
+                placeholder="Please choose one or more..."
+                component={renderConfig.MULTI_SELECT}
+                data={dangerousOccurenceSubparagraphOptions}
+                required
+                validate={[requiredList]}
+                disabled={!isEditMode}
+              />
+            </Col>
+          )}
           {formValues.verbal_notification_provided && (
             <Col md={12} xs={24}>
               <Field
@@ -126,7 +129,7 @@ const IncidentFormMinistryFollowup: FC<IncidentFormMinistryFollowupProps> = ({
                 placeholder="Please select date"
                 validate={[
                   dateNotInFutureTZ,
-                  dateNotBeforeStrictOther(formValues.incident_timestamp),
+                  dateNotBeforeStrictOther(formValues.incident_timestamp, "Incident date & time"),
                 ]}
               />
             </Col>


### PR DESCRIPTION
## Objective 

[MDS-6684](https://bcmines.atlassian.net/browse/MDS-6684)

An inspector reported an issue where he was unable to create an incident in Core because of date comparison validation triggering when it shouldn't have.  This seems to have been caused by several of the dates were being entered as `now`, but the incident timestamp that has to be before all other dates is lower in the form, so time passed before that was entered, causing the previously entered dates to now be _before_ the incident.
The current error message just showed an unformatted date string which made it difficult to parse where the conflict was.  
Enhanced the error message to show the field in conflict and properly parse the date to match what was in the field being entered.

<img width="1629" height="674" alt="image" src="https://github.com/user-attachments/assets/fe4f3593-73e8-44e3-996a-a82863d90885" />

_Why are you making this change? Provide a short explanation and/or screenshots_
