### PR TITLE
[MDS-6569] Hide template conditions from extracted permits

### DIFF
--- a/services/common/src/components/permits/PermitConditionViewEdit.tsx
+++ b/services/common/src/components/permits/PermitConditionViewEdit.tsx
@@ -255,7 +255,8 @@ const PermitConditionViewEdit: FC<PermitConditionViewEditProps> = ({
                 >
                   Add Condition
                 </CoreButton>
-                {!isStandardConditionEditor && (
+                {/* Template conditions should only be available in the NoW permit drafting flow. */}
+                {isNowEditor && !isStandardConditionEditor && (
                   <CoreButton
                     type="primary"
                     loading={loading}

--- a/services/core-web/src/tests/components/mine/Permit/PermitConditions.spec.tsx
+++ b/services/core-web/src/tests/components/mine/Permit/PermitConditions.spec.tsx
@@ -148,6 +148,9 @@ describe("PermitConditions", () => {
     expect(editCondition).toHaveLength(0);
     const editCategory = queryByTitle("Click to edit");
     expect(editCategory).not.toBeInTheDocument();
+    // Template conditions button should never be visible outside NoW drafting flow
+    const templateBtn = queryByText("Insert Template Conditions");
+    expect(templateBtn).not.toBeInTheDocument();
   });
 
   it("only allows specific actions when permit has been generated in Core", async () => {
@@ -202,6 +205,8 @@ describe("PermitConditions", () => {
     expect(addConditionButton).not.toBeInTheDocument();
     const editCategory = queryByTitle("Click to edit");
     expect(editCategory).not.toBeInTheDocument();
+    const templateBtn = queryByText("Insert Template Conditions");
+    expect(templateBtn).not.toBeInTheDocument();
   });
 
   it("does not allow editing without being assigned to the category", async () => {
@@ -234,6 +239,8 @@ describe("PermitConditions", () => {
     expect(Array.from(assignReviewer).length).toEqual(
       MOCK.PERMITS[0].permit_amendments[0].condition_categories.length
     );
+    const templateBtn = queryByText("Insert Template Conditions");
+    expect(templateBtn).not.toBeInTheDocument();
   });
 
   it("enables adding a condition category in a modal", async () => {

--- a/services/core-web/src/tests/components/mine/Permit/__snapshots__/PermitConditions.spec.tsx.snap
+++ b/services/core-web/src/tests/components/mine/Permit/__snapshots__/PermitConditions.spec.tsx.snap
@@ -816,14 +816,6 @@ exports[`PermitConditions renders properly 1`] = `
                                           Add Condition
                                         </span>
                                       </button>
-                                      <button
-                                        class="ant-btn ant-btn-primary core-btn core-btn-primary"
-                                        type="button"
-                                      >
-                                        <span>
-                                          Insert Template Conditions
-                                        </span>
-                                      </button>
                                     </div>
                                   </div>
                                   <form


### PR DESCRIPTION
## Objective 

[MDS-6569](https://bcmines.atlassian.net/browse/MDS-5659)

Only show insert template condition button for NoW permits
