### PR TITLE
[FIX] Browse Reports page bug

### DIFF
--- a/services/common/src/redux/selectors/reportSelectors.ts
+++ b/services/common/src/redux/selectors/reportSelectors.ts
@@ -1,7 +1,7 @@
 import { createSelector } from "reselect";
 import { reportReducerType } from "@mds/common/redux/slices/reportSlice";
 
-export const getReports = (state) => state[reportReducerType].reportReducerType;
+export const getReports = (state) => state[reportReducerType].reports;
 export const getReportsPageData = (state) => state[reportReducerType].reportsPageData;
 export const getMineReports = (state) => state[reportReducerType].mineReports;
 export const getMineReportById = (state, reportGuid) => {

--- a/services/common/src/redux/slices/reportSlice.ts
+++ b/services/common/src/redux/slices/reportSlice.ts
@@ -116,7 +116,7 @@ const reportSlice = createAppSlice({
     ),
 
     fetchReports: create.asyncThunk(
-      async ({ params = {} }: { params?: any }, thunkApi) => {
+      async (params: any, thunkApi) => {
         const headers = createRequestHeader();
         thunkApi.dispatch(showLoading());
         let response;

--- a/services/common/src/redux/slices/reportsSlice.spec.ts
+++ b/services/common/src/redux/slices/reportsSlice.spec.ts
@@ -119,7 +119,7 @@ describe("reportSlice", () => {
         })
       );
 
-      await store.dispatch<any>(fetchReports({ params: {} }));
+      await store.dispatch<any>(fetchReports({}));
 
       expect(showLoadingMock).toHaveBeenCalledTimes(1);
       expect(hideLoadingMock).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## Objective 
To fix bug where no reports were showing up on the Core "Browse Reports" page and params weren't being sent to BE.
- made `params` be what is expected to be sent to the action instead of `{ params }`
- selector was looking at wrong spot in state
- Reports page for a mine was unaffected - uses different action & selector (verified that ReportsHomePage is the only file that uses the `fetchReports` function)

<img width="1365" height="663" alt="image" src="https://github.com/user-attachments/assets/d0d99751-dafe-4131-bba1-2e52d3802a6d" />
