### PR TITLE
[MDS-6699] Added support for connecting to non-public azure resources for the permit service

### DIFF
--- a/services/core-api/app/api/mines/permits/permit_conditions/resources/permit_conditions_search_resource.py
+++ b/services/core-api/app/api/mines/permits/permit_conditions/resources/permit_conditions_search_resource.py
@@ -20,6 +20,7 @@ class PermitConditionsSearchResource(Resource, UserMixin):
             mimetype="text/event-stream",
             headers={
                 "Cache-Control": "no-cache",
+                "X-Accel-Buffering": "no",
                 "Connection": "keep-alive",
             },
         )

--- a/services/permits/app/pipelines/permit_condition_search/components/azure_blob_upload.py
+++ b/services/permits/app/pipelines/permit_condition_search/components/azure_blob_upload.py
@@ -8,15 +8,17 @@ logger = logging.getLogger(__name__)
 
 @component
 class AzureBlobUploader:
-    def __init__(self, connection_string: str, container_name: str):
+    def __init__(self, connection_string: str, container_name: str, blob_service_endpoint: str | None = None):
         """
         Initialize the blob uploader
         Args:
             connection_string: Azure Storage connection string
             container_name: Azure Storage container name
+            blob_service_endpoint: Optional override for the blob service endpoint
         """
         self.connection_string = connection_string
         self.container_name = container_name
+        self.blob_service_endpoint = blob_service_endpoint
         
         if not self.connection_string:
             raise ValueError("connection_string cannot be empty")
@@ -28,7 +30,15 @@ class AzureBlobUploader:
         """
         Uploads a file to Azure Blob Storage in the indexing folder
         """
+        # BlobService
         blob_service_client = BlobServiceClient.from_connection_string(self.connection_string)
+
+        if self.blob_service_endpoint:
+            blob_service_client = BlobServiceClient(
+                account_url=self.blob_service_endpoint,
+                credential=blob_service_client.credential
+            )
+
         container_client = blob_service_client.get_container_client(self.container_name)
         
         # Upload to an 'indexing' folder in the container

--- a/services/permits/app/pipelines/permit_condition_search/config.py
+++ b/services/permits/app/pipelines/permit_condition_search/config.py
@@ -33,6 +33,7 @@ class AzureSearchConfig:
 class AzureStorageConfig:
     connection_string: str
     container_name: str
+    blob_service_endpoint: Optional[str] = None
 
 @dataclass
 class ElasticsearchConfig:
@@ -75,7 +76,8 @@ class Config:
         # Azure Storage configuration
         storage = AzureStorageConfig(
             connection_string=os.environ["AZURE_STORAGE_CONNECTION_STRING"],
-            container_name=os.environ["AZURE_STORAGE_CONTAINER"]
+            container_name=os.environ["AZURE_STORAGE_CONTAINER"],
+            blob_service_endpoint=os.environ.get("AZURE_STORAGE_BLOB_SERVICE_ENDPOINT")
         )
 
         # Elasticsearch configuration

--- a/services/permits/app/pipelines/permit_condition_search/create_search_index.py
+++ b/services/permits/app/pipelines/permit_condition_search/create_search_index.py
@@ -25,11 +25,15 @@ from azure.search.documents.indexes.models import (
 )
 
 search_api_key = config.search.api_key.resolve_value()
+search_api_endpoint = config.search.endpoint.resolve_value()
+assert search_api_key is not None, "Search API key is required"
 assert search_api_key is not None, "Search API key is required"
 
 # Initialize the search client
 credential = AzureKeyCredential(search_api_key)
