### PR TITLE
[MDS-6692] Syncfusion fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,10 @@
     "@types/react": "16.9.49",
     "@types/react-dom": "16.9.8",
     "@types/react-router-dom": "5.3.3",
-    "cheerio": "1.0.0-rc.3"
+    "cheerio": "1.0.0-rc.3",
+    "@syncfusion/ej2-base": "31.1.17",
+    "@syncfusion/ej2-react-pdfviewer": "31.1.17",
+    "@syncfusion/ej2-pdfviewer": "31.1.17"
   },
   "scripts": {
     "postinstall": "husky install"

--- a/services/filesystem-provider/ej2-amazon-s3-aspcore-file-provider/Controllers/PdfViewerController.cs
+++ b/services/filesystem-provider/ej2-amazon-s3-aspcore-file-provider/Controllers/PdfViewerController.cs
@@ -113,6 +113,17 @@ namespace EJ2AmazonS3ASPCoreFileProvider.Controllers
 
         [AcceptVerbs("Post")]
         [HttpPost]
+        [Route("RenderPdfTexts")]
+        [Authorize("View")]
+        public IActionResult RenderPdfTexts([FromBody] Dictionary<string, string> jsonObject)
+        {
+            PdfRenderer pdfviewer = new PdfRenderer(_mCache);
+            object jsonResult = pdfviewer.GetDocumentText(jsonObject);
+            return Content(JsonConvert.SerializeObject(jsonResult));
+        }
+
+        [AcceptVerbs("Post")]
+        [HttpPost]
         [Route("RenderAnnotationComments")]
         [Authorize("View")]
         public IActionResult RenderAnnotationComments([FromBody] Dictionary<string, string> jsonObject)

--- a/yarn.lock
+++ b/yarn.lock
@@ -4066,17 +4066,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@syncfusion/ej2-base@npm:~31.1.17, @syncfusion/ej2-base@npm:~31.1.20, @syncfusion/ej2-base@npm:~31.1.22":
-  version: 31.1.22
-  resolution: "@syncfusion/ej2-base@npm:31.1.22"
-  dependencies:
-    "@syncfusion/ej2-icons": ~31.1.17
-  bin:
-    syncfusion-license: bin/syncfusion-license.js
-  checksum: 260c14b18cac65b6a4abbb7d1cbef312f56076bf8dc3e1051aa891befc47e502304a5e2ce1b66a45b50e38643076096b9600a28c5936dd742682afaad26691af
-  languageName: node
-  linkType: hard
-
 "@syncfusion/ej2-buttons@npm:31.1.17":
   version: 31.1.17
   resolution: "@syncfusion/ej2-buttons@npm:31.1.17"


### PR DESCRIPTION
## Objective 
- BE to add missing resource
- force correct package resolution on FE (the pdf viewer was stubbornly v28 even after wiping node modules and yarn lock)

[MDS-6692](https://bcmines.atlassian.net/browse/MDS-6692)

