### PR TITLE
[FIX] Project Summary 'Edit mode'

### DIFF
--- a/services/common/src/components/projects/ProjectOverviewTab.tsx
+++ b/services/common/src/components/projects/ProjectOverviewTab.tsx
@@ -205,7 +205,7 @@ const ProjectOverviewTab: FC = () => {
     const handleNavigateProjectSummary = () => {
         const url = isProjectSummarySubmitted
             ? GLOBAL_ROUTES?.EDIT_PROJECT.dynamicRoute(project_guid, "project-description")
-            : GLOBAL_ROUTES?.EDIT_PROJECT_SUMMARY.dynamicRoute(project_guid, project_summary_guid, "basic-information", false);
+            : GLOBAL_ROUTES?.EDIT_PROJECT_SUMMARY.dynamicRoute(project_guid, project_summary_guid, "basic-information", isCore);
 
         history.push(url);
     };

--- a/services/common/src/components/projects/ProjectOverviewTab.tsx
+++ b/services/common/src/components/projects/ProjectOverviewTab.tsx
@@ -205,7 +205,7 @@ const ProjectOverviewTab: FC = () => {
     const handleNavigateProjectSummary = () => {
         const url = isProjectSummarySubmitted
             ? GLOBAL_ROUTES?.EDIT_PROJECT.dynamicRoute(project_guid, "project-description")
-            : GLOBAL_ROUTES?.EDIT_PROJECT_SUMMARY.dynamicRoute(project_guid, project_summary_guid, "basic-information", isCore);
+            : GLOBAL_ROUTES?.EDIT_PROJECT_SUMMARY.dynamicRoute(project_guid, project_summary_guid, "basic-information", isProjectSummarySubmitted);
 
         history.push(url);
     };

--- a/services/common/src/components/projects/ProjectOverviewTab.tsx
+++ b/services/common/src/components/projects/ProjectOverviewTab.tsx
@@ -205,7 +205,7 @@ const ProjectOverviewTab: FC = () => {
     const handleNavigateProjectSummary = () => {
         const url = isProjectSummarySubmitted
             ? GLOBAL_ROUTES?.EDIT_PROJECT.dynamicRoute(project_guid, "project-description")
-            : GLOBAL_ROUTES?.EDIT_PROJECT_SUMMARY.dynamicRoute(project_guid, project_summary_guid);
+            : GLOBAL_ROUTES?.EDIT_PROJECT_SUMMARY.dynamicRoute(project_guid, project_summary_guid, "basic-information", false);
 
         history.push(url);
     };

--- a/services/minespace-web/src/components/pages/Project/ProjectSummaryPage.tsx
+++ b/services/minespace-web/src/components/pages/Project/ProjectSummaryPage.tsx
@@ -173,7 +173,12 @@ export const ProjectSummaryPage = () => {
       )
     ).then(({ data: { project_guid, project_summary_guid } }) => {
       history.replace(
-        EDIT_PROJECT_SUMMARY.dynamicRoute(project_guid, project_summary_guid, projectFormTabs[1])
+        EDIT_PROJECT_SUMMARY.dynamicRoute(
+          project_guid,
+          project_summary_guid,
+          projectFormTabs[1],
+          !isEditMode
+        )
       );
     });
   };
@@ -183,7 +188,7 @@ export const ProjectSummaryPage = () => {
       return;
     }
     const url = !isNewProject
-      ? EDIT_PROJECT_SUMMARY.dynamicRoute(projectGuid, projectSummaryGuid, newTab)
+      ? EDIT_PROJECT_SUMMARY.dynamicRoute(projectGuid, projectSummaryGuid, newTab, !isEditMode)
       : ADD_PROJECT_SUMMARY.dynamicRoute(mineGuid, newTab);
     history.push(url);
   };


### PR DESCRIPTION
## Objective 
- with a project summary in draft status, was experiencing two issues on MS:
  - on project overview tab, clicking "resume" was bringing me to View mode, and so I couldn't edit the form
  - if I created a new project, it would navigate to the next page of the form in "view" mode, so I couldn't complete the form
So, looked at where the route was being used, and made sure to correctly pass in the param indicating that we're editing