-index_client = SearchIndexClient(endpoint=config.search.endpoint.resolve_value(), credential=credential)
+
+
+index_client = SearchIndexClient(endpoint=search_api_endpoint,credential=credential)
 
 # Vector search configuration
 vector_search = VectorSearch(

--- a/services/permits/app/pipelines/permit_condition_search/create_search_indexer.py
+++ b/services/permits/app/pipelines/permit_condition_search/create_search_indexer.py
@@ -1,5 +1,6 @@
 
 from datetime import timedelta
+
 from app.pipelines.permit_condition_search.config import config
 from azure.core.credentials import AzureKeyCredential
 from azure.search.documents.indexes import SearchIndexerClient
@@ -83,7 +84,8 @@ def create_indexer():
                 parsing_mode=BlobIndexerParsingMode.DELIMITED_TEXT,
                 first_line_contains_headers=True,
                 query_timeout=None
-            )
+            ),
+            execution_environment='private'
         ),
         schedule=IndexingSchedule(interval=timedelta(minutes=5)),
         output_field_mappings=[

--- a/services/permits/app/pipelines/permit_condition_search/permit_condition_search_pipeline.py
+++ b/services/permits/app/pipelines/permit_condition_search/permit_condition_search_pipeline.py
@@ -79,8 +79,6 @@ def create_permit_condition_search_indexing_pipeline():
     """
     index_pipeline = Pipeline()
 
-    assert config.storage.connection_string, "Storage connection string must be provided to create the blob uploader"
-
     blob_uploader = AzureBlobUploader(
         connection_string=config.storage.connection_string,
         container_name=config.storage.container_name,

--- a/services/permits/app/pipelines/permit_condition_search/permit_condition_search_pipeline.py
+++ b/services/permits/app/pipelines/permit_condition_search/permit_condition_search_pipeline.py
@@ -1,7 +1,5 @@
 import logging
 import os
-from datetime import datetime
-from typing import List
 
 import yaml
 from app.pipelines.permit_condition_search.components.azure_blob_upload import (
@@ -21,12 +19,11 @@ from app.pipelines.permit_condition_search.stores.ai_search_document_store impor
 )
 from azure.search.documents.indexes.models import VectorSearch
 from haystack import AsyncPipeline, Pipeline
-from haystack.components.builders import ChatPromptBuilder, PromptBuilder
+from haystack.components.builders import ChatPromptBuilder
 from haystack.components.embedders import AzureOpenAITextEmbedder
 from haystack.components.extractors.llm_metadata_extractor import (
     AzureOpenAIChatGenerator,
 )
-from haystack.components.generators import AzureOpenAIGenerator
 from haystack.dataclasses import ChatMessage
 from haystack_integrations.components.retrievers.azure_ai_search import (
     AzureAISearchHybridRetriever,
@@ -82,17 +79,21 @@ def create_permit_condition_search_indexing_pipeline():
     """
     index_pipeline = Pipeline()
 
+    assert config.storage.connection_string, "Storage connection string must be provided to create the blob uploader"
+
     blob_uploader = AzureBlobUploader(
         connection_string=config.storage.connection_string,
         container_name=config.storage.container_name,
+        blob_service_endpoint=config.storage.blob_service_endpoint,
     )
 
     api_key = config.search.api_key.resolve_value()
-
     assert api_key is not None, "API key must be provided to create the indexer"
+    search_endpoint = config.search.endpoint.resolve_value()
+    assert search_endpoint is not None, "Search endpoint must be provided to create the indexer"
 
     indexer_runner = IndexerRunner(
-        search_endpoint=config.search.endpoint.resolve_value(),
+        search_endpoint=search_endpoint,
         search_api_key=api_key,
     )
 
@@ -112,6 +113,7 @@ def create_blob_uploader_pipeline():
     blob_uploader = AzureBlobUploader(
         connection_string=config.storage.connection_string,
         container_name=config.storage.container_name,
+        blob_service_endpoint=config.storage.blob_service_endpoint,
     )
 
     blob_uploader_pipeline.add_component("blob_uploader", blob_uploader)

--- a/services/permits/tests/test_permit_condition_search_pipeline.py
+++ b/services/permits/tests/test_permit_condition_search_pipeline.py
@@ -67,3 +67,18 @@ def test_blob_upload_pipeline_validates(mock_components):
 
     except Exception as e:
         pytest.fail(f"Pipeline validation failed with error: {str(e)}")
+
+def test_pipeline_uses_blob_service_endpoint_config(mock_components):
+    with patch("app.pipelines.permit_condition_search.permit_condition_search_pipeline.config") as mock_config:
+        # Setup mock config
+        mock_config.storage.connection_string = "test_conn"
+        mock_config.storage.container_name = "test_container"
+        mock_config.storage.blob_service_endpoint = "https://custom.endpoint.com"
+        mock_config.search.api_key.resolve_value.return_value = "test_key"
+        mock_config.search.endpoint.resolve_value.return_value = "test_endpoint"
+
+        # Test indexing pipeline
+        create_permit_condition_search_indexing_pipeline()
+                
+        call_args = AzureBlobUploader.__init__.call_args
+        assert call_args.kwargs.get("blob_service_endpoint") == "https://custom.endpoint.com"

--- a/services/permits/tests/test_permit_conditions_pipeline.py
+++ b/services/permits/tests/test_permit_conditions_pipeline.py
@@ -1,16 +1,31 @@
+from unittest.mock import patch
+
 import pytest
 from app.pipelines.permit_condition_extraction.permit_condition_pipeline import (
     permit_condition_pipeline,
 )
 
 
-def test_permit_condition_pipeline_validation_fails_without_params():
+@pytest.fixture
+def mock_config():
+    with patch("app.pipelines.permit_condition_extraction.permit_condition_pipeline.config") as mock_config:
+        mock_config.document_intelligence.api_key.resolve_value.return_value = "test_key"
+        mock_config.document_intelligence.endpoint = "test_endpoint"
+        mock_config.document_intelligence.api_version = "test_version"
+        mock_config.openai.endpoint.resolve_value.return_value = "test_endpoint"
+        mock_config.openai.api_version = "test_version"
+        mock_config.openai.deployment_name = "test_deployment"
+        mock_config.openai.api_key.resolve_value.return_value = "test_key"
+        yield mock_config
+
+
+def test_permit_condition_pipeline_validation_fails_without_params(mock_config):
     pipeline = permit_condition_pipeline()
 
     with pytest.raises(ValueError):
         pipeline._validate_input({})
 
 
-def test_permit_condition_pipeline_validation_with_params():
+def test_permit_condition_pipeline_validation_with_params(mock_config):
     pipeline = permit_condition_pipeline()
     pipeline._validate_input({"pdf_converter": {"file_path": "test.pdf"}})


### PR DESCRIPTION
## Objective 

[MDS-6699](https://bcmines.atlassian.net/browse/MDS-6699)

Added support for overriding the blob storage endpoint used for permit service file uploads. This will enable us to connect to the new storage blob in the new AZ Landing zone.
Also added in a `"X-Accel-Buffering": "no",` response header to the permit service search endpoint in an attempt to fix streaming of search results back to the frontend when deployed in dev/test/prod, as currently it buffers the full result before returning making it appear slower than it actually is