### PR TITLE
[MDS-6668] Recurring Report Generation

### DIFF
--- a/services/core-api/app/api/mines/reports/models/mine_report.py
+++ b/services/core-api/app/api/mines/reports/models/mine_report.py
@@ -426,6 +426,51 @@ class MineReport(SoftDeleteMixin, AuditMixin, Base):
         except ValueError:
             return None
 
+    @classmethod
+    def create_from_permit_report_requirement(cls, requirement, due_date):
+        """
+        Create a MineReport from a MineReportPermitRequirement.
+        This is used for creating recurring reports based on permit requirements.
+        
+        Args:
+            requirement: MineReportPermitRequirement instance
+            due_date: The specific due date for this report instance
+        """
+        # Import here to avoid circular import
+        from app.api.mines.permits.permit_amendment.models.permit_amendment import PermitAmendment
+        from app.api.mines.mine.models.mine import Mine
+        
+        # Get the permit amendment to find the mine
+        permit_amendment = PermitAmendment.find_by_permit_amendment_id(requirement.permit_amendment_id)
+        if not permit_amendment:
+            raise ValueError(f"Could not find permit amendment with id {requirement.permit_amendment_id} for report requirement '{requirement.report_name}' (ID: {requirement.mine_report_permit_requirement_id})")
+        
+        # Get the mine directly from the permit amendment to avoid _context_mine requirement
+        mine_guid = permit_amendment.mine_guid
+        permit_id = permit_amendment.permit_id
+        
+        mine = Mine.find_by_mine_guid(mine_guid)
+        if not mine:
+            raise ValueError(f"Could not find mine with guid {mine_guid} for permit amendment {requirement.permit_amendment_id}")
+        
+        mine_report = cls.create(
+            mine_report_definition_id=None,  # PRR reports don't use mine_report_definition
+            mine_guid=mine.mine_guid,
+            due_date=due_date,  # Use the passed-in due date
+            received_date=None,  # Not received yet
+            submission_year=None,  # Will be set when submitted
+            description_comment=None,  # Will be set when submitted
+            submitter_name="",  # Will be set when submitted
+            permit_id=permit_id,
+            permit_condition_category_code=None,  # PRR reports don't use this
+            mine_report_permit_requirement_id=requirement.mine_report_permit_requirement_id,
+            submitter_email="",  # Will be set when submitted
+            add_to_session=True,
+            system_created=True
+        )
+        
+        return mine_report
+
     @validates('mine_report_definition_id')
     def validate_mine_report_definition_id(self, key, mine_report_definition_id):
         if mine_report_definition_id and self.permit_condition_category_code:

