### PR TITLE
[MDS-6706] Restore route for Mine Permits in MineDashboardRoutes

### DIFF
--- a/services/core-web/src/routes/MineDashboardRoutes.tsx
+++ b/services/core-web/src/routes/MineDashboardRoutes.tsx
@@ -7,6 +7,7 @@ const MineDashboardRoutes: FC = () => (
   <Switch>
     <Route exact path={routes.MINE_CONTACTS.route} component={routes.MINE_CONTACTS.component} />
     <Route exact path={routes.MINE_GENERAL.route} component={routes.MINE_GENERAL.component} />
+    <Route exact path={routes.MINE_PERMITS.route} component={routes.MINE_PERMITS.component} />
     <Route exact path={routes.MINE_ACCESS.route} component={routes.MINE_ACCESS.component} />
     <Route exact path={routes.MINE_DOCUMENTS.route} component={routes.MINE_DOCUMENTS.component} />
     <Route


### PR DESCRIPTION
## Objective 

The route to the permits page in core was accidentally removed when adding a new route.
This just restores it.

[MDS-6706](https://bcmines.atlassian.net/browse/MDS-6706)

<img width="1665" height="645" alt="image" src="https://github.com/user-attachments/assets/d695a534-c3b6-4526-aea9-b9f1a4fd8e91" />
