### PR TITLE
[MDS-6722] - Remove previous amendment document title validation on NoW

### DIFF
--- a/services/core-web/src/components/noticeOfWork/applications/process/ProcessPermit.js
+++ b/services/core-web/src/components/noticeOfWork/applications/process/ProcessPermit.js
@@ -641,27 +641,6 @@ export class ProcessPermit extends Component {
       });
     }
 
-    // Previous permit amendment document titles
-    const previousAmendment = this.createPermitGenObject(
-      this.props.noticeOfWork,
-      this.props.draftPermit,
-      this.props.draftAmendment
-    ).previous_amendment;
-    if (!isEmpty(previousAmendment)) {
-      titlesMissing = previousAmendment.related_documents?.filter(
-        ({ preamble_title }) => !preamble_title
-      ).length;
-      if (titlesMissing !== 0) {
-        validationMessages.push({
-          message: `The previous amendment has ${titlesMissing} documents that require a title.`,
-          route: route.NOTICE_OF_WORK_APPLICATION.dynamicRoute(
-            this.props.noticeOfWork.now_application_guid,
-            "draft-permit/#preamble"
-          ),
-        });
-      }
-    }
-
     // Inspector signature
     const signature = this.props.noticeOfWork?.issuing_inspector?.signature;
     if (!signature) {


### PR DESCRIPTION
## Objective 

- Previous amendments to a permit that did not have a preamble_title were preventing the issuance of a new amendment.
- Removed the validation triggering this blockage.
- Tested locally and was not able to observe any adverse side effects after removing the validation and completing a submission.

[MDS-6722](https://bcmines.atlassian.net/browse/MDS-6722)

_Why are you making this change? Provide a short explanation and/or screenshots_
