### PR TITLE
[MDS-6701] BE error on submitting document categories

### DIFF
--- a/services/common/src/constants/strings.tsx
+++ b/services/common/src/constants/strings.tsx
@@ -225,7 +225,7 @@ export const MAJOR_MINES_APPLICATION_DOCUMENT_SUBTYPE_CODE = {
   SPR: {
     QPD: "Qualified Professional Declaration Form",
     TOC: "Table of Concordance",
-    SPT: "Supporting Documents",
+    SPR: "Supporting Documents",
     CIF: "Confidential Information"
   }
 };


### PR DESCRIPTION
## Objective 
This was the BE error that was coming up behind the "internal server error":
<img width="1586" height="323" alt="image" src="https://github.com/user-attachments/assets/a15e1a20-6d96-401d-b4a1-6a841946cfe8" />
- I had at one point accidentally used "SPT" to refer to Supporting documents (SPT is already in use for Spatial)
- when I fixed it, I missed the bit on the FE 🤦‍♀️ 
- so it was sending an invalid value back to the BE when "Supporting documents --> Supporting documents" was selected

[MDS-6701](https://bcmines.atlassian.net/browse/MDS-6701)