### PR TITLE
[MDS-6702] Core Major Mine Application Tab white screen

### DIFF
--- a/services/core-web/src/components/mine/Projects/MajorMineApplicationTab.tsx
+++ b/services/core-web/src/components/mine/Projects/MajorMineApplicationTab.tsx
@@ -92,7 +92,7 @@ const MajorMineApplicationTab: FC = () => {
     { href: "spatial-components", documents: majorMineApplicationDocs.filter((doc) => doc.major_mine_application_document_type_code === "SPT") },
     { href: "supporting-documents", documents: majorMineApplicationDocs.filter((doc) => doc.major_mine_application_document_type_code === "SPR") },
     decisionPackageEnabled && { href: "ministry-decision-documents", documents: project?.project_decision_package?.documents ?? [] },
-  ].map((section) => section && ({ ...section, title: formatUrlToUpperCaseString(section.href) }));
+  ].filter(Boolean).map((section) => section && ({ ...section, title: formatUrlToUpperCaseString(section.href) }));
 
   const archiveMenuOption = archiveFeatureEnabled && { href: "archived-documents", title: "Archived Documents" }
   const menuOptions = [{ href: "basic-information", title: "Basic Information" }, ...documentSections, archiveMenuOption].filter(Boolean);


### PR DESCRIPTION
## Objective 
- white screen with console error was breaking Core major mine application tab on project page
- it was because a feature flag being off returned a list of objects with one being `false` and the mapping function didn't like it
- filtered out the false

[MDS-6702](https://bcmines.atlassian.net/browse/MDS-6702)

_Why are you making this change? Provide a short explanation and/or screenshots_
