### PR TITLE
[MDS-6632] - Email Tracking

### DIFF
--- a/migrations/sql/V2025.09.23.09.45__create_email_tracking_table.sql
+++ b/migrations/sql/V2025.09.23.09.45__create_email_tracking_table.sql
@@ -16,10 +16,10 @@ CREATE TYPE recipient_type_enum AS ENUM (
 
 -- Create generic email tracking table for all entities
 CREATE TABLE email_tracking (
-                                email_tracking_id uuid DEFAULT gen_random_uuid() PRIMARY KEY,
+                                email_tracking_guid uuid DEFAULT gen_random_uuid() PRIMARY KEY,
 
     -- Generic reference to any entity this email relates to
-                                reference_id uuid NOT NULL,
+                                reference_id varchar NOT NULL,
                                 reference_table varchar(100) NOT NULL,
                                 reference_email_type varchar(100),
 
@@ -57,7 +57,7 @@ CREATE TABLE email_tracking (
 
 -- Add comments for documentation
 COMMENT ON TABLE email_tracking IS 'Generic email tracking table for all entities using CHES service';
-COMMENT ON COLUMN email_tracking.reference_id IS 'UUID of the entity this email relates to (can reference any table)';
+COMMENT ON COLUMN email_tracking.reference_id IS 'Primary key of the entity this email relates to (can reference any table)';
 COMMENT ON COLUMN email_tracking.reference_table IS 'Name of the table that the reference_id points to';
 COMMENT ON COLUMN email_tracking.reference_email_type IS 'Type of email this is (e.g. documents uploaded, submission confirmation, etc.).  Needed for non template emails to differentiate between email types';
 COMMENT ON COLUMN email_tracking.email_template_name IS 'Name/identifier of the email template used';

--- a/migrations/sql/V2025.09.23.09.45__create_email_tracking_table.sql
+++ b/migrations/sql/V2025.09.23.09.45__create_email_tracking_table.sql
@@ -3,7 +3,7 @@ CREATE TYPE email_status_enum AS ENUM (
     'sent',
     'accepted',
     'cancelled',
-    'completed'
+    'completed',
     'failed',
     'pending'
 );

--- a/migrations/sql/V2025.09.23.09.45__create_email_tracking_table.sql
+++ b/migrations/sql/V2025.09.23.09.45__create_email_tracking_table.sql
@@ -1,0 +1,81 @@
+-- Create enum types for email tracking
+CREATE TYPE email_status_enum AS ENUM (
+    'sent',
+    'accepted',
+    'cancelled',
+    'completed'
+    'failed',
+    'pending'
+);
+
+CREATE TYPE recipient_type_enum AS ENUM (
+    'primary',
+    'cc',
+    'bcc'
+);
+
+-- Create generic email tracking table for all entities
+CREATE TABLE email_tracking (
+                                email_tracking_id uuid DEFAULT gen_random_uuid() PRIMARY KEY,
+
+    -- Generic reference to any entity this email relates to
+                                reference_id uuid NOT NULL,
+                                reference_table varchar(100) NOT NULL,
+                                reference_email_type varchar(100),
+
+    -- Email content and template information
+                                email_template_name varchar(255),
+                                email_subject varchar(500),
+
+    -- Recipient information
+                                recipient_email varchar(320) NOT NULL, -- RFC 5321 max email length
+                                recipient_name varchar(255),
+                                recipient_type recipient_type_enum NOT NULL DEFAULT 'primary',
+
+    -- Email status tracking
+                                email_status email_status_enum NOT NULL DEFAULT 'pending',
+                                sent_timestamp timestamp with time zone,
+                                delivered_timestamp timestamp with time zone,
+                                failed_timestamp timestamp with time zone,
+
+    -- Error tracking
+                                error_message text,
+
+    -- CHES specific fields
+                                ches_message_id uuid, -- CHES returns a message ID for tracking
+                                ches_transaction_id varchar(255), -- CHES transaction identifier
+
+    -- Audit fields
+                                create_user varchar(60) NOT NULL,
+                                create_timestamp timestamp with time zone DEFAULT now() NOT NULL,
+                                update_user varchar(60) NOT NULL,
+                                update_timestamp timestamp with time zone DEFAULT now() NOT NULL
+);
+
+-- Add comments for documentation
+COMMENT ON TABLE email_tracking IS 'Generic email tracking table for all entities using CHES service';
+COMMENT ON COLUMN email_tracking.reference_id IS 'UUID of the entity this email relates to (can reference any table)';
+COMMENT ON COLUMN email_tracking.reference_table IS 'Name of the table that the reference_id points to';
+COMMENT ON COLUMN email_tracking.reference_email_type IS 'Type of email this is (e.g. documents uploaded, submission confirmation, etc.).  Needed for non template emails to differentiate between email types';
+COMMENT ON COLUMN email_tracking.email_template_name IS 'Name/identifier of the email template used';
+COMMENT ON COLUMN email_tracking.recipient_email IS 'Email address of the recipient';
+COMMENT ON COLUMN email_tracking.email_status IS 'Current status of the email (enum: pending, accepted, sent, delivered, failed, bounced, cancelled, completed)';
+COMMENT ON COLUMN email_tracking.ches_message_id IS 'CHES service message identifier for tracking';
+COMMENT ON COLUMN email_tracking.ches_transaction_id IS 'CHES transaction identifier';
+
+-- Add comments for enum types
+COMMENT ON TYPE email_status_enum IS 'Email status values: sent (transmitted), accepted (by CHES), pending (queued), failed (permanent failure), cancelled (user cancelled), completed (final success state)';
+COMMENT ON TYPE recipient_type_enum IS 'Recipient type: primary, cc, bcc';
+
+-- Create indexes for performance
+CREATE INDEX idx_email_tracking_reference ON email_tracking(reference_id, reference_table);
+CREATE INDEX idx_email_tracking_status ON email_tracking(email_status);
+CREATE INDEX idx_email_tracking_template ON email_tracking(email_template_name);
+CREATE INDEX idx_email_tracking_recipient ON email_tracking(recipient_email);
+CREATE INDEX idx_email_tracking_sent_timestamp ON email_tracking(sent_timestamp);
+CREATE INDEX idx_email_tracking_ches_message_id ON email_tracking(ches_message_id);
+
+-- Create composite index for common query patterns
+CREATE INDEX idx_email_tracking_ref_status ON email_tracking(reference_id, reference_table, email_status);
+CREATE INDEX idx_email_tracking_template_status ON email_tracking(email_template_name, email_status);
+CREATE INDEX idx_email_tracking_table_status ON email_tracking(reference_table, email_status);

--- a/migrations/sql/V2025.09.23.09.45__create_email_tracking_table.sql
+++ b/migrations/sql/V2025.09.23.09.45__create_email_tracking_table.sql
@@ -49,7 +49,10 @@ CREATE TABLE email_tracking (
                                 create_user varchar(60) NOT NULL,
                                 create_timestamp timestamp with time zone DEFAULT now() NOT NULL,
                                 update_user varchar(60) NOT NULL,
-                                update_timestamp timestamp with time zone DEFAULT now() NOT NULL
+                                update_timestamp timestamp with time zone DEFAULT now() NOT NULL,
+
+                                retry_count integer DEFAULT 0,
+                                max_retries integer DEFAULT 3
 );
 
 -- Add comments for documentation

--- a/migrations/sql/V2025.09.23.09.45__create_email_tracking_table.sql
+++ b/migrations/sql/V2025.09.23.09.45__create_email_tracking_table.sql
@@ -43,7 +43,7 @@ CREATE TABLE email_tracking (
 
     -- CHES specific fields
                                 ches_message_id uuid, -- CHES returns a message ID for tracking
-                                ches_transaction_id varchar(255), -- CHES transaction identifier
+                                ches_transaction_id uuid, -- CHES transaction identifier
 
     -- Audit fields
                                 create_user varchar(60) NOT NULL,

--- a/migrations/sql/V2025.09.23.09.45__create_email_tracking_table.sql
+++ b/migrations/sql/V2025.09.23.09.45__create_email_tracking_table.sql
@@ -19,8 +19,8 @@ CREATE TABLE email_tracking (
                                 email_tracking_guid uuid DEFAULT gen_random_uuid() PRIMARY KEY,
 
     -- Generic reference to any entity this email relates to
-                                reference_id varchar NOT NULL,
-                                reference_table varchar(100) NOT NULL,
+                                reference_id varchar,
+                                reference_table varchar(100),
                                 reference_email_type varchar(100),
 
     -- Email content and template information

--- a/services/core-api/app/__init__.py
+++ b/services/core-api/app/__init__.py
@@ -129,7 +129,8 @@ def make_celery(app):
         beat_schedule=Config.CELERY_BEAT_SCHEDULE,
         beat_scheduler='redbeat.RedBeatScheduler',
         redbeat_redis_url=Config.CELERY_READBEAT_BROKER_URL,
-        redbeat_lock_key='core-api')
+        redbeat_lock_key='core-api',
+        imports=['app.api.email_tracking.email_status_tasks'])
 
     celery.steps['worker'].add(HealthCheckProbe)
 

--- a/services/core-api/app/api/email_tracking/email_status_tasks.py
+++ b/services/core-api/app/api/email_tracking/email_status_tasks.py
@@ -1,0 +1,113 @@
+from datetime import datetime, timezone
+from flask import current_app
+from celery import Task
+
+from app.api.email_tracking.models.email_tracking import EmailTracking, EmailStatus
+from app.api.services.email_service import EmailService
+from app.tasks.celery import celery
+
+
+class EmailTaskBase(Task):
+    def __call__(self, *args, **kwargs):
+        from app.tasks.celery_entrypoint import celery_app
+
+        with celery_app.app_context():
+            return Task.__call__(self, *args, **kwargs)
+
+
+@celery.task(base=EmailTaskBase, bind=True, max_retries=5, default_retry_delay=300)
+def poll_ches_email_status(self, ches_message_id):
+    """
+    Poll CHES API for email status and update tracking record.
+
+    Args:
+        ches_message_id: UUID string of the CHES message to check
+
+    Returns:
+        dict: Status update result
+    """
+    try:
+        # Find the email tracking record
+        tracking_record = EmailTracking.find_by_ches_message_id(ches_message_id)
+        if not tracking_record:
+            current_app.logger.error(f"No email tracking record found for CHES message ID: {ches_message_id}")
+            return {"status": "error", "message": "Tracking record not found"}
+
+        # Skip if email is already in a final state
+        if tracking_record.email_status in [EmailStatus.delivered, EmailStatus.completed, EmailStatus.failed, EmailStatus.cancelled]:
+            current_app.logger.info(f"Email {ches_message_id} already in final state: {tracking_record.email_status}")
+            return {"status": "complete", "message": f"Email already in final state: {tracking_record.email_status}"}
+
+        # Get status from CHES via EmailService
+        status_result = EmailService.get_ches_email_status(ches_message_id)
+
+        if status_result["status"] == "not_found":
+            # Don't retry for 404s, but don't mark as failed either
+            return status_result
+
+        if status_result["status"] == "unknown_status":
+            # Don't update for unknown statuses
+            return status_result
+
+        if status_result["status"] == "error":
+            # Will be handled by the exception block for retries
+            raise Exception(status_result["message"])
+
+        # Extract status information
+        ches_status = status_result["ches_status"]
+        new_status = status_result["email_status"]
+        ches_data = status_result["ches_data"]
+        updated_timestamp = status_result["updated_timestamp"]
+        if isinstance(updated_timestamp, int):
+            updated_timestamp = datetime.fromtimestamp(updated_timestamp / 1000, timezone.utc)
+
+        # Update tracking record if status has changed
+        if tracking_record.email_status != new_status:
+            current_app.logger.info(f"Updating email {ches_message_id} status from {tracking_record.email_status} to {new_status}")
+
+            # Update status with appropriate timestamp
+            if new_status == EmailStatus.delivered:
+                tracking_record.mark_as_delivered(updated_timestamp)
+            elif new_status == EmailStatus.failed:
+                # Extract error information from CHES response
+                smtp_response = ches_data.get('smtpResponse', {})
+                error_message = smtp_response.get('response', 'Email delivery failed')
+                tracking_record.mark_as_failed(error_message=error_message, increment_retry=False)
+            else:
+                # For accepted, pending, cancelled statuses
+                timestamp_field = None
+                if new_status == EmailStatus.accepted:
+                    # CHES accepted the message
+                    timestamp_field = 'sent_timestamp'
+
+                tracking_record.update_status(new_status, timestamp_field=timestamp_field)
+
+        # Schedule next poll if email is not in final state
+        if new_status in [EmailStatus.pending, EmailStatus.accepted, EmailStatus.sent]:
+            # Schedule next poll in 5 minutes
+            current_app.logger.info(f"Scheduling next poll for email {ches_message_id} in 5 minutes")
+            poll_ches_email_status.apply_async(args=[ches_message_id], countdown=300)
+        else:
+            current_app.logger.info(f"Email {ches_message_id} reached final status: {new_status}")
+
+        return {
+            "status": "success",
+            "message": f"Status updated to {new_status}",
+            "ches_status": ches_status,
+            "email_status": new_status.value
+        }
+
+    except Exception as exc:
+        current_app.logger.error(f"Error polling CHES status for {ches_message_id}: {str(exc)}")
+
+        # Retry connecting to CHES with exponential backoff
+        retry_count = self.request.retries
+        if retry_count < self.max_retries:
+            # Exponential backoff: 5min, 10min, 20min, 40min, 80min
+            retry_delay = 300 * (2 ** retry_count)
+            current_app.logger.info(f"Retrying CHES status poll for {ches_message_id} in {retry_delay} seconds (attempt {retry_count + 1}/{self.max_retries})")
+            raise self.retry(countdown=retry_delay, exc=exc)
+        else:
+            # (the email might have been delivered, we just can't verify it)
+            current_app.logger.error(f"Max retries reached for CHES status polling: {ches_message_id}")
+            return {"status": "error", "message": f"Max retries reached: {str(exc)}"}

--- a/services/core-api/app/api/email_tracking/email_status_tasks.py
+++ b/services/core-api/app/api/email_tracking/email_status_tasks.py
@@ -34,7 +34,7 @@ def poll_ches_email_status(self, ches_message_id):
             return {"status": "error", "message": "Tracking record not found"}
 
         # Skip if email is already in a final state
-        if tracking_record.email_status in [EmailStatus.delivered, EmailStatus.completed, EmailStatus.failed, EmailStatus.cancelled]:
+        if tracking_record.email_status in [EmailStatus.completed, EmailStatus.failed, EmailStatus.cancelled]:
             current_app.logger.info(f"Email {ches_message_id} already in final state: {tracking_record.email_status}")
             return {"status": "complete", "message": f"Email already in final state: {tracking_record.email_status}"}
 
@@ -66,7 +66,7 @@ def poll_ches_email_status(self, ches_message_id):
             current_app.logger.info(f"Updating email {ches_message_id} status from {tracking_record.email_status} to {new_status}")
 
             # Update status with appropriate timestamp
-            if new_status == EmailStatus.delivered:
+            if new_status == EmailStatus.completed:
                 tracking_record.mark_as_delivered(updated_timestamp)
             elif new_status == EmailStatus.failed:
                 # Extract error information from CHES response

--- a/services/core-api/app/api/email_tracking/email_status_tasks.py
+++ b/services/core-api/app/api/email_tracking/email_status_tasks.py
@@ -4,18 +4,11 @@ from celery import Task
 
 from app.api.email_tracking.models.email_tracking import EmailTracking, EmailStatus
 from app.api.services.email_service import EmailService
+from app.api.tasks.celery_task_base import TaskBase
 from app.tasks.celery import celery
 
 
-class EmailTaskBase(Task):
-    def __call__(self, *args, **kwargs):
-        from app.tasks.celery_entrypoint import celery_app
-
-        with celery_app.app_context():
-            return Task.__call__(self, *args, **kwargs)
-
-
-@celery.task(base=EmailTaskBase, bind=True, max_retries=5, default_retry_delay=300)
+@celery.task(base=TaskBase, bind=True, max_retries=5, default_retry_delay=300)
 def poll_ches_email_status(self, ches_message_id):
     """
     Poll CHES API for email status and update tracking record.
@@ -50,6 +43,7 @@ def poll_ches_email_status(self, ches_message_id):
             return status_result
 
         if status_result["status"] == "error":
+            current_app.logger.error(f"Error polling CHES status for {ches_message_id}: {status_result['message']}")
             # Will be handled by the exception block for retries
             raise Exception(status_result["message"])
 
@@ -86,7 +80,7 @@ def poll_ches_email_status(self, ches_message_id):
         if new_status in [EmailStatus.pending, EmailStatus.accepted, EmailStatus.sent]:
             # Schedule next poll in 5 minutes
             current_app.logger.info(f"Scheduling next poll for email {ches_message_id} in 5 minutes")
-            poll_ches_email_status.apply_async(args=[ches_message_id], countdown=300)
+            poll_ches_email_status.retry(args=[ches_message_id], countdown=300)
         else:
             current_app.logger.info(f"Email {ches_message_id} reached final status: {new_status}")
 

--- a/services/core-api/app/api/email_tracking/models/email_tracking.py
+++ b/services/core-api/app/api/email_tracking/models/email_tracking.py
@@ -36,8 +36,8 @@ class EmailTracking(AuditMixin, Base):
     email_tracking_guid = db.Column(UUID(as_uuid=True), primary_key=True, server_default=FetchedValue())
 
     # Generic reference to tracked entity
-    reference_id = db.Column(db.String(100), nullable=False)
-    reference_table = db.Column(db.String(100), nullable=False)
+    reference_id = db.Column(db.String(100), nullable=True)
+    reference_table = db.Column(db.String(100), nullable=True)
     reference_email_type = db.Column(db.String(255), nullable=True  )
 
     email_template_name = db.Column(db.String(255), nullable=True)

--- a/services/core-api/app/api/email_tracking/models/email_tracking.py
+++ b/services/core-api/app/api/email_tracking/models/email_tracking.py
@@ -1,0 +1,191 @@
+from datetime import timedelta, datetime, timezone
+from enum import Enum
+
+from pytz import utc
+from sqlalchemy import desc, and_
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.schema import FetchedValue
+from app.extensions import db
+from app.api.utils.models_mixins import AuditMixin, Base
+from flask import current_app
+
+
+class EmailStatus(Enum):
+    pending = 'pending'
+    accepted = 'accepted'
+    sent = 'sent'
+    delivered = 'delivered'
+    failed = 'failed'
+    bounced = 'bounced'
+    cancelled = 'cancelled'
+    completed = 'completed'
+
+    def __str__(self):
+        return self.value
+
+
+class RecipientType(Enum):
+    primary = 'primary'
+    cc = 'cc'
+    bcc = 'bcc'
+
+    def __str__(self):
+        return self.value
+
+
+class EmailTracking(AuditMixin, Base):
+    __tablename__ = "email_tracking"
+
+    email_tracking_id = db.Column(UUID(as_uuid=True), primary_key=True, server_default=FetchedValue())
+
+    # Generic reference to tracked entity
+    reference_id = db.Column(UUID(as_uuid=True), nullable=False)
+    reference_table = db.Column(db.String(100), nullable=False)
+    reference_email_type = db.Column(db.String(255), nullable=True  )
+
+    email_template_name = db.Column(db.String(255), nullable=True)
+    email_subject = db.Column(db.String(500))
+
+    recipient_email = db.Column(db.String(320), nullable=False)  # RFC 5321 max email length
+    recipient_name = db.Column(db.String(255))
+    recipient_type = db.Column(db.Enum(RecipientType), nullable=False, default=RecipientType.primary)
+
+    email_status = db.Column(db.Enum(EmailStatus), nullable=False, default=EmailStatus.pending)
+    sent_timestamp = db.Column(db.DateTime(timezone=True))
+    delivered_timestamp = db.Column(db.DateTime(timezone=True))
+    failed_timestamp = db.Column(db.DateTime(timezone=True))
+
+    error_message = db.Column(db.Text)
+
+    ches_message_id = db.Column(UUID(as_uuid=True))
+    ches_transaction_id = db.Column(db.String(255))
+
+    retry_count = db.Column(db.Integer, default=0)
+    max_retries = db.Column(db.Integer, default=3)
+
+    @classmethod
+    def create(cls,
+               reference_id,
+               reference_table,
+               reference_email_type,
+               email_template_name,
+               recipient_email,
+               email_subject=None,
+               recipient_name=None,
+               recipient_type=RecipientType.primary,
+               max_retries=3,
+               add_to_session=True):
+        new_email_tracking = cls(
+            reference_id=reference_id,
+            reference_table=reference_table,
+            reference_email_type=reference_email_type,
+            email_template_name=email_template_name,
+            recipient_email=recipient_email,
+            email_subject=email_subject,
+            recipient_name=recipient_name,
+            recipient_type=recipient_type,
+            max_retries=max_retries,
+            email_status=EmailStatus.pending
+        )
+
+        if add_to_session:
+            new_email_tracking.save()
+
+        return new_email_tracking
+
+    @classmethod
+    def find_all(cls,
+                 reference_id=None,
+                 reference_table=None,
+                 email_status=None,
+                 email_template_name=None,
+                 recipient_email=None):
+        query = cls.query.order_by(desc(cls.create_timestamp))
+
+        if reference_id:
+            query = query.filter_by(reference_id=reference_id)
+        if reference_table:
+            query = query.filter_by(reference_table=reference_table)
+        if email_status:
+            query = query.filter_by(email_status=email_status)
+        if email_template_name:
+            query = query.filter_by(email_template_name=email_template_name)
+        if recipient_email:
+            query = query.filter_by(recipient_email=recipient_email)
+
+        result = query.all()
+        return dict([('total', len(result)), ('records', result)])
+
+    @classmethod
+    def find_latest_by_reference(cls, reference_id, reference_table, email_reference_type):
+        """Find the latest email tracking record for a specific entity"""
+        query = cls.query.filter(
+            and_(
+                cls.reference_id == reference_id,
+                cls.reference_table == reference_table,
+                cls.reference_email_type == email_reference_type
+            )
+        ).order_by(desc(cls.create_timestamp))
+        return query.first()
+
+    @classmethod
+    def find_by_ches_message_id(cls, ches_message_id):
+        """Find email tracking record by CHES message ID"""
+        return cls.query.filter_by(ches_message_id=ches_message_id).first()
+
+    def update_status(self, status, timestamp_field=None, error_message=None, error_code=None):
+        """Update email status and related timestamp"""
+        self.email_status = status
+
+        if timestamp_field and hasattr(self, timestamp_field):
+            setattr(self, timestamp_field, db.func.now())
+
+        if error_message:
+            self.error_message = error_message
+        if error_code:
+            self.error_code = error_code
+
+        self.save()
+
+    def mark_as_sent(self, ches_message_id=None, ches_transaction_id=None):
+        """Mark email as sent"""
+        self.email_status = EmailStatus.sent
+        self.sent_timestamp = db.func.now()
+
+        if ches_message_id:
+            self.ches_message_id = ches_message_id
+        if ches_transaction_id:
+            self.ches_transaction_id = ches_transaction_id
+
+        self.save()
+
+    def mark_as_delivered(self, updated_timestamp=None):
+        """Mark email as delivered"""
+        self.email_status = EmailStatus.delivered
+        self.delivered_timestamp = updated_timestamp if updated_timestamp else db.func.now()
+        self.save()
+
+    def mark_as_failed(self, error_message=None, error_code=None, increment_retry=True, updated_timestamp=None):
+        """Mark email as failed"""
+        self.email_status = EmailStatus.failed
+        self.failed_timestamp = updated_timestamp if updated_timestamp else db.func.now()
+
+        if error_message:
+            self.error_message = error_message
+        if error_code:
+            self.error_code = error_code
+
+        if increment_retry:
+            self.retry_count += 1
+
+        self.save()
+
+    def update(self, **kwargs):
+        """Update email tracking record with provided kwargs"""
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+        self.save()
+
+    def check_email_sent_within_timeframe(self, timeframe=24):
+        """Check if email was sent within the timeframe in hours (default: 24)"""
+        return (self.sent_timestamp + timedelta(hours=timeframe)) > datetime.now(utc)

--- a/services/core-api/app/api/email_tracking/models/email_tracking.py
+++ b/services/core-api/app/api/email_tracking/models/email_tracking.py
@@ -10,14 +10,12 @@ from app.api.utils.models_mixins import AuditMixin, Base
 
 
 class EmailStatus(Enum):
-    pending = 'pending'
-    accepted = 'accepted'
     sent = 'sent'
-    delivered = 'delivered'
-    failed = 'failed'
-    bounced = 'bounced'
+    accepted = 'accepted'
     cancelled = 'cancelled'
     completed = 'completed'
+    pending = 'pending'
+    failed = 'failed'
 
     def __str__(self):
         return self.value

--- a/services/core-api/app/api/email_tracking/models/email_tracking.py
+++ b/services/core-api/app/api/email_tracking/models/email_tracking.py
@@ -7,7 +7,6 @@ from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.schema import FetchedValue
 from app.extensions import db
 from app.api.utils.models_mixins import AuditMixin, Base
-from flask import current_app
 
 
 class EmailStatus(Enum):
@@ -165,15 +164,13 @@ class EmailTracking(AuditMixin, Base):
         self.delivered_timestamp = updated_timestamp if updated_timestamp else db.func.now()
         self.save()
 
-    def mark_as_failed(self, error_message=None, error_code=None, increment_retry=True, updated_timestamp=None):
+    def mark_as_failed(self, error_message=None, increment_retry=True, updated_timestamp=None):
         """Mark email as failed"""
         self.email_status = EmailStatus.failed
         self.failed_timestamp = updated_timestamp if updated_timestamp else db.func.now()
 
         if error_message:
             self.error_message = error_message
-        if error_code:
-            self.error_code = error_code
 
         if increment_retry:
             self.retry_count += 1

--- a/services/core-api/app/api/email_tracking/models/email_tracking.py
+++ b/services/core-api/app/api/email_tracking/models/email_tracking.py
@@ -33,10 +33,10 @@ class RecipientType(Enum):
 class EmailTracking(AuditMixin, Base):
     __tablename__ = "email_tracking"
 
-    email_tracking_id = db.Column(UUID(as_uuid=True), primary_key=True, server_default=FetchedValue())
+    email_tracking_guid = db.Column(UUID(as_uuid=True), primary_key=True, server_default=FetchedValue())
 
     # Generic reference to tracked entity
-    reference_id = db.Column(UUID(as_uuid=True), nullable=False)
+    reference_id = db.Column(db.String(100), nullable=False)
     reference_table = db.Column(db.String(100), nullable=False)
     reference_email_type = db.Column(db.String(255), nullable=True  )
 
@@ -55,7 +55,7 @@ class EmailTracking(AuditMixin, Base):
     error_message = db.Column(db.Text)
 
     ches_message_id = db.Column(UUID(as_uuid=True))
-    ches_transaction_id = db.Column(db.String(255))
+    ches_transaction_id = db.Column(UUID(as_uuid=True))
 
     retry_count = db.Column(db.Integer, default=0)
     max_retries = db.Column(db.Integer, default=3)
@@ -98,9 +98,10 @@ class EmailTracking(AuditMixin, Base):
                  email_template_name=None,
                  recipient_email=None):
         query = cls.query.order_by(desc(cls.create_timestamp))
+        string_reference_id = str(reference_id) if reference_id else None
 
         if reference_id:
-            query = query.filter_by(reference_id=reference_id)
+            query = query.filter_by(reference_id=string_reference_id)
         if reference_table:
             query = query.filter_by(reference_table=reference_table)
         if email_status:
@@ -115,10 +116,11 @@ class EmailTracking(AuditMixin, Base):
 
     @classmethod
     def find_latest_by_reference(cls, reference_id, reference_table, email_reference_type):
+        string_reference_id = str(reference_id) if reference_id else None
         """Find the latest email tracking record for a specific entity"""
         query = cls.query.filter(
             and_(
-                cls.reference_id == reference_id,
+                cls.reference_id == string_reference_id,
                 cls.reference_table == reference_table,
                 cls.reference_email_type == email_reference_type
             )

--- a/services/core-api/app/api/email_tracking/models/email_tracking.py
+++ b/services/core-api/app/api/email_tracking/models/email_tracking.py
@@ -158,7 +158,7 @@ class EmailTracking(AuditMixin, Base):
 
     def mark_as_delivered(self, updated_timestamp=None):
         """Mark email as delivered"""
-        self.email_status = EmailStatus.delivered
+        self.email_status = EmailStatus.completed
         self.delivered_timestamp = updated_timestamp if updated_timestamp else db.func.now()
         self.save()
 

--- a/services/core-api/app/api/mines/permits/permit_conditions/tasks.py
+++ b/services/core-api/app/api/mines/permits/permit_conditions/tasks.py
@@ -1,20 +1,13 @@
 import csv
 import datetime
 import io
+
+from app.api.tasks.celery_task_base import TaskBase
 from app.cli_commands.export_permit_conditions import headers, export_permit_conditions
 from app.api.search.search.permit_search_service import PermitSearchService
 from app.tasks.celery import celery
-from celery import Task
 
-class PermitConditionTaskBase(Task):
-    def __call__(self, *args, **kwargs):
-        from app.tasks.celery_entrypoint import celery_app
-
-        # Make sure app context is set up when running the task so we can access the database
-        with celery_app.app_context():
-            return Task.__call__(self, *args, **kwargs)
-
-@celery.task(base=PermitConditionTaskBase)
+@celery.task(base=TaskBase)
 def export_and_index_permit_amendments(permit_amendment_guids, is_manual=False):
     """
     Export conditions for a permit amendment as a CSV file and index them in the search service.

--- a/services/core-api/app/api/projects/information_requirements_table/models/information_requirements_table.py
+++ b/services/core-api/app/api/projects/information_requirements_table/models/information_requirements_table.py
@@ -100,8 +100,7 @@ class InformationRequirementsTable(SoftDeleteMixin, AuditMixin, Base):
             body,
             reference_id=self.irt_guid,
             reference_table='information_requirements_table',
-            reference_email_type='irt_submit_email',
-            create_tracking_record=True
+            reference_email_type='irt_submit_email'
         )
 
     def send_irt_status_notifications(self, project_guid: str, status_code: str):
@@ -142,9 +141,7 @@ class InformationRequirementsTable(SoftDeleteMixin, AuditMixin, Base):
                 core_template,
                 project_context,
                 reference_id=self.irt_guid,
-                reference_table='information_requirements_table',
-                email_template_name='ministry_irt_status_notification',
-                create_tracking_record=True
+                reference_table='information_requirements_table'
             )
         if minespace_recipients != []:
             EmailService.send_template_email(
@@ -153,9 +150,7 @@ class InformationRequirementsTable(SoftDeleteMixin, AuditMixin, Base):
                 minespace_template,
                 project_context,
                 reference_id=self.irt_guid,
-                reference_table='information_requirements_table',
-                email_template_name='minespace_irt_status_notification',
-                create_tracking_record=True
+                reference_table='information_requirements_table'
             )
 
         mine = Mine.find_by_mine_guid(project.mine_guid)
@@ -180,8 +175,7 @@ class InformationRequirementsTable(SoftDeleteMixin, AuditMixin, Base):
             body,
             send_to_proponent=True,
             reference_id=self.irt_guid,
-            reference_table='information_requirements_table',
-            create_tracking_record=True
+            reference_table='information_requirements_table'
         )
 
     def update(self, irt_data, import_file=None, document_guid=None, add_to_session=True):