--- a/services/core-api/app/api/mines/reports/models/mine_report_permit_requirement.py
+++ b/services/core-api/app/api/mines/reports/models/mine_report_permit_requirement.py
@@ -88,7 +88,7 @@ class MineReportPermitRequirement(SoftDeleteMixin, AuditMixin, HistoryMixin, Bas
         return None
     
     @classmethod
-    def find_by_report_name(cls, report_name, permit_amendment_id) -> Self:
+    def find_by_report_name(cls, report_name, permit_amendment_id) -> Self | None:
         return cls.query.filter_by(report_name=report_name, permit_amendment_id=permit_amendment_id).one_or_none()
 
     @classmethod
@@ -98,7 +98,13 @@ class MineReportPermitRequirement(SoftDeleteMixin, AuditMixin, HistoryMixin, Bas
         except ValueError:
             return None
         
-
+    @classmethod
+    def get_all_recurring(cls) -> list[Self]:
+        return cls.query.filter_by(deleted_ind=False, active_ind=True).filter(
+            cls.due_date_period_months > 0,
+            cls.initial_due_date != None
+        ).all()
+    
     def update_permit_conditions(self, new_permit_condition_ids) -> None:
         current_condition_ids = self.permit_condition_ids
         

--- a/services/core-api/app/api/mines/reports/tasks.py
+++ b/services/core-api/app/api/mines/reports/tasks.py
@@ -1,0 +1,103 @@
+from app.api.mines.reports.models.mine_report_permit_requirement import MineReportPermitRequirement
+from app.api.mines.reports.models.mine_report import MineReport
+from app.extensions import db
+from app.tasks.celery import celery
+from datetime import datetime
+from dateutil.relativedelta import relativedelta
+
+
+@celery.task()
+def create_new_recurring_report_requests():
+    """
+    Create new recurring report requests based on permit requirements.
+    This task finds all recurring requirements and creates missing reports
+    for the next year, ensuring no duplicates are created.
+    """
+    print("Starting creation of recurring report requests...")
+    
+    # Get all recurring requirements
+    requirements = MineReportPermitRequirement.get_all_recurring()
+    print(f"Found {len(requirements)} recurring report requirements")
+    
+    total_created = 0
+    failed_requirements = []
+    
+    for requirement in requirements:
+        print(f"Processing requirement: {requirement.report_name} (ID: {requirement.mine_report_permit_requirement_id})")
+        
+        # Skip if no initial due date (should not happen due to our query filter)
+        if not requirement.initial_due_date:
+            print(f"  Skipping - no initial due date")
+            continue
+        
+        # Get existing reports for this requirement
+        existing_reports = MineReport.query.filter_by(
+            mine_report_permit_requirement_id=requirement.mine_report_permit_requirement_id,
+            deleted_ind=False
+        ).all()
+        
+        print(f"  Found {len(existing_reports)} existing reports")
+        
+        # Calculate due dates for the next year starting from initial_due_date
+        current_date = datetime.now().date()
+        one_year_from_now = current_date + relativedelta(years=1)
+        
+        existing_due_dates = {report.due_date.date() for report in existing_reports}
+        latest_existing_due_date = max(existing_due_dates) if existing_due_dates else None
+        
+        # Start from the appropriate date and advance to first future date
+        if latest_existing_due_date:
+            next_due_date = latest_existing_due_date + relativedelta(months=requirement.due_date_period_months)
+        else:
+            next_due_date = requirement.initial_due_date
+        
+        # Advance to the first future date
+        while next_due_date <= current_date:
+            next_due_date = next_due_date + relativedelta(months=requirement.due_date_period_months)
+        
+        # Collect all future dates within the one-year horizon
+        missing_due_dates = []
+        while next_due_date <= one_year_from_now:
+            if next_due_date not in existing_due_dates:
+                missing_due_dates.append(next_due_date)
+            next_due_date = next_due_date + relativedelta(months=requirement.due_date_period_months)
+        
+        print(f"  Need to create {len(missing_due_dates)} new reports")
+        
+        # Create missing reports
+        created_count = 0
+        failed_count = 0
+        for due_date in missing_due_dates:
+            try:
+                mine_report = MineReport.create_from_permit_report_requirement(requirement, due_date)
+                mine_report.submission_year = due_date.year
+                mine_report.save()
+                db.session.commit()
+                created_count += 1
+                print(f"    Created report due {due_date}")
+            except Exception as e:
+                print(f"    Error creating report for due date {due_date}: {str(e)}")
+                db.session.rollback()
+                failed_count += 1
+        
+        if failed_count > 0:
+            failed_requirements.append({
+                'requirement_id': requirement.mine_report_permit_requirement_id,
+                'report_name': requirement.report_name,
+                'failed_count': failed_count
+            })
+        
+        total_created += created_count
+        print(f"  Successfully created {created_count} reports for this requirement")
+    
+    print(f"\nCompleted! Total reports created: {total_created}")
+    
+    if failed_requirements:
+        print(f"\nWarning: Some requirements had failures:")
+        for failed in failed_requirements:
+            print(f"  - Requirement ID {failed['requirement_id']} ({failed['report_name']}): {failed['failed_count']} failed reports")
+    
+    return {
+        'total_created': total_created,
+        'failed_requirements': failed_requirements
+    }

--- a/services/core-api/app/api/mines/reports/tasks.py
+++ b/services/core-api/app/api/mines/reports/tasks.py
@@ -6,6 +6,79 @@ from datetime import datetime
 from dateutil.relativedelta import relativedelta
 
 
+def _calculate_missing_due_dates(requirement, existing_due_dates, current_date, one_year_from_now):
+    """Calculate which due dates need new reports created."""
+    latest_existing_due_date = max(existing_due_dates) if existing_due_dates else None
+    
+    # Start from the appropriate date
+    if latest_existing_due_date:
+        next_due_date = latest_existing_due_date + relativedelta(months=requirement.due_date_period_months)
+    else:
+        next_due_date = requirement.initial_due_date
+    
+    # Advance to the first future date
+    while next_due_date <= current_date:
+        next_due_date = next_due_date + relativedelta(months=requirement.due_date_period_months)
+    
+    # Collect all future dates within the one-year horizon
+    missing_due_dates = []
+    while next_due_date <= one_year_from_now:
+        if next_due_date not in existing_due_dates:
+            missing_due_dates.append(next_due_date)
+        next_due_date = next_due_date + relativedelta(months=requirement.due_date_period_months)
+    
+    return missing_due_dates
+
+
+def _create_report_for_due_date(requirement, due_date):
+    """Create a single mine report for the given due date."""
+    mine_report = MineReport.create_from_permit_report_requirement(requirement, due_date)
+    mine_report.submission_year = due_date.year
+    mine_report.save()
+    db.session.commit()
+    return mine_report
+
+
+def _process_single_requirement(requirement, current_date, one_year_from_now):
+    """Process a single requirement and create missing reports."""
+    print(f"Processing requirement: {requirement.report_name} (ID: {requirement.mine_report_permit_requirement_id})")
+    
+    if not requirement.initial_due_date:
+        print("  Skipping - no initial due date")
+        return 0, 0
+    
+    # Get existing reports
+    existing_reports = MineReport.query.filter_by(
+        mine_report_permit_requirement_id=requirement.mine_report_permit_requirement_id,
+        deleted_ind=False
+    ).all()
+    
+    print(f"  Found {len(existing_reports)} existing reports")
+    
+    existing_due_dates = {report.due_date.date() for report in existing_reports}
+    missing_due_dates = _calculate_missing_due_dates(
+        requirement, existing_due_dates, current_date, one_year_from_now
+    )
+    
+    print(f"  Need to create {len(missing_due_dates)} new reports")
+    
+    # Create missing reports
+    created_count = 0
+    failed_count = 0
+    for due_date in missing_due_dates:
+        try:
+            _create_report_for_due_date(requirement, due_date)
+            created_count += 1
+            print(f"    Created report due {due_date}")
+        except Exception as e:
+            print(f"    Error creating report for due date {due_date}: {str(e)}")
+            db.session.rollback()
+            failed_count += 1
+    
+    print(f"  Successfully created {created_count} reports for this requirement")
+    return created_count, failed_count
+
+
 @celery.task()
 def create_new_recurring_report_requests():
     """
@@ -15,70 +88,21 @@ def create_new_recurring_report_requests():
     """
     print("Starting creation of recurring report requests...")
     
-    # Get all recurring requirements
     requirements = MineReportPermitRequirement.get_all_recurring()
     print(f"Found {len(requirements)} recurring report requirements")
+    
+    current_date = datetime.now().date()
+    one_year_from_now = current_date + relativedelta(years=1)
     
     total_created = 0
     failed_requirements = []
     
     for requirement in requirements:
-        print(f"Processing requirement: {requirement.report_name} (ID: {requirement.mine_report_permit_requirement_id})")
+        created_count, failed_count = _process_single_requirement(
+            requirement, current_date, one_year_from_now
+        )
         
-        # Skip if no initial due date (should not happen due to our query filter)
-        if not requirement.initial_due_date:
-            print(f"  Skipping - no initial due date")
-            continue
-        
-        # Get existing reports for this requirement
-        existing_reports = MineReport.query.filter_by(
-            mine_report_permit_requirement_id=requirement.mine_report_permit_requirement_id,
-            deleted_ind=False
-        ).all()
-        
-        print(f"  Found {len(existing_reports)} existing reports")
-        
-        # Calculate due dates for the next year starting from initial_due_date
-        current_date = datetime.now().date()
-        one_year_from_now = current_date + relativedelta(years=1)
-        
-        existing_due_dates = {report.due_date.date() for report in existing_reports}
-        latest_existing_due_date = max(existing_due_dates) if existing_due_dates else None
-        
-        # Start from the appropriate date and advance to first future date
-        if latest_existing_due_date:
-            next_due_date = latest_existing_due_date + relativedelta(months=requirement.due_date_period_months)
-        else:
-            next_due_date = requirement.initial_due_date
-        
-        # Advance to the first future date
-        while next_due_date <= current_date:
-            next_due_date = next_due_date + relativedelta(months=requirement.due_date_period_months)
-        
-        # Collect all future dates within the one-year horizon
-        missing_due_dates = []
-        while next_due_date <= one_year_from_now:
-            if next_due_date not in existing_due_dates:
-                missing_due_dates.append(next_due_date)
-            next_due_date = next_due_date + relativedelta(months=requirement.due_date_period_months)
-        
-        print(f"  Need to create {len(missing_due_dates)} new reports")
-        
-        # Create missing reports
-        created_count = 0
-        failed_count = 0
-        for due_date in missing_due_dates:
-            try:
-                mine_report = MineReport.create_from_permit_report_requirement(requirement, due_date)
-                mine_report.submission_year = due_date.year
-                mine_report.save()
-                db.session.commit()
-                created_count += 1
-                print(f"    Created report due {due_date}")
-            except Exception as e:
-                print(f"    Error creating report for due date {due_date}: {str(e)}")
-                db.session.rollback()
-                failed_count += 1
+        total_created += created_count
         
         if failed_count > 0:
             failed_requirements.append({
@@ -86,14 +110,11 @@ def create_new_recurring_report_requests():
                 'report_name': requirement.report_name,
                 'failed_count': failed_count
             })
-        
-        total_created += created_count
-        print(f"  Successfully created {created_count} reports for this requirement")
     
     print(f"\nCompleted! Total reports created: {total_created}")
     
     if failed_requirements:
-        print(f"\nWarning: Some requirements had failures:")
+        print("\nWarning: Some requirements had failures:")
         for failed in failed_requirements:
             print(f"  - Requirement ID {failed['requirement_id']} ({failed['report_name']}): {failed['failed_count']} failed reports")
     

--- a/services/core-api/app/commands.py
+++ b/services/core-api/app/commands.py
@@ -144,6 +144,16 @@ def register_commands(app):
         with current_app.app_context():
             notify_and_update_expired_party_appointments()
 
+    @app.cli.command('create_new_recurring_report_requests')
+    def create_new_recurring_report_requests():
+        from app import auth
+        from app.api.mines.reports.tasks import create_new_recurring_report_requests
+        auth.apply_security = False
+
+        with current_app.app_context():
+            create_new_recurring_report_requests()
+            print("celery job started: create_new_recurring_report_requests")
+
     @app.cli.command('revoke_mines_act_permit_vc_and_offer_newest')
     @click.argument('credential_exchange_id')
     @click.argument('permit_guid')

--- a/services/core-api/app/config.py
+++ b/services/core-api/app/config.py
@@ -282,6 +282,10 @@ class Config(object):
             'task': 'app.api.parties.party_appt.tasks.notify_and_update_expired_party_appointments',
             'schedule': crontab(minute="*/15"),
         },
+        'create_new_recurring_report_requests': {
+            'task': 'app.api.mines.reports.tasks.create_new_recurring_report_requests',
+            'schedule': crontab(hour="10", minute="0"),  # Run daily at 2am (10am UTC)
+        },
         'push_untp_map_data_to_publisher': {
             'task': 'app.api.verifiable_credentials.manager.push_untp_map_data_to_publisher',
             'schedule': crontab(day_of_week="1", hour="16", minute="0"),                             #Run 8am Mondays

--- a/services/core-api/tests/reports/models/test_mine_report_model.py
+++ b/services/core-api/tests/reports/models/test_mine_report_model.py
@@ -1,0 +1,87 @@
+import pytest
+from datetime import date
+from dateutil.relativedelta import relativedelta
+
+from app.api.mines.reports.models.mine_report import MineReport
+from tests.factories import (
+    MineReportPermitRequirementFactory,
+    create_mine_and_permit
+)
+
+
+def test_mine_report_create_from_permit_report_requirement_creates_correct_attributes(db_session):
+    mine, permit = create_mine_and_permit(num_permit_amendments=1)
+    permit_amendment = permit.permit_amendments[0]
+    
+    # Create a permit requirement
+    requirement = MineReportPermitRequirementFactory(
+        permit_amendment=permit_amendment,
+        report_name="Test Environmental Report",
+        due_date_period_months=6,
+        initial_due_date=date.today() - relativedelta(months=3),
+        active_ind=True,
+        deleted_ind=False
+    )
+    
+    # Test creating a report from the requirement
+    due_date = date.today() + relativedelta(months=3)
+    mine_report = MineReport.create_from_permit_report_requirement(requirement, due_date)
+    
+    # Verify the report was created correctly
+    assert mine_report is not None
+    assert mine_report.mine_guid == mine.mine_guid
+    assert mine_report.permit_id == permit.permit_id
+    assert mine_report.due_date == due_date
+    assert mine_report.mine_report_permit_requirement_id == requirement.mine_report_permit_requirement_id
+    assert mine_report.received_date is None
+    assert mine_report.submission_year is None
+    assert mine_report.submitter_name == ""
+    assert mine_report.submitter_email == ""
+    assert mine_report.created_by_idir == 'system'
+    assert mine_report.mine_report_definition_id is None
+    assert mine_report.permit_condition_category_code is None
+    assert mine_report.mine_report_status_code == 'NON'
+
+def test_mine_report_create_from_permit_report_requirement_handles_date_objects_correctly(db_session):
+    mine, permit = create_mine_and_permit(num_permit_amendments=1)
+    permit_amendment = permit.permit_amendments[0]
+    
+    requirement = MineReportPermitRequirementFactory(
+        permit_amendment=permit_amendment,
+        report_name="Date Test Report",
+        due_date_period_months=12,
+        initial_due_date=date.today(),
+        active_ind=True,
+        deleted_ind=False
+    )
+    
+    # Test with a date object
+    test_due_date = date(2026, 6, 15)
+    mine_report = MineReport.create_from_permit_report_requirement(requirement, test_due_date)
+    
+    assert mine_report.due_date == test_due_date
+
+
+def test_mine_report_create_from_permit_report_requirement_sets_system_creation_flags(db_session):
+    mine, permit = create_mine_and_permit(num_permit_amendments=1)
+    permit_amendment = permit.permit_amendments[0]
+    
+    requirement = MineReportPermitRequirementFactory(
+        permit_amendment=permit_amendment,
+        report_name="System Flag Test Report",
+        due_date_period_months=3,
+        initial_due_date=date.today(),
+        active_ind=True,
+        deleted_ind=False
+    )
+    
+    due_date = date.today() + relativedelta(months=6)
+    mine_report = MineReport.create_from_permit_report_requirement(requirement, due_date)
+    
+    # Verify system creation flags
+    assert mine_report.created_by_idir == 'system'
+    assert mine_report.create_user == 'system'
+    assert mine_report.update_user == 'system'
+    
+    # Verify it's added to session by default
+    assert mine_report in db_session.new

--- a/services/core-api/tests/reports/models/test_mine_report_permit_requirement_model.py
+++ b/services/core-api/tests/reports/models/test_mine_report_permit_requirement_model.py
@@ -1,0 +1,162 @@
+from datetime import date
+from dateutil.relativedelta import relativedelta
+
+from app.api.mines.reports.models.mine_report_permit_requirement import MineReportPermitRequirement
+from tests.factories import (
+    MineReportPermitRequirementFactory,
+    create_mine_and_permit
+)
+
+
+def test_mine_report_permit_requirement_get_all_recurring_returns_only_recurring_requirements(db_session):
+    mine, permit = create_mine_and_permit(num_permit_amendments=1)
+    permit_amendment = permit.permit_amendments[0]
+    
+    # Create a recurring requirement (quarterly)
+    recurring_quarterly = MineReportPermitRequirementFactory(
+        permit_amendment=permit_amendment,
+        report_name="Quarterly Report",
+        due_date_period_months=3,
+        initial_due_date=date.today() - relativedelta(months=6),
+        active_ind=True,
+        deleted_ind=False
+    )
+    
+    # Create another recurring requirement (annual)
+    recurring_annual = MineReportPermitRequirementFactory(
+        permit_amendment=permit_amendment,
+        report_name="Annual Report", 
+        due_date_period_months=12,
+        initial_due_date=date.today() - relativedelta(months=3),
+        active_ind=True,
+        deleted_ind=False
+    )
+    
+    # Create a non-recurring requirement (due_date_period_months = 0)
+    non_recurring = MineReportPermitRequirementFactory(
+        permit_amendment=permit_amendment,
+        report_name="One-time Report",
+        due_date_period_months=0,
+        initial_due_date=date.today() + relativedelta(months=6),
+        active_ind=True,
+        deleted_ind=False
+    )
+    
+    # Get all recurring requirements
+    recurring_requirements = MineReportPermitRequirement.get_all_recurring()
+    recurring_ids = [req.mine_report_permit_requirement_id for req in recurring_requirements]
+    
+    # Should include the recurring requirements but not the non-recurring one
+    assert recurring_quarterly.mine_report_permit_requirement_id in recurring_ids
+    assert recurring_annual.mine_report_permit_requirement_id in recurring_ids
+    assert non_recurring.mine_report_permit_requirement_id not in recurring_ids
+
+
+def test_mine_report_permit_requirement_get_all_recurring_excludes_inactive_requirements(db_session):
+    mine, permit = create_mine_and_permit(num_permit_amendments=1)
+    permit_amendment = permit.permit_amendments[0]
+    
+    # Create an active recurring requirement
+    active_requirement = MineReportPermitRequirementFactory(
+        permit_amendment=permit_amendment,
+        report_name="Active Quarterly Report",
+        due_date_period_months=3,
+        initial_due_date=date.today() - relativedelta(months=6),
+        active_ind=True,
+        deleted_ind=False
+    )
+    
+    # Create an inactive recurring requirement
+    inactive_requirement = MineReportPermitRequirementFactory(
+        permit_amendment=permit_amendment,
+        report_name="Inactive Quarterly Report",
+        due_date_period_months=3,
+        initial_due_date=date.today() - relativedelta(months=6),
+        active_ind=False,  # Inactive
+        deleted_ind=False
+    )
+    
+    # Get all recurring requirements
+    recurring_requirements = MineReportPermitRequirement.get_all_recurring()
+    recurring_ids = [req.mine_report_permit_requirement_id for req in recurring_requirements]
+    
+    # Should include only the active requirement
+    assert active_requirement.mine_report_permit_requirement_id in recurring_ids
+    assert inactive_requirement.mine_report_permit_requirement_id not in recurring_ids
+
+
+def test_mine_report_permit_requirement_get_all_recurring_excludes_deleted_requirements(db_session):
+    mine, permit = create_mine_and_permit(num_permit_amendments=1)
+    permit_amendment = permit.permit_amendments[0]
+    
+    # Create a non-deleted recurring requirement
+    valid_requirement = MineReportPermitRequirementFactory(
+        permit_amendment=permit_amendment,
+        report_name="Valid Quarterly Report",
+        due_date_period_months=3,
+        initial_due_date=date.today() - relativedelta(months=6),
+        active_ind=True,
+        deleted_ind=False
+    )
+    
+    # Create a deleted recurring requirement
+    deleted_requirement = MineReportPermitRequirementFactory(
+        permit_amendment=permit_amendment,
+        report_name="Deleted Quarterly Report",
+        due_date_period_months=3,
+        initial_due_date=date.today() - relativedelta(months=6),
+        active_ind=True,
+        deleted_ind=True  # Deleted
+    )
+    
+    # Get all recurring requirements
+    recurring_requirements = MineReportPermitRequirement.get_all_recurring()
+    recurring_ids = [req.mine_report_permit_requirement_id for req in recurring_requirements]
+    
+    # Should include only the non-deleted requirement
+    assert valid_requirement.mine_report_permit_requirement_id in recurring_ids
+    assert deleted_requirement.mine_report_permit_requirement_id not in recurring_ids
+
+
+def test_mine_report_permit_requirement_get_all_recurring_excludes_requirements_without_initial_due_date(db_session):
+    mine, permit = create_mine_and_permit(num_permit_amendments=1)
+    permit_amendment = permit.permit_amendments[0]
+    
+    # Create a requirement with initial due date
+    with_due_date = MineReportPermitRequirementFactory(
+        permit_amendment=permit_amendment,
+        report_name="Report with Due Date",
+        due_date_period_months=6,
+        initial_due_date=date.today() - relativedelta(months=3),
+        active_ind=True,
+        deleted_ind=False
+    )
+    
+    # Create a requirement without initial due date
+    without_due_date = MineReportPermitRequirementFactory(
+        permit_amendment=permit_amendment,
+        report_name="Report without Due Date",
+        due_date_period_months=6,
+        initial_due_date=None,  # No initial due date
+        active_ind=True,
+        deleted_ind=False
+    )
+    
+    # Get all recurring requirements
+    recurring_requirements = MineReportPermitRequirement.get_all_recurring()
+    recurring_ids = [req.mine_report_permit_requirement_id for req in recurring_requirements]
+    
+    # Should include only the requirement with initial due date
+    assert with_due_date.mine_report_permit_requirement_id in recurring_ids
+    assert without_due_date.mine_report_permit_requirement_id not in recurring_ids
+
+
+def test_mine_report_permit_requirement_get_all_recurring_returns_empty_list_when_no_recurring_requirements(db_session):
+    # Don't create any requirements
+    
+    # Get all recurring requirements
+    recurring_requirements = MineReportPermitRequirement.get_all_recurring()
+    
+    # Should return empty list
+    assert isinstance(recurring_requirements, list)
+    assert len(recurring_requirements) == 0

--- a/services/core-api/tests/reports/test_report_tasks.py
+++ b/services/core-api/tests/reports/test_report_tasks.py
@@ -1,0 +1,305 @@
+import pytest
+from unittest import mock
+from datetime import datetime, date
+from dateutil.relativedelta import relativedelta
+
+from app.api.mines.reports.tasks import create_new_recurring_report_requests
+from app.api.mines.reports.models.mine_report import MineReport
+from app.api.mines.reports.models.mine_report_permit_requirement import MineReportPermitRequirement
+from tests.factories import (
+    MineReportPermitRequirementFactory,
+    MineReportFactory,
+    create_mine_and_permit
+)
+
+
+@pytest.fixture(scope="function")
+def db_session(db_session):
+    # Fixes "Instance is not bound to a session" error with celery/pytest/flask combination
+    # https://github.com/jeancochrane/pytest-flask-sqlalchemy/issues/27
+    with mock.patch.object(db_session, "remove", lambda: None):
+        yield db_session
+
+
+@pytest.fixture
+def setup_recurring_requirements(db_session):
+    """Set up test data with a mine, permit, and recurring report requirements."""
+    mine, permit = create_mine_and_permit(num_permit_amendments=1)
+    permit_amendment = permit.permit_amendments[0]
+    today = date.today()
+    
+    quarterly_requirement = MineReportPermitRequirementFactory(
+        permit_amendment=permit_amendment,
+        report_name="Quarterly Environmental Report",
+        due_date_period_months=3,
+        initial_due_date=today - relativedelta(months=6),
+        active_ind=True,
+        deleted_ind=False
+    )
+    
+    annual_requirement = MineReportPermitRequirementFactory(
+        permit_amendment=permit_amendment,
+        report_name="Annual Safety Report",
+        due_date_period_months=12,
+        initial_due_date=today - relativedelta(months=3),
+        active_ind=True,
+        deleted_ind=False
+    )
+    
+    non_recurring_requirement = MineReportPermitRequirementFactory(
+        permit_amendment=permit_amendment,
+        report_name="One-time Report",
+        due_date_period_months=0,
+        initial_due_date=today + relativedelta(months=6),
+        active_ind=True,
+        deleted_ind=False
+    )
+    
+    yield {
+        'mine': mine,
+        'permit': permit,
+        'permit_amendment': permit_amendment,
+        'quarterly_requirement': quarterly_requirement,
+        'annual_requirement': annual_requirement,
+        'non_recurring_requirement': non_recurring_requirement
+    }
+
+
+@pytest.fixture
+def setup_with_existing_reports(setup_recurring_requirements):
+    data = setup_recurring_requirements
+    quarterly_req = data['quarterly_requirement']
+    today = date.today()
+    
+    # Create existing reports for the quarterly requirement
+    MineReportFactory(
+        mine=data['mine'],
+        permit=data['permit'],
+        mine_report_permit_requirement=quarterly_req,
+        due_date=today - relativedelta(months=3),
+        submission_year=(today - relativedelta(months=3)).year,
+        deleted_ind=False
+    )
+    
+    MineReportFactory(
+        mine=data['mine'],
+        permit=data['permit'],
+        mine_report_permit_requirement=quarterly_req,
+        due_date=today,
+        submission_year=today.year,
+        deleted_ind=False
+    )
+    
+    yield data
+
+
+class TestCreateNewRecurringReportRequests:
+    
+    def test_task_creates_missing_reports_for_next_year(self, setup_recurring_requirements):
+        today = date.today()
+        quarterly_req = setup_recurring_requirements['quarterly_requirement']
+        annual_req = setup_recurring_requirements['annual_requirement']
+        
+        # Set initial due dates in the past to trigger future report creation
+        quarterly_req.initial_due_date = today - relativedelta(months=6)
+        quarterly_req.save()
+        annual_req.initial_due_date = today - relativedelta(months=3)
+        annual_req.save()
+        
+        result = create_new_recurring_report_requests()
+        
+        assert result['total_created'] > 0
+        assert len(result['failed_requirements']) == 0
+        
+        # Verify reports were created for both requirements
+        quarterly_count = MineReport.query.filter_by(
+            mine_report_permit_requirement_id=quarterly_req.mine_report_permit_requirement_id,
+            deleted_ind=False
+        ).count()
+        
+        annual_count = MineReport.query.filter_by(
+            mine_report_permit_requirement_id=annual_req.mine_report_permit_requirement_id,
+            deleted_ind=False
+        ).count()
+        
+        assert quarterly_count > 0
+        assert annual_count > 0
+    
+    def test_task_integration_with_real_data(self, setup_recurring_requirements):
+        today = date.today()
+        quarterly_req = setup_recurring_requirements['quarterly_requirement']
+        
+        quarterly_req.initial_due_date = today - relativedelta(months=4)
+        quarterly_req.save()
+        
+        result = create_new_recurring_report_requests()
+        
+        assert result['total_created'] > 0
+        assert len(result['failed_requirements']) == 0
+        
+        reports_count = MineReport.query.filter_by(
+            mine_report_permit_requirement_id=quarterly_req.mine_report_permit_requirement_id,
+            deleted_ind=False
+        ).count()
+        
+        assert reports_count > 0
+    
+    def test_task_respects_existing_reports(self, setup_with_existing_reports):
+        today = date.today()
+        quarterly_req = setup_with_existing_reports['quarterly_requirement']
+        
+        # Set initial date far in the past to ensure future reports are needed
+        quarterly_req.initial_due_date = today - relativedelta(months=15)
+        quarterly_req.save()
+        
+        # Clear existing reports and create a controlled test scenario
+        MineReport.query.filter_by(
+            mine_report_permit_requirement_id=quarterly_req.mine_report_permit_requirement_id
+        ).delete()
+        
+        # Create an existing report that will require future reports
+        existing_report_date = today - relativedelta(months=9, days=10)  
+        report1 = MineReport.create_from_permit_report_requirement(quarterly_req, existing_report_date)
+        
+        # Verify the existing report due date for debugging
+        report1_due_date = report1.due_date
+        if isinstance(report1_due_date, datetime):
+            report1_due_date = report1_due_date.date()
+        
+        initial_count = MineReport.query.filter_by(
+            mine_report_permit_requirement_id=quarterly_req.mine_report_permit_requirement_id,
+            deleted_ind=False
+        ).count()
+        
+        assert initial_count == 1
+        
+        result = create_new_recurring_report_requests()
+        
+        final_count = MineReport.query.filter_by(
+            mine_report_permit_requirement_id=quarterly_req.mine_report_permit_requirement_id,
+            deleted_ind=False
+        ).count()
+        
+        assert final_count > initial_count, f"Expected more than {initial_count} reports, got {final_count}"
+
+        # Verify no duplicate due dates
+        all_reports = MineReport.query.filter_by(
+            mine_report_permit_requirement_id=quarterly_req.mine_report_permit_requirement_id,
+            deleted_ind=False
+        ).all()
+        
+        due_dates = [r.due_date for r in all_reports]
+        unique_due_dates = set(due_dates)
+        assert len(due_dates) == len(unique_due_dates), f"Found duplicate due dates: {due_dates}"
+    
+    def test_task_ignores_non_recurring_requirements(self, setup_recurring_requirements):
+        today = date.today()
+        non_recurring_req = setup_recurring_requirements['non_recurring_requirement']
+        
+        non_recurring_req.initial_due_date = today - relativedelta(months=2)
+        non_recurring_req.save()
+        
+        result = create_new_recurring_report_requests()
+        
+        # Should not create reports for non-recurring requirements
+        non_recurring_count = MineReport.query.filter_by(
+            mine_report_permit_requirement_id=non_recurring_req.mine_report_permit_requirement_id,
+            deleted_ind=False
+        ).count()
+        
+        assert non_recurring_count == 0
+    
+    def test_task_handles_missing_permit_amendment_gracefully(self, setup_recurring_requirements):
+        # Test error handling by mocking create_from_permit_report_requirement to fail
+        with mock.patch('app.api.mines.reports.models.mine_report.MineReport.create_from_permit_report_requirement') as mock_create:
+            mock_create.side_effect = [Exception("Simulated failure"), mock.DEFAULT]
+            
+            result = create_new_recurring_report_requests()
+            
+            assert 'total_created' in result
+            assert 'failed_requirements' in result
+            assert len(result['failed_requirements']) >= 0
+    
+    def test_task_only_creates_future_reports(self, setup_recurring_requirements):
+        today = date.today()
+        quarterly_req = setup_recurring_requirements['quarterly_requirement']
+        annual_req = setup_recurring_requirements['annual_requirement']
+        
+        quarterly_req.initial_due_date = today - relativedelta(months=8)
+        quarterly_req.save()
+        annual_req.initial_due_date = today - relativedelta(months=6)
+        annual_req.save()
+        
+        result = create_new_recurring_report_requests()
+        
+        # All created reports should have future due dates
+        all_reports = MineReport.query.filter(
+            MineReport.mine_report_permit_requirement_id.in_([
+                quarterly_req.mine_report_permit_requirement_id,
+                annual_req.mine_report_permit_requirement_id
+            ]),
+            MineReport.deleted_ind == False
+        ).all()
+        
+        for report in all_reports:
+            report_due_date = report.due_date.date()
+            assert report_due_date > today, f"Report due date {report_due_date} should be after {today}"
+    
+    def test_task_respects_one_year_horizon(self, setup_recurring_requirements):
+        today = date.today()
+        quarterly_req = setup_recurring_requirements['quarterly_requirement']
+        annual_req = setup_recurring_requirements['annual_requirement']
+        
+        # Set initial dates far in the past to generate multiple future reports
+        quarterly_req.initial_due_date = today - relativedelta(months=15)
+        quarterly_req.save()
+        annual_req.initial_due_date = today - relativedelta(months=15)
+        annual_req.save()
+        
+        result = create_new_recurring_report_requests()
+        
+        # No reports should have due dates beyond one year from today
+        all_reports = MineReport.query.filter(
+            MineReport.mine_report_permit_requirement_id.in_([
+                quarterly_req.mine_report_permit_requirement_id,
+                annual_req.mine_report_permit_requirement_id
+            ]),
+            MineReport.deleted_ind == False
+        ).all()
+        
+        max_date = today + relativedelta(years=1)
+        for report in all_reports:
+            report_due_date = report.due_date.date()
+            assert report_due_date <= max_date, f"Report due date {report_due_date} should not be after {max_date}"
+    
+    @mock.patch('app.api.mines.reports.tasks.MineReportPermitRequirement.get_all_recurring')
+    def test_task_with_no_recurring_requirements(self, mock_get_all_recurring):
+        mock_get_all_recurring.return_value = []
+        
+        result = create_new_recurring_report_requests()
+        
+        assert result['total_created'] == 0
+        assert len(result['failed_requirements']) == 0
+    
+    def test_task_creates_reports_with_correct_attributes(self, setup_recurring_requirements):
+        today = date.today()
+        quarterly_req = setup_recurring_requirements['quarterly_requirement']
+        
+        quarterly_req.initial_due_date = today - relativedelta(months=6)
+        quarterly_req.save()
+        
+        result = create_new_recurring_report_requests()
+        
+        reports = MineReport.query.filter_by(
+            mine_report_permit_requirement_id=quarterly_req.mine_report_permit_requirement_id,
+            deleted_ind=False
+        ).all()
+        
+        # All reports should be system-created with appropriate defaults
+        for report in reports:
+            assert report.created_by_idir == 'system'
+            assert report.submitter_name == ""
+            assert report.submitter_email == ""
+            assert report.received_date is None
+            assert report.submission_year == report.due_date.year
+            assert report.mine_report_status_code == 'NON' # Report Requested


### PR DESCRIPTION
## Objective 
- create recurring report instances up to a year in the future
- don't create duplicates
- celery schedule, daily 2am PST

[MDS-6668](https://bcmines.atlassian.net/browse/MDS-6668)

_Why are you making this change? Provide a short explanation and/or screenshots_
Console output:
<img width="541" height="225" alt="image" src="https://github.com/user-attachments/assets/d3161049-41cb-4e89-bb2d-f969f2380651" />

Core FE after generating (empty before):
<img width="1356" height="360" alt="image" src="https://github.com/user-attachments/assets/1712609c-e50e-49ce-ab62-e44297283a4b" />

MS FE:
<img width="1060" height="480" alt="image" src="https://github.com/user-attachments/assets/e8f6034c-7a79-4520-a06c-06ef83c29d23" />
