### PR TITLE
[MDS-6693] Enable same day start date as end date of previous appointments

### DIFF
--- a/migrations/sql/V2025.10.29.11.45__update_mine_party_appt_constraint.sql
+++ b/migrations/sql/V2025.10.29.11.45__update_mine_party_appt_constraint.sql
@@ -1,0 +1,6 @@
+-- remove existing date overlap constraint
+ALTER TABLE mine_party_appt DROP CONSTRAINT mine_party_appt_mine_guid_daterange_excl;
+
+-- only constrain non-deleted contacts and allow overlaps on the end date
+ALTER TABLE mine_party_appt ADD EXCLUDE USING gist ((mine_guid::text) WITH =, daterange(start_date,end_date,'[)')
+    WITH &&) WHERE ( mine_party_appt_type_code = 'MMG' AND NOT deleted_ind);

--- a/services/common/src/redux/utils/Validate.spec.ts
+++ b/services/common/src/redux/utils/Validate.spec.ts
@@ -319,7 +319,7 @@ describe("Validate class", () => {
                 },
             ];
             const newAppt = {
-                start_date: "2019-06-20",
+                start_date: "2019-06-19",
                 end_date: "2019-06-25",
                 party_guid: randomString(),
             };

--- a/services/common/src/redux/utils/Validate.ts
+++ b/services/common/src/redux/utils/Validate.ts
@@ -377,7 +377,7 @@ export const validateDateRanges = (
   } else {
     // If (NewApptEnd >= ApptStart) and (NewApptStart <= ApptEnd) ; “Overlap”)
     conflictingAppointments = dateAppointments.filter(
-      (appt) => newDateAppt.end_date >= appt.start_date && newDateAppt.start_date <= appt.end_date
+      (appt) => newDateAppt.end_date >= appt.start_date && newDateAppt.start_date < appt.end_date
     );
   }
   if (conflictingAppointments.length > 0) {

--- a/services/core-api/tests/parties/party_appt/resources/test_mine_party_appt_mm_overlap.py
+++ b/services/core-api/tests/parties/party_appt/resources/test_mine_party_appt_mm_overlap.py
@@ -124,7 +124,7 @@ def test_put_mine_manager_overlap_one_day_start(test_client, db_session, auth_he
 
     test_data = {
         'start_date': str(existing_start - APPT_LENGTH),
-        'end_date': str(existing_start),
+        'end_date': str(existing_start + timedelta(days=1)),
     }
     put_resp = test_client.put(
         f'/parties/mines/{setup_info["moving_mine_manager"].mine_party_appt_guid}',

--- a/services/core-api/tests/parties/party_appt/resources/test_mine_party_appt_mm_overlap.py
+++ b/services/core-api/tests/parties/party_appt/resources/test_mine_party_appt_mm_overlap.py
@@ -136,7 +136,7 @@ def test_put_mine_manager_overlap_one_day_start(test_client, db_session, auth_he
 
 def test_put_mine_manager_overlap_one_day_end(test_client, db_session, auth_headers, setup_info):
     test_data = {
-        'start_date': str(setup_info['existing_mine_manager'].end_date.date()),
+        'start_date': str(setup_info['existing_mine_manager'].end_date.date() - timedelta(days=1)),
         'end_date': None,
     }
     put_resp = test_client.put(

--- a/services/core-api/tests/parties/party_appt/resources/test_mine_party_appt_mm_overlap.py
+++ b/services/core-api/tests/parties/party_appt/resources/test_mine_party_appt_mm_overlap.py
@@ -79,7 +79,7 @@ def test_post_mine_manager_overlap_one_day_end(test_client, db_session, auth_hea
         'mine_guid': setup_info['mine_guid'],
         'party_guid': setup_info['party_guid'],
         'mine_party_appt_type_code': "MMG",
-        'start_date': str(setup_info['existing_mine_manager'].end_date.date()),
+        'start_date': str(setup_info['existing_mine_manager'].end_date.date() - timedelta(days=1)),
         'end_date': None,
     }
     post_resp = test_client.post(


### PR DESCRIPTION
## Objective 

Realized that the sub task of the ticket contained additional AC not covered in the original PR.  
This addresses the ability to assign a start date for a mine party appointment that is the same date as the end date of a previous appointment.

[MDS-6693](https://bcmines.atlassian.net/browse/MDS-6693)