--- a/services/core-api/app/api/projects/information_requirements_table/models/information_requirements_table.py
+++ b/services/core-api/app/api/projects/information_requirements_table/models/information_requirements_table.py
@@ -94,7 +94,15 @@ class InformationRequirementsTable(SoftDeleteMixin, AuditMixin, Base):
 
         link = f'{Config.CORE_WEB_URL}/pre-applications/{self.project.project_guid}/information-requirements-table/{self.irt_guid}/intro-project-overview'
         body += f'<p>View IRT in Core: <a href="{link}" target="_blank">{link}</a></p>'
-        EmailService.send_email(subject, recipients, body)
+        EmailService.send_email(
+            subject,
+            recipients,
+            body,
+            reference_id=self.irt_guid,
+            reference_table='information_requirements_table',
+            reference_email_type='irt_submit_email',
+            create_tracking_record=True
+        )
 
     def send_irt_status_notifications(self, project_guid: str, status_code: str):
         project: Project = self.project
@@ -128,9 +136,27 @@ class InformationRequirementsTable(SoftDeleteMixin, AuditMixin, Base):
         subject = f'IRT Status Updated for {project.mine_name}:{project.project_title}'
 
         if core_recipients != []:
-            EmailService.send_template_email(subject, core_recipients, core_template, project_context)
+            EmailService.send_template_email(
+                subject,
+                core_recipients,
+                core_template,
+                project_context,
+                reference_id=self.irt_guid,
+                reference_table='information_requirements_table',
+                email_template_name='ministry_irt_status_notification',
+                create_tracking_record=True
+            )
         if minespace_recipients != []:
