### PR TITLE
[MDS-6725] Add early return for empty recipients in email tracking creation

### DIFF
--- a/services/core-api/app/api/services/email_service.py
+++ b/services/core-api/app/api/services/email_service.py
@@ -236,6 +236,10 @@ class EmailService():
             List of created EmailTracking records
         """
         tracking_records = []
+
+        if not recipients:
+            return tracking_records
+
         for recipient_email in recipients:
             tracking_record = EmailTracking.create(
                 recipient_email=recipient_email,


### PR DESCRIPTION
## Objective 

Report submission was failing when it went to create email tracking records with no people on the recipients list.  Added an early return in the email tracking function if there are no recipients.  

This error was likely only an issue in situations where a mine doesn't have project contacts being added to the message which is probably not common in production, but it should work now at any rate.

[MDS-6725](https://bcmines.atlassian.net/browse/MDS-6725)
