### PR TITLE
[MDS-6696] - Fix closeModal dispatch in mine party appointment

### DIFF
--- a/services/core-web/src/components/mine/ContactInfo/ViewPartyRelationships.tsx
+++ b/services/core-web/src/components/mine/ContactInfo/ViewPartyRelationships.tsx
@@ -15,7 +15,7 @@ import { createTailingsStorageFacility } from "@mds/common/redux/slices/tailings
 import { Col, Divider, Dropdown, Menu, Popconfirm, Row } from "antd";
 import { debounce, uniq, uniqBy } from "lodash";
 import moment from "moment";
-import React, { FC, useEffect } from "react";
+import React, { FC } from "react";
 
 import Loading from "@/components/common/Loading";
 import NullScreen from "@/components/common/NullScreen";

--- a/services/core-web/src/components/parties/RelationshipProfile.tsx
+++ b/services/core-web/src/components/parties/RelationshipProfile.tsx
@@ -25,12 +25,7 @@ import {
   useAppSelector as useSelector,
   useAppSelector,
 } from "@mds/common/redux/rootState";
-import {
-  IOption,
-  IPartyAppt,
-  IPermit,
-  ITailingsStorageFacility,
-} from "@mds/common/interfaces";
+import { IOption, IPartyAppt, IPermit, ITailingsStorageFacility } from "@mds/common/interfaces";
 import { renderTextColumn } from "@mds/common/components/common/CoreTableCommonColumns";
 import CoreButton from "@mds/common/components/common/CoreButton";
 import { closeModal, openModal } from "@mds/common/redux/actions/modalActions";
@@ -161,7 +156,7 @@ export const RelationshipProfile: FC = () => {
         include_permit_contacts: "true",
       })
     );
-    dispatch(closeModal);
+    dispatch(closeModal());
   };
 
   const handleOpenEditPartyRelationshipModal = (record: ITransformedValues) => {


### PR DESCRIPTION
The dispatch to close the modal after submitting changes to a mine party appointment wasn't passed correctly on the history page.  

[MDS-6696](https://bcmines.atlassian.net/browse/MDS-6696)