-            EmailService.send_template_email(subject, minespace_recipients, minespace_template, project_context)
+            EmailService.send_template_email(
+                subject,
+                minespace_recipients,
+                minespace_template,
+                project_context,
+                reference_id=self.irt_guid,
+                reference_table='information_requirements_table',
+                email_template_name='minespace_irt_status_notification',
+                create_tracking_record=True
+            )
 
         mine = Mine.find_by_mine_guid(project.mine_guid)
 
@@ -148,7 +174,15 @@ class InformationRequirementsTable(SoftDeleteMixin, AuditMixin, Base):
         body = f'<p>An IRT has been approved for {self.project.mine_name}:(Mine no: {self.project.mine_no})-{self.project.project_title}.</p>'
         body += f'<p>View IRT in Minespace: <a href="{link}" target="_blank">{link}</a></p>'
 
-        EmailService.send_email(subject, recipients, body, send_to_proponent=True)
+        EmailService.send_email(
+            subject,
+            recipients,
+            body,
+            send_to_proponent=True,
+            reference_id=self.irt_guid,
+            reference_table='information_requirements_table',
+            create_tracking_record=True
+        )
 
     def update(self, irt_data, import_file=None, document_guid=None, add_to_session=True):
         mine_doc = None

--- a/services/core-api/app/api/projects/major_mine_application/models/major_mine_application.py
+++ b/services/core-api/app/api/projects/major_mine_application/models/major_mine_application.py
@@ -122,8 +122,7 @@ class MajorMineApplication(SoftDeleteMixin, AuditMixin, Base):
             send_to_proponent=True,
             reference_id=self.major_mine_application_guid,
             reference_table='major_mine_application',
-            reference_email_type='mma_submit_email',
-            create_tracking_record=True
+            reference_email_type='mma_submit_email'
         )
 
     @classmethod
@@ -243,9 +242,7 @@ class MajorMineApplication(SoftDeleteMixin, AuditMixin, Base):
                 core_template,
                 context,
                 reference_id=self.major_mine_application_guid,
-                reference_table='major_mine_application',
-                email_template_name='ministry_project_section_email',
-                create_tracking_record=True
+                reference_table='major_mine_application'
             )
         if minespace_recipients != []:
             EmailService.send_template_email(
@@ -254,9 +251,7 @@ class MajorMineApplication(SoftDeleteMixin, AuditMixin, Base):
                 minespace_template,
                 context,
                 reference_id=self.major_mine_application_guid,
-                reference_table='major_mine_application',
-                email_template_name='minespace_project_section_email',
-                create_tracking_record=True
+                reference_table='major_mine_application'
             )
 
     def send_mma_status_notifications(self, status_code):
@@ -295,7 +290,6 @@ class MajorMineApplication(SoftDeleteMixin, AuditMixin, Base):
 
         extra_data = {'project': {'project_guid': str(self.project.project_guid)}}
         idempotency_key = f'{self.project_guid}-{self.major_mine_application_guid}'
-        print('SHOULD TRIGGER NOTIFICATIONS')
         trigger_notification(message, ActivityType.project_app_documents_updated, mine,
                              'MajorMineApplication', self.major_mine_application_guid, extra_data, idempotency_key,
                              ActivityRecipients.all_users, True, 24 * 60)

--- a/services/core-api/app/api/projects/major_mine_application/models/major_mine_application.py
+++ b/services/core-api/app/api/projects/major_mine_application/models/major_mine_application.py
@@ -6,6 +6,7 @@ from werkzeug.exceptions import NotFound
 from app.api.activity.models.activity_notification import ActivityType, ActivityRecipients
 from app.api.activity.utils import trigger_notification
 from app.api.constants import MAJOR_MINES_OFFICE_EMAIL
+from app.api.email_tracking.models.email_tracking import EmailTracking
 from app.api.mines.documents.models.mine_document import MineDocument
 from app.api.mines.documents.models.mine_document_bundle import MineDocumentBundle
 from app.api.mines.mine.models.mine import Mine
@@ -114,7 +115,16 @@ class MajorMineApplication(SoftDeleteMixin, AuditMixin, Base):
             body += f'<ul>{"".join(list(map(generate_list_element, supporting_documents)))}</ul>'
         body += f'<p>View Major Mine Application in Minespace: <a href="{link}" target="_blank">{link}</a></p>'
 
