### PR TITLE
[MDS-6434] Report management page revamp

### DIFF
--- a/services/common/src/components/permits/PermitConditionCategory.tsx
+++ b/services/common/src/components/permits/PermitConditionCategory.tsx
@@ -64,7 +64,7 @@ export const EditPermitConditionCategoryInline: FC<IPermitConditionCategoryProps
   if (!isEditMode) {
     return (
       <Tooltip title="Click to edit">
-        <div onClick={enableEditMode} onKeyDown={enableEditMode}>
+        <div data-title="Click to edit" onClick={enableEditMode} onKeyDown={enableEditMode}>
           {titleElement}
         </div>
       </Tooltip>

--- a/services/common/src/interfaces/reports/mineReportParams.interface.ts
+++ b/services/common/src/interfaces/reports/mineReportParams.interface.ts
@@ -12,7 +12,7 @@ export interface MineReportParams {
   status?: string[];
   sort_field?: string;
   sort_dir?: string;
-  mine_reports_type?: string;
+  mine_reports_type?: string | string[];
   permit_guid?: string;
   page?: string;
   per_page?: string;

--- a/services/common/src/redux/actionCreators/reportActionCreator.ts
+++ b/services/common/src/redux/actionCreators/reportActionCreator.ts
@@ -53,18 +53,20 @@ export const createMineReport = (mineGuid, payload) => (dispatch) => {
 
 export const fetchMineReports = (
   mineGuid,
-  reportsType = Strings.MINE_REPORTS_TYPE.codeRequiredReports,
+  reportsType: string | string[] = Strings.MINE_REPORTS_TYPE.codeRequiredReports,
   params = {}
 ) => (dispatch) => {
   dispatch(mineReportActions.clearMineReports());
   dispatch(request(NetworkReducerTypes.GET_MINE_REPORTS));
   dispatch(showLoading());
   const filteredParams = removeNullValues(params);
+  // Allow multiple mine_reports_type values; if array, pass as-is so query-string serializes repeats
+  const mineReportsTypeParam = Array.isArray(reportsType) ? reportsType : reportsType;
   return CustomAxios()
     .get(
       `${ENVIRONMENT.apiUrl}${API.MINE_REPORTS(mineGuid, {
         ...filteredParams,
-        mine_reports_type: reportsType,
+        mine_reports_type: mineReportsTypeParam,
       })}`,
       createRequestHeader()
     )

--- a/services/common/src/redux/actionCreators/reportActionCreator.ts
+++ b/services/common/src/redux/actionCreators/reportActionCreator.ts
@@ -60,13 +60,12 @@ export const fetchMineReports = (
   dispatch(request(NetworkReducerTypes.GET_MINE_REPORTS));
   dispatch(showLoading());
   const filteredParams = removeNullValues(params);
-  // Allow multiple mine_reports_type values; if array, pass as-is so query-string serializes repeats
-  const mineReportsTypeParam = Array.isArray(reportsType) ? reportsType : reportsType;
+
   return CustomAxios()
     .get(
       `${ENVIRONMENT.apiUrl}${API.MINE_REPORTS(mineGuid, {
         ...filteredParams,
-        mine_reports_type: mineReportsTypeParam,
+        mine_reports_type: reportsType,
       })}`,
       createRequestHeader()
     )

--- a/services/common/src/tests/permits/PermitConditionViewEdit.spec.tsx
+++ b/services/common/src/tests/permits/PermitConditionViewEdit.spec.tsx
@@ -1,0 +1,166 @@
+import React from "react";
+import { render, fireEvent, screen, waitFor } from "@testing-library/react";
+import { ReduxWrapper } from "@mds/common/tests/utils/ReduxWrapper";
+import * as MOCK from "@mds/common/tests/mocks/dataMocks";
+import { PERMITS, STATIC_CONTENT } from "@mds/common/constants/reducerTypes";
+import PermitConditionViewEdit from "@mds/common/components/permits/PermitConditionViewEdit";
+import { PermitConditionsProvider } from "@mds/common/components/permits/PermitConditionsContext";
+import { FORM } from "@mds/common/constants/forms";
+import { Feature } from "@mds/common/utils/featureFlag";
+
+// We will mock the feature flag hook so we can toggle features deterministically
+jest.mock("@mds/common/providers/featureFlags/useFeatureFlag", () => ({
+    useFeatureFlag: () => ({
+        isFeatureEnabled: (f: Feature) => {
+            // Always enable modify permit conditions so tests focus on component logic
+            if (f === Feature.MODIFY_PERMIT_CONDITIONS) return true;
+            if (f === Feature.PERMIT_CONDITION_TAGS) return true;
+            return true;
+        }
+    })
+}));
+
+// Minimal formatted categories derived from mocks (reuse first amendment category + first condition)
+const amendment = MOCK.PERMITS[0].permit_amendments[0];
+const baseCategory = amendment.condition_categories[0];
+const firstCondition = amendment.conditions.find(c => c.condition_category_code === baseCategory.condition_category_code);
+
+// IMPORTANT: condition_category must include condition_category_code for permission logic
+const formattedCategories = [
+    {
+        href: baseCategory.condition_category_code,
+        condition_category: {
+            condition_category_code: baseCategory.condition_category_code,
+            description: baseCategory.description,
+            step: baseCategory.step,
+            display_order: baseCategory.display_order ?? 0,
+        },
+        conditions: [firstCondition],
+        condition_category_code: baseCategory.condition_category_code,
+        step: baseCategory.step,
+        description: baseCategory.description,
+        title: `${baseCategory.step} ${baseCategory.description}`,
+    }
+];
+
+const initialState = {
+    [PERMITS]: {
+        permits: MOCK.PERMITS,
+        latestPermitAmendments: { [MOCK.PERMITS[0].permit_guid]: amendment },
+        permitConditionTags: MOCK.PERMIT_CONDITION_TAGS,
+    },
+    [STATIC_CONTENT]: MOCK.BULK_STATIC_CONTENT_RESPONSE,
+};
+
+const providerValue = {
+    mineGuid: MOCK.PERMITS[0].mine_guid,
+    permitGuid: MOCK.PERMITS[0].permit_guid,
+    currentAmendment: amendment,
+    latestAmendment: amendment,
+    previousAmendment: MOCK.PERMITS[0].permit_amendments[1],
+    loading: false,
+    setLoading: jest.fn(),
+    refreshData: jest.fn().mockResolvedValue(undefined),
+    isStandardConditionEditor: false,
+    isNowEditor: false,
+};
+
+describe("PermitConditionViewEdit", () => {
+    it("renders category and condition with edit controls enabled when userCanEdit + review assignment", () => {
+        const setEditingFormName = jest.fn();
+        const { container } = render(
+            <ReduxWrapper initialState={initialState}>
+                <PermitConditionsProvider value={providerValue}>
+                    <PermitConditionViewEdit
+                        userCanEdit
+                        formattedCategories={formattedCategories as any}
+                        isExtracted
+                        userReviewCategoryCodes={[baseCategory.condition_category_code]}
+                        editingFormName={""}
+                        setEditingFormName={setEditingFormName}
+                        addingToCategoryCode={null}
+                        setAddingToCategoryCode={jest.fn()}
+                    />
+                </PermitConditionsProvider>
+            </ReduxWrapper>
+        );
+
+        // Add Condition button visible
+        expect(screen.getByText("Add Condition")).toBeInTheDocument();
+
+        // Category inline edit (title has aria button with title 'Click to edit')
+        const editCategory = container.querySelector('[title="Click to edit"]');
+        expect(editCategory).toBeInTheDocument();
+
+        // Condition edit button has aria-label starting with Edit Condition
+        const editConditionButton = container.querySelector('[aria-label^="Edit Condition"]');
+        expect(editConditionButton).toBeInTheDocument();
+    });
+
+    it("hides edit actions when user cannot edit or not assigned", () => {
+        render(
+            <ReduxWrapper initialState={initialState}>
+                <PermitConditionsProvider value={providerValue}>
+                    <PermitConditionViewEdit
+                        userCanEdit={false}
+                        formattedCategories={formattedCategories as any}
+                        isExtracted
+                        userReviewCategoryCodes={[]}
+                        editingFormName={""}
+                        setEditingFormName={jest.fn()}
+                        addingToCategoryCode={null}
+                        setAddingToCategoryCode={jest.fn()}
+                    />
+                </PermitConditionsProvider>
+            </ReduxWrapper>
+        );
+
+        expect(screen.queryByText("Add Condition")).not.toBeInTheDocument();
+        expect(screen.queryByTitle("Click to edit")).not.toBeInTheDocument();
+        expect(screen.queryByLabelText(/Edit Condition/)).not.toBeInTheDocument();
+    });
+
+    it("allows clicking Add Condition to show SubConditionForm (identified by Cancel button)", async () => {
+        const { rerender } = render(
+            <ReduxWrapper initialState={initialState}>
+                <PermitConditionsProvider value={providerValue}>
+                    <PermitConditionViewEdit
+                        userCanEdit
+                        formattedCategories={formattedCategories as any}
+                        isExtracted
+                        userReviewCategoryCodes={[baseCategory.condition_category_code]}
+                        editingFormName={""}
+                        setEditingFormName={jest.fn()}
+                        addingToCategoryCode={null}
+                        setAddingToCategoryCode={jest.fn()}
+                    />
+                </PermitConditionsProvider>
+            </ReduxWrapper>
+        );
+
+        fireEvent.click(screen.getByText("Add Condition"));
+
+        // re-render with editing form name like component would set (simulate state lift)
+        rerender(
+            <ReduxWrapper initialState={initialState}>
+                <PermitConditionsProvider value={providerValue}>
+                    <PermitConditionViewEdit
+                        userCanEdit
+                        formattedCategories={formattedCategories as any}
+                        isExtracted
+                        userReviewCategoryCodes={[baseCategory.condition_category_code]}
+                        editingFormName={FORM.EDIT_PERMIT_CONDITION}
+                        setEditingFormName={jest.fn()}
+                        addingToCategoryCode={baseCategory.condition_category_code}
+                        setAddingToCategoryCode={jest.fn()}
+                    />
+                </PermitConditionsProvider>
+            </ReduxWrapper>
+        );
+
+        await waitFor(() => {
+            // SubConditionForm uses a cancel button (text may be 'Cancel')
+            expect(screen.getByText(/Cancel/i)).toBeInTheDocument();
+        });
+    });
+});

--- a/services/common/src/tests/permits/PermitConditionViewEdit.spec.tsx
+++ b/services/common/src/tests/permits/PermitConditionViewEdit.spec.tsx
@@ -89,7 +89,7 @@ describe("PermitConditionViewEdit", () => {
         expect(screen.getByText("Add Condition")).toBeInTheDocument();
 
         // Category inline edit (title has aria button with title 'Click to edit')
-        const editCategory = container.querySelector('[title="Click to edit"]');
+        const editCategory = container.querySelector('[data-title="Click to edit"]');
         expect(editCategory).toBeInTheDocument();
 
         // Condition edit button has aria-label starting with Edit Condition
@@ -140,7 +140,6 @@ describe("PermitConditionViewEdit", () => {
 
         fireEvent.click(screen.getByText("Add Condition"));
 
-        // re-render with editing form name like component would set (simulate state lift)
         rerender(
             <ReduxWrapper initialState={initialState}>
                 <PermitConditionsProvider value={providerValue}>
@@ -159,8 +158,7 @@ describe("PermitConditionViewEdit", () => {
         );
 
         await waitFor(() => {
-            // SubConditionForm uses a cancel button (text may be 'Cancel')
-            expect(screen.getByText(/Cancel/i)).toBeInTheDocument();
+            expect(screen.getByLabelText('Cancel')).toBeInTheDocument();
         });
     });
 });

--- a/services/common/src/utils/featureFlag.ts
+++ b/services/common/src/utils/featureFlag.ts
@@ -34,6 +34,7 @@ export enum Feature {
   PERMIT_CONDITION_SEARCH = "PERMIT_CONDITION_SEARCH",
   STANDARD_PERMIT_CONDITIONS_EDITOR = "standard_permit_conditions_new_editor",
   NOW_PERMIT_CONDITIONS_EDITOR = "now_permit_conditions_new_editor",
+  REPORT_MANAGEMENT_V2 = "report_management_v2",
 }
 
 export const initializeFlagsmith = async (flagsmithUrl, flagsmithKey) => {

--- a/services/common/src/utils/feature_flags.json
+++ b/services/common/src/utils/feature_flags.json
@@ -28,5 +28,6 @@
     "modify_permit_conditions": true,
     "major_project_refactor": true,
     "help_guide": true,
-    "PERMIT_CONDITION_SEARCH": true
+    "PERMIT_CONDITION_SEARCH": true,
+    "report_management_v2": true
 }

--- a/services/core-api/app/api/mines/reports/resources/mine_reports.py
+++ b/services/core-api/app/api/mines/reports/resources/mine_reports.py
@@ -1,3 +1,4 @@
+import uuid
 from datetime import datetime
 
 from app.api.activity.models.activity_notification import (
@@ -6,6 +7,8 @@ from app.api.activity.models.activity_notification import (
 )
 from app.api.activity.utils import trigger_notification
 from app.api.constants import MINE_REPORT_TYPE
+from app.api.mines.documents.models.mine_document import MineDocument
+from app.api.mines.exceptions.mine_exceptions import MineException
 from app.api.mines.mine.models.mine import Mine
 from app.api.mines.permits.permit.models.permit import Permit
 from app.api.mines.permits.permit_conditions.models.permit_condition_category import (
@@ -15,9 +18,13 @@ from app.api.mines.reports.models.mine_report import MineReport
 from app.api.mines.reports.models.mine_report_category import MineReportCategory
 from app.api.mines.reports.models.mine_report_contact import MineReportContact
 from app.api.mines.reports.models.mine_report_definition import MineReportDefinition
+from app.api.mines.reports.models.mine_report_document_xref import (
+    MineReportDocumentXref,
+)
 from app.api.mines.reports.models.mine_report_permit_requirement import (
     MineReportPermitRequirement,
 )
+from app.api.mines.reports.models.mine_report_submission import MineReportSubmission
 from app.api.mines.reports.report_helpers import ReportFilterHelper
 from app.api.mines.response_models import MINE_REPORT_MODEL, PAGINATED_REPORT_LIST
 from app.api.utils.access_decorators import (
@@ -33,7 +40,7 @@ from app.api.utils.resources_mixins import UserMixin
 from app.extensions import api
 from flask import current_app, request
 from flask_restx import Resource
-from sqlalchemy import or_
+from sqlalchemy.orm import joinedload
 from werkzeug.exceptions import BadRequest, InternalServerError, NotFound
 
 PAGE_DEFAULT = 1

--- a/services/core-api/app/api/mines/reports/resources/mine_reports.py
+++ b/services/core-api/app/api/mines/reports/resources/mine_reports.py
@@ -1,34 +1,40 @@
-import uuid
-from flask_restx import Resource
-from flask import request, current_app
 from datetime import datetime
 
-from sqlalchemy.orm import joinedload
-from werkzeug.exceptions import BadRequest, NotFound, InternalServerError
-
+from app.api.activity.models.activity_notification import (
+    ActivityRecipients,
+    ActivityType,
+)
+from app.api.activity.utils import trigger_notification
 from app.api.constants import MINE_REPORT_TYPE
+from app.api.mines.mine.models.mine import Mine
+from app.api.mines.permits.permit.models.permit import Permit
+from app.api.mines.permits.permit_conditions.models.permit_condition_category import (
+    PermitConditionCategory,
+)
+from app.api.mines.reports.models.mine_report import MineReport
 from app.api.mines.reports.models.mine_report_category import MineReportCategory
 from app.api.mines.reports.models.mine_report_contact import MineReportContact
-from app.api.mines.reports.report_helpers import ReportFilterHelper
-from app.extensions import api
-from app.api.utils.resources_mixins import UserMixin
-from app.api.utils.access_decorators import requires_any_of, requires_role_edit_report, EDIT_REPORT, MINESPACE_PROPONENT, VIEW_ALL, is_minespace_user
-from app.api.activity.models.activity_notification import ActivityType
-from app.api.activity.models.activity_notification import ActivityRecipients
-from app.api.activity.utils import trigger_notification
-
-from app.api.mines.mine.models.mine import Mine
-from app.api.mines.reports.models.mine_report import MineReport
-from app.api.mines.reports.models.mine_report_submission import MineReportSubmission
-from app.api.mines.permits.permit.models.permit import Permit
 from app.api.mines.reports.models.mine_report_definition import MineReportDefinition
-from app.api.mines.reports.models.mine_report_document_xref import MineReportDocumentXref
-from app.api.mines.documents.models.mine_document import MineDocument
-from app.api.mines.permits.permit_conditions.models.permit_condition_category import PermitConditionCategory
-from app.api.mines.reports.models.mine_report_permit_requirement import MineReportPermitRequirement
-from app.api.utils.custom_reqparser import CustomReqparser
+from app.api.mines.reports.models.mine_report_permit_requirement import (
+    MineReportPermitRequirement,
+)
+from app.api.mines.reports.report_helpers import ReportFilterHelper
 from app.api.mines.response_models import MINE_REPORT_MODEL, PAGINATED_REPORT_LIST
-from app.api.mines.exceptions.mine_exceptions import MineException
+from app.api.utils.access_decorators import (
+    EDIT_REPORT,
+    MINESPACE_PROPONENT,
+    VIEW_ALL,
+    is_minespace_user,
+    requires_any_of,
+    requires_role_edit_report,
+)
+from app.api.utils.custom_reqparser import CustomReqparser
+from app.api.utils.resources_mixins import UserMixin
+from app.extensions import api
+from flask import current_app, request
+from flask_restx import Resource
+from sqlalchemy import or_
+from werkzeug.exceptions import BadRequest, InternalServerError, NotFound
 
 PAGE_DEFAULT = 1
 PER_PAGE_DEFAULT = 10
@@ -102,18 +108,41 @@ class MineReportListResource(Resource, UserMixin):
         if mrd_category:
             return MineReport.find_by_mine_guid_and_category(mine_guid, mrd_category)
 
-        reports_type = request.args.get('mine_reports_type', None)
+        # Support multiple report types via repeated mine_reports_type query params
+        requested_types = set(request.args.getlist('mine_reports_type', type=str) or [])
 
-        query = MineReport.query.filter_by(mine_guid=mine_guid, deleted_ind=False).order_by(MineReport.due_date.asc())
+        # Base query; ordering is applied via ReportFilterHelper
+        query = MineReport.query.filter_by(mine_guid=mine_guid, deleted_ind=False)
 
-        if reports_type == MINE_REPORT_TYPE['PERMIT REQUIRED REPORTS']:
-            query = query.filter(MineReport.mine_report_definition_id.is_(None))
-        elif reports_type == MINE_REPORT_TYPE['CODE REQUIRED REPORTS']:
-            query = query.filter(MineReport.mine_report_definition_id.isnot(None))
-        elif reports_type == MINE_REPORT_TYPE['TAILINGS REPORTS']:
-            query = query.join(MineReport.mine_report_definition).join(MineReportDefinition.categories).filter(
-                MineReportCategory.mine_report_category == 'TSF'
-            )
+        if requested_types:
+            conditions = []
+
+            # PRR: No definition id
+            if MINE_REPORT_TYPE['PERMIT REQUIRED REPORTS'] in requested_types:
+                conditions.append(MineReport.mine_report_definition_id.is_(None))
+
+            # CRR: Has definition id; optionally exclude TSF unless TAR explicitly requested
+            if MINE_REPORT_TYPE['CODE REQUIRED REPORTS'] in requested_types:
+                crr_cond = MineReport.mine_report_definition_id.isnot(None)
+                if MINE_REPORT_TYPE['TAILINGS REPORTS'] not in requested_types:
+                    crr_cond = crr_cond & (~MineReport.mine_report_definition.has(
+                        MineReportDefinition.categories.any(
+                            MineReportCategory.mine_report_category == 'TSF'
+                        )
+                    ))
+                conditions.append(crr_cond)
+
+            # TAR: TSF category on definition
+            if MINE_REPORT_TYPE['TAILINGS REPORTS'] in requested_types:
+                tar_cond = MineReport.mine_report_definition.has(
+                    MineReportDefinition.categories.any(
+                        MineReportCategory.mine_report_category == 'TSF'
+                    )
+                )
+                conditions.append(tar_cond)
+
+            if conditions:
+                query = query.filter(or_(*conditions))
 
         records, pagination_details = ReportFilterHelper.apply_filters_and_pagination(query, args, mine_guid)
 

--- a/services/core-api/app/api/mines/reports/resources/mine_reports.py
+++ b/services/core-api/app/api/mines/reports/resources/mine_reports.py
@@ -132,12 +132,12 @@ class MineReportListResource(Resource, UserMixin):
             # CRR: Has definition id; optionally exclude TSF unless TAR explicitly requested
             if MINE_REPORT_TYPE['CODE REQUIRED REPORTS'] in requested_types:
                 crr_cond = MineReport.mine_report_definition_id.isnot(None)
-                if MINE_REPORT_TYPE['TAILINGS REPORTS'] not in requested_types:
-                    crr_cond = crr_cond & (~MineReport.mine_report_definition.has(
-                        MineReportDefinition.categories.any(
-                            MineReportCategory.mine_report_category == 'TSF'
-                        )
-                    ))
+                # if MINE_REPORT_TYPE['TAILINGS REPORTS'] not in requested_types:
+                #     crr_cond = crr_cond & (~MineReport.mine_report_definition.has(
+                #         MineReportDefinition.categories.any(
+                #             MineReportCategory.mine_report_category == 'TSF'
+                #         )
+                #     ))
                 conditions.append(crr_cond)
 
             # TAR: TSF category on definition

--- a/services/core-api/app/api/mines/reports/resources/mine_reports.py
+++ b/services/core-api/app/api/mines/reports/resources/mine_reports.py
@@ -40,6 +40,7 @@ from app.api.utils.resources_mixins import UserMixin
 from app.extensions import api
 from flask import current_app, request
 from flask_restx import Resource
+from sqlalchemy import or_
 from sqlalchemy.orm import joinedload
 from werkzeug.exceptions import BadRequest, InternalServerError, NotFound
 

--- a/services/core-api/tests/reports/resource/test_mine_reports_resource.py
+++ b/services/core-api/tests/reports/resource/test_mine_reports_resource.py
@@ -1,12 +1,11 @@
 import json
 import uuid
-from datetime import datetime, timedelta, date
-from flask import current_app
+from datetime import date, datetime, timedelta
 
+from app.api.constants import MINE_REPORT_TYPE
 from app.api.mines.mine.models.mine import Mine
 from app.api.mines.reports.models.mine_report_definition import MineReportDefinition
-from app.api.constants import MINE_REPORT_TYPE
-
+from flask import current_app
 from tests.factories import MineFactory, MineReportFactory
 
 THREE_REPORTS = 3
@@ -53,21 +52,23 @@ def test_get_code_required_reports_for_mine(test_client, db_session, auth_header
     assert get_resp.status_code == 200
     assert all(report['report_name'] == specific_report_name for report in get_data['records'])
 
-    # Test filter by received date range
-    start_date = mine.mine_reports[0].received_date - timedelta(days=1)
-    end_date = mine.mine_reports[0].received_date + timedelta(days=1)
+    # Test filter by received date range (robust to date or datetime values from factories)
+    base_rd = mine.mine_reports[0].received_date
+    base_rd_date = base_rd.date() if isinstance(base_rd, datetime) else base_rd
+    start_date = base_rd_date - timedelta(days=1)
+    end_date = base_rd_date + timedelta(days=1)
 
     get_resp = test_client.get(
-        f'/mines/{mine.mine_guid}/reports?mine_reports_type=CRR&due_date_start={start_date.strftime("%Y-%m-%d")}&due_date_end={end_date.strftime("%Y-%m-%d")}',
+        f'/mines/{mine.mine_guid}/reports?mine_reports_type=CRR&received_date_start={start_date.strftime("%Y-%m-%d")}&received_date_end={end_date.strftime("%Y-%m-%d")}',
         headers=auth_headers['full_auth_header'])
     get_data = json.loads(get_resp.data.decode())
     assert get_resp.status_code == 200
 
     for report in get_data['records']:
-        received_date = datetime.strptime(report['received_date'], '%Y-%m-%d')
+        received_date = datetime.strptime(report['received_date'], '%Y-%m-%d').date()
 
-        assert (start_date.date() <= received_date.date())
-        assert (received_date.date() <= end_date)
+        assert (start_date <= received_date)
+        assert (received_date <= end_date)
 
 
 def test_get_permit_required_reports_for_mine(test_client, db_session, auth_headers):
@@ -243,3 +244,42 @@ def test_delete_mine_report(test_client, db_session, auth_headers):
         f'/mines/{mine.mine_guid}/reports/{mine.mine_reports[0].mine_report_guid}',
         headers=auth_headers['full_auth_header'])
     assert delete_resp.status_code == 204, delete_resp.response
+
+
+def test_get_prr_and_crr_reports_for_mine(test_client, db_session, auth_headers):
+    # Create a mine with no reports, then add one CRR (non-TSF) and one PRR
+    mine = MineFactory(mine_reports=0)
+
+    # Pick a non-TSF code-required report definition to avoid TAR filtering
+    defs = MineReportDefinition.get_all()
+    non_tsf_def = next(
+        d for d in defs if not any(getattr(c, 'mine_report_category', None) == 'TSF' for c in d.categories)
+    )
+
+    # Create CRR (has definition) and PRR (no definition) reports
+    MineReportFactory(mine=mine, mine_report_definition_id=non_tsf_def.mine_report_definition_id)
+    MineReportFactory(mine=mine, permit_required_reports=True)
+
+    # Request only CRR
+    get_resp = test_client.get(
+        f'/mines/{mine.mine_guid}/reports?mine_reports_type=CRR',
+        headers=auth_headers['full_auth_header']
+    )
+    get_data = json.loads(get_resp.data.decode())
+
+    assert get_resp.status_code == 200
+    assert len(get_data['records']) == 1
+
+
+    # Request both CRR and PRR
+    get_resp = test_client.get(
+        f'/mines/{mine.mine_guid}/reports?mine_reports_type=CRR&mine_reports_type=PRR',
+        headers=auth_headers['full_auth_header']
+    )
+    get_data = json.loads(get_resp.data.decode())
+
+    assert get_resp.status_code == 200
+    assert len(get_data['records']) == 2
+    has_prr = any(r.get('mine_report_definition_guid') is None for r in get_data['records'])
+    has_crr = any(r.get('mine_report_definition_guid') is not None for r in get_data['records'])
+    assert has_prr and has_crr

--- a/services/core-web/src/styles/components/CommonPageHeader.scss
+++ b/services/core-web/src/styles/components/CommonPageHeader.scss
@@ -61,6 +61,7 @@
         // offset-x, offset-y, blur, spread, colour
         box-shadow: 0 0 2px 0 $transparent-dark-grey; // $darkest-grey at 10% opacity
         background-color: $pure-white;
+        width: 100%;
 
     }
 }

--- a/services/core-web/src/tests/components/mine/Permit/__snapshots__/PermitConditions.spec.tsx.snap
+++ b/services/core-web/src/tests/components/mine/Permit/__snapshots__/PermitConditions.spec.tsx.snap
@@ -792,7 +792,9 @@ exports[`PermitConditions renders properly 1`] = `
                                       class="ant-typography margin-none"
                                       id="hsc"
                                     >
-                                      <div>
+                                      <div
+                                        data-title="Click to edit"
+                                      >
                                         <span
                                           style="margin-bottom: 0px;"
                                         >

--- a/services/minespace-web/src/components/dashboard/mine/reports/ReportManagement.tsx
+++ b/services/minespace-web/src/components/dashboard/mine/reports/ReportManagement.tsx
@@ -1,5 +1,4 @@
 import React, { FC, useContext, useEffect, useState } from "react";
-import { useDispatch } from "react-redux";
 import { Row, Col, Typography, Tabs, Alert, Button } from "antd";
 import { SidebarContext } from "@mds/common/components/common/SidebarWrapper";
 import { IMine, IPermit } from "@mds/common/interfaces";
@@ -18,14 +17,14 @@ import {
   PlusCircleFilled,
 } from "@ant-design/icons";
 import ResponsivePagination from "@mds/common/components/common/ResponsivePagination";
-import { useAppSelector } from "@mds/common/redux/rootState";
+import { useAppDispatch, useAppSelector } from "@mds/common/redux/rootState";
 import { getPermits } from "@mds/common/redux/selectors/permitSelectors";
 import { fetchPermits } from "@mds/common/redux/actionCreators/permitActionCreator";
 
 const REPORTS_PAGE_SIZE = 20;
 
 const ReportManagement: FC = () => {
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
   const history = useHistory();
   const { mine } = useContext<{ mine: IMine }>(SidebarContext);
   const [isLoaded, setIsLoaded] = useState(false);
@@ -37,7 +36,6 @@ const ReportManagement: FC = () => {
   const activePermits = permits?.filter((permit) => permit.permit_status_code === "O").length;
   const pageData = useAppSelector(getReportsPageData) as any;
 
-  console.log(permits);
   useEffect(() => {
     let isMounted = true;
     setIsLoaded(true);

--- a/services/minespace-web/src/components/dashboard/mine/reports/ReportManagement.tsx
+++ b/services/minespace-web/src/components/dashboard/mine/reports/ReportManagement.tsx
@@ -1,0 +1,177 @@
+import React, { FC, useContext, useEffect, useState } from "react";
+import { useDispatch } from "react-redux";
+import { Row, Col, Typography, Tabs, Alert, Button } from "antd";
+import { SidebarContext } from "@mds/common/components/common/SidebarWrapper";
+import { IMine, IPermit } from "@mds/common/interfaces";
+import { fetchMineReports } from "@mds/common/redux/actionCreators/reportActionCreator";
+import { getMineReports, getReportsPageData } from "@mds/common/redux/selectors/reportSelectors";
+import { IMineReport } from "@mds/common/interfaces/reports/mineReport.interface";
+import * as Strings from "@mds/common/constants/strings";
+import ReportsTable from "@/components/dashboard/mine/reports/ReportsTable";
+import { Link, useHistory } from "react-router-dom";
+import * as routes from "@/constants/routes";
+import TableSummaryCard from "@/components/common/TableSummaryCard";
+import {
+  ClockCircleOutlined,
+  ExclamationCircleOutlined,
+  FileTextOutlined,
+  PlusCircleFilled,
+} from "@ant-design/icons";
+import ResponsivePagination from "@mds/common/components/common/ResponsivePagination";
+import { useAppSelector } from "@mds/common/redux/rootState";
+import { getPermits } from "@mds/common/redux/selectors/permitSelectors";
+import { fetchPermits } from "@mds/common/redux/actionCreators/permitActionCreator";
+
+const REPORTS_PAGE_SIZE = 20;
+
+const ReportManagement: FC = () => {
+  const dispatch = useDispatch();
+  const history = useHistory();
+  const { mine } = useContext<{ mine: IMine }>(SidebarContext);
+  const [isLoaded, setIsLoaded] = useState(false);
+  const [allReports, setAllReports] = useState<IMineReport[]>([]);
+
+  const mineReports: IMineReport[] = useAppSelector(getMineReports);
+  const permits: IPermit[] = useAppSelector(getPermits);
+
+  const activePermits = permits?.filter((permit) => permit.permit_status_code === "O").length;
+  const pageData = useAppSelector(getReportsPageData) as any;
+
+  console.log(permits);
+  useEffect(() => {
+    let isMounted = true;
+    setIsLoaded(true);
+
+    onAllReportsPageChange(1);
+
+    dispatch(fetchPermits(mine.mine_guid));
+
+    return () => {
+      isMounted = false;
+    };
+  }, [mine.mine_guid]);
+
+  useEffect(() => {
+    setAllReports(mineReports || []);
+  }, [mineReports]);
+
+  const reportsOverdue = 3;
+  const reportsDueNext90 = 4;
+
+  const openReport = (reportRecord: IMineReport, isEditMode: boolean) => {
+    history.push(
+      routes.REPORT_VIEW_EDIT.dynamicRoute(mine.mine_guid, reportRecord.mine_report_guid),
+      {
+        isEditMode,
+      }
+    );
+  };
+
+  const onAllReportsPageChange = (page: number) => {
+    setIsLoaded(false);
+    Promise.resolve(
+      dispatch(
+        fetchMineReports(
+          mine.mine_guid,
+          [
+            Strings.MINE_REPORTS_TYPE.codeRequiredReports,
+            Strings.MINE_REPORTS_TYPE.permitRequiredReports,
+          ],
+          { page, per_page: REPORTS_PAGE_SIZE }
+        )
+      )
+    ).then(() => setIsLoaded(true));
+  };
+
+  return (
+    <Row gutter={[0, 24]}>
+      <Col span={24}>
+        <Row justify={"space-between"} align={"middle"}>
+          <Col>
+            <Typography.Title level={1}>Report Management</Typography.Title>
+          </Col>
+          <Col>
+            <Link to={routes.REPORTS_CREATE_NEW.dynamicRoute(mine.mine_guid)}>
+              <Button className="dashboard-add-button" type="primary">
+                <PlusCircleFilled />
+                Submit Report
+              </Button>
+            </Link>
+          </Col>
+        </Row>
+        <Typography.Paragraph>
+          Review and manage reports required for your mine's permit and Health, Safety and
+          Reclamation Code obligations.
+        </Typography.Paragraph>
+      </Col>
+      <Col span={24}>
+        <Row gutter={[16, 16]}>
+          <Col sm={24} md={10} lg={6}>
+            <TableSummaryCard
+              title="Active Permits"
+              content={activePermits}
+              Icon={FileTextOutlined}
+              type="success"
+            />
+          </Col>
+          <Col sm={24} md={10} lg={6}>
+            <TableSummaryCard
+              title="Reports Overdue"
+              content={reportsOverdue}
+              Icon={ClockCircleOutlined}
+              type="error"
+            />
+          </Col>
+          <Col sm={24} md={10} lg={6}>
+            <TableSummaryCard
+              title="Reports Due in the Next 90 Days"
+              content={reportsDueNext90}
+              Icon={ExclamationCircleOutlined}
+              type="warning"
+            />
+          </Col>
+        </Row>
+      </Col>
+      <Col span={24}>
+        <Tabs type="card">
+          <Tabs.TabPane tab="All Reports" key="all_reports">
+            <Typography.Title level={2}>All Reports</Typography.Title>
+            <Typography.Paragraph>
+              This table shows the reporting requirements for your permits. It highlights overdue,
+              upcoming, and requested reports to help you stay compliant. Drafts and previously
+              submitted reports are also included for your reference.
+            </Typography.Paragraph>
+
+            <div className="margin-large--bottom">
+              <Alert
+                message="Reminder"
+                showIcon
+                type="info"
+                description={
+                  "Your permit is the official source of reporting requirements. Use this table as a reference, but always check your permit to confirm compliance."
+                }
+              />
+            </div>
+
+            <ReportsTable
+              openReport={openReport}
+              mineReports={allReports}
+              isLoaded={isLoaded}
+              backendPaginated
+            />
+            <Row justify="center" className="margin-large--bottom">
+              <ResponsivePagination
+                onPageChange={onAllReportsPageChange}
+                currentPage={Number(pageData?.current_page || 1)}
+                pageTotal={Number(pageData?.total || allReports.length)}
+                itemsPerPage={Number(pageData?.items_per_page || REPORTS_PAGE_SIZE)}
+              />
+            </Row>
+          </Tabs.TabPane>
+        </Tabs>
+      </Col>
+    </Row>
+  );
+};
+
+export default ReportManagement;

--- a/services/minespace-web/src/components/dashboard/mine/reports/ReportManagement.tsx
+++ b/services/minespace-web/src/components/dashboard/mine/reports/ReportManagement.tsx
@@ -28,7 +28,10 @@ const ReportManagement: FC = () => {
   const history = useHistory();
   const { mine } = useContext<{ mine: IMine }>(SidebarContext);
   const [isLoaded, setIsLoaded] = useState(false);
-  const [allReports, setAllReports] = useState<IMineReport[]>([]);
+
+  const [allReports, setAllReports] = useState<IMineReport[]>(
+    (useAppSelector(getMineReports) as IMineReport[]) || []
+  );
 
   const mineReports: IMineReport[] = useAppSelector(getMineReports);
   const permits: IPermit[] = useAppSelector(getPermits);
@@ -37,20 +40,15 @@ const ReportManagement: FC = () => {
   const pageData = useAppSelector(getReportsPageData) as any;
 
   useEffect(() => {
-    let isMounted = true;
     setIsLoaded(true);
-
     onAllReportsPageChange(1);
-
     dispatch(fetchPermits(mine.mine_guid));
-
-    return () => {
-      isMounted = false;
-    };
   }, [mine.mine_guid]);
 
   useEffect(() => {
-    setAllReports(mineReports || []);
+    if (mineReports && mineReports.length > 0) {
+      setAllReports(mineReports);
+    }
   }, [mineReports]);
 
   const reportsOverdue = 3;

--- a/services/minespace-web/src/components/dashboard/mine/reports/Reports.tsx
+++ b/services/minespace-web/src/components/dashboard/mine/reports/Reports.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useContext, useEffect, useState } from "react";
+import React, { FC, useContext, useEffect, useMemo, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import PlusCircleFilled from "@ant-design/icons/PlusCircleFilled";
 import { Button, Col, Row, Typography } from "antd";
@@ -6,13 +6,16 @@ import { fetchMineReports } from "@mds/common/redux/actionCreators/reportActionC
 import { getMineReports, getReportsPageData } from "@mds/common/redux/selectors/reportSelectors";
 import ReportsTable from "@/components/dashboard/mine/reports/ReportsTable";
 import AuthorizationWrapper from "@/components/common/wrappers/AuthorizationWrapper";
-import { IMine, IMineReport, IPageData } from "@mds/common/interfaces";
+import { IMine, IMineReport, IPageData, IPermit } from "@mds/common/interfaces";
 import { Link, useHistory } from "react-router-dom";
 import * as routes from "@/constants/routes";
 import { Link as ScrollLink, Element } from "react-scroll";
 import { SidebarContext } from "@mds/common/components/common/SidebarWrapper";
 import ResponsivePagination from "@mds/common/components/common/ResponsivePagination";
 import * as Strings from "@mds/common/constants/strings";
+import { useFeatureFlag } from "@mds/common/providers/featureFlags/useFeatureFlag";
+import { Feature } from "@mds/common/utils";
+import ReportManagement from "@/components/dashboard/mine/reports/ReportManagement";
 
 export const Reports: FC = () => {
   const dispatch = useDispatch();
@@ -20,6 +23,8 @@ export const Reports: FC = () => {
   const { mine } = useContext<{ mine: IMine }>(SidebarContext);
   const pageData = useSelector(getReportsPageData);
   const mineReports: IMineReport[] = useSelector(getMineReports);
+  const { isFeatureEnabled } = useFeatureFlag();
+  const isV2Enabled = isFeatureEnabled(Feature.REPORT_MANAGEMENT_V2);
 
   const [isLoaded, setIsLoaded] = useState(false);
   const [permitRequiredReports, setPermitRequiredReports] = useState<IMineReport[]>([]);
@@ -48,6 +53,7 @@ export const Reports: FC = () => {
   }, [mineReports]);
 
   useEffect(() => {
+    if (isV2Enabled) return; // v2 handles its own fetching inside the component
     let isMounted = true;
     setIsLoaded(false);
     Promise.all([
@@ -58,11 +64,10 @@ export const Reports: FC = () => {
         setIsLoaded(true);
       }
     });
-
     return () => {
       isMounted = false;
     };
-  }, []);
+  }, [isV2Enabled]);
 
   const openReport = (reportRecord: IMineReport) => {
     history.push(
@@ -87,6 +92,11 @@ export const Reports: FC = () => {
       })
     );
   };
+
+  // V2 layout
+  if (isV2Enabled) {
+    return <ReportManagement />;
+  }
 
   return (
     <Row>
@@ -162,6 +172,7 @@ export const Reports: FC = () => {
               openReport={openReport}
               mineReports={permitRequiredReports}
               isLoaded={isLoaded}
+              backendPaginated
             />
             <Row justify="center" className="margin-large--bottom">
               <ResponsivePagination

--- a/services/minespace-web/src/components/dashboard/mine/reports/ReportsTable.tsx
+++ b/services/minespace-web/src/components/dashboard/mine/reports/ReportsTable.tsx
@@ -13,10 +13,11 @@ import { MINE_REPORT_SUBMISSION_CODES } from "@mds/common/constants/enums";
 import { IMineReport } from "@mds/common/interfaces/reports/mineReport.interface";
 import { MINE_REPORT_STATUS_HASH } from "@mds/common/constants/strings";
 import { useAppSelector as useSelector } from "@mds/common/redux/rootState";
+import { EditOutlined } from "@ant-design/icons";
 
 interface ReportsTableProps {
   mineReports: IMineReport[];
-  openReport: (record: IMineReport) => void;
+  openReport: (record: IMineReport, isEditMode?: boolean) => void;
   isLoaded: boolean;
   backendPaginated?: boolean;
 }
@@ -50,7 +51,28 @@ export const ReportsTable: FC<ReportsTableProps> = (props) => {
       },
       icon: <EyeOutlined />,
     },
+    {
+      key: "submit",
+      label: "Submit",
+      clickFunction: (_event, record) => {
+        props.openReport(record, true);
+      },
+      icon: <EditOutlined />,
+    },
   ];
+
+  const recordActionsFilter = (record: IMineReport, actionList: any[]) => {
+    // Hide view action for NON and REQ statuses, show submit for others
+    if (
+      [MINE_REPORT_SUBMISSION_CODES.NON, MINE_REPORT_SUBMISSION_CODES.REQ].includes(
+        record.mine_report_status_code
+      )
+    ) {
+      return actionList.filter((action) => action.key !== "view");
+    }
+
+    return actionList.filter((action) => action.key !== "submit");
+  };
 
   let columns: ColumnsType<IMineReport> = [
     renderTextColumn("report_name", "Report Name", !props.backendPaginated),
@@ -69,8 +91,8 @@ export const ReportsTable: FC<ReportsTableProps> = (props) => {
         ) : null;
       },
     },
-    renderTextColumn("submission_year", "Compliance Year", !props.backendPaginated, null, 5),
-    renderTextColumn("due_date", "Due", true, null, 5),
+    renderTextColumn("submission_year", "Compliance Year", !props.backendPaginated, null, 50),
+    renderTextColumn("due_date", "Due", true, null, 100),
     renderTextColumn(["latest_submission", "received_date"], "Submitted On", true),
     renderTextColumn("created_by_idir", "Requested By", true),
     {
@@ -81,13 +103,13 @@ export const ReportsTable: FC<ReportsTableProps> = (props) => {
         return <Badge status={reportStatusSeverity(text)} text={MINE_REPORT_STATUS_HASH[text]} />;
       },
     },
-    renderActionsColumn({ actions }),
+    renderActionsColumn({ actions, recordActionsFilter }),
   ];
 
   if (props.mineReports.some((report) => report.permit_guid)) {
     columns = columns.map((col) => {
       if (col.key === "code_section") {
-        return renderTextColumn("permit_number", "Permit #", true, null, 5);
+        return renderTextColumn("permit_number", "Permit #", true, null, 125);
       } else {
         return col;
       }

--- a/services/minespace-web/src/tests/components/dashboard/mine/reports/ReportManagement.spec.tsx
+++ b/services/minespace-web/src/tests/components/dashboard/mine/reports/ReportManagement.spec.tsx
@@ -1,0 +1,135 @@
+import React from "react";
+import { render, screen, within, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { SidebarContext } from "@mds/common/components/common/SidebarWrapper";
+import { ReduxWrapper } from "@/tests/utils/ReduxWrapper";
+import ReportManagement from "@/components/dashboard/mine/reports/ReportManagement";
+import * as Strings from "@mds/common/constants/strings";
+import { lastMineReportsRequest, lastPermitsRequest } from "@/tests/handlers";
+import {
+  PERMITS as MOCK_PERMITS,
+  MINE_REPORTS as MOCK_MINE_REPORTS,
+  MINE_REPORT_RESPONSE as MOCK_MINE_REPORT_RESPONSE,
+  MINE_REPORT_DEFINITION_OPTIONS as MOCK_REPORT_DEFS,
+} from "@mds/common/tests/mocks/dataMocks";
+
+describe("ReportManagement", () => {
+  // Use a real GUID from mocks where possible to keep data coherent
+  const mineGuid = "8e9ca839-a28e-427e-997e-9ef23d9d97cd";
+
+  const initialState = {
+    // Minimal report reducer shape to render table and pagination props using shared mocks
+    REPORTS: {
+      reports: [],
+      reportsPageData: MOCK_MINE_REPORT_RESPONSE,
+      mineReports: MOCK_MINE_REPORTS,
+      mineReportGuid: "",
+      reportComments: [],
+    },
+    // Permits reducer seeded from common mocks
+    PERMITS: {
+      permits: MOCK_PERMITS,
+      draftPermits: [],
+      permitConditions: [],
+      editingConditionFlag: false,
+      editingPreambleFlag: false,
+      standardPermitConditions: [],
+      latestPermitAmendments: {},
+      permitAmendments: {},
+    },
+    // Compliance report definitions so Code Section can render correctly
+    complianceReports: {
+      reportPageData: {
+        records: MOCK_REPORT_DEFS,
+        current_page: 1,
+        items_per_page: MOCK_REPORT_DEFS.length,
+        total: MOCK_REPORT_DEFS.length,
+        total_pages: 1,
+      },
+      params: {},
+      dueDateTypes: [],
+      expiredMineReportDefinition: undefined,
+    },
+  } as any;
+
+  const renderWithProviders = () => {
+    const mine: any = { mine_guid: mineGuid };
+    return render(
+      <ReduxWrapper initialState={initialState}>
+        <MemoryRouter>
+          <SidebarContext.Provider value={{ mine }}>
+            <ReportManagement />
+          </SidebarContext.Provider>
+        </MemoryRouter>
+      </ReduxWrapper>
+    );
+  };
+
+  it("renders heading, description, summary cards, and Submit Report link", async () => {
+    const { container } = renderWithProviders();
+
+    expect(screen.getByRole("heading", { name: /Report Management/i })).toBeInTheDocument();
+    expect(
+      screen.getByText(/Review and manage reports required for your mine's permit/i)
+    ).toBeInTheDocument();
+
+    const submitLink = screen.getByRole("link", { name: /Submit Report/i });
+    expect(submitLink).toBeInTheDocument();
+    expect(submitLink).toHaveAttribute("href", `/mines/${mineGuid}/reports/new`);
+
+    const activePermitsCard = screen.getByText("Active Permits").closest(".table-summary-card");
+    expect(activePermitsCard).toBeTruthy();
+    // From mocks, there are 3 active permits with status code 'O'
+    expect(within(activePermitsCard as HTMLElement).getByText("3")).toBeInTheDocument();
+
+    const overdueCard = screen.getByText("Reports Overdue").closest(".table-summary-card");
+    expect(within(overdueCard as HTMLElement).getByText("3")).toBeInTheDocument();
+
+    const dueNextCard = screen
+      .getByText("Reports Due in the Next 90 Days")
+      .closest(".table-summary-card");
+    expect(within(dueNextCard as HTMLElement).getByText("4")).toBeInTheDocument();
+
+    // "Reminder" alert content
+    expect(
+      screen.getByText(/Your permit is the official source of reporting requirements/i)
+    ).toBeInTheDocument();
+
+    // Tab section title
+    expect(screen.getByRole("heading", { name: /All Reports/i })).toBeInTheDocument();
+
+    // Table content should include at least one of the mocked report names
+    const reportNameMatches = screen.getAllByText(
+      /Annual DSI|TSF, WSF or Dam As-built Report|Underground Oil and Grease Storage Area Report/
+    );
+    expect(reportNameMatches.length).toBeGreaterThan(0);
+
+    // Verify network calls were made with expected params via MSW handlers capture
+    await waitFor(() => {
+      expect(lastMineReportsRequest?.mineGuid).toEqual(mineGuid);
+      // mine_reports_type should contain both CRR and PRR
+      const mrt = lastMineReportsRequest?.query?.mine_reports_type;
+      const asArray = Array.isArray(mrt) ? mrt : mrt ? [mrt] : [];
+      expect(asArray).toEqual(
+        expect.arrayContaining([
+          Strings.MINE_REPORTS_TYPE.codeRequiredReports,
+          Strings.MINE_REPORTS_TYPE.permitRequiredReports,
+        ])
+      );
+      expect(lastMineReportsRequest?.query?.page).toBe("1");
+      expect(lastMineReportsRequest?.query?.per_page).toBe("20");
+
+      expect(lastPermitsRequest?.mineGuid).toEqual(mineGuid);
+    });
+  });
+
+  it("renders and matches snapshot", async () => {
+    const { container } = renderWithProviders();
+
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { name: /All Reports/i })).toBeInTheDocument()
+    );
+
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/services/minespace-web/src/tests/components/dashboard/mine/reports/Reports.spec.tsx
+++ b/services/minespace-web/src/tests/components/dashboard/mine/reports/Reports.spec.tsx
@@ -1,14 +1,27 @@
 import React from "react";
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+import { BrowserRouter } from "react-router-dom";
 import { Reports } from "@/components/dashboard/mine/reports/Reports";
 import * as MOCK from "@mds/common/tests/mocks/dataMocks";
 import { ReduxWrapper } from "@/tests/utils/ReduxWrapper";
 import { SidebarProvider } from "@mds/common/components/common/SidebarWrapper";
-import { REPORTS } from "@mds/common/constants/reducerTypes";
+import { REPORTS, AUTHENTICATION } from "@mds/common/constants/reducerTypes";
 import {
   complianceReportReducerType,
   reportParamsGetAll,
 } from "@mds/common/redux/slices/complianceReportsSlice";
+import { Feature } from "@mds/common/utils/featureFlag";
+
+// Force the legacy reports UI by turning off the v2 feature flag for this test suite
+jest.mock("@mds/common/providers/featureFlags/useFeatureFlag", () => ({
+  useFeatureFlag: () => ({
+    isFeatureEnabled: (f: Feature) => {
+      if (f === Feature.REPORT_MANAGEMENT_V2) return false;
+      // Default: keep other flags enabled unless a test needs otherwise
+      return true;
+    },
+  }),
+}));
 
 const initialState = {
   [REPORTS]: { mineReports: MOCK.MINE_REPORTS, reportsPageData: MOCK.PAGE_DATA },
@@ -22,6 +35,15 @@ const initialState = {
     },
     params: reportParamsGetAll,
   },
+  // Ensure AuthorizationWrapper renders actions by setting proponent access
+  [AUTHENTICATION]: {
+    isAuthenticated: true,
+    userAccessData: [],
+    userInfo: {},
+    redirect: false,
+    isProponent: true,
+    systemFlag: undefined,
+  },
 };
 
 const mine = MOCK.MINES.mines[MOCK.MINES.mineIds[0]];
@@ -29,12 +51,50 @@ const mine = MOCK.MINES.mines[MOCK.MINES.mineIds[0]];
 describe("Reports", () => {
   it("renders properly", () => {
     const { container } = render(
-      <ReduxWrapper initialState={initialState}>
-        <SidebarProvider value={{ mine } as any}>
-          <Reports />
-        </SidebarProvider>
-      </ReduxWrapper>
+      <BrowserRouter>
+        <ReduxWrapper initialState={initialState}>
+          <SidebarProvider value={{ mine } as any}>
+            <Reports />
+          </SidebarProvider>
+        </ReduxWrapper>
+      </BrowserRouter>
     );
     expect(container).toMatchSnapshot();
+  });
+  it("renders primary UI elements", async () => {
+    render(
+      <BrowserRouter>
+        <ReduxWrapper initialState={initialState}>
+          <SidebarProvider value={{ mine } as any}>
+            <Reports />
+          </SidebarProvider>
+        </ReduxWrapper>
+      </BrowserRouter>
+    );
+    // Header and intro text (v1)
+    expect(screen.getByRole("heading", { name: /^reports$/i })).toBeInTheDocument();
+    expect(screen.getByText(/view all/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/code required reports/i)[0]).toBeInTheDocument();
+    expect(screen.getAllByText(/permit required reports/i)[0]).toBeInTheDocument();
+
+    // CTA button remains
+    expect(screen.getByRole("button", { name: /submit report/i })).toBeInTheDocument();
+
+    // Section headings (v1)
+    expect(
+      screen.getAllByRole("heading", { level: 4, name: /code required reports/i })[0]
+    ).toBeInTheDocument();
+    expect(
+      screen.getAllByRole("heading", { level: 4, name: /permit required reports/i })[0]
+    ).toBeInTheDocument();
+
+    // Table headers present (two tables render the same headers)
+    expect(screen.getAllByText(/report name/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/code section/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/compliance year/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/^due$/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/submitted on/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/requested by/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/^status$/i).length).toBeGreaterThan(0);
   });
 });

--- a/services/minespace-web/src/tests/components/dashboard/mine/reports/Reports.v2.spec.tsx
+++ b/services/minespace-web/src/tests/components/dashboard/mine/reports/Reports.v2.spec.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { BrowserRouter } from "react-router-dom";
 import { Reports } from "@/components/dashboard/mine/reports/Reports";
 import * as MOCK from "@mds/common/tests/mocks/dataMocks";
@@ -12,13 +12,11 @@ import {
 } from "@mds/common/redux/slices/complianceReportsSlice";
 import { Feature } from "@mds/common/utils/featureFlag";
 
-// Force the legacy reports UI by turning off the v2 feature flag for this test suite
+// Force the v2 reports UI by turning on the feature flag for this test suite
 jest.mock("@mds/common/providers/featureFlags/useFeatureFlag", () => ({
   useFeatureFlag: () => ({
     isFeatureEnabled: (f: Feature) => {
-      if (f === Feature.REPORT_MANAGEMENT_V2) {
-        return false;
-      }
+      if (f === Feature.REPORT_MANAGEMENT_V2) return true;
       return true;
     },
   }),
@@ -49,20 +47,8 @@ const initialState = {
 
 const mine = MOCK.MINES.mines[MOCK.MINES.mineIds[0]];
 
-describe("Reports", () => {
-  it("renders properly", () => {
-    const { container } = render(
-      <BrowserRouter>
-        <ReduxWrapper initialState={initialState}>
-          <SidebarProvider value={{ mine } as any}>
-            <Reports />
-          </SidebarProvider>
-        </ReduxWrapper>
-      </BrowserRouter>
-    );
-    expect(container).toMatchSnapshot();
-  });
-  it("renders primary UI elements", async () => {
+describe("Reports (v2)", () => {
+  it("renders v2 layout with primary UI elements when feature flag is enabled", async () => {
     render(
       <BrowserRouter>
         <ReduxWrapper initialState={initialState}>
@@ -72,30 +58,30 @@ describe("Reports", () => {
         </ReduxWrapper>
       </BrowserRouter>
     );
-    // Header and intro text (v1)
-    expect(screen.getByRole("heading", { name: /^reports$/i })).toBeInTheDocument();
-    expect(screen.getByText(/view all/i)).toBeInTheDocument();
-    expect(screen.getAllByText(/code required reports/i)[0]).toBeInTheDocument();
-    expect(screen.getAllByText(/permit required reports/i)[0]).toBeInTheDocument();
 
-    // CTA button remains
-    expect(screen.getByRole("button", { name: /submit report/i })).toBeInTheDocument();
+    // v2 page heading and key elements
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { name: /Report Management/i })).toBeInTheDocument()
+    );
+    expect(screen.getByRole("link", { name: /Submit Report/i })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 2, name: /All Reports/i })).toBeInTheDocument();
+  });
 
-    // Section headings (v1)
-    expect(
-      screen.getAllByRole("heading", { level: 4, name: /code required reports/i })[0]
-    ).toBeInTheDocument();
-    expect(
-      screen.getAllByRole("heading", { level: 4, name: /permit required reports/i })[0]
-    ).toBeInTheDocument();
+  it("matches snapshot (v2)", async () => {
+    const { container } = render(
+      <BrowserRouter>
+        <ReduxWrapper initialState={initialState}>
+          <SidebarProvider value={{ mine } as any}>
+            <Reports />
+          </SidebarProvider>
+        </ReduxWrapper>
+      </BrowserRouter>
+    );
 
-    // Table headers present (two tables render the same headers)
-    expect(screen.getAllByText(/report name/i).length).toBeGreaterThan(0);
-    expect(screen.getAllByText(/code section/i).length).toBeGreaterThan(0);
-    expect(screen.getAllByText(/compliance year/i).length).toBeGreaterThan(0);
-    expect(screen.getAllByText(/^due$/i).length).toBeGreaterThan(0);
-    expect(screen.getAllByText(/submitted on/i).length).toBeGreaterThan(0);
-    expect(screen.getAllByText(/requested by/i).length).toBeGreaterThan(0);
-    expect(screen.getAllByText(/^status$/i).length).toBeGreaterThan(0);
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { name: /All Reports/i })).toBeInTheDocument()
+    );
+
+    expect(container).toMatchSnapshot();
   });
 });

--- a/services/minespace-web/src/tests/components/dashboard/mine/reports/ReportsTable.spec.tsx
+++ b/services/minespace-web/src/tests/components/dashboard/mine/reports/ReportsTable.spec.tsx
@@ -1,0 +1,193 @@
+import React from "react";
+import { render, screen, within, fireEvent, waitFor } from "@testing-library/react";
+import {
+  ReportsTable,
+  reportStatusSeverity,
+} from "@/components/dashboard/mine/reports/ReportsTable";
+import { ReduxWrapper } from "@/tests/utils/ReduxWrapper";
+import { complianceReportReducerType } from "@mds/common/redux/slices/complianceReportsSlice";
+import { IMineReport, IMineReportDefinition } from "@mds/common/interfaces";
+import { MINE_REPORT_SUBMISSION_CODES } from "@mds/common/constants/enums";
+
+// Minimal report definition with a compliance article so Code Section can render
+const DEF_GUID = "def-guid-1";
+const REPORT_DEF: IMineReportDefinition = {
+  mine_report_definition_guid: DEF_GUID,
+  report_name: "Test Report",
+  description: "",
+  due_date_period_months: 12,
+  mine_report_due_date_type: "FIS" as any,
+  default_due_date: "2020-03-31",
+  categories: [],
+  compliance_articles: [
+    {
+      compliance_article_id: 1,
+      article_act_code: "HSRCM",
+      section: "10",
+      sub_section: "5",
+      paragraph: "1",
+      sub_paragraph: "1",
+      description: "General",
+      long_description: "General",
+      effective_date: "1970-01-01",
+      expiry_date: "9999-12-31",
+      help_reference_link: "",
+      cim_or_cpo: "Both",
+      reports: [],
+    },
+  ],
+  active_ind: true,
+  is_common: false,
+  is_prr_only: false,
+};
+
+const initialComplianceState = {
+  [complianceReportReducerType]: {
+    reportPageData: {
+      records: [REPORT_DEF],
+      current_page: 1,
+      items_per_page: 1,
+      total: 1,
+      total_pages: 1,
+    },
+    params: {},
+  },
+};
+
+const baseReport = (overrides: Partial<IMineReport> = {}): IMineReport =>
+  ({
+    mine_report_guid: (overrides as any).mine_report_guid || Math.random().toString(36).slice(2),
+    mine_report_definition_guid: DEF_GUID,
+    report_name: "Test Report",
+    submission_year: 2024 as any,
+    due_date: "2024-12-31" as any,
+    latest_submission: { received_date: "2024-01-15" } as any,
+    created_by_idir: "idir_user",
+    mine_report_status_code: MINE_REPORT_SUBMISSION_CODES.NRQ,
+    permit_guid: null,
+    ...overrides,
+  }) as IMineReport;
+
+describe("ReportsTable", () => {
+  it("renders Code Section column when no reports have a permit", () => {
+    const openReport = jest.fn();
+    const mineReports: IMineReport[] = [baseReport()];
+
+    render(
+      <ReduxWrapper initialState={initialComplianceState}>
+        <ReportsTable
+          mineReports={mineReports}
+          openReport={openReport}
+          isLoaded
+          backendPaginated={false}
+        />
+      </ReduxWrapper>
+    );
+
+    expect(screen.getByText("Code Section")).toBeInTheDocument();
+    // A formatted code such as 10.5.1.1 should appear (no description in Minespace helpers)
+    expect(screen.getByText(/^10\.5\.1\.1$/)).toBeInTheDocument();
+  });
+
+  it("renders Permit # column when any report has a permit_guid", () => {
+    const openReport = jest.fn();
+    const mineReports: IMineReport[] = [
+      baseReport({ mine_report_guid: "r1", permit_guid: "permit-1" } as any),
+      baseReport({ mine_report_guid: "r2" } as any),
+    ];
+
+    render(
+      <ReduxWrapper initialState={initialComplianceState}>
+        <ReportsTable
+          mineReports={mineReports}
+          openReport={openReport}
+          isLoaded
+          backendPaginated={false}
+        />
+      </ReduxWrapper>
+    );
+
+    expect(screen.getByText("Permit #")).toBeInTheDocument();
+    expect(screen.queryByText("Code Section")).not.toBeInTheDocument();
+  });
+
+  it("filters actions correctly and calls openReport with proper args", async () => {
+    const openReport = jest.fn();
+    const r1 = baseReport({
+      mine_report_guid: "s1",
+      mine_report_status_code: MINE_REPORT_SUBMISSION_CODES.NON,
+    } as any);
+    const r2 = baseReport({
+      mine_report_guid: "s2",
+      mine_report_status_code: MINE_REPORT_SUBMISSION_CODES.REC,
+    } as any);
+    const mineReports: IMineReport[] = [r1, r2];
+
+    render(
+      <ReduxWrapper initialState={initialComplianceState}>
+        <ReportsTable
+          mineReports={mineReports}
+          openReport={openReport}
+          isLoaded
+          backendPaginated={false}
+        />
+      </ReduxWrapper>
+    );
+
+    // There should be an Actions button per row
+    const actionButtons = screen.getAllByRole("button", { name: /Actions/i });
+    expect(actionButtons.length).toBe(2);
+
+    // Helper to scope queries to the most recently opened dropdown (AntD renders in a portal)
+    const getLastDropdown = () => {
+      const dropdowns = document.body.querySelectorAll(".ant-dropdown");
+      return dropdowns.length ? (dropdowns[dropdowns.length - 1] as HTMLElement) : null;
+    };
+
+    // Row 1 (status NON): should show Submit but not View
+    // AntD Dropdown opens on hover by default; use mouseEnter and explicitly wait until the menu exists
+    fireEvent.mouseEnter(actionButtons[0]);
+    await waitFor(() => expect(getLastDropdown()).not.toBeNull());
+    const firstMenu = getLastDropdown()!;
+    expect(within(firstMenu).queryByTestId("action-button-view")).not.toBeInTheDocument();
+    expect(within(firstMenu).getByTestId("action-button-submit")).toBeInTheDocument();
+    fireEvent.click(within(firstMenu).getByTestId("action-button-submit"));
+    expect(openReport).toHaveBeenCalledWith(
+      expect.objectContaining({ mine_report_guid: "s1" }),
+      true
+    );
+
+    // Ensure the first dropdown is closed before validating the next row to avoid stale portal content
+    fireEvent.mouseLeave(actionButtons[0]);
+    // Some environments require a click outside to dismiss the menu; do both and wait until hidden
+    fireEvent.click(document.body);
+    await waitFor(() => {
+      const maybeDropdown = getLastDropdown();
+      expect(maybeDropdown).not.toBeNull();
+      expect(maybeDropdown!.classList.contains("ant-dropdown-hidden")).toBe(true);
+    });
+
+    // Row 2 (status ACC): should show View but not Submit
+    fireEvent.mouseEnter(actionButtons[1]);
+    await waitFor(() =>
+      expect(document.body.querySelectorAll(".ant-dropdown").length).toBeGreaterThan(1)
+    );
+    let secondMenu = getLastDropdown();
+    expect(within(secondMenu).getByTestId("action-button-view")).toBeInTheDocument();
+    expect(within(secondMenu).queryByTestId("action-button-submit")).not.toBeInTheDocument();
+    fireEvent.click(within(secondMenu).getByTestId("action-button-view"));
+    expect(openReport).toHaveBeenCalledWith(expect.objectContaining({ mine_report_guid: "s2" }));
+  });
+});
+
+describe("reportStatusSeverity", () => {
+  it("maps statuses to correct badge severities", () => {
+    expect(reportStatusSeverity(MINE_REPORT_SUBMISSION_CODES.REQ)).toBe("warning");
+    expect(reportStatusSeverity(MINE_REPORT_SUBMISSION_CODES.REC)).toBe("warning");
+    expect(reportStatusSeverity(MINE_REPORT_SUBMISSION_CODES.NON)).toBe("warning");
+    expect(reportStatusSeverity(MINE_REPORT_SUBMISSION_CODES.ACC)).toBe("success");
+    expect(reportStatusSeverity(MINE_REPORT_SUBMISSION_CODES.NRQ)).toBe("success");
+    expect(reportStatusSeverity(MINE_REPORT_SUBMISSION_CODES.INI)).toBe("success");
+    expect(reportStatusSeverity(MINE_REPORT_SUBMISSION_CODES.WTD)).toBe("default");
+  });
+});

--- a/services/minespace-web/src/tests/components/dashboard/mine/reports/__snapshots__/ReportManagement.spec.tsx.snap
+++ b/services/minespace-web/src/tests/components/dashboard/mine/reports/__snapshots__/ReportManagement.spec.tsx.snap
@@ -1,0 +1,1044 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ReportManagement renders and matches snapshot 1`] = `
+<div>
+  <div
+    class="ant-row"
+    style="margin-top: -12px; margin-bottom: -12px;"
+  >
+    <div
+      class="ant-col ant-col-24"
+      style="padding-top: 12px; padding-bottom: 12px;"
+    >
+      <div
+        class="ant-row ant-row-space-between ant-row-middle"
+      >
+        <div
+          class="ant-col"
+        >
+          <h1
+            class="ant-typography"
+          >
+            Report Management
+          </h1>
+        </div>
+        <div
+          class="ant-col"
+        >
+          <a
+            href="/mines/8e9ca839-a28e-427e-997e-9ef23d9d97cd/reports/new"
+          >
+            <button
+              class="ant-btn ant-btn-primary dashboard-add-button"
+              type="button"
+            >
+              <span
+                aria-label="plus-circle"
+                class="anticon anticon-plus-circle"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  class=""
+                  data-icon="plus-circle"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm192 472c0 4.4-3.6 8-8 8H544v152c0 4.4-3.6 8-8 8h-48c-4.4 0-8-3.6-8-8V544H328c-4.4 0-8-3.6-8-8v-48c0-4.4 3.6-8 8-8h152V328c0-4.4 3.6-8 8-8h48c4.4 0 8 3.6 8 8v152h152c4.4 0 8 3.6 8 8v48z"
+                  />
+                </svg>
+              </span>
+              <span>
+                Submit Report
+              </span>
+            </button>
+          </a>
+        </div>
+      </div>
+      <div
+        class="ant-typography"
+      >
+        Review and manage reports required for your mine's permit and Health, Safety and Reclamation Code obligations.
+      </div>
+    </div>
+    <div
+      class="ant-col ant-col-24"
+      style="padding-top: 12px; padding-bottom: 12px;"
+    >
+      <div
+        class="ant-row"
+        style="margin: -8px -8px -8px -8px;"
+      >
+        <div
+          class="ant-col ant-col-sm-24 ant-col-md-10 ant-col-lg-6"
+          style="padding: 8px 8px 8px 8px;"
+        >
+          <div
+            class="table-summary-card"
+          >
+            <div>
+              <span
+                aria-label="file-text"
+                class="anticon anticon-file-text table-summary-card-icon color-success"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  class=""
+                  data-icon="file-text"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M854.6 288.6L639.4 73.4c-6-6-14.1-9.4-22.6-9.4H192c-17.7 0-32 14.3-32 32v832c0 17.7 14.3 32 32 32h640c17.7 0 32-14.3 32-32V311.3c0-8.5-3.4-16.7-9.4-22.7zM790.2 326H602V137.8L790.2 326zm1.8 562H232V136h302v216a42 42 0 0042 42h216v494zM504 618H320c-4.4 0-8 3.6-8 8v48c0 4.4 3.6 8 8 8h184c4.4 0 8-3.6 8-8v-48c0-4.4-3.6-8-8-8zM312 490v48c0 4.4 3.6 8 8 8h384c4.4 0 8-3.6 8-8v-48c0-4.4-3.6-8-8-8H320c-4.4 0-8 3.6-8 8z"
+                  />
+                </svg>
+              </span>
+              <span
+                class="table-summary-card-title"
+              >
+                Active Permits
+              </span>
+            </div>
+            <div
+              class="table-summary-card-content"
+            >
+              3
+            </div>
+          </div>
+        </div>
+        <div
+          class="ant-col ant-col-sm-24 ant-col-md-10 ant-col-lg-6"
+          style="padding: 8px 8px 8px 8px;"
+        >
+          <div
+            class="table-summary-card"
+          >
+            <div>
+              <span
+                aria-label="clock-circle"
+                class="anticon anticon-clock-circle table-summary-card-icon color-error"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  class=""
+                  data-icon="clock-circle"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                  />
+                  <path
+                    d="M686.7 638.6L544.1 535.5V288c0-4.4-3.6-8-8-8H488c-4.4 0-8 3.6-8 8v275.4c0 2.6 1.2 5 3.3 6.5l165.4 120.6c3.6 2.6 8.6 1.8 11.2-1.7l28.6-39c2.6-3.7 1.8-8.7-1.8-11.2z"
+                  />
+                </svg>
+              </span>
+              <span
+                class="table-summary-card-title"
+              >
+                Reports Overdue
+              </span>
+            </div>
+            <div
+              class="table-summary-card-content"
+            >
+              3
+            </div>
+          </div>
+        </div>
+        <div
+          class="ant-col ant-col-sm-24 ant-col-md-10 ant-col-lg-6"
+          style="padding: 8px 8px 8px 8px;"
+        >
+          <div
+            class="table-summary-card"
+          >
+            <div>
+              <span
+                aria-label="exclamation-circle"
+                class="anticon anticon-exclamation-circle table-summary-card-icon color-warning"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  class=""
+                  data-icon="exclamation-circle"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                  />
+                  <path
+                    d="M464 688a48 48 0 1096 0 48 48 0 10-96 0zm24-112h48c4.4 0 8-3.6 8-8V296c0-4.4-3.6-8-8-8h-48c-4.4 0-8 3.6-8 8v272c0 4.4 3.6 8 8 8z"
+                  />
+                </svg>
+              </span>
+              <span
+                class="table-summary-card-title"
+              >
+                Reports Due in the Next 90 Days
+              </span>
+            </div>
+            <div
+              class="table-summary-card-content"
+            >
+              4
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="ant-col ant-col-24"
+      style="padding-top: 12px; padding-bottom: 12px;"
+    >
+      <div
+        class="ant-tabs ant-tabs-top ant-tabs-card"
+      >
+        <div
+          class="ant-tabs-nav"
+          role="tablist"
+        >
+          <div
+            class="ant-tabs-nav-wrap"
+          >
+            <div
+              class="ant-tabs-nav-list"
+              style="transform: translate(0px, 0px);"
+            >
+              <div
+                class="ant-tabs-tab ant-tabs-tab-active"
+                data-node-key="all_reports"
+              >
+                <div
+                  aria-controls="rc-tabs-test-panel-all_reports"
+                  aria-selected="true"
+                  class="ant-tabs-tab-btn"
+                  id="rc-tabs-test-tab-all_reports"
+                  role="tab"
+                  tabindex="0"
+                >
+                  All Reports
+                </div>
+              </div>
+              <div
+                class="ant-tabs-ink-bar ant-tabs-ink-bar-animated"
+                style="left: 0px; width: 0px;"
+              />
+            </div>
+          </div>
+          <div
+            class="ant-tabs-nav-operations ant-tabs-nav-operations-hidden"
+          >
+            <button
+              aria-controls="rc-tabs-test-more-popup"
+              aria-expanded="false"
+              aria-haspopup="listbox"
+              aria-hidden="true"
+              class="ant-tabs-nav-more"
+              id="rc-tabs-test-more"
+              style="visibility: hidden; order: 1;"
+              tabindex="-1"
+              type="button"
+            >
+              <span
+                aria-label="ellipsis"
+                class="anticon anticon-ellipsis"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-icon="ellipsis"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M176 511a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0z"
+                  />
+                </svg>
+              </span>
+            </button>
+          </div>
+        </div>
+        <div
+          class="ant-tabs-content-holder"
+        >
+          <div
+            class="ant-tabs-content ant-tabs-content-top"
+          >
+            <div
+              aria-hidden="false"
+              aria-labelledby="rc-tabs-test-tab-all_reports"
+              class="ant-tabs-tabpane ant-tabs-tabpane-active"
+              id="rc-tabs-test-panel-all_reports"
+              role="tabpanel"
+              tabindex="0"
+            >
+              <h2
+                class="ant-typography"
+              >
+                All Reports
+              </h2>
+              <div
+                class="ant-typography"
+              >
+                This table shows the reporting requirements for your permits. It highlights overdue, upcoming, and requested reports to help you stay compliant. Drafts and previously submitted reports are also included for your reference.
+              </div>
+              <div
+                class="margin-large--bottom"
+              >
+                <div
+                  class="ant-alert ant-alert-info ant-alert-with-description"
+                  data-show="true"
+                  role="alert"
+                >
+                  <span
+                    aria-label="info-circle"
+                    class="anticon anticon-info-circle ant-alert-icon"
+                    role="img"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      data-icon="info-circle"
+                      fill="currentColor"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                      />
+                      <path
+                        d="M464 336a48 48 0 1096 0 48 48 0 10-96 0zm72 112h-48c-4.4 0-8 3.6-8 8v272c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V456c0-4.4-3.6-8-8-8z"
+                      />
+                    </svg>
+                  </span>
+                  <div
+                    class="ant-alert-content"
+                  >
+                    <div
+                      class="ant-alert-message"
+                    >
+                      Reminder
+                    </div>
+                    <div
+                      class="ant-alert-description"
+                    >
+                      Your permit is the official source of reporting requirements. Use this table as a reference, but always check your permit to confirm compliance.
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="ant-table-wrapper  core-table"
+              >
+                <div
+                  class="ant-spin-nested-loading"
+                >
+                  <div>
+                    <div
+                      aria-busy="true"
+                      aria-live="polite"
+                      class="ant-spin ant-spin-spinning"
+                    >
+                      <span
+                        class="ant-spin-dot ant-spin-dot-spin"
+                      >
+                        <i
+                          class="ant-spin-dot-item"
+                        />
+                        <i
+                          class="ant-spin-dot-item"
+                        />
+                        <i
+                          class="ant-spin-dot-item"
+                        />
+                        <i
+                          class="ant-spin-dot-item"
+                        />
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="ant-spin-container ant-spin-blur"
+                  >
+                    <div
+                      class="ant-table ant-table-small ant-table-has-fix-right"
+                    >
+                      <div
+                        class="ant-table-container"
+                      >
+                        <div
+                          class="ant-table-content"
+                        >
+                          <table
+                            style="table-layout: auto;"
+                          >
+                            <colgroup>
+                              <col />
+                              <col />
+                              <col
+                                style="width: 50px;"
+                              />
+                              <col
+                                style="width: 100px;"
+                              />
+                            </colgroup>
+                            <thead
+                              class="ant-table-thead"
+                            >
+                              <tr>
+                                <th
+                                  class="ant-table-cell"
+                                >
+                                  Report Name
+                                </th>
+                                <th
+                                  class="ant-table-cell"
+                                >
+                                  Code Section
+                                </th>
+                                <th
+                                  class="ant-table-cell"
+                                >
+                                  Compliance Year
+                                </th>
+                                <th
+                                  aria-label="Due"
+                                  class="ant-table-cell ant-table-column-has-sorters"
+                                  tabindex="0"
+                                >
+                                  <div
+                                    class="ant-table-column-sorters"
+                                  >
+                                    <span
+                                      class="ant-table-column-title"
+                                    >
+                                      Due
+                                    </span>
+                                    <span
+                                      class="ant-table-column-sorter ant-table-column-sorter-full"
+                                    >
+                                      <span
+                                        class="ant-table-column-sorter-inner"
+                                      >
+                                        <span
+                                          aria-label="caret-up"
+                                          class="anticon anticon-caret-up ant-table-column-sorter-up"
+                                          role="presentation"
+                                        >
+                                          <svg
+                                            aria-hidden="true"
+                                            data-icon="caret-up"
+                                            fill="currentColor"
+                                            focusable="false"
+                                            height="1em"
+                                            viewBox="0 0 1024 1024"
+                                            width="1em"
+                                          >
+                                            <path
+                                              d="M858.9 689L530.5 308.2c-9.4-10.9-27.5-10.9-37 0L165.1 689c-12.2 14.2-1.2 35 18.5 35h656.8c19.7 0 30.7-20.8 18.5-35z"
+                                            />
+                                          </svg>
+                                        </span>
+                                        <span
+                                          aria-label="caret-down"
+                                          class="anticon anticon-caret-down ant-table-column-sorter-down"
+                                          role="presentation"
+                                        >
+                                          <svg
+                                            aria-hidden="true"
+                                            data-icon="caret-down"
+                                            fill="currentColor"
+                                            focusable="false"
+                                            height="1em"
+                                            viewBox="0 0 1024 1024"
+                                            width="1em"
+                                          >
+                                            <path
+                                              d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
+                                            />
+                                          </svg>
+                                        </span>
+                                      </span>
+                                    </span>
+                                  </div>
+                                </th>
+                                <th
+                                  aria-label="Submitted On"
+                                  class="ant-table-cell ant-table-column-has-sorters"
+                                  tabindex="0"
+                                >
+                                  <div
+                                    class="ant-table-column-sorters"
+                                  >
+                                    <span
+                                      class="ant-table-column-title"
+                                    >
+                                      Submitted On
+                                    </span>
+                                    <span
+                                      class="ant-table-column-sorter ant-table-column-sorter-full"
+                                    >
+                                      <span
+                                        class="ant-table-column-sorter-inner"
+                                      >
+                                        <span
+                                          aria-label="caret-up"
+                                          class="anticon anticon-caret-up ant-table-column-sorter-up"
+                                          role="presentation"
+                                        >
+                                          <svg
+                                            aria-hidden="true"
+                                            data-icon="caret-up"
+                                            fill="currentColor"
+                                            focusable="false"
+                                            height="1em"
+                                            viewBox="0 0 1024 1024"
+                                            width="1em"
+                                          >
+                                            <path
+                                              d="M858.9 689L530.5 308.2c-9.4-10.9-27.5-10.9-37 0L165.1 689c-12.2 14.2-1.2 35 18.5 35h656.8c19.7 0 30.7-20.8 18.5-35z"
+                                            />
+                                          </svg>
+                                        </span>
+                                        <span
+                                          aria-label="caret-down"
+                                          class="anticon anticon-caret-down ant-table-column-sorter-down"
+                                          role="presentation"
+                                        >
+                                          <svg
+                                            aria-hidden="true"
+                                            data-icon="caret-down"
+                                            fill="currentColor"
+                                            focusable="false"
+                                            height="1em"
+                                            viewBox="0 0 1024 1024"
+                                            width="1em"
+                                          >
+                                            <path
+                                              d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
+                                            />
+                                          </svg>
+                                        </span>
+                                      </span>
+                                    </span>
+                                  </div>
+                                </th>
+                                <th
+                                  aria-label="Requested By"
+                                  class="ant-table-cell ant-table-column-has-sorters"
+                                  tabindex="0"
+                                >
+                                  <div
+                                    class="ant-table-column-sorters"
+                                  >
+                                    <span
+                                      class="ant-table-column-title"
+                                    >
+                                      Requested By
+                                    </span>
+                                    <span
+                                      class="ant-table-column-sorter ant-table-column-sorter-full"
+                                    >
+                                      <span
+                                        class="ant-table-column-sorter-inner"
+                                      >
+                                        <span
+                                          aria-label="caret-up"
+                                          class="anticon anticon-caret-up ant-table-column-sorter-up"
+                                          role="presentation"
+                                        >
+                                          <svg
+                                            aria-hidden="true"
+                                            data-icon="caret-up"
+                                            fill="currentColor"
+                                            focusable="false"
+                                            height="1em"
+                                            viewBox="0 0 1024 1024"
+                                            width="1em"
+                                          >
+                                            <path
+                                              d="M858.9 689L530.5 308.2c-9.4-10.9-27.5-10.9-37 0L165.1 689c-12.2 14.2-1.2 35 18.5 35h656.8c19.7 0 30.7-20.8 18.5-35z"
+                                            />
+                                          </svg>
+                                        </span>
+                                        <span
+                                          aria-label="caret-down"
+                                          class="anticon anticon-caret-down ant-table-column-sorter-down"
+                                          role="presentation"
+                                        >
+                                          <svg
+                                            aria-hidden="true"
+                                            data-icon="caret-down"
+                                            fill="currentColor"
+                                            focusable="false"
+                                            height="1em"
+                                            viewBox="0 0 1024 1024"
+                                            width="1em"
+                                          >
+                                            <path
+                                              d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
+                                            />
+                                          </svg>
+                                        </span>
+                                      </span>
+                                    </span>
+                                  </div>
+                                </th>
+                                <th
+                                  aria-label="Status"
+                                  class="ant-table-cell ant-table-column-has-sorters"
+                                  tabindex="0"
+                                >
+                                  <div
+                                    class="ant-table-column-sorters"
+                                  >
+                                    <span
+                                      class="ant-table-column-title"
+                                    >
+                                      Status
+                                    </span>
+                                    <span
+                                      class="ant-table-column-sorter ant-table-column-sorter-full"
+                                    >
+                                      <span
+                                        class="ant-table-column-sorter-inner"
+                                      >
+                                        <span
+                                          aria-label="caret-up"
+                                          class="anticon anticon-caret-up ant-table-column-sorter-up"
+                                          role="presentation"
+                                        >
+                                          <svg
+                                            aria-hidden="true"
+                                            data-icon="caret-up"
+                                            fill="currentColor"
+                                            focusable="false"
+                                            height="1em"
+                                            viewBox="0 0 1024 1024"
+                                            width="1em"
+                                          >
+                                            <path
+                                              d="M858.9 689L530.5 308.2c-9.4-10.9-27.5-10.9-37 0L165.1 689c-12.2 14.2-1.2 35 18.5 35h656.8c19.7 0 30.7-20.8 18.5-35z"
+                                            />
+                                          </svg>
+                                        </span>
+                                        <span
+                                          aria-label="caret-down"
+                                          class="anticon anticon-caret-down ant-table-column-sorter-down"
+                                          role="presentation"
+                                        >
+                                          <svg
+                                            aria-hidden="true"
+                                            data-icon="caret-down"
+                                            fill="currentColor"
+                                            focusable="false"
+                                            height="1em"
+                                            viewBox="0 0 1024 1024"
+                                            width="1em"
+                                          >
+                                            <path
+                                              d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
+                                            />
+                                          </svg>
+                                        </span>
+                                      </span>
+                                    </span>
+                                  </div>
+                                </th>
+                                <th
+                                  class="ant-table-cell actions-column ant-table-cell-fix-right ant-table-cell-fix-right-first"
+                                  style="position: sticky; right: 0px;"
+                                />
+                              </tr>
+                            </thead>
+                            <tbody
+                              class="ant-table-tbody"
+                            >
+                              <tr
+                                class="ant-table-row ant-table-row-level-0 fade-in"
+                                data-row-key="9f98a719-720a-40a5-ac5b-e91e8a526fad"
+                              >
+                                <td
+                                  class="ant-table-cell"
+                                >
+                                  <div
+                                    class="report_name-column"
+                                    title="Report Name"
+                                  >
+                                    Underground Oil and Grease Storage Area Report
+                                  </div>
+                                </td>
+                                <td
+                                  class="ant-table-cell"
+                                >
+                                  <div
+                                    title="Code Section"
+                                  >
+                                    4.3.4
+                                  </div>
+                                </td>
+                                <td
+                                  class="ant-table-cell"
+                                >
+                                  <div
+                                    class="submission_year-column"
+                                    title="Compliance Year"
+                                  >
+                                    2020
+                                  </div>
+                                </td>
+                                <td
+                                  class="ant-table-cell"
+                                >
+                                  <div
+                                    class="due_date-column"
+                                    title="Due"
+                                  >
+                                    2020-01-02
+                                  </div>
+                                </td>
+                                <td
+                                  class="ant-table-cell"
+                                >
+                                  <div
+                                    class="latest_submission,received_date-column"
+                                    title="Submitted On"
+                                  >
+                                    2020-01-10
+                                  </div>
+                                </td>
+                                <td
+                                  class="ant-table-cell"
+                                >
+                                  <div
+                                    class="created_by_idir-column"
+                                    title="Requested By"
+                                  >
+                                    idir\\TEST
+                                  </div>
+                                </td>
+                                <td
+                                  class="ant-table-cell"
+                                >
+                                  <span
+                                    class="ant-badge ant-badge-status ant-badge-not-a-wrapper"
+                                  >
+                                    <span
+                                      class="ant-badge-status-dot ant-badge-status-success"
+                                    />
+                                    <span
+                                      class="ant-badge-status-text"
+                                    >
+                                      Not Requested
+                                    </span>
+                                  </span>
+                                </td>
+                                <td
+                                  class="ant-table-cell actions-column ant-table-cell-fix-right ant-table-cell-fix-right-first"
+                                  style="position: sticky; right: 0px;"
+                                >
+                                  <button
+                                    class="ant-btn ant-btn-text ant-dropdown-trigger actions-dropdown-button"
+                                    data-cy="menu-actions-button"
+                                    type="button"
+                                  >
+                                    <span>
+                                      Actions
+                                    </span>
+                                    <span
+                                      alt="Menu"
+                                      aria-label="caret-down"
+                                      class="anticon anticon-caret-down"
+                                      role="img"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        class=""
+                                        data-icon="caret-down"
+                                        fill="currentColor"
+                                        focusable="false"
+                                        height="1em"
+                                        viewBox="0 0 1024 1024"
+                                        width="1em"
+                                      >
+                                        <path
+                                          d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </button>
+                                </td>
+                              </tr>
+                              <tr
+                                class="ant-table-row ant-table-row-level-0 fade-in"
+                                data-row-key="b59a166e-749e-4e6c-a232-d4c55f1f227c"
+                              >
+                                <td
+                                  class="ant-table-cell"
+                                >
+                                  <div
+                                    class="report_name-column"
+                                    title="Report Name"
+                                  >
+                                    TSF, WSF or Dam As-built Report
+                                  </div>
+                                </td>
+                                <td
+                                  class="ant-table-cell"
+                                >
+                                  <div
+                                    title="Code Section"
+                                  >
+                                    10.5.1.1
+                                  </div>
+                                </td>
+                                <td
+                                  class="ant-table-cell"
+                                >
+                                  <div
+                                    class="submission_year-column"
+                                    title="Compliance Year"
+                                  >
+                                    2020
+                                  </div>
+                                </td>
+                                <td
+                                  class="ant-table-cell"
+                                >
+                                  <div
+                                    class="due_date-column"
+                                    title="Due"
+                                  >
+                                    2020-03-31
+                                  </div>
+                                </td>
+                                <td
+                                  class="ant-table-cell"
+                                >
+                                  <div
+                                    class="latest_submission,received_date-column"
+                                    title="Submitted On"
+                                  >
+                                    2020-01-02
+                                  </div>
+                                </td>
+                                <td
+                                  class="ant-table-cell"
+                                >
+                                  <div
+                                    class="created_by_idir-column"
+                                    title="Requested By"
+                                  >
+                                    idir\\TEST
+                                  </div>
+                                </td>
+                                <td
+                                  class="ant-table-cell"
+                                >
+                                  <span
+                                    class="ant-badge ant-badge-status ant-badge-not-a-wrapper"
+                                  >
+                                    <span
+                                      class="ant-badge-status-dot ant-badge-status-success"
+                                    />
+                                    <span
+                                      class="ant-badge-status-text"
+                                    >
+                                      Not Requested
+                                    </span>
+                                  </span>
+                                </td>
+                                <td
+                                  class="ant-table-cell actions-column ant-table-cell-fix-right ant-table-cell-fix-right-first"
+                                  style="position: sticky; right: 0px;"
+                                >
+                                  <button
+                                    class="ant-btn ant-btn-text ant-dropdown-trigger actions-dropdown-button"
+                                    data-cy="menu-actions-button"
+                                    type="button"
+                                  >
+                                    <span>
+                                      Actions
+                                    </span>
+                                    <span
+                                      alt="Menu"
+                                      aria-label="caret-down"
+                                      class="anticon anticon-caret-down"
+                                      role="img"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        class=""
+                                        data-icon="caret-down"
+                                        fill="currentColor"
+                                        focusable="false"
+                                        height="1em"
+                                        viewBox="0 0 1024 1024"
+                                        width="1em"
+                                      >
+                                        <path
+                                          d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </button>
+                                </td>
+                              </tr>
+                              <tr
+                                class="ant-table-row ant-table-row-level-0 fade-in"
+                                data-row-key="92327cd3-eec0-4e18-b898-25539ac408e9"
+                              >
+                                <td
+                                  class="ant-table-cell"
+                                >
+                                  <div
+                                    class="report_name-column"
+                                    title="Report Name"
+                                  >
+                                    Annual DSI
+                                  </div>
+                                </td>
+                                <td
+                                  class="ant-table-cell"
+                                >
+                                  <div
+                                    title="Code Section"
+                                  >
+                                    10.4.4
+                                  </div>
+                                </td>
+                                <td
+                                  class="ant-table-cell"
+                                >
+                                  <div
+                                    class="submission_year-column"
+                                    title="Compliance Year"
+                                  >
+                                    2020
+                                  </div>
+                                </td>
+                                <td
+                                  class="ant-table-cell"
+                                >
+                                  <div
+                                    class="due_date-column"
+                                    title="Due"
+                                  >
+                                    2020-03-31
+                                  </div>
+                                </td>
+                                <td
+                                  class="ant-table-cell"
+                                >
+                                  <div
+                                    class="latest_submission,received_date-column"
+                                    title="Submitted On"
+                                  >
+                                    2025-02-01
+                                  </div>
+                                </td>
+                                <td
+                                  class="ant-table-cell"
+                                >
+                                  <div
+                                    class="created_by_idir-column"
+                                    title="Requested By"
+                                  >
+                                    idir\\TEST
+                                  </div>
+                                </td>
+                                <td
+                                  class="ant-table-cell"
+                                >
+                                  <span
+                                    class="ant-badge ant-badge-status ant-badge-not-a-wrapper"
+                                  >
+                                    <span
+                                      class="ant-badge-status-dot ant-badge-status-warning"
+                                    />
+                                    <span
+                                      class="ant-badge-status-text"
+                                    >
+                                      Report Requested
+                                    </span>
+                                  </span>
+                                </td>
+                                <td
+                                  class="ant-table-cell actions-column ant-table-cell-fix-right ant-table-cell-fix-right-first"
+                                  style="position: sticky; right: 0px;"
+                                >
+                                  <button
+                                    class="ant-btn ant-btn-text ant-dropdown-trigger actions-dropdown-button"
+                                    data-cy="menu-actions-button"
+                                    type="button"
+                                  >
+                                    <span>
+                                      Actions
+                                    </span>
+                                    <span
+                                      alt="Menu"
+                                      aria-label="caret-down"
+                                      class="anticon anticon-caret-down"
+                                      role="img"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        class=""
+                                        data-icon="caret-down"
+                                        fill="currentColor"
+                                        focusable="false"
+                                        height="1em"
+                                        viewBox="0 0 1024 1024"
+                                        width="1em"
+                                      >
+                                        <path
+                                          d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </button>
+                                </td>
+                              </tr>
+                            </tbody>
+                          </table>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="ant-row ant-row-center margin-large--bottom"
+              >
+                <div />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/services/minespace-web/src/tests/components/dashboard/mine/reports/__snapshots__/ReportManagement.spec.tsx.snap
+++ b/services/minespace-web/src/tests/components/dashboard/mine/reports/__snapshots__/ReportManagement.spec.tsx.snap
@@ -355,32 +355,8 @@ exports[`ReportManagement renders and matches snapshot 1`] = `
                 <div
                   class="ant-spin-nested-loading"
                 >
-                  <div>
-                    <div
-                      aria-busy="true"
-                      aria-live="polite"
-                      class="ant-spin ant-spin-spinning"
-                    >
-                      <span
-                        class="ant-spin-dot ant-spin-dot-spin"
-                      >
-                        <i
-                          class="ant-spin-dot-item"
-                        />
-                        <i
-                          class="ant-spin-dot-item"
-                        />
-                        <i
-                          class="ant-spin-dot-item"
-                        />
-                        <i
-                          class="ant-spin-dot-item"
-                        />
-                      </span>
-                    </div>
-                  </div>
                   <div
-                    class="ant-spin-container ant-spin-blur"
+                    class="ant-spin-container"
                   >
                     <div
                       class="ant-table ant-table-small ant-table-has-fix-right"

--- a/services/minespace-web/src/tests/components/dashboard/mine/reports/__snapshots__/Reports.spec.tsx.snap
+++ b/services/minespace-web/src/tests/components/dashboard/mine/reports/__snapshots__/Reports.spec.tsx.snap
@@ -15,7 +15,40 @@ exports[`Reports renders properly 1`] = `
           class="ant-col ant-col-24"
         >
           <div>
-            <span />
+            <span>
+              <a
+                href="/mines/18133c75-49ad-4101-85f3-a43e35ae989a/reports/new"
+              >
+                <button
+                  class="ant-btn ant-btn-primary dashboard-add-button"
+                  type="button"
+                >
+                  <span
+                    aria-label="plus-circle"
+                    class="anticon anticon-plus-circle"
+                    role="img"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class=""
+                      data-icon="plus-circle"
+                      fill="currentColor"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm192 472c0 4.4-3.6 8-8 8H544v152c0 4.4-3.6 8-8 8h-48c-4.4 0-8-3.6-8-8V544H328c-4.4 0-8-3.6-8-8v-48c0-4.4 3.6-8 8-8h152V328c0-4.4 3.6-8 8-8h48c4.4 0 8 3.6 8 8v152h152c4.4 0 8 3.6 8 8v48z"
+                      />
+                    </svg>
+                  </span>
+                  <span>
+                    Submit Report
+                  </span>
+                </button>
+              </a>
+            </span>
           </div>
           <h1
             class="ant-typography report-title"
@@ -117,10 +150,10 @@ exports[`Reports renders properly 1`] = `
                           <col />
                           <col />
                           <col
-                            style="width: 5px;"
+                            style="width: 50px;"
                           />
                           <col
-                            style="width: 5px;"
+                            style="width: 100px;"
                           />
                         </colgroup>
                         <thead
@@ -816,10 +849,10 @@ exports[`Reports renders properly 1`] = `
                           <col />
                           <col />
                           <col
-                            style="width: 5px;"
+                            style="width: 50px;"
                           />
                           <col
-                            style="width: 5px;"
+                            style="width: 100px;"
                           />
                         </colgroup>
                         <thead
@@ -827,65 +860,9 @@ exports[`Reports renders properly 1`] = `
                         >
                           <tr>
                             <th
-                              aria-label="Report Name"
-                              class="ant-table-cell ant-table-column-has-sorters"
-                              tabindex="0"
+                              class="ant-table-cell"
                             >
-                              <div
-                                class="ant-table-column-sorters"
-                              >
-                                <span
-                                  class="ant-table-column-title"
-                                >
-                                  Report Name
-                                </span>
-                                <span
-                                  class="ant-table-column-sorter ant-table-column-sorter-full"
-                                >
-                                  <span
-                                    class="ant-table-column-sorter-inner"
-                                  >
-                                    <span
-                                      aria-label="caret-up"
-                                      class="anticon anticon-caret-up ant-table-column-sorter-up"
-                                      role="presentation"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        data-icon="caret-up"
-                                        fill="currentColor"
-                                        focusable="false"
-                                        height="1em"
-                                        viewBox="0 0 1024 1024"
-                                        width="1em"
-                                      >
-                                        <path
-                                          d="M858.9 689L530.5 308.2c-9.4-10.9-27.5-10.9-37 0L165.1 689c-12.2 14.2-1.2 35 18.5 35h656.8c19.7 0 30.7-20.8 18.5-35z"
-                                        />
-                                      </svg>
-                                    </span>
-                                    <span
-                                      aria-label="caret-down"
-                                      class="anticon anticon-caret-down ant-table-column-sorter-down"
-                                      role="presentation"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        data-icon="caret-down"
-                                        fill="currentColor"
-                                        focusable="false"
-                                        height="1em"
-                                        viewBox="0 0 1024 1024"
-                                        width="1em"
-                                      >
-                                        <path
-                                          d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
-                                        />
-                                      </svg>
-                                    </span>
-                                  </span>
-                                </span>
-                              </div>
+                              Report Name
                             </th>
                             <th
                               class="ant-table-cell"
@@ -893,65 +870,9 @@ exports[`Reports renders properly 1`] = `
                               Code Section
                             </th>
                             <th
-                              aria-label="Compliance Year"
-                              class="ant-table-cell ant-table-column-has-sorters"
-                              tabindex="0"
+                              class="ant-table-cell"
                             >
-                              <div
-                                class="ant-table-column-sorters"
-                              >
-                                <span
-                                  class="ant-table-column-title"
-                                >
-                                  Compliance Year
-                                </span>
-                                <span
-                                  class="ant-table-column-sorter ant-table-column-sorter-full"
-                                >
-                                  <span
-                                    class="ant-table-column-sorter-inner"
-                                  >
-                                    <span
-                                      aria-label="caret-up"
-                                      class="anticon anticon-caret-up ant-table-column-sorter-up"
-                                      role="presentation"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        data-icon="caret-up"
-                                        fill="currentColor"
-                                        focusable="false"
-                                        height="1em"
-                                        viewBox="0 0 1024 1024"
-                                        width="1em"
-                                      >
-                                        <path
-                                          d="M858.9 689L530.5 308.2c-9.4-10.9-27.5-10.9-37 0L165.1 689c-12.2 14.2-1.2 35 18.5 35h656.8c19.7 0 30.7-20.8 18.5-35z"
-                                        />
-                                      </svg>
-                                    </span>
-                                    <span
-                                      aria-label="caret-down"
-                                      class="anticon anticon-caret-down ant-table-column-sorter-down"
-                                      role="presentation"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        data-icon="caret-down"
-                                        fill="currentColor"
-                                        focusable="false"
-                                        height="1em"
-                                        viewBox="0 0 1024 1024"
-                                        width="1em"
-                                      >
-                                        <path
-                                          d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
-                                        />
-                                      </svg>
-                                    </span>
-                                  </span>
-                                </span>
-                              </div>
+                              Compliance Year
                             </th>
                             <th
                               aria-label="Due"

--- a/services/minespace-web/src/tests/components/dashboard/mine/reports/__snapshots__/Reports.v2.spec.tsx.snap
+++ b/services/minespace-web/src/tests/components/dashboard/mine/reports/__snapshots__/Reports.v2.spec.tsx.snap
@@ -1,0 +1,1044 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Reports (v2) matches snapshot (v2) 1`] = `
+<div>
+  <div
+    class="ant-row"
+    style="margin-top: -12px; margin-bottom: -12px;"
+  >
+    <div
+      class="ant-col ant-col-24"
+      style="padding-top: 12px; padding-bottom: 12px;"
+    >
+      <div
+        class="ant-row ant-row-space-between ant-row-middle"
+      >
+        <div
+          class="ant-col"
+        >
+          <h1
+            class="ant-typography"
+          >
+            Report Management
+          </h1>
+        </div>
+        <div
+          class="ant-col"
+        >
+          <a
+            href="/mines/18133c75-49ad-4101-85f3-a43e35ae989a/reports/new"
+          >
+            <button
+              class="ant-btn ant-btn-primary dashboard-add-button"
+              type="button"
+            >
+              <span
+                aria-label="plus-circle"
+                class="anticon anticon-plus-circle"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  class=""
+                  data-icon="plus-circle"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm192 472c0 4.4-3.6 8-8 8H544v152c0 4.4-3.6 8-8 8h-48c-4.4 0-8-3.6-8-8V544H328c-4.4 0-8-3.6-8-8v-48c0-4.4 3.6-8 8-8h152V328c0-4.4 3.6-8 8-8h48c4.4 0 8 3.6 8 8v152h152c4.4 0 8 3.6 8 8v48z"
+                  />
+                </svg>
+              </span>
+              <span>
+                Submit Report
+              </span>
+            </button>
+          </a>
+        </div>
+      </div>
+      <div
+        class="ant-typography"
+      >
+        Review and manage reports required for your mine's permit and Health, Safety and Reclamation Code obligations.
+      </div>
+    </div>
+    <div
+      class="ant-col ant-col-24"
+      style="padding-top: 12px; padding-bottom: 12px;"
+    >
+      <div
+        class="ant-row"
+        style="margin: -8px -8px -8px -8px;"
+      >
+        <div
+          class="ant-col ant-col-sm-24 ant-col-md-10 ant-col-lg-6"
+          style="padding: 8px 8px 8px 8px;"
+        >
+          <div
+            class="table-summary-card"
+          >
+            <div>
+              <span
+                aria-label="file-text"
+                class="anticon anticon-file-text table-summary-card-icon color-success"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  class=""
+                  data-icon="file-text"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M854.6 288.6L639.4 73.4c-6-6-14.1-9.4-22.6-9.4H192c-17.7 0-32 14.3-32 32v832c0 17.7 14.3 32 32 32h640c17.7 0 32-14.3 32-32V311.3c0-8.5-3.4-16.7-9.4-22.7zM790.2 326H602V137.8L790.2 326zm1.8 562H232V136h302v216a42 42 0 0042 42h216v494zM504 618H320c-4.4 0-8 3.6-8 8v48c0 4.4 3.6 8 8 8h184c4.4 0 8-3.6 8-8v-48c0-4.4-3.6-8-8-8zM312 490v48c0 4.4 3.6 8 8 8h384c4.4 0 8-3.6 8-8v-48c0-4.4-3.6-8-8-8H320c-4.4 0-8 3.6-8 8z"
+                  />
+                </svg>
+              </span>
+              <span
+                class="table-summary-card-title"
+              >
+                Active Permits
+              </span>
+            </div>
+            <div
+              class="table-summary-card-content"
+            >
+              0
+            </div>
+          </div>
+        </div>
+        <div
+          class="ant-col ant-col-sm-24 ant-col-md-10 ant-col-lg-6"
+          style="padding: 8px 8px 8px 8px;"
+        >
+          <div
+            class="table-summary-card"
+          >
+            <div>
+              <span
+                aria-label="clock-circle"
+                class="anticon anticon-clock-circle table-summary-card-icon color-error"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  class=""
+                  data-icon="clock-circle"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                  />
+                  <path
+                    d="M686.7 638.6L544.1 535.5V288c0-4.4-3.6-8-8-8H488c-4.4 0-8 3.6-8 8v275.4c0 2.6 1.2 5 3.3 6.5l165.4 120.6c3.6 2.6 8.6 1.8 11.2-1.7l28.6-39c2.6-3.7 1.8-8.7-1.8-11.2z"
+                  />
+                </svg>
+              </span>
+              <span
+                class="table-summary-card-title"
+              >
+                Reports Overdue
+              </span>
+            </div>
+            <div
+              class="table-summary-card-content"
+            >
+              3
+            </div>
+          </div>
+        </div>
+        <div
+          class="ant-col ant-col-sm-24 ant-col-md-10 ant-col-lg-6"
+          style="padding: 8px 8px 8px 8px;"
+        >
+          <div
+            class="table-summary-card"
+          >
+            <div>
+              <span
+                aria-label="exclamation-circle"
+                class="anticon anticon-exclamation-circle table-summary-card-icon color-warning"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  class=""
+                  data-icon="exclamation-circle"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                  />
+                  <path
+                    d="M464 688a48 48 0 1096 0 48 48 0 10-96 0zm24-112h48c4.4 0 8-3.6 8-8V296c0-4.4-3.6-8-8-8h-48c-4.4 0-8 3.6-8 8v272c0 4.4 3.6 8 8 8z"
+                  />
+                </svg>
+              </span>
+              <span
+                class="table-summary-card-title"
+              >
+                Reports Due in the Next 90 Days
+              </span>
+            </div>
+            <div
+              class="table-summary-card-content"
+            >
+              4
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="ant-col ant-col-24"
+      style="padding-top: 12px; padding-bottom: 12px;"
+    >
+      <div
+        class="ant-tabs ant-tabs-top ant-tabs-card"
+      >
+        <div
+          class="ant-tabs-nav"
+          role="tablist"
+        >
+          <div
+            class="ant-tabs-nav-wrap"
+          >
+            <div
+              class="ant-tabs-nav-list"
+              style="transform: translate(0px, 0px);"
+            >
+              <div
+                class="ant-tabs-tab ant-tabs-tab-active"
+                data-node-key="all_reports"
+              >
+                <div
+                  aria-controls="rc-tabs-test-panel-all_reports"
+                  aria-selected="true"
+                  class="ant-tabs-tab-btn"
+                  id="rc-tabs-test-tab-all_reports"
+                  role="tab"
+                  tabindex="0"
+                >
+                  All Reports
+                </div>
+              </div>
+              <div
+                class="ant-tabs-ink-bar ant-tabs-ink-bar-animated"
+                style="left: 0px; width: 0px;"
+              />
+            </div>
+          </div>
+          <div
+            class="ant-tabs-nav-operations ant-tabs-nav-operations-hidden"
+          >
+            <button
+              aria-controls="rc-tabs-test-more-popup"
+              aria-expanded="false"
+              aria-haspopup="listbox"
+              aria-hidden="true"
+              class="ant-tabs-nav-more"
+              id="rc-tabs-test-more"
+              style="visibility: hidden; order: 1;"
+              tabindex="-1"
+              type="button"
+            >
+              <span
+                aria-label="ellipsis"
+                class="anticon anticon-ellipsis"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-icon="ellipsis"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M176 511a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0zm280 0a56 56 0 10112 0 56 56 0 10-112 0z"
+                  />
+                </svg>
+              </span>
+            </button>
+          </div>
+        </div>
+        <div
+          class="ant-tabs-content-holder"
+        >
+          <div
+            class="ant-tabs-content ant-tabs-content-top"
+          >
+            <div
+              aria-hidden="false"
+              aria-labelledby="rc-tabs-test-tab-all_reports"
+              class="ant-tabs-tabpane ant-tabs-tabpane-active"
+              id="rc-tabs-test-panel-all_reports"
+              role="tabpanel"
+              tabindex="0"
+            >
+              <h2
+                class="ant-typography"
+              >
+                All Reports
+              </h2>
+              <div
+                class="ant-typography"
+              >
+                This table shows the reporting requirements for your permits. It highlights overdue, upcoming, and requested reports to help you stay compliant. Drafts and previously submitted reports are also included for your reference.
+              </div>
+              <div
+                class="margin-large--bottom"
+              >
+                <div
+                  class="ant-alert ant-alert-info ant-alert-with-description"
+                  data-show="true"
+                  role="alert"
+                >
+                  <span
+                    aria-label="info-circle"
+                    class="anticon anticon-info-circle ant-alert-icon"
+                    role="img"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      data-icon="info-circle"
+                      fill="currentColor"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                      />
+                      <path
+                        d="M464 336a48 48 0 1096 0 48 48 0 10-96 0zm72 112h-48c-4.4 0-8 3.6-8 8v272c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V456c0-4.4-3.6-8-8-8z"
+                      />
+                    </svg>
+                  </span>
+                  <div
+                    class="ant-alert-content"
+                  >
+                    <div
+                      class="ant-alert-message"
+                    >
+                      Reminder
+                    </div>
+                    <div
+                      class="ant-alert-description"
+                    >
+                      Your permit is the official source of reporting requirements. Use this table as a reference, but always check your permit to confirm compliance.
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="ant-table-wrapper  core-table"
+              >
+                <div
+                  class="ant-spin-nested-loading"
+                >
+                  <div>
+                    <div
+                      aria-busy="true"
+                      aria-live="polite"
+                      class="ant-spin ant-spin-spinning"
+                    >
+                      <span
+                        class="ant-spin-dot ant-spin-dot-spin"
+                      >
+                        <i
+                          class="ant-spin-dot-item"
+                        />
+                        <i
+                          class="ant-spin-dot-item"
+                        />
+                        <i
+                          class="ant-spin-dot-item"
+                        />
+                        <i
+                          class="ant-spin-dot-item"
+                        />
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="ant-spin-container ant-spin-blur"
+                  >
+                    <div
+                      class="ant-table ant-table-small ant-table-has-fix-right"
+                    >
+                      <div
+                        class="ant-table-container"
+                      >
+                        <div
+                          class="ant-table-content"
+                        >
+                          <table
+                            style="table-layout: auto;"
+                          >
+                            <colgroup>
+                              <col />
+                              <col />
+                              <col
+                                style="width: 50px;"
+                              />
+                              <col
+                                style="width: 100px;"
+                              />
+                            </colgroup>
+                            <thead
+                              class="ant-table-thead"
+                            >
+                              <tr>
+                                <th
+                                  class="ant-table-cell"
+                                >
+                                  Report Name
+                                </th>
+                                <th
+                                  class="ant-table-cell"
+                                >
+                                  Code Section
+                                </th>
+                                <th
+                                  class="ant-table-cell"
+                                >
+                                  Compliance Year
+                                </th>
+                                <th
+                                  aria-label="Due"
+                                  class="ant-table-cell ant-table-column-has-sorters"
+                                  tabindex="0"
+                                >
+                                  <div
+                                    class="ant-table-column-sorters"
+                                  >
+                                    <span
+                                      class="ant-table-column-title"
+                                    >
+                                      Due
+                                    </span>
+                                    <span
+                                      class="ant-table-column-sorter ant-table-column-sorter-full"
+                                    >
+                                      <span
+                                        class="ant-table-column-sorter-inner"
+                                      >
+                                        <span
+                                          aria-label="caret-up"
+                                          class="anticon anticon-caret-up ant-table-column-sorter-up"
+                                          role="presentation"
+                                        >
+                                          <svg
+                                            aria-hidden="true"
+                                            data-icon="caret-up"
+                                            fill="currentColor"
+                                            focusable="false"
+                                            height="1em"
+                                            viewBox="0 0 1024 1024"
+                                            width="1em"
+                                          >
+                                            <path
+                                              d="M858.9 689L530.5 308.2c-9.4-10.9-27.5-10.9-37 0L165.1 689c-12.2 14.2-1.2 35 18.5 35h656.8c19.7 0 30.7-20.8 18.5-35z"
+                                            />
+                                          </svg>
+                                        </span>
+                                        <span
+                                          aria-label="caret-down"
+                                          class="anticon anticon-caret-down ant-table-column-sorter-down"
+                                          role="presentation"
+                                        >
+                                          <svg
+                                            aria-hidden="true"
+                                            data-icon="caret-down"
+                                            fill="currentColor"
+                                            focusable="false"
+                                            height="1em"
+                                            viewBox="0 0 1024 1024"
+                                            width="1em"
+                                          >
+                                            <path
+                                              d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
+                                            />
+                                          </svg>
+                                        </span>
+                                      </span>
+                                    </span>
+                                  </div>
+                                </th>
+                                <th
+                                  aria-label="Submitted On"
+                                  class="ant-table-cell ant-table-column-has-sorters"
+                                  tabindex="0"
+                                >
+                                  <div
+                                    class="ant-table-column-sorters"
+                                  >
+                                    <span
+                                      class="ant-table-column-title"
+                                    >
+                                      Submitted On
+                                    </span>
+                                    <span
+                                      class="ant-table-column-sorter ant-table-column-sorter-full"
+                                    >
+                                      <span
+                                        class="ant-table-column-sorter-inner"
+                                      >
+                                        <span
+                                          aria-label="caret-up"
+                                          class="anticon anticon-caret-up ant-table-column-sorter-up"
+                                          role="presentation"
+                                        >
+                                          <svg
+                                            aria-hidden="true"
+                                            data-icon="caret-up"
+                                            fill="currentColor"
+                                            focusable="false"
+                                            height="1em"
+                                            viewBox="0 0 1024 1024"
+                                            width="1em"
+                                          >
+                                            <path
+                                              d="M858.9 689L530.5 308.2c-9.4-10.9-27.5-10.9-37 0L165.1 689c-12.2 14.2-1.2 35 18.5 35h656.8c19.7 0 30.7-20.8 18.5-35z"
+                                            />
+                                          </svg>
+                                        </span>
+                                        <span
+                                          aria-label="caret-down"
+                                          class="anticon anticon-caret-down ant-table-column-sorter-down"
+                                          role="presentation"
+                                        >
+                                          <svg
+                                            aria-hidden="true"
+                                            data-icon="caret-down"
+                                            fill="currentColor"
+                                            focusable="false"
+                                            height="1em"
+                                            viewBox="0 0 1024 1024"
+                                            width="1em"
+                                          >
+                                            <path
+                                              d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
+                                            />
+                                          </svg>
+                                        </span>
+                                      </span>
+                                    </span>
+                                  </div>
+                                </th>
+                                <th
+                                  aria-label="Requested By"
+                                  class="ant-table-cell ant-table-column-has-sorters"
+                                  tabindex="0"
+                                >
+                                  <div
+                                    class="ant-table-column-sorters"
+                                  >
+                                    <span
+                                      class="ant-table-column-title"
+                                    >
+                                      Requested By
+                                    </span>
+                                    <span
+                                      class="ant-table-column-sorter ant-table-column-sorter-full"
+                                    >
+                                      <span
+                                        class="ant-table-column-sorter-inner"
+                                      >
+                                        <span
+                                          aria-label="caret-up"
+                                          class="anticon anticon-caret-up ant-table-column-sorter-up"
+                                          role="presentation"
+                                        >
+                                          <svg
+                                            aria-hidden="true"
+                                            data-icon="caret-up"
+                                            fill="currentColor"
+                                            focusable="false"
+                                            height="1em"
+                                            viewBox="0 0 1024 1024"
+                                            width="1em"
+                                          >
+                                            <path
+                                              d="M858.9 689L530.5 308.2c-9.4-10.9-27.5-10.9-37 0L165.1 689c-12.2 14.2-1.2 35 18.5 35h656.8c19.7 0 30.7-20.8 18.5-35z"
+                                            />
+                                          </svg>
+                                        </span>
+                                        <span
+                                          aria-label="caret-down"
+                                          class="anticon anticon-caret-down ant-table-column-sorter-down"
+                                          role="presentation"
+                                        >
+                                          <svg
+                                            aria-hidden="true"
+                                            data-icon="caret-down"
+                                            fill="currentColor"
+                                            focusable="false"
+                                            height="1em"
+                                            viewBox="0 0 1024 1024"
+                                            width="1em"
+                                          >
+                                            <path
+                                              d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
+                                            />
+                                          </svg>
+                                        </span>
+                                      </span>
+                                    </span>
+                                  </div>
+                                </th>
+                                <th
+                                  aria-label="Status"
+                                  class="ant-table-cell ant-table-column-has-sorters"
+                                  tabindex="0"
+                                >
+                                  <div
+                                    class="ant-table-column-sorters"
+                                  >
+                                    <span
+                                      class="ant-table-column-title"
+                                    >
+                                      Status
+                                    </span>
+                                    <span
+                                      class="ant-table-column-sorter ant-table-column-sorter-full"
+                                    >
+                                      <span
+                                        class="ant-table-column-sorter-inner"
+                                      >
+                                        <span
+                                          aria-label="caret-up"
+                                          class="anticon anticon-caret-up ant-table-column-sorter-up"
+                                          role="presentation"
+                                        >
+                                          <svg
+                                            aria-hidden="true"
+                                            data-icon="caret-up"
+                                            fill="currentColor"
+                                            focusable="false"
+                                            height="1em"
+                                            viewBox="0 0 1024 1024"
+                                            width="1em"
+                                          >
+                                            <path
+                                              d="M858.9 689L530.5 308.2c-9.4-10.9-27.5-10.9-37 0L165.1 689c-12.2 14.2-1.2 35 18.5 35h656.8c19.7 0 30.7-20.8 18.5-35z"
+                                            />
+                                          </svg>
+                                        </span>
+                                        <span
+                                          aria-label="caret-down"
+                                          class="anticon anticon-caret-down ant-table-column-sorter-down"
+                                          role="presentation"
+                                        >
+                                          <svg
+                                            aria-hidden="true"
+                                            data-icon="caret-down"
+                                            fill="currentColor"
+                                            focusable="false"
+                                            height="1em"
+                                            viewBox="0 0 1024 1024"
+                                            width="1em"
+                                          >
+                                            <path
+                                              d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
+                                            />
+                                          </svg>
+                                        </span>
+                                      </span>
+                                    </span>
+                                  </div>
+                                </th>
+                                <th
+                                  class="ant-table-cell actions-column ant-table-cell-fix-right ant-table-cell-fix-right-first"
+                                  style="position: sticky; right: 0px;"
+                                />
+                              </tr>
+                            </thead>
+                            <tbody
+                              class="ant-table-tbody"
+                            >
+                              <tr
+                                class="ant-table-row ant-table-row-level-0 fade-in"
+                                data-row-key="9f98a719-720a-40a5-ac5b-e91e8a526fad"
+                              >
+                                <td
+                                  class="ant-table-cell"
+                                >
+                                  <div
+                                    class="report_name-column"
+                                    title="Report Name"
+                                  >
+                                    Underground Oil and Grease Storage Area Report
+                                  </div>
+                                </td>
+                                <td
+                                  class="ant-table-cell"
+                                >
+                                  <div
+                                    title="Code Section"
+                                  >
+                                    4.3.4
+                                  </div>
+                                </td>
+                                <td
+                                  class="ant-table-cell"
+                                >
+                                  <div
+                                    class="submission_year-column"
+                                    title="Compliance Year"
+                                  >
+                                    2020
+                                  </div>
+                                </td>
+                                <td
+                                  class="ant-table-cell"
+                                >
+                                  <div
+                                    class="due_date-column"
+                                    title="Due"
+                                  >
+                                    2020-01-02
+                                  </div>
+                                </td>
+                                <td
+                                  class="ant-table-cell"
+                                >
+                                  <div
+                                    class="latest_submission,received_date-column"
+                                    title="Submitted On"
+                                  >
+                                    2020-01-10
+                                  </div>
+                                </td>
+                                <td
+                                  class="ant-table-cell"
+                                >
+                                  <div
+                                    class="created_by_idir-column"
+                                    title="Requested By"
+                                  >
+                                    idir\\TEST
+                                  </div>
+                                </td>
+                                <td
+                                  class="ant-table-cell"
+                                >
+                                  <span
+                                    class="ant-badge ant-badge-status ant-badge-not-a-wrapper"
+                                  >
+                                    <span
+                                      class="ant-badge-status-dot ant-badge-status-success"
+                                    />
+                                    <span
+                                      class="ant-badge-status-text"
+                                    >
+                                      Not Requested
+                                    </span>
+                                  </span>
+                                </td>
+                                <td
+                                  class="ant-table-cell actions-column ant-table-cell-fix-right ant-table-cell-fix-right-first"
+                                  style="position: sticky; right: 0px;"
+                                >
+                                  <button
+                                    class="ant-btn ant-btn-text ant-dropdown-trigger actions-dropdown-button"
+                                    data-cy="menu-actions-button"
+                                    type="button"
+                                  >
+                                    <span>
+                                      Actions
+                                    </span>
+                                    <span
+                                      alt="Menu"
+                                      aria-label="caret-down"
+                                      class="anticon anticon-caret-down"
+                                      role="img"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        class=""
+                                        data-icon="caret-down"
+                                        fill="currentColor"
+                                        focusable="false"
+                                        height="1em"
+                                        viewBox="0 0 1024 1024"
+                                        width="1em"
+                                      >
+                                        <path
+                                          d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </button>
+                                </td>
+                              </tr>
+                              <tr
+                                class="ant-table-row ant-table-row-level-0 fade-in"
+                                data-row-key="b59a166e-749e-4e6c-a232-d4c55f1f227c"
+                              >
+                                <td
+                                  class="ant-table-cell"
+                                >
+                                  <div
+                                    class="report_name-column"
+                                    title="Report Name"
+                                  >
+                                    TSF, WSF or Dam As-built Report
+                                  </div>
+                                </td>
+                                <td
+                                  class="ant-table-cell"
+                                >
+                                  <div
+                                    title="Code Section"
+                                  >
+                                    10.5.1.1
+                                  </div>
+                                </td>
+                                <td
+                                  class="ant-table-cell"
+                                >
+                                  <div
+                                    class="submission_year-column"
+                                    title="Compliance Year"
+                                  >
+                                    2020
+                                  </div>
+                                </td>
+                                <td
+                                  class="ant-table-cell"
+                                >
+                                  <div
+                                    class="due_date-column"
+                                    title="Due"
+                                  >
+                                    2020-03-31
+                                  </div>
+                                </td>
+                                <td
+                                  class="ant-table-cell"
+                                >
+                                  <div
+                                    class="latest_submission,received_date-column"
+                                    title="Submitted On"
+                                  >
+                                    2020-01-02
+                                  </div>
+                                </td>
+                                <td
+                                  class="ant-table-cell"
+                                >
+                                  <div
+                                    class="created_by_idir-column"
+                                    title="Requested By"
+                                  >
+                                    idir\\TEST
+                                  </div>
+                                </td>
+                                <td
+                                  class="ant-table-cell"
+                                >
+                                  <span
+                                    class="ant-badge ant-badge-status ant-badge-not-a-wrapper"
+                                  >
+                                    <span
+                                      class="ant-badge-status-dot ant-badge-status-success"
+                                    />
+                                    <span
+                                      class="ant-badge-status-text"
+                                    >
+                                      Not Requested
+                                    </span>
+                                  </span>
+                                </td>
+                                <td
+                                  class="ant-table-cell actions-column ant-table-cell-fix-right ant-table-cell-fix-right-first"
+                                  style="position: sticky; right: 0px;"
+                                >
+                                  <button
+                                    class="ant-btn ant-btn-text ant-dropdown-trigger actions-dropdown-button"
+                                    data-cy="menu-actions-button"
+                                    type="button"
+                                  >
+                                    <span>
+                                      Actions
+                                    </span>
+                                    <span
+                                      alt="Menu"
+                                      aria-label="caret-down"
+                                      class="anticon anticon-caret-down"
+                                      role="img"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        class=""
+                                        data-icon="caret-down"
+                                        fill="currentColor"
+                                        focusable="false"
+                                        height="1em"
+                                        viewBox="0 0 1024 1024"
+                                        width="1em"
+                                      >
+                                        <path
+                                          d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </button>
+                                </td>
+                              </tr>
+                              <tr
+                                class="ant-table-row ant-table-row-level-0 fade-in"
+                                data-row-key="92327cd3-eec0-4e18-b898-25539ac408e9"
+                              >
+                                <td
+                                  class="ant-table-cell"
+                                >
+                                  <div
+                                    class="report_name-column"
+                                    title="Report Name"
+                                  >
+                                    Annual DSI
+                                  </div>
+                                </td>
+                                <td
+                                  class="ant-table-cell"
+                                >
+                                  <div
+                                    title="Code Section"
+                                  >
+                                    10.4.4
+                                  </div>
+                                </td>
+                                <td
+                                  class="ant-table-cell"
+                                >
+                                  <div
+                                    class="submission_year-column"
+                                    title="Compliance Year"
+                                  >
+                                    2020
+                                  </div>
+                                </td>
+                                <td
+                                  class="ant-table-cell"
+                                >
+                                  <div
+                                    class="due_date-column"
+                                    title="Due"
+                                  >
+                                    2020-03-31
+                                  </div>
+                                </td>
+                                <td
+                                  class="ant-table-cell"
+                                >
+                                  <div
+                                    class="latest_submission,received_date-column"
+                                    title="Submitted On"
+                                  >
+                                    2025-02-01
+                                  </div>
+                                </td>
+                                <td
+                                  class="ant-table-cell"
+                                >
+                                  <div
+                                    class="created_by_idir-column"
+                                    title="Requested By"
+                                  >
+                                    idir\\TEST
+                                  </div>
+                                </td>
+                                <td
+                                  class="ant-table-cell"
+                                >
+                                  <span
+                                    class="ant-badge ant-badge-status ant-badge-not-a-wrapper"
+                                  >
+                                    <span
+                                      class="ant-badge-status-dot ant-badge-status-warning"
+                                    />
+                                    <span
+                                      class="ant-badge-status-text"
+                                    >
+                                      Report Requested
+                                    </span>
+                                  </span>
+                                </td>
+                                <td
+                                  class="ant-table-cell actions-column ant-table-cell-fix-right ant-table-cell-fix-right-first"
+                                  style="position: sticky; right: 0px;"
+                                >
+                                  <button
+                                    class="ant-btn ant-btn-text ant-dropdown-trigger actions-dropdown-button"
+                                    data-cy="menu-actions-button"
+                                    type="button"
+                                  >
+                                    <span>
+                                      Actions
+                                    </span>
+                                    <span
+                                      alt="Menu"
+                                      aria-label="caret-down"
+                                      class="anticon anticon-caret-down"
+                                      role="img"
+                                    >
+                                      <svg
+                                        aria-hidden="true"
+                                        class=""
+                                        data-icon="caret-down"
+                                        fill="currentColor"
+                                        focusable="false"
+                                        height="1em"
+                                        viewBox="0 0 1024 1024"
+                                        width="1em"
+                                      >
+                                        <path
+                                          d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
+                                        />
+                                      </svg>
+                                    </span>
+                                  </button>
+                                </td>
+                              </tr>
+                            </tbody>
+                          </table>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="ant-row ant-row-center margin-large--bottom"
+              >
+                <div />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/services/minespace-web/src/tests/components/dashboard/mine/reports/__snapshots__/Reports.v2.spec.tsx.snap
+++ b/services/minespace-web/src/tests/components/dashboard/mine/reports/__snapshots__/Reports.v2.spec.tsx.snap
@@ -110,7 +110,7 @@ exports[`Reports (v2) matches snapshot (v2) 1`] = `
             <div
               class="table-summary-card-content"
             >
-              0
+              3
             </div>
           </div>
         </div>
@@ -355,32 +355,8 @@ exports[`Reports (v2) matches snapshot (v2) 1`] = `
                 <div
                   class="ant-spin-nested-loading"
                 >
-                  <div>
-                    <div
-                      aria-busy="true"
-                      aria-live="polite"
-                      class="ant-spin ant-spin-spinning"
-                    >
-                      <span
-                        class="ant-spin-dot ant-spin-dot-spin"
-                      >
-                        <i
-                          class="ant-spin-dot-item"
-                        />
-                        <i
-                          class="ant-spin-dot-item"
-                        />
-                        <i
-                          class="ant-spin-dot-item"
-                        />
-                        <i
-                          class="ant-spin-dot-item"
-                        />
-                      </span>
-                    </div>
-                  </div>
                   <div
-                    class="ant-spin-container ant-spin-blur"
+                    class="ant-spin-container"
                   >
                     <div
                       class="ant-table ant-table-small ant-table-has-fix-right"

--- a/services/minespace-web/src/tests/handlers.ts
+++ b/services/minespace-web/src/tests/handlers.ts
@@ -1,5 +1,51 @@
 import commonHandlers from "@mds/common/tests/handlers";
+import { http, HttpResponse } from "msw";
+import queryString from "query-string";
+import {
+  PERMITS as MOCK_PERMITS,
+  MINE_REPORT_RESPONSE as MOCK_MINE_REPORT_RESPONSE,
+} from "@mds/common/tests/mocks/dataMocks";
 
-const handlers = [...commonHandlers];
+// Exported for tests to assert request parameters
+export let lastMineReportsRequest: { mineGuid: string; query: any } | null = null;
+export let lastPermitsRequest: { mineGuid: string } | null = null;
+
+// Handle GET mine reports with optional multiple mine_reports_type params
+const mineReportsHandler = http.get(
+  "/%3CAPI_URL%3E/mines/:mineGuid/reports",
+  async ({ params, request }) => {
+    const { mineGuid } = params as { mineGuid: string };
+    const url = new URL(request.url);
+    const qs = queryString.parse(url.searchParams.toString());
+    lastMineReportsRequest = { mineGuid, query: qs };
+
+    // Respect per_page if provided; default to the mock count
+    const perPageRaw = qs.per_page as string | string[] | undefined;
+    const perPage = Array.isArray(perPageRaw)
+      ? parseInt(perPageRaw[0] ?? "", 10)
+      : parseInt(perPageRaw ?? "", 10);
+    const effectivePerPage = Number.isFinite(perPage)
+      ? perPage
+      : MOCK_MINE_REPORT_RESPONSE.records.length;
+
+    const records = MOCK_MINE_REPORT_RESPONSE.records.slice(0, effectivePerPage);
+    const response = {
+      ...MOCK_MINE_REPORT_RESPONSE,
+      records,
+      items_per_page: effectivePerPage,
+    };
+    return HttpResponse.json(response);
+  }
+);
+
+// Handle GET permits for a mine
+const permitsHandler = http.get("/%3CAPI_URL%3E/mines/:mineGuid/permits", async ({ params }) => {
+  const { mineGuid } = params as { mineGuid: string };
+  lastPermitsRequest = { mineGuid };
+  return HttpResponse.json({ records: MOCK_PERMITS });
+});
+
+const handlers = [mineReportsHandler, permitsHandler, ...commonHandlers];
 
 export default handlers;
+export { mineReportsHandler, permitsHandler };


### PR DESCRIPTION
## Objective 

[MDS-6434](https://bcmines.atlassian.net/browse/MDS-6434)

Created an All Reports page in Minespace (behind feature flag). This will replace the current reports page where PRRs and CRRs were displayed in separate tables. 

To be completed in separate ticket: Show # of overdue / upcoming reports (currently just a hardcoded number)

<img width="2479" height="1050" alt="image" src="https://github.com/user-attachments/assets/b50ef8a0-8f2f-4fb7-9423-3e86ae8db265" />