-        EmailService.send_email(subject, recipients, body, send_to_proponent=True)
+        EmailService.send_email(
+            subject,
+            recipients,
+            body,
+            send_to_proponent=True,
+            reference_id=self.major_mine_application_guid,
+            reference_table='major_mine_application',
+            reference_email_type='mma_submit_email',
+            create_tracking_record=True
+        )
 
     @classmethod
     def create(cls,
@@ -199,8 +209,8 @@ class MajorMineApplication(SoftDeleteMixin, AuditMixin, Base):
             doc.mine_document.delete(False)
         return super(MajorMineApplication, self).delete(commit)
 
-    def send_application_emails(self, status_code: str, project: Project, subject: str, message: str):
-        minespace_recipients = [contact.email for contact in project.contacts]
+    def send_application_emails(self, status_code: str, project: Project, subject: str, message: str, limit_minespace_resend: bool = False):
+        minespace_recipients = [contact.email for contact in project.contacts] if not limit_minespace_resend else []
         core_recipients = []
         if status_code not in ['CHR', 'UNR']:
             core_recipients.append(MAJOR_MINES_OFFICE_EMAIL)
@@ -227,9 +237,27 @@ class MajorMineApplication(SoftDeleteMixin, AuditMixin, Base):
         core_template = "email/projects/ministry_project_section_email.html"
 
         if core_recipients != []:
-            EmailService.send_template_email(subject, core_recipients, core_template, context)
+            EmailService.send_template_email(
+                subject,
+                core_recipients,
+                core_template,
+                context,
+                reference_id=self.major_mine_application_guid,
+                reference_table='major_mine_application',
+                email_template_name='ministry_project_section_email',
+                create_tracking_record=True
+            )
         if minespace_recipients != []:
-            EmailService.send_template_email(subject, minespace_recipients, minespace_template, context)
+            EmailService.send_template_email(
+                subject,
+                minespace_recipients,
+                minespace_template,
+                context,
+                reference_id=self.major_mine_application_guid,
+                reference_table='major_mine_application',
+                email_template_name='minespace_project_section_email',
+                create_tracking_record=True
+            )
 
     def send_mma_status_notifications(self, status_code):
             project: Project = self.project
@@ -253,7 +281,17 @@ class MajorMineApplication(SoftDeleteMixin, AuditMixin, Base):
         message = f'{message_start} been uploaded for the project {self.project.project_title} for {self.project.mine_name}.'
         subject = f'Application documents updated for {project.mine_name}:{project.project_title}'
 
-        self.send_application_emails(status_code, project, subject, message)
+        limit_minespace_resend = False
+        email_tracking: EmailTracking = EmailTracking.find_latest_by_reference(
+            reference_id=self.major_mine_application_guid,
+            reference_table='major_mine_application',
+            email_reference_type='ministry_project_section_email'
+        )
+        if email_tracking:
+            if email_tracking.check_email_sent_within_timeframe():
+                limit_minespace_resend = True
+
+        self.send_application_emails(status_code, project, subject, message, limit_minespace_resend)
 
         extra_data = {'project': {'project_guid': str(self.project.project_guid)}}
         idempotency_key = f'{self.project_guid}-{self.major_mine_application_guid}'

--- a/services/core-api/app/api/projects/project_summary/models/project_summary.py
+++ b/services/core-api/app/api/projects/project_summary/models/project_summary.py
@@ -1339,7 +1339,17 @@ class ProjectSummary(SoftDeleteMixin, AuditMixin, Base):
                     "message": message,
                     "core_project_summary_link": f'{Config.CORE_WEB_URL}/pre-applications/{self.project.project_guid}/overview'
                 }
-                EmailService.send_template_email(subject, email_recipients, ministry_template, ministry_context, cc=cc)
+                EmailService.send_template_email(
+                    subject,
+                    email_recipients,
+                    ministry_template,
+                    ministry_context,
+                    cc=cc,
+                    reference_id=self.project_summary_guid,
+                    reference_table='project_summary',
+                    email_template_name='ministry_project_summary_document_update',
+                    create_tracking_record=True
+                )
 
 
     def send_project_summary_email(self, mine, message) -> None:
@@ -1386,6 +1396,26 @@ class ProjectSummary(SoftDeleteMixin, AuditMixin, Base):
             "ema_auth_link": f'{Config.EMA_AUTH_LINK}',
         }
 
-        EmailService.send_template_email(subject, ministry_recipients, ministry_template, ministry_context, cc=cc)
+        EmailService.send_template_email(
+            subject,
+            ministry_recipients,
+            ministry_template,
+            ministry_context,
+            cc=cc,
+            reference_id=self.project_summary_guid,
+            reference_table='project_summary',
+            email_template_name='ministry_project_summary_notification',
+            create_tracking_record=True
+        )
         if send_ms_email:
-            EmailService.send_template_email(subject, minespace_recipients, minespace_template, minespace_context, cc=cc)
+            EmailService.send_template_email(
+                subject,
+                minespace_recipients,
+                minespace_template,
+                minespace_context,
+                cc=cc,
+                reference_id=self.project_summary_guid,
+                reference_table='project_summary',
+                email_template_name='minespace_project_summary_notification',
+                create_tracking_record=True
+            )

--- a/services/core-api/app/api/projects/project_summary/models/project_summary.py
+++ b/services/core-api/app/api/projects/project_summary/models/project_summary.py
@@ -1346,9 +1346,7 @@ class ProjectSummary(SoftDeleteMixin, AuditMixin, Base):
                     ministry_context,
                     cc=cc,
                     reference_id=self.project_summary_guid,
-                    reference_table='project_summary',
-                    email_template_name='ministry_project_summary_document_update',
-                    create_tracking_record=True
+                    reference_table='project_summary'
                 )
 
 
@@ -1403,9 +1401,7 @@ class ProjectSummary(SoftDeleteMixin, AuditMixin, Base):
             ministry_context,
             cc=cc,
             reference_id=self.project_summary_guid,
-            reference_table='project_summary',
-            email_template_name='ministry_project_summary_notification',
-            create_tracking_record=True
+            reference_table='project_summary'
         )
         if send_ms_email:
             EmailService.send_template_email(
@@ -1415,7 +1411,5 @@ class ProjectSummary(SoftDeleteMixin, AuditMixin, Base):
                 minespace_context,
                 cc=cc,
                 reference_id=self.project_summary_guid,
-                reference_table='project_summary',
-                email_template_name='minespace_project_summary_notification',
-                create_tracking_record=True
+                reference_table='project_summary'
             )

--- a/services/core-api/app/api/services/email_service.py
+++ b/services/core-api/app/api/services/email_service.py
@@ -4,9 +4,12 @@ import json
 from enum import Enum
 from flask import current_app
 
+from app.tasks.celery import celery
+
 from app.config import Config
 from app.api.constants import CORE_PURPLE_LOGO_BASE64_ENCODED, MINESPACE_LOGO_BASE64_ENCODED, BC_GOV_LOGO_BASE64_ENCODED
 from app.api.email_tracking.models.email_tracking import EmailTracking, EmailStatus, RecipientType
+from werkzeug.exceptions import BadRequest
 
 
 class EmailBodyType(Enum):
@@ -348,10 +351,9 @@ class EmailService():
 
             # Update tracking records with failure status
             if create_tracking_record:
-                error_code = str(resp.status_code)
                 error_message = resp_data.get('detail', 'Email send failed') if resp_data else 'Email send failed'
                 for tracking_record in tracking_records:
-                    tracking_record.mark_as_failed(error_message=error_message, error_code=error_code)
+                    tracking_record.mark_as_failed(error_message=error_message)
             return
 
         if create_tracking_record and resp_data:

--- a/services/core-api/app/api/services/email_service.py
+++ b/services/core-api/app/api/services/email_service.py
@@ -385,7 +385,7 @@ class EmailService():
                             reference_table=None,
                             reference_email_type=None,
                             email_template_name=None,
-                            create_tracking_record=True):
+                            create_tracking_record=False):
         '''Sends an email using Jinja2 template rendering.
 
         Args:

--- a/services/core-api/app/api/services/email_service.py
+++ b/services/core-api/app/api/services/email_service.py
@@ -1,3 +1,5 @@
+import os
+
 import requests
 import json
 
@@ -262,9 +264,7 @@ class EmailService():
                    # Email tracking parameters
                    reference_id=None,
                    reference_table=None,
-                   email_template_name=None,
-                   reference_email_type=None,
-                   create_tracking_record=False):
+                   reference_email_type=None):
         '''Sends an email.'''
 
         # Validate enum parameters.
@@ -292,22 +292,22 @@ class EmailService():
 
         # Create email tracking records before sending
         tracking_records = []
-        if create_tracking_record:
-            tracking_record_kwargs = {
-                'reference_id': reference_id,
-                'reference_table': reference_table,
-                'email_template_name': email_template_name,
-                'reference_email_type': reference_email_type,
-                'email_subject': subject,
-            }
 
-            # Create tracking records for all recipient types
-            tracking_records.extend(cls._create_tracking_records_for_recipients(
-                original_recipients, RecipientType.primary, tracking_record_kwargs))
-            tracking_records.extend(cls._create_tracking_records_for_recipients(
-                cc, RecipientType.cc, tracking_record_kwargs))
-            tracking_records.extend(cls._create_tracking_records_for_recipients(
-                bcc, RecipientType.bcc, tracking_record_kwargs))
+        tracking_record_kwargs = {
+            'reference_id': reference_id,
+            'reference_table': reference_table,
+            'email_template_name': None,
+            'reference_email_type': reference_email_type,
+            'email_subject': subject,
+        }
+
+        # Create tracking records for all recipient types
+        tracking_records.extend(cls._create_tracking_records_for_recipients(
+            original_recipients, RecipientType.primary, tracking_record_kwargs))
+        tracking_records.extend(cls._create_tracking_records_for_recipients(
+            cc, RecipientType.cc, tracking_record_kwargs))
+        tracking_records.extend(cls._create_tracking_records_for_recipients(
+            bcc, RecipientType.bcc, tracking_record_kwargs))
 
 
         EmailService.perform_health_check()
@@ -350,15 +350,14 @@ class EmailService():
             current_app.logger.error(message)
 
             # Update tracking records with failure status
-            if create_tracking_record:
-                error_message = resp_data.get('detail', 'Email send failed') if resp_data else 'Email send failed'
-                for tracking_record in tracking_records:
-                    tracking_record.mark_as_failed(error_message=error_message)
+            error_message = resp_data.get('detail', 'Email send failed') if resp_data else 'Email send failed'
+            for tracking_record in tracking_records:
+                tracking_record.mark_as_failed(error_message=error_message)
             return
 
-        if create_tracking_record and resp_data:
-            # Update tracking records with sent status
-            cls._handle_successful_email_response(resp_data, tracking_records)
+
+        # Update tracking records with sent status
+        cls._handle_successful_email_response(resp_data, tracking_records)
 
         current_app.logger.info(
             f'Common Services email request successful.\nEmail Subject: {subject}\nResponse: {resp_data}\nRecipients: {original_recipients}'
@@ -383,9 +382,7 @@ class EmailService():
                             # Email tracking parameters
                             reference_id=None,
                             reference_table=None,
-                            reference_email_type=None,
-                            email_template_name=None,
-                            create_tracking_record=False):
+                            reference_email_type=None):
         '''Sends an email using Jinja2 template rendering.
 
         Args:
@@ -400,10 +397,6 @@ class EmailService():
             raise Exception('Email encoding is invalid')
         if not priority in EmailPriority._value2member_map_:
             raise Exception('Email priority is invalid')
-
-        # Validate tracking parameters if tracking is enabled
-        if create_tracking_record and (not reference_id or not reference_table):
-            raise BadRequest('Email tracking requires reference_id and reference_table')
 
         # NOTE: Be careful when enabling emails in local/dev/test. You could possibly be sending spam emails!
         is_not_prod = Config.ENVIRONMENT_NAME != 'prod'
@@ -423,6 +416,8 @@ class EmailService():
         try:
             # Render template with Jinja2
             template = current_app.jinja_env.get_template(template_path)
+            file_name = os.path.basename(template_path)
+            email_template_name = os.path.splitext(file_name)[0]
 
             # Add logos to context for template rendering
             template_context = context.copy()
@@ -438,22 +433,22 @@ class EmailService():
 
         # Create email tracking records before sending
         tracking_records = []
-        if create_tracking_record:
-            tracking_record_kwargs = {
-                'reference_id': reference_id,
-                'reference_table': reference_table,
-                'email_template_name': email_template_name,
-                'reference_email_type': reference_email_type if reference_email_type else email_template_name,
-                'email_subject': subject,
-            }
 
-            # Create tracking records for all recipient types
-            tracking_records.extend(cls._create_tracking_records_for_recipients(
-                original_recipients, RecipientType.primary, tracking_record_kwargs))
-            tracking_records.extend(cls._create_tracking_records_for_recipients(
-                cc, RecipientType.cc, tracking_record_kwargs))
-            tracking_records.extend(cls._create_tracking_records_for_recipients(
-                bcc, RecipientType.bcc, tracking_record_kwargs))
+        tracking_record_kwargs = {
+            'reference_id': reference_id,
+            'reference_table': reference_table,
+            'email_template_name': email_template_name,
+            'reference_email_type': reference_email_type if reference_email_type else email_template_name,
+            'email_subject': subject,
+        }
+
+        # Create tracking records for all recipient types
+        tracking_records.extend(cls._create_tracking_records_for_recipients(
+            original_recipients, RecipientType.primary, tracking_record_kwargs))
+        tracking_records.extend(cls._create_tracking_records_for_recipients(
+            cc, RecipientType.cc, tracking_record_kwargs))
+        tracking_records.extend(cls._create_tracking_records_for_recipients(
+            bcc, RecipientType.bcc, tracking_record_kwargs))
 
         EmailService.perform_health_check()
 
@@ -488,16 +483,16 @@ class EmailService():
             current_app.logger.error(message)
 
             # Update tracking records with failure status
-            if create_tracking_record:
-                error_code = str(resp.status_code)
-                error_message = resp_data.get('detail', 'Template email send failed') if resp_data else 'Template email send failed'
-                for tracking_record in tracking_records:
-                    tracking_record.mark_as_failed(error_message=error_message, error_code=error_code)
+            error_code = str(resp.status_code)
+            error_message = resp_data.get('detail', 'Template email send failed') if resp_data else 'Template email send failed'
+
+            for tracking_record in tracking_records:
+                tracking_record.mark_as_failed(error_message=error_message, error_code=error_code)
             return
 
-        if create_tracking_record and resp_data:
-            # Update tracking records with sent status if applicable
-            cls._handle_successful_email_response(resp_data, tracking_records)
+
+        # Update tracking records with sent status if applicable
+        cls._handle_successful_email_response(resp_data, tracking_records)
 
         current_app.logger.info(
             f'Common Services email request successful.\nEmail Subject: {subject}\nResponse: {resp_data}\nRecipients: {original_recipients}'

--- a/services/core-api/app/api/services/email_service.py
+++ b/services/core-api/app/api/services/email_service.py
@@ -163,7 +163,7 @@ class EmailService():
             status_mapping = {
                 'accepted': EmailStatus.accepted,
                 'pending': EmailStatus.pending,
-                'completed': EmailStatus.delivered,
+                'completed': EmailStatus.completed,
                 'failed': EmailStatus.failed,
                 'cancelled': EmailStatus.cancelled
             }

--- a/services/core-api/app/api/services/email_service.py
+++ b/services/core-api/app/api/services/email_service.py
@@ -6,6 +6,7 @@ from flask import current_app
 
 from app.config import Config
 from app.api.constants import CORE_PURPLE_LOGO_BASE64_ENCODED, MINESPACE_LOGO_BASE64_ENCODED, BC_GOV_LOGO_BASE64_ENCODED
+from app.api.email_tracking.models.email_tracking import EmailTracking, EmailStatus, RecipientType
 
 
 class EmailBodyType(Enum):
@@ -112,6 +113,133 @@ class EmailService():
                 message = f'Common Services dependency "{name}" is not healthy and requests may be unsuccessful.\nInfo: {info}'
                 current_app.logger.warning(message)
 
+    @classmethod
+    def get_ches_email_status(cls, ches_message_id):
+        """
+        Get email status from CHES API for a given message ID.
+
+        Args:
+            ches_message_id: UUID string of the CHES message to check
+
+        Returns:
+            dict: Status response with status, ches_status, email_status, and message
+        """
+        try:
+            # Get auth token for CHES API
+            auth_token = cls.get_auth_token()
+            if not auth_token:
+                current_app.logger.error("Failed to get CHES auth token")
+                return {"status": "error", "message": "Failed to authenticate with CHES"}
+
+            # Call CHES status endpoint
+            url = f'{Config.COMMON_SERVICES_EMAIL_HOST}/status/{ches_message_id}'
+            headers = {'Authorization': f'Bearer {auth_token}'}
+
+            current_app.logger.info(f"Polling CHES status for message: {ches_message_id}")
+            resp = requests.get(url, headers=headers)
+
+            if resp.status_code == 404:
+                current_app.logger.warning(f"CHES message not found: {ches_message_id}")
+                return {"status": "not_found", "message": "Message not found in CHES"}
+
+            if resp.status_code != 200:
+                current_app.logger.error(f"CHES status request failed with status {resp.status_code}")
+                return {"status": "error", "message": f"CHES API returned status {resp.status_code}"}
+
+            try:
+                ches_data = resp.json()
+            except ValueError as e:
+                current_app.logger.error(f"Failed to parse CHES response JSON: {e}")
+                return {"status": "error", "message": "Invalid JSON response from CHES"}
+
+            # Map CHES status to our EmailStatus
+            ches_status = ches_data.get('status')
+            smtpResponse = ches_data.get('smtpResponse')
+            smptResponseMessage = smtpResponse.get('response') if smtpResponse else None
+
+            status_mapping = {
+                'accepted': EmailStatus.accepted,
+                'pending': EmailStatus.pending,
+                'completed': EmailStatus.delivered,
+                'failed': EmailStatus.failed,
+                'cancelled': EmailStatus.cancelled
+            }
+
+            if ches_status not in status_mapping:
+                current_app.logger.warning(f"Unknown CHES status: {ches_status}")
+                return {"status": "unknown_status", "message": f"Unknown CHES status: {ches_status}"}
+
+            email_status = status_mapping[ches_status]
+            updated_timestamp = ches_data.get('updatedTS')
+
+            return {
+                "updated_timestamp": updated_timestamp,
+                "status": "success",
+                "ches_status": ches_status,
+                "email_status": email_status,
+                "ches_data": ches_data,
+                "message": smptResponseMessage if smptResponseMessage else f"Status retrieved: {ches_status}"
+            }
+
+        except Exception as exc:
+            current_app.logger.error(f"Error getting CHES status for {ches_message_id}: {str(exc)}")
+            return {"status": "error", "message": str(exc)}
+
+    @classmethod
+    def _handle_successful_email_response(cls, resp_data, tracking_records):
+        """
+        Helper method to handle successful email responses from CHES.
+        Updates tracking records and schedules status polling tasks.
+        """
+
+        # Extract messages array from CHES response
+        messages = resp_data.get('messages', [])
+
+        if messages:
+            # CHES returns one message object per email send
+            message = messages[0]
+            ches_message_id = message.get('msgId')
+            ches_transaction_id = resp_data.get('txId')
+
+            # Update all tracking records with the same CHES IDs
+            for tracking_record in tracking_records:
+                tracking_record.mark_as_sent(
+                    ches_message_id=ches_message_id,
+                    ches_transaction_id=ches_transaction_id
+                )
+
+            if ches_message_id:
+                # Schedule a status polling task in 1 minute
+                try:
+                    celery.send_task('app.api.email_tracking.email_status_tasks.poll_ches_email_status',
+                                     args=[ches_message_id],
+                                     countdown=60)
+                except Exception as e:
+                    current_app.logger.error(f"Failed to schedule status polling task: {str(e)}")
+
+    @classmethod
+    def _create_tracking_records_for_recipients(cls, recipients, recipient_type, tracking_record_kwargs):
+        """
+        Helper method to create tracking records for a list of recipients of a specific type.
+
+        Args:
+            recipients: List of recipient email addresses
+            recipient_type: RecipientType enum value (primary, cc, bcc)
+            tracking_record_kwargs: Dictionary of common tracking record parameters
+
+        Returns:
+            List of created EmailTracking records
+        """
+        tracking_records = []
+        for recipient_email in recipients:
+            tracking_record = EmailTracking.create(
+                recipient_email=recipient_email,
+                recipient_type=recipient_type,
+                **tracking_record_kwargs
+            )
+            tracking_records.append(tracking_record)
+        return tracking_records
+
     # NOTE: See here for details: https://ches.nrs.gov.bc.ca/api/v1/docs#tag/Email
     @classmethod
     def send_email(cls,
@@ -127,7 +255,13 @@ class EmailService():
                    encoding=EmailEncoding.UTF8.value,
                    priority=EmailPriority.NORMAL.value,
                    tag=None,
-                   send_to_proponent=False):
+                   send_to_proponent=False,
+                   # Email tracking parameters
+                   reference_id=None,
+                   reference_table=None,
+                   email_template_name=None,
+                   reference_email_type=None,
+                   create_tracking_record=False):
         '''Sends an email.'''
 
         # Validate enum parameters.
@@ -152,6 +286,26 @@ class EmailService():
 
         if Config.EMAIL_RECIPIENT_OVERRIDE:
             recipients = [Config.EMAIL_RECIPIENT_OVERRIDE]
+
+        # Create email tracking records before sending
+        tracking_records = []
+        if create_tracking_record:
+            tracking_record_kwargs = {
+                'reference_id': reference_id,
+                'reference_table': reference_table,
+                'email_template_name': email_template_name,
+                'reference_email_type': reference_email_type,
+                'email_subject': subject,
+            }
+
+            # Create tracking records for all recipient types
+            tracking_records.extend(cls._create_tracking_records_for_recipients(
+                original_recipients, RecipientType.primary, tracking_record_kwargs))
+            tracking_records.extend(cls._create_tracking_records_for_recipients(
+                cc, RecipientType.cc, tracking_record_kwargs))
+            tracking_records.extend(cls._create_tracking_records_for_recipients(
+                bcc, RecipientType.bcc, tracking_record_kwargs))
+
 
         EmailService.perform_health_check()
 
@@ -191,7 +345,18 @@ class EmailService():
                 message += f'\nError: {resp_data.get("title")}\nDescription: {resp_data.get("detail")}'
                 current_app.logger.debug(resp_data)
             current_app.logger.error(message)
+
+            # Update tracking records with failure status
+            if create_tracking_record:
+                error_code = str(resp.status_code)
+                error_message = resp_data.get('detail', 'Email send failed') if resp_data else 'Email send failed'
+                for tracking_record in tracking_records:
+                    tracking_record.mark_as_failed(error_message=error_message, error_code=error_code)
             return
+
+        if create_tracking_record and resp_data:
+            # Update tracking records with sent status
+            cls._handle_successful_email_response(resp_data, tracking_records)
 
         current_app.logger.info(
             f'Common Services email request successful.\nEmail Subject: {subject}\nResponse: {resp_data}\nRecipients: {original_recipients}'
@@ -212,14 +377,20 @@ class EmailService():
                             delay=0,
                             encoding=EmailEncoding.UTF8.value,
                             priority=EmailPriority.NORMAL.value,
-                            tag=None):
+                            tag=None,
+                            # Email tracking parameters
+                            reference_id=None,
+                            reference_table=None,
+                            reference_email_type=None,
+                            email_template_name=None,
+                            create_tracking_record=True):
         '''Sends an email using Jinja2 template rendering.
-        
+
         Args:
             template_path: Path to a Jinja2 template (e.g., "email/report_error/core_error_report_email.html")
             context: Dictionary of variables to pass to the template
         '''
-        
+
         # Validate enum parameters.
         if not body_type in EmailBodyType._value2member_map_:
             raise Exception('Email body type is invalid')
@@ -227,6 +398,10 @@ class EmailService():
             raise Exception('Email encoding is invalid')
         if not priority in EmailPriority._value2member_map_:
             raise Exception('Email priority is invalid')
+
+        # Validate tracking parameters if tracking is enabled
+        if create_tracking_record and (not reference_id or not reference_table):
+            raise BadRequest('Email tracking requires reference_id and reference_table')
 
         # NOTE: Be careful when enabling emails in local/dev/test. You could possibly be sending spam emails!
         is_not_prod = Config.ENVIRONMENT_NAME != 'prod'
@@ -246,18 +421,37 @@ class EmailService():
         try:
             # Render template with Jinja2
             template = current_app.jinja_env.get_template(template_path)
-            
+
             # Add logos to context for template rendering
             template_context = context.copy()
             template_context['bc_gov_logo'] = BC_GOV_LOGO_BASE64_ENCODED
             template_context['core_logo'] = CORE_PURPLE_LOGO_BASE64_ENCODED
             template_context['minespace_logo'] = MINESPACE_LOGO_BASE64_ENCODED
-            
+
             rendered_body = template.render(**template_context)
-            
+
         except Exception as e:
             current_app.logger.error(f"Error rendering template {template_path}: {e}")
             raise Exception(f"Template rendering failed: {e}")
+
+        # Create email tracking records before sending
+        tracking_records = []
+        if create_tracking_record:
+            tracking_record_kwargs = {
+                'reference_id': reference_id,
+                'reference_table': reference_table,
+                'email_template_name': email_template_name,
+                'reference_email_type': reference_email_type if reference_email_type else email_template_name,
+                'email_subject': subject,
+            }
+
+            # Create tracking records for all recipient types
+            tracking_records.extend(cls._create_tracking_records_for_recipients(
+                original_recipients, RecipientType.primary, tracking_record_kwargs))
+            tracking_records.extend(cls._create_tracking_records_for_recipients(
+                cc, RecipientType.cc, tracking_record_kwargs))
+            tracking_records.extend(cls._create_tracking_records_for_recipients(
+                bcc, RecipientType.bcc, tracking_record_kwargs))
 
         EmailService.perform_health_check()
 
@@ -290,7 +484,18 @@ class EmailService():
                 message += f'\nError: {resp_data.get("title")}\nDescription: {resp_data.get("detail")}'
                 current_app.logger.debug(resp_data)
             current_app.logger.error(message)
+
+            # Update tracking records with failure status
+            if create_tracking_record:
+                error_code = str(resp.status_code)
+                error_message = resp_data.get('detail', 'Template email send failed') if resp_data else 'Template email send failed'
+                for tracking_record in tracking_records:
+                    tracking_record.mark_as_failed(error_message=error_message, error_code=error_code)
             return
+
+        if create_tracking_record and resp_data:
+            # Update tracking records with sent status if applicable
+            cls._handle_successful_email_response(resp_data, tracking_records)
 
         current_app.logger.info(
             f'Common Services email request successful.\nEmail Subject: {subject}\nResponse: {resp_data}\nRecipients: {original_recipients}'

--- a/services/core-api/app/api/tasks/celery_task_base.py
+++ b/services/core-api/app/api/tasks/celery_task_base.py
@@ -1,0 +1,8 @@
+from celery import Task
+
+class TaskBase(Task):
+    def __call__(self, *args, **kwargs):
+        from app.tasks.celery_entrypoint import celery_app
+
+        with celery_app.app_context():
+            return Task.__call__(self, *args, **kwargs)

--- a/services/core-api/tests/email/test_email_service_integration.py
+++ b/services/core-api/tests/email/test_email_service_integration.py
@@ -12,7 +12,7 @@ from app.api.services.email_service import EmailService
 @patch('app.config.Config.EMAIL_ENABLED', True)
 @patch('app.config.Config.ENVIRONMENT_NAME', 'test')
 @patch('app.config.Config.EMAIL_RECIPIENT_OVERRIDE', 'test@example.com')
-def test_send_template_email_renders_jinja2_templates_correctly(mock_health_check, mock_get_auth_token, mock_post, test_client):
+def test_send_template_email_renders_jinja2_templates_correctly(mock_health_check, mock_get_auth_token, mock_post, test_client, db_session):
     # Mock the HTTP response
     mock_response = MagicMock()
     mock_response.status_code = 201  # requests.codes.created
@@ -66,7 +66,7 @@ def test_send_template_email_renders_jinja2_templates_correctly(mock_health_chec
 @patch('app.config.Config.EMAIL_ENABLED', True)
 @patch('app.config.Config.ENVIRONMENT_NAME', 'test')
 @patch('app.config.Config.EMAIL_RECIPIENT_OVERRIDE', 'test@example.com')
-def test_minespace_template_renders_with_correct_branding(mock_health_check, mock_get_auth_token, mock_post, test_client):
+def test_minespace_template_renders_with_correct_branding(mock_health_check, mock_get_auth_token, mock_post, test_client, db_session):
     # Mock the HTTP response
     mock_response = MagicMock()
     mock_response.status_code = 201
@@ -115,7 +115,7 @@ def test_minespace_template_renders_with_correct_branding(mock_health_check, moc
 @patch('app.config.Config.EMAIL_ENABLED', True)
 @patch('app.config.Config.ENVIRONMENT_NAME', 'test')
 @patch('app.config.Config.EMAIL_RECIPIENT_OVERRIDE', 'test@example.com')
-def test_logos_and_brand_colors_injected_automatically(mock_health_check, mock_get_auth_token, mock_post, test_client):
+def test_logos_and_brand_colors_injected_automatically(mock_health_check, mock_get_auth_token, mock_post, test_client, db_session):
     # Mock the HTTP response
     mock_response = MagicMock()
     mock_response.status_code = 201

--- a/services/core-api/tests/email_tracking/test_email_tracking.py
+++ b/services/core-api/tests/email_tracking/test_email_tracking.py
@@ -7,10 +7,9 @@ from tests.factories import EmailTrackingFactory, MajorMineApplicationFactory, P
 
 
 def test_email_tracking_create(db_session):
-    """Test creating an EmailTracking record"""
     email_tracking = EmailTrackingFactory()
 
-    assert email_tracking.email_tracking_id is not None
+    assert email_tracking.email_tracking_guid is not None
     assert email_tracking.reference_id is not None
     assert email_tracking.reference_table == 'major_mine_application'
     assert email_tracking.recipient_email is not None
@@ -18,7 +17,6 @@ def test_email_tracking_create(db_session):
 
 
 def test_email_tracking_create_class_method(db_session):
-    """Test the create class method"""
     mma = MajorMineApplicationFactory()
 
     email_tracking = EmailTracking.create(
@@ -32,7 +30,7 @@ def test_email_tracking_create_class_method(db_session):
         recipient_type=RecipientType.primary
     )
 
-    assert email_tracking.reference_id == mma.major_mine_application_guid
+    assert email_tracking.reference_id == str(mma.major_mine_application_guid)
     assert email_tracking.reference_table == 'major_mine_application'
     assert email_tracking.reference_email_type == 'mma_submit_email'
     assert email_tracking.email_template_name == 'submit_confirmation'
@@ -44,7 +42,6 @@ def test_email_tracking_create_class_method(db_session):
 
 
 def test_email_tracking_find_all(db_session):
-    """Test finding all email tracking records with filters"""
     mma = MajorMineApplicationFactory()
 
     # Create multiple tracking records
@@ -81,7 +78,6 @@ def test_email_tracking_find_all(db_session):
 
 
 def test_email_tracking_find_latest_by_reference(db_session):
-    """Test finding the latest email tracking record for a specific entity"""
     mma = MajorMineApplicationFactory()
 
     # Create multiple records for the same reference
@@ -105,23 +101,21 @@ def test_email_tracking_find_latest_by_reference(db_session):
     )
 
     assert latest is not None
-    assert latest.email_tracking_id == email2.email_tracking_id
+    assert latest.email_tracking_guid == email2.email_tracking_guid
 
 
 def test_email_tracking_find_by_ches_message_id(db_session):
-    """Test finding email tracking record by CHES message ID"""
     ches_message_id = uuid.uuid4()
     email_tracking = EmailTrackingFactory(ches_message_id=ches_message_id)
 
     found = EmailTracking.find_by_ches_message_id(ches_message_id)
 
     assert found is not None
-    assert found.email_tracking_id == email_tracking.email_tracking_id
+    assert found.email_tracking_guid == email_tracking.email_tracking_guid
     assert found.ches_message_id == ches_message_id
 
 
 def test_email_tracking_update_status(db_session):
-    """Test updating email status"""
     email_tracking = EmailTrackingFactory()
 
     email_tracking.update_status(
@@ -136,7 +130,6 @@ def test_email_tracking_update_status(db_session):
 
 
 def test_email_tracking_mark_as_sent(db_session):
-    """Test marking email as sent"""
     email_tracking = EmailTrackingFactory()
     ches_message_id = uuid.uuid4()
     ches_transaction_id = uuid.uuid4()
@@ -153,7 +146,6 @@ def test_email_tracking_mark_as_sent(db_session):
 
 
 def test_email_tracking_mark_as_delivered(db_session):
-    """Test marking email as delivered"""
     email_tracking = EmailTrackingFactory(sent=True)
 
     email_tracking.mark_as_delivered()
@@ -163,7 +155,6 @@ def test_email_tracking_mark_as_delivered(db_session):
 
 
 def test_email_tracking_mark_as_failed(db_session):
-    """Test marking email as failed"""
     email_tracking = EmailTrackingFactory()
     error_message = 'Delivery failed'
 
@@ -175,7 +166,6 @@ def test_email_tracking_mark_as_failed(db_session):
     assert email_tracking.retry_count == 1
 
 def test_email_tracking_update(db_session):
-    """Test updating email tracking record with kwargs"""
     email_tracking = EmailTrackingFactory()
 
     email_tracking.update(
@@ -189,7 +179,6 @@ def test_email_tracking_update(db_session):
     assert email_tracking.retry_count == 2
 
 def test_email_tracking_check_email_sent_within_timeframe(db_session):
-    """Test checking if email was sent within timeframe"""
     # Create an email that was sent 12 hours ago
     past_time = datetime.now(utc) - timedelta(hours=12)
     email_tracking = EmailTrackingFactory(
@@ -204,7 +193,6 @@ def test_email_tracking_check_email_sent_within_timeframe(db_session):
     assert email_tracking.check_email_sent_within_timeframe(6) == False
 
 def test_email_tracking_different_recipient_types(db_session):
-    """Test creating email tracking records with different recipient types"""
     mma = MajorMineApplicationFactory()
 
     primary = EmailTrackingFactory(
@@ -225,7 +213,6 @@ def test_email_tracking_different_recipient_types(db_session):
     assert bcc.recipient_type == RecipientType.bcc
 
 def test_email_tracking_with_project_summary_reference(db_session):
-    """Test email tracking with project summary reference"""
     project_summary = ProjectSummaryFactory()
 
     email_tracking = EmailTrackingFactory(

--- a/services/core-api/tests/email_tracking/test_email_tracking.py
+++ b/services/core-api/tests/email_tracking/test_email_tracking.py
@@ -1,0 +1,297 @@
+import pytest
+from datetime import datetime, timedelta
+from pytz import utc
+
+from tests.factories import EmailTrackingFactory, MajorMineApplicationFactory, ProjectSummaryFactory
+from app.api.email_tracking.models.email_tracking import EmailTracking, EmailStatus, RecipientType
+
+
+def test_email_tracking_create(db_session):
+    """Test creating an EmailTracking record"""
+    email_tracking = EmailTrackingFactory()
+
+    assert email_tracking.email_tracking_id is not None
+    assert email_tracking.reference_id is not None
+    assert email_tracking.reference_table == 'major_mine_application'
+    assert email_tracking.recipient_email is not None
+    assert email_tracking.email_status == EmailStatus.pending
+
+
+def test_email_tracking_create_class_method(db_session):
+    """Test the create class method"""
+    mma = MajorMineApplicationFactory()
+
+    email_tracking = EmailTracking.create(
+        reference_id=mma.major_mine_application_guid,
+        reference_table='major_mine_application',
+        reference_email_type='mma_submit_email',
+        email_template_name='submit_confirmation',
+        recipient_email='test@example.com',
+        email_subject='Test Subject',
+        recipient_name='Test User',
+        recipient_type=RecipientType.primary
+    )
+
+    assert email_tracking.reference_id == mma.major_mine_application_guid
+    assert email_tracking.reference_table == 'major_mine_application'
+    assert email_tracking.reference_email_type == 'mma_submit_email'
+    assert email_tracking.email_template_name == 'submit_confirmation'
+    assert email_tracking.recipient_email == 'test@example.com'
+    assert email_tracking.email_subject == 'Test Subject'
+    assert email_tracking.recipient_name == 'Test User'
+    assert email_tracking.recipient_type == RecipientType.primary
+    assert email_tracking.email_status == EmailStatus.pending
+
+
+def test_email_tracking_find_all(db_session):
+    """Test finding all email tracking records with filters"""
+    mma = MajorMineApplicationFactory()
+
+    # Create multiple tracking records
+    email1 = EmailTrackingFactory(
+        reference_id=mma.major_mine_application_guid,
+        reference_table='major_mine_application',
+        email_status=EmailStatus.sent
+    )
+    email2 = EmailTrackingFactory(
+        reference_id=mma.major_mine_application_guid,
+        reference_table='major_mine_application',
+        email_status=EmailStatus.pending
+    )
+    email3 = EmailTrackingFactory(
+        reference_table='project_summary',
+        email_status=EmailStatus.delivered
+    )
+
+    # Test finding all records
+    result = EmailTracking.find_all()
+    assert result['total'] >= 3
+
+    # Test filtering by reference_id
+    result = EmailTracking.find_all(reference_id=mma.major_mine_application_guid)
+    assert result['total'] == 2
+
+    # Test filtering by reference_table
+    result = EmailTracking.find_all(reference_table='major_mine_application')
+    assert result['total'] == 2
+
+    # Test filtering by email_status
+    result = EmailTracking.find_all(email_status=EmailStatus.sent)
+    assert result['total'] >= 1
+
+
+def test_email_tracking_find_latest_by_reference(db_session):
+    """Test finding the latest email tracking record for a specific entity"""
+    mma = MajorMineApplicationFactory()
+
+    # Create multiple records for the same reference
+    email1 = EmailTrackingFactory(
+        reference_id=mma.major_mine_application_guid,
+        reference_table='major_mine_application',
+        reference_email_type='mma_submit_email'
+    )
+
+    # Create a newer record
+    email2 = EmailTrackingFactory(
+        reference_id=mma.major_mine_application_guid,
+        reference_table='major_mine_application',
+        reference_email_type='mma_submit_email'
+    )
+
+    latest = EmailTracking.find_latest_by_reference(
+        reference_id=mma.major_mine_application_guid,
+        reference_table='major_mine_application',
+        email_reference_type='mma_submit_email'
+    )
+
+    assert latest is not None
+    assert latest.email_tracking_id == email2.email_tracking_id
+
+
+def test_email_tracking_find_by_ches_message_id(db_session):
+    """Test finding email tracking record by CHES message ID"""
+    ches_message_id = 'test-ches-message-id'
+    email_tracking = EmailTrackingFactory(ches_message_id=ches_message_id)
+
+    found = EmailTracking.find_by_ches_message_id(ches_message_id)
+
+    assert found is not None
+    assert found.email_tracking_id == email_tracking.email_tracking_id
+    assert found.ches_message_id == ches_message_id
+
+
+def test_email_tracking_update_status(db_session):
+    """Test updating email status"""
+    email_tracking = EmailTrackingFactory()
+
+    email_tracking.update_status(
+        status=EmailStatus.sent,
+        timestamp_field='sent_timestamp',
+        error_message=None,
+        error_code=None
+    )
+
+    assert email_tracking.email_status == EmailStatus.sent
+    assert email_tracking.sent_timestamp is not None
+
+
+def test_email_tracking_mark_as_sent(db_session):
+    """Test marking email as sent"""
+    email_tracking = EmailTrackingFactory()
+    ches_message_id = 'test-message-id'
+    ches_transaction_id = 'test-transaction-id'
+
+    email_tracking.mark_as_sent(
+        ches_message_id=ches_message_id,
+        ches_transaction_id=ches_transaction_id
+    )
+
+    assert email_tracking.email_status == EmailStatus.sent
+    assert email_tracking.sent_timestamp is not None
+    assert email_tracking.ches_message_id == ches_message_id
+    assert email_tracking.ches_transaction_id == ches_transaction_id
+
+
+def test_email_tracking_mark_as_delivered(db_session):
+    """Test marking email as delivered"""
+    email_tracking = EmailTrackingFactory(sent=True)
+
+    email_tracking.mark_as_delivered()
+
+    assert email_tracking.email_status == EmailStatus.delivered
+    assert email_tracking.delivered_timestamp is not None
+
+
+def test_email_tracking_mark_as_failed(db_session):
+    """Test marking email as failed"""
+    email_tracking = EmailTrackingFactory()
+    error_message = 'Delivery failed'
+    error_code = '500'
+
+    email_tracking.mark_as_failed(
+        error_message=error_message,
+        error_code=error_code
+    )
+
+    assert email_tracking.email_status == EmailStatus.failed
+    assert email_tracking.failed_timestamp is not None
+    assert email_tracking.error_message == error_message
+    assert email_tracking.error_code == error_code
+    assert email_tracking.retry_count == 1
+
+
+def test_email_tracking_mark_as_failed_no_retry_increment(db_session):
+    """Test marking email as failed without incrementing retry count"""
+    email_tracking = EmailTrackingFactory()
+    initial_retry_count = email_tracking.retry_count
+
+    email_tracking.mark_as_failed(
+        error_message='Test error',
+        increment_retry=False
+    )
+
+    assert email_tracking.email_status == EmailStatus.failed
+    assert email_tracking.retry_count == initial_retry_count
+
+
+def test_email_tracking_update(db_session):
+    """Test updating email tracking record with kwargs"""
+    email_tracking = EmailTrackingFactory()
+
+    email_tracking.update(
+        email_status=EmailStatus.delivered,
+        recipient_name='Updated Name',
+        retry_count=2
+    )
+
+    assert email_tracking.email_status == EmailStatus.delivered
+    assert email_tracking.recipient_name == 'Updated Name'
+    assert email_tracking.retry_count == 2
+
+
+def test_email_tracking_check_email_sent_within_timeframe(db_session):
+    """Test checking if email was sent within timeframe"""
+    # Create an email that was sent 12 hours ago
+    past_time = datetime.now(utc) - timedelta(hours=12)
+    email_tracking = EmailTrackingFactory(
+        sent=True,
+        sent_timestamp=past_time
+    )
+
+    # Should be within 24 hour timeframe
+    assert email_tracking.check_email_sent_within_timeframe(24) == True
+
+    # Should not be within 6 hour timeframe
+    assert email_tracking.check_email_sent_within_timeframe(6) == False
+
+
+def test_email_tracking_check_email_sent_within_timeframe_no_sent_timestamp(db_session):
+    """Test checking timeframe when no sent timestamp exists"""
+    email_tracking = EmailTrackingFactory(email_status=EmailStatus.pending)
+
+    # Should handle None sent_timestamp gracefully
+    with pytest.raises(TypeError):
+        email_tracking.check_email_sent_within_timeframe(24)
+
+
+def test_email_tracking_different_recipient_types(db_session):
+    """Test creating email tracking records with different recipient types"""
+    mma = MajorMineApplicationFactory()
+
+    primary = EmailTrackingFactory(
+        reference_id=mma.major_mine_application_guid,
+        recipient_type=RecipientType.primary
+    )
+    cc = EmailTrackingFactory(
+        reference_id=mma.major_mine_application_guid,
+        recipient_type=RecipientType.cc
+    )
+    bcc = EmailTrackingFactory(
+        reference_id=mma.major_mine_application_guid,
+        recipient_type=RecipientType.bcc
+    )
+
+    assert primary.recipient_type == RecipientType.primary
+    assert cc.recipient_type == RecipientType.cc
+    assert bcc.recipient_type == RecipientType.bcc
+
+
+def test_email_tracking_different_email_statuses(db_session):
+    """Test creating email tracking records with different statuses"""
+    pending = EmailTrackingFactory(email_status=EmailStatus.pending)
+    sent = EmailTrackingFactory(sent=True)
+    delivered = EmailTrackingFactory(delivered=True)
+    failed = EmailTrackingFactory(failed=True)
+
+    assert pending.email_status == EmailStatus.pending
+    assert sent.email_status == EmailStatus.sent
+    assert delivered.email_status == EmailStatus.delivered
+    assert failed.email_status == EmailStatus.failed
+
+
+def test_email_tracking_with_project_summary_reference(db_session):
+    """Test email tracking with project summary reference"""
+    project_summary = ProjectSummaryFactory()
+
+    email_tracking = EmailTrackingFactory(
+        reference_id=project_summary.project_summary_guid,
+        reference_table='project_summary',
+        reference_email_type='status_update'
+    )
+
+    assert email_tracking.reference_id == project_summary.project_summary_guid
+    assert email_tracking.reference_table == 'project_summary'
+    assert email_tracking.reference_email_type == 'status_update'
+
+
+def test_email_tracking_retry_logic(db_session):
+    """Test retry logic for failed emails"""
+    email_tracking = EmailTrackingFactory(max_retries=3)
+
+    # Fail the email multiple times
+    for i in range(4):
+        email_tracking.mark_as_failed(error_message=f'Attempt {i+1} failed')
+
+    assert email_tracking.retry_count == 4
+    assert email_tracking.retry_count > email_tracking.max_retries
+    assert email_tracking.email_status == EmailStatus.failed

--- a/services/core-api/tests/email_tracking/test_email_tracking.py
+++ b/services/core-api/tests/email_tracking/test_email_tracking.py
@@ -1,9 +1,11 @@
-import pytest
+import uuid
 from datetime import datetime, timedelta
+
+import pytest
 from pytz import utc
 
-from tests.factories import EmailTrackingFactory, MajorMineApplicationFactory, ProjectSummaryFactory
 from app.api.email_tracking.models.email_tracking import EmailTracking, EmailStatus, RecipientType
+from tests.factories import EmailTrackingFactory, MajorMineApplicationFactory, ProjectSummaryFactory
 
 
 def test_email_tracking_create(db_session):
@@ -110,7 +112,7 @@ def test_email_tracking_find_latest_by_reference(db_session):
 
 def test_email_tracking_find_by_ches_message_id(db_session):
     """Test finding email tracking record by CHES message ID"""
-    ches_message_id = 'test-ches-message-id'
+    ches_message_id = uuid.uuid4()
     email_tracking = EmailTrackingFactory(ches_message_id=ches_message_id)
 
     found = EmailTracking.find_by_ches_message_id(ches_message_id)
@@ -138,8 +140,8 @@ def test_email_tracking_update_status(db_session):
 def test_email_tracking_mark_as_sent(db_session):
     """Test marking email as sent"""
     email_tracking = EmailTrackingFactory()
-    ches_message_id = 'test-message-id'
-    ches_transaction_id = 'test-transaction-id'
+    ches_message_id = uuid.uuid4()
+    ches_transaction_id = uuid.uuid4()
 
     email_tracking.mark_as_sent(
         ches_message_id=ches_message_id,
@@ -166,33 +168,13 @@ def test_email_tracking_mark_as_failed(db_session):
     """Test marking email as failed"""
     email_tracking = EmailTrackingFactory()
     error_message = 'Delivery failed'
-    error_code = '500'
 
-    email_tracking.mark_as_failed(
-        error_message=error_message,
-        error_code=error_code
-    )
+    email_tracking.mark_as_failed(error_message=error_message)
 
     assert email_tracking.email_status == EmailStatus.failed
     assert email_tracking.failed_timestamp is not None
     assert email_tracking.error_message == error_message
-    assert email_tracking.error_code == error_code
     assert email_tracking.retry_count == 1
-
-
-def test_email_tracking_mark_as_failed_no_retry_increment(db_session):
-    """Test marking email as failed without incrementing retry count"""
-    email_tracking = EmailTrackingFactory()
-    initial_retry_count = email_tracking.retry_count
-
-    email_tracking.mark_as_failed(
-        error_message='Test error',
-        increment_retry=False
-    )
-
-    assert email_tracking.email_status == EmailStatus.failed
-    assert email_tracking.retry_count == initial_retry_count
-
 
 def test_email_tracking_update(db_session):
     """Test updating email tracking record with kwargs"""
@@ -207,7 +189,6 @@ def test_email_tracking_update(db_session):
     assert email_tracking.email_status == EmailStatus.delivered
     assert email_tracking.recipient_name == 'Updated Name'
     assert email_tracking.retry_count == 2
-
 
 def test_email_tracking_check_email_sent_within_timeframe(db_session):
     """Test checking if email was sent within timeframe"""
@@ -255,20 +236,6 @@ def test_email_tracking_different_recipient_types(db_session):
     assert cc.recipient_type == RecipientType.cc
     assert bcc.recipient_type == RecipientType.bcc
 
-
-def test_email_tracking_different_email_statuses(db_session):
-    """Test creating email tracking records with different statuses"""
-    pending = EmailTrackingFactory(email_status=EmailStatus.pending)
-    sent = EmailTrackingFactory(sent=True)
-    delivered = EmailTrackingFactory(delivered=True)
-    failed = EmailTrackingFactory(failed=True)
-
-    assert pending.email_status == EmailStatus.pending
-    assert sent.email_status == EmailStatus.sent
-    assert delivered.email_status == EmailStatus.delivered
-    assert failed.email_status == EmailStatus.failed
-
-
 def test_email_tracking_with_project_summary_reference(db_session):
     """Test email tracking with project summary reference"""
     project_summary = ProjectSummaryFactory()
@@ -282,16 +249,3 @@ def test_email_tracking_with_project_summary_reference(db_session):
     assert email_tracking.reference_id == project_summary.project_summary_guid
     assert email_tracking.reference_table == 'project_summary'
     assert email_tracking.reference_email_type == 'status_update'
-
-
-def test_email_tracking_retry_logic(db_session):
-    """Test retry logic for failed emails"""
-    email_tracking = EmailTrackingFactory(max_retries=3)
-
-    # Fail the email multiple times
-    for i in range(4):
-        email_tracking.mark_as_failed(error_message=f'Attempt {i+1} failed')
-
-    assert email_tracking.retry_count == 4
-    assert email_tracking.retry_count > email_tracking.max_retries
-    assert email_tracking.email_status == EmailStatus.failed

--- a/services/core-api/tests/email_tracking/test_email_tracking.py
+++ b/services/core-api/tests/email_tracking/test_email_tracking.py
@@ -1,7 +1,5 @@
 import uuid
 from datetime import datetime, timedelta
-
-import pytest
 from pytz import utc
 
 from app.api.email_tracking.models.email_tracking import EmailTracking, EmailStatus, RecipientType

--- a/services/core-api/tests/email_tracking/test_email_tracking.py
+++ b/services/core-api/tests/email_tracking/test_email_tracking.py
@@ -158,7 +158,7 @@ def test_email_tracking_mark_as_delivered(db_session):
 
     email_tracking.mark_as_delivered()
 
-    assert email_tracking.email_status == EmailStatus.delivered
+    assert email_tracking.email_status == EmailStatus.completed
     assert email_tracking.delivered_timestamp is not None
 
 
@@ -179,12 +179,12 @@ def test_email_tracking_update(db_session):
     email_tracking = EmailTrackingFactory()
 
     email_tracking.update(
-        email_status=EmailStatus.delivered,
+        email_status=EmailStatus.completed,
         recipient_name='Updated Name',
         retry_count=2
     )
 
-    assert email_tracking.email_status == EmailStatus.delivered
+    assert email_tracking.email_status == EmailStatus.completed
     assert email_tracking.recipient_name == 'Updated Name'
     assert email_tracking.retry_count == 2
 
@@ -202,16 +202,6 @@ def test_email_tracking_check_email_sent_within_timeframe(db_session):
 
     # Should not be within 6 hour timeframe
     assert email_tracking.check_email_sent_within_timeframe(6) == False
-
-
-def test_email_tracking_check_email_sent_within_timeframe_no_sent_timestamp(db_session):
-    """Test checking timeframe when no sent timestamp exists"""
-    email_tracking = EmailTrackingFactory(email_status=EmailStatus.pending)
-
-    # Should handle None sent_timestamp gracefully
-    with pytest.raises(TypeError):
-        email_tracking.check_email_sent_within_timeframe(24)
-
 
 def test_email_tracking_different_recipient_types(db_session):
     """Test creating email tracking records with different recipient types"""

--- a/services/core-api/tests/email_tracking/test_email_tracking.py
+++ b/services/core-api/tests/email_tracking/test_email_tracking.py
@@ -62,7 +62,7 @@ def test_email_tracking_find_all(db_session):
     )
     email3 = EmailTrackingFactory(
         reference_table='project_summary',
-        email_status=EmailStatus.delivered
+        email_status=EmailStatus.completed
     )
 
     # Test finding all records

--- a/services/core-api/tests/factories.py
+++ b/services/core-api/tests/factories.py
@@ -2068,7 +2068,6 @@ class EmailTrackingFactory(BaseFactory):
     delivered_timestamp = None
     failed_timestamp = None
     error_message = None
-    error_code = None
     ches_message_id = GUID
     ches_transaction_id = GUID
     retry_count = 0

--- a/services/core-api/tests/factories.py
+++ b/services/core-api/tests/factories.py
@@ -2046,7 +2046,7 @@ class EmailTrackingFactory(BaseFactory):
             error_code='500'
         )
 
-    email_tracking_id = GUID
+    email_tracking_guid = GUID
     reference_id = factory.SelfAttribute('major_mine_application.major_mine_application_guid')
     reference_table = 'major_mine_application'
     reference_email_type = factory.LazyFunction(lambda: random.choice([

--- a/services/core-api/tests/factories.py
+++ b/services/core-api/tests/factories.py
@@ -2035,7 +2035,7 @@ class EmailTrackingFactory(BaseFactory):
             sent_timestamp=TODAY
         )
         delivered = factory.Trait(
-            email_status=EmailStatus.delivered,
+            email_status=EmailStatus.completed,
             sent_timestamp=TODAY,
             delivered_timestamp=TODAY
         )

--- a/services/core-api/tests/factories.py
+++ b/services/core-api/tests/factories.py
@@ -134,6 +134,7 @@ from app.extensions import db
 from pytz import timezone, utc
 from tests.mines import permit
 from tests.status_code_gen import *
+from app.api.email_tracking.models.email_tracking import EmailTracking, EmailStatus, RecipientType
 
 GUID = factory.LazyFunction(uuid.uuid4)
 TODAY = factory.LazyFunction(datetime.now)
@@ -2018,3 +2019,57 @@ class AmsFinalApplicationFactory(BaseFactory):
 
         AmsFinalApplicationDocumentXrefFactory.create_batch(
             size=extracted, ams_final_application=obj, mine_document__mine=None, **kwargs)
+
+class EmailTrackingFactory(BaseFactory):
+
+    class Meta:
+        model = EmailTracking
+
+    class Params:
+        major_mine_application = factory.SubFactory('tests.factories.MajorMineApplicationFactory')
+        project_summary = factory.SubFactory('tests.factories.ProjectSummaryFactory')
+
+        # Email status traits
+        sent = factory.Trait(
+            email_status=EmailStatus.sent,
+            sent_timestamp=TODAY
+        )
+        delivered = factory.Trait(
+            email_status=EmailStatus.delivered,
+            sent_timestamp=TODAY,
+            delivered_timestamp=TODAY
+        )
+        failed = factory.Trait(
+            email_status=EmailStatus.failed,
+            failed_timestamp=TODAY,
+            error_message='Email delivery failed',
+            error_code='500'
+        )
+
+    email_tracking_id = GUID
+    reference_id = factory.SelfAttribute('major_mine_application.major_mine_application_guid')
+    reference_table = 'major_mine_application'
+    reference_email_type = factory.LazyFunction(lambda: random.choice([
+        'mma_submit_email',
+        'ministry_project_section_email',
+        'minespace_project_section_email'
+    ]))
+    email_template_name = factory.LazyFunction(lambda: random.choice([
+        'ministry_project_section_email',
+        'minespace_project_section_email',
+        'mma_submit_email'
+    ]))
+    email_subject = factory.Faker('sentence', nb_words=6)
+    recipient_email = factory.Faker('email')
+    recipient_name = factory.Faker('name')
+    recipient_type = RecipientType.primary
+    email_status = EmailStatus.pending
+    sent_timestamp = None
+    delivered_timestamp = None
+    failed_timestamp = None
+    error_message = None
+    error_code = None
+    ches_message_id = GUID
+    ches_transaction_id = GUID
+    retry_count = 0
+    max_retries = 3

--- a/services/core-api/tests/projects/information_requirements_table/resources/test_information_requirements_table_notifications.py
+++ b/services/core-api/tests/projects/information_requirements_table/resources/test_information_requirements_table_notifications.py
@@ -51,15 +51,23 @@ def test_information_requirements_table_notifications(mock_send_template_email, 
     expected_calls = [
         call(
             subject,
-            minespace_recipients,
-            "email/projects/minespace_project_section_email.html",
-            context
+            [MAJOR_MINES_OFFICE_EMAIL, project.project_lead.email],
+            "email/projects/ministry_project_section_email.html",
+            context,
+            reference_id=irt.irt_guid,
+            reference_table='information_requirements_table',
+            email_template_name='ministry_irt_status_notification',
+            create_tracking_record=True
         ),
         call(
             subject,
-            [MAJOR_MINES_OFFICE_EMAIL, project.project_lead.email],
-            "email/projects/ministry_project_section_email.html",
-            context
+            minespace_recipients,
+            "email/projects/minespace_project_section_email.html",
+            context,
+            reference_id=irt.irt_guid,
+            reference_table='information_requirements_table',
+            email_template_name='minespace_irt_status_notification',
+            create_tracking_record=True
         )
     ]
 

--- a/services/core-api/tests/projects/information_requirements_table/resources/test_information_requirements_table_notifications.py
+++ b/services/core-api/tests/projects/information_requirements_table/resources/test_information_requirements_table_notifications.py
@@ -55,9 +55,7 @@ def test_information_requirements_table_notifications(mock_send_template_email, 
             "email/projects/ministry_project_section_email.html",
             context,
             reference_id=irt.irt_guid,
-            reference_table='information_requirements_table',
-            email_template_name='ministry_irt_status_notification',
-            create_tracking_record=True
+            reference_table='information_requirements_table'
         ),
         call(
             subject,
@@ -65,9 +63,7 @@ def test_information_requirements_table_notifications(mock_send_template_email, 
             "email/projects/minespace_project_section_email.html",
             context,
             reference_id=irt.irt_guid,
-            reference_table='information_requirements_table',
-            email_template_name='minespace_irt_status_notification',
-            create_tracking_record=True
+            reference_table='information_requirements_table'
         )
     ]
 

--- a/services/core-api/tests/projects/major_mines_application/resources/test_application_emails.py
+++ b/services/core-api/tests/projects/major_mines_application/resources/test_application_emails.py
@@ -83,19 +83,31 @@ def test_major_mine_application_notifications(mock_send_template_email, mock_tri
                     'project_title': project.project_title,
                     'submitted': format_datetime_to_string(major_mine_application.update_timestamp)
                 }
-            }
+            },
+            reference_id=major_mine_application.major_mine_application_guid,
+            reference_table='major_mine_application',
+            email_template_name='minespace_project_section_email',
+            create_tracking_record=True
         ),
         call(
             document_subject,
             [MAJOR_MINES_OFFICE_EMAIL, project.project_lead.email],
             "email/projects/ministry_project_section_email.html",
-            document_context
+            document_context,
+            reference_id=major_mine_application.major_mine_application_guid,
+            reference_table='major_mine_application',
+            email_template_name='ministry_project_section_email',
+            create_tracking_record=True
         ),
         call(
             document_subject,
             minespace_recipients,
             "email/projects/minespace_project_section_email.html",
-            document_context
+            document_context,
+            reference_id=major_mine_application.major_mine_application_guid,
+            reference_table='major_mine_application',
+            email_template_name='minespace_project_section_email',
+            create_tracking_record=True
         )
     ]
 

--- a/services/core-api/tests/projects/major_mines_application/resources/test_application_emails.py
+++ b/services/core-api/tests/projects/major_mines_application/resources/test_application_emails.py
@@ -85,9 +85,7 @@ def test_major_mine_application_notifications(mock_send_template_email, mock_tri
                 }
             },
             reference_id=major_mine_application.major_mine_application_guid,
-            reference_table='major_mine_application',
-            email_template_name='minespace_project_section_email',
-            create_tracking_record=True
+            reference_table='major_mine_application'
         ),
         call(
             document_subject,
@@ -95,9 +93,7 @@ def test_major_mine_application_notifications(mock_send_template_email, mock_tri
             "email/projects/ministry_project_section_email.html",
             document_context,
             reference_id=major_mine_application.major_mine_application_guid,
-            reference_table='major_mine_application',
-            email_template_name='ministry_project_section_email',
-            create_tracking_record=True
+            reference_table='major_mine_application'
         ),
         call(
             document_subject,
@@ -105,9 +101,7 @@ def test_major_mine_application_notifications(mock_send_template_email, mock_tri
             "email/projects/minespace_project_section_email.html",
             document_context,
             reference_id=major_mine_application.major_mine_application_guid,
-            reference_table='major_mine_application',
-            email_template_name='minespace_project_section_email',
-            create_tracking_record=True
+            reference_table='major_mine_application'
         )
     ]
 

--- a/services/core-api/tests/projects/project_summaries/resources/test_project_summary_emails.py
+++ b/services/core-api/tests/projects/project_summaries/resources/test_project_summary_emails.py
@@ -50,8 +50,7 @@ def test_sub_to_asg(mock_send_template_email, test_client, db_session, auth_head
         cc=[MDS_EMAIL],
         reference_id=project_summary.project_summary_guid,
         reference_table='project_summary',
-        email_template_name='ministry_project_summary_notification',
-        create_tracking_record=True
+
     )
 
     assert put_resp.status_code == 200

--- a/services/core-api/tests/projects/project_summaries/resources/test_project_summary_emails.py
+++ b/services/core-api/tests/projects/project_summaries/resources/test_project_summary_emails.py
@@ -42,7 +42,17 @@ def test_sub_to_asg(mock_send_template_email, test_client, db_session, auth_head
         }
     
     # ARGS: subject, recipients, body, context, cc (ignore comparison with ANY)
-    ministry_call = call(f'Project Description Notification for {project_summary.mine_name}', ANY, ANY, ministry_context, cc=[MDS_EMAIL])
+    ministry_call = call(
+        f'Project Description Notification for {project_summary.mine_name}',
+        ANY,
+        ANY,
+        ministry_context,
+        cc=[MDS_EMAIL],
+        reference_id=project_summary.project_summary_guid,
+        reference_table='project_summary',
+        email_template_name='ministry_project_summary_notification',
+        create_tracking_record=True
+    )
 
     assert put_resp.status_code == 200
     calls = [ministry_call]


### PR DESCRIPTION
## Objective 

Implement the ability to track the status of emails that have sent through CHES. 

- Added a new table `email_tracking`
  - Created as a generic so this could be used by any other existing entity and referenced
  - Added Tracking for the status of the send, various timestamps and tracking ids
  - Tracks the template name if this is a template email and a reference_email_type for non templates
- Added a celery task that will poll CHES for the status of email messages
- Integrated the email_tracking into the email_service if a track_email boolean is passed when initiating a send
- Updated documents flow for major applications so that it will only notify Minespace users of document updates once every 24 hours.

[MDS-6632](https://bcmines.atlassian.net/browse/MDS-6632)

_Why are you making this change? Provide a short explanation and/or screenshots_
