### PR TITLE
[MDS-6731] Fixed logic to associate the correct NOW document to a condition when indexing for search

### DIFF
--- a/services/core-api/app/cli_commands/export_permit_conditions.py
+++ b/services/core-api/app/cli_commands/export_permit_conditions.py
@@ -7,7 +7,11 @@ from app.api.mines.permits.permit_amendment.models.permit_amendment import (
 from app.api.mines.permits.permit_conditions.models.permit_conditions import (
     PermitConditions,
 )
-from app.api.now_applications.now_template_transformer import calculate_liability, replace_condition_value_with_data, transform_variables_to_data
+from app.api.now_applications.now_template_transformer import (
+    calculate_liability,
+    replace_condition_value_with_data,
+    transform_variables_to_data,
+)
 
 headers = [
     'step', 'category', 'status', 'display_order', 'issue_date',
@@ -16,6 +20,40 @@ headers = [
     'mine_guid', 'permit_amendment_guid', 'permit_condition_guid',
     'step_path', 'parent_ids', 'sibling_ids', 'child_ids', 'report_name', 'permit_type', 'tenure', 'verification_status'
 ]
+
+
+def get_final_issued_permit_document(amendment):
+    if not amendment.now_application_identity or not amendment.now_application_identity.now_application:
+        return None
+        
+    now_application = amendment.now_application_identity.now_application
+    
+    # Get all PMT/PMA documents from NoW
+    now_permit_docs = [
+        doc for doc in now_application.documents 
+        if doc.now_application_document_type_code in ['PMT', 'PMA']
+    ]
+    
+    if not now_permit_docs:
+        return None
+
+    # If amendment has related documents, try to find a match
+    if amendment.related_documents:
+        related_guids = {doc.document_manager_guid for doc in amendment.related_documents}
+        
+        # Find NoW docs that are also in related_documents
+        issued_docs = [
+            doc for doc in now_permit_docs 
+            if doc.mine_document.document_manager_guid in related_guids
+        ]
+        
+        if issued_docs:
+            # Return the latest one
+            issued_docs.sort(key=lambda x: x.create_timestamp, reverse=True)
+            return issued_docs[0]
+    
+    return None
+            
 
 
 def export_permit_conditions(permit_amendment_guid, csv_writer=None):
@@ -55,10 +93,12 @@ def export_permit_conditions(permit_amendment_guid, csv_writer=None):
     document_name = ''
     document_guid = ''
 
-    if is_now and amendment.now_application_documents:
-        doc = amendment.now_application_documents[0].mine_document
-        document_name = doc.document_name
-        document_guid = doc.document_manager_guid
+    if is_now and amendment.now_application_identity and amendment.now_application_identity.now_application:
+        now_permit_doc = get_final_issued_permit_document(amendment)
+        
+        if now_permit_doc:
+            document_name = now_permit_doc.mine_document.document_name
+            document_guid = now_permit_doc.mine_document.document_manager_guid
 
     elif latest_task and latest_task.permit_amendment_document:
         doc = latest_task.permit_amendment_document

--- a/services/core-api/app/commands.py
+++ b/services/core-api/app/commands.py
@@ -2,8 +2,12 @@ from multiprocessing.dummy import Pool as ThreadPool
 from typing import List
 
 import click
+from app.api.mines.mine.models.mine import Mine
 from app.api.mines.permits.permit.models.permit import Permit
-from app.api.mines.permits.permit_amendment.models.permit_amendment import PermitAmendment
+from app.api.mines.permits.permit_amendment.models.permit_amendment import (
+    PermitAmendment,
+)
+from app.api.users.minespace.models.minespace_user import MinespaceUser
 from app.api.utils.include.user_info import User
 from app.config import Config
 from app.extensions import db
@@ -16,8 +20,7 @@ from tests.factories import (
     MinespaceUserFactory,
     NOWApplicationIdentityFactory,
 )
-from app.api.mines.mine.models.mine import Mine
-from app.api.users.minespace.models.minespace_user import MinespaceUser
+
 from .cli_commands.generate_history_table_migration import (
     generate_history_table_migration,
     generate_table_migration,
@@ -290,7 +293,9 @@ def register_commands(app):
                         bceid_username=full_user_name,
                         keycloak_guid='b28dfc3a-5e5c-4501-ab2f-399d8e64f2c8')
                 else:
-                    from app.api.users.minespace.models.minespace_user_mine import MinespaceUserMine
+                    from app.api.users.minespace.models.minespace_user_mine import (
+                        MinespaceUserMine,
+                    )
                     existing_subscriptions = MinespaceUserMine.query.filter_by(user_id=minespace_user.user_id).all()
                     subscribed_mine_guids = [s.mine_guid for s in existing_subscriptions]
                 for mine in all_mines:
@@ -418,34 +423,75 @@ def register_commands(app):
     @click.argument('permit_type', type=click.STRING, required=False)
     @click.option('--amendment_guids', type=click.STRING, required=False)
     @click.option('--batch_size', type=click.INT, required=False, default=500)
-    def bulk_export_and_index_permit_conditions(permit_type, amendment_guids, batch_size):
+    @click.option('--apply', is_flag=True, default=False, help="If provided, uploads to blob storage to trigger indexing. Otherwise saves to local CSV.")
+    @click.option('--output-dir', type=click.Path(exists=True, file_okay=False, dir_okay=True), required=False, help="Directory to save the CSV file in dry-run mode.")
+    def bulk_export_and_index_permit_conditions(permit_type, amendment_guids, batch_size, apply, output_dir):
         """
-        Bulk export permit conditions and index them in the search service.
+        Bulk export permit conditions. 
+        By default, exports to a local CSV file for verification.
+        If --apply is passed, uploads to blob storage to trigger indexing.
 
         Example usage:
             flask bulk_export_and_index_permit_conditions
-            flask bulk_export_and_index_permit_conditions NOW
-            flask bulk_export_and_index_permit_conditions MM
+            flask bulk_export_and_index_permit_conditions NOW --apply
             flask bulk_export_and_index_permit_conditions --amendment_guids=b1af0a62-2379-4ac0-85a9-be4f2b229cd6
         """
-        from app import auth
+        import csv
+        import datetime
+        import os
 
-        from app.api.mines.permits.permit_conditions.tasks import export_and_index_permit_amendments
+        from app import auth
+        from app.api.mines.permits.permit_conditions.tasks import (
+            export_and_index_permit_amendments,
+        )
+
+        from .cli_commands.export_permit_conditions import (
+            export_permit_conditions,
+            headers,
+        )
         
         auth.apply_security = False
         is_now = permit_type.lower() == 'now' if permit_type else False
 
         if amendment_guids:
-            print(f"Exporting and indexing permit amendments with guids: {amendment_guids}")
+            print(f"Exporting permit amendments with guids: {amendment_guids}")
             permit_amendment_guids = amendment_guids.split(',')
         elif permit_type:
             permit_amendment_guids = PermitAmendment.find_all_guids_with_extracted_conditions(is_now)
-            print(f"Exporting and indexing {len(permit_amendment_guids)} {'Notice of Work' if is_now else 'Major Mine'} permit amendments")
+            print(f"Exporting {len(permit_amendment_guids)} {'Notice of Work' if is_now else 'Major Mine'} permit amendments")
         else:
             permit_amendment_guids = PermitAmendment.find_all_guids_with_extracted_conditions()
-            print(f"Exporting and indexing {len(permit_amendment_guids)} permit amendments with extracted conditions for all types")
+            print(f"Exporting {len(permit_amendment_guids)} permit amendments with extracted conditions for all types")
 
-        batches = _batch(permit_amendment_guids, batch_size)
-        for guids in batches:
-            with current_app.app_context():
-                export_and_index_permit_amendments(permit_amendment_guids=guids, is_manual=True)
+        if apply:
+            print("Apply flag set: Uploading to blob storage for indexing...")
+            batches = _batch(permit_amendment_guids, batch_size)
+            for guids in batches:
+                with current_app.app_context():
+                    export_and_index_permit_amendments(permit_amendment_guids=guids, is_manual=True)
+        else:
+            timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+            filename = f'permit_conditions_verify_{timestamp}.csv'
+            
+            if output_dir:
+                filename = os.path.join(output_dir, filename)
+
+            print(f"Dry run: Exporting to local file {filename}...")
+            
+            with open(filename, 'w', newline='') as csvfile:
+                writer = csv.DictWriter(csvfile, fieldnames=headers)
+                writer.writeheader()
+                
+                count = 0
+                total = len(permit_amendment_guids)
+                
+                for guid in permit_amendment_guids:
+                    try:
+                        export_permit_conditions(guid, csv_writer=writer)
+                        count += 1
+                        if count % 10 == 0:
+                            print(f"Processed {count}/{total}...")
+                    except Exception as e:
+                        print(f"Error processing {guid}: {e}")
+            
+            print(f"Done. Verify content in {filename}")

--- a/services/core-api/tests/cli_commands/test_export_permit_conditions_logic.py
+++ b/services/core-api/tests/cli_commands/test_export_permit_conditions_logic.py
@@ -1,0 +1,137 @@
+
+import uuid
+from datetime import datetime, timedelta
+
+from app.api.now_applications.models.now_application_document_type import (
+    NOWApplicationDocumentType,
+)
+from app.api.now_applications.models.now_application_document_xref import (
+    NOWApplicationDocumentXref,
+)
+from app.cli_commands.export_permit_conditions import get_final_issued_permit_document
+from app.extensions import db
+from tests.factories import (
+    MineDocumentFactory,
+    NOWApplicationIdentityFactory,
+    PermitAmendmentDocumentFactory,
+    PermitAmendmentFactory,
+    create_mine_and_permit,
+)
+
+
+def create_now_document(now_application, mine, doc_type_code, created_at=None, document_manager_guid=None):
+    if not document_manager_guid:
+        document_manager_guid = uuid.uuid4()
+        
+    mine_doc = MineDocumentFactory(
+        mine=mine,
+        document_manager_guid=document_manager_guid,
+        document_name=f"test_doc_{doc_type_code}.pdf"
+    )
+    
+    # Manually set create_timestamp if provided (AuditMixin usually handles this)
+    if created_at:
+        mine_doc.create_timestamp = created_at
+        mine_doc.save()
+
+    xref = NOWApplicationDocumentXref(
+        now_application_id=now_application.now_application_id,
+        mine_document_guid=mine_doc.mine_document_guid,
+        now_application_document_type_code=doc_type_code
+    )
+    now_application.documents.append(xref)
+    now_application.save()
+    return xref
+
+def test_get_final_issued_permit_document_no_now(db_session):
+    """Test returns None if no NoW application linked"""
+    mine, permit = create_mine_and_permit()
+    amendment = permit.permit_amendments[0]
+    assert get_final_issued_permit_document(amendment) is None
+
+def test_get_final_issued_permit_document_no_docs(db_session):
+    """Test returns None if NoW has no PMT/PMA documents"""
+    mine, permit = create_mine_and_permit()
+    amendment = permit.permit_amendments[0]
+    now_identity = NOWApplicationIdentityFactory(mine=mine)
+    amendment.now_application_identity = now_identity
+    amendment.save()
+    
+    assert get_final_issued_permit_document(amendment) is None
+
+def test_get_final_issued_permit_document_draft_only(db_session):
+    """Test returns None if no issued documents exist"""
+    mine, permit = create_mine_and_permit()
+    amendment = permit.permit_amendments[0]
+    now_identity = NOWApplicationIdentityFactory(mine=mine)
+    amendment.now_application_identity = now_identity
+    amendment.save()
+    
+    now_app = now_identity.now_application
+
+    # Create two draft PMT documents
+    date1 = datetime.utcnow() - timedelta(days=2)
+    date2 = datetime.utcnow() - timedelta(days=1)
+    
+    doc1 = create_now_document(now_app, mine, 'PMT', created_at=date1)
+    doc2 = create_now_document(now_app, mine, 'PMT', created_at=date2)
+    
+    # Should return None
+    result = get_final_issued_permit_document(amendment)
+    assert result is None
+
+def test_get_final_issued_permit_document_issued_match(db_session):
+    """Test returns issued document if it matches one in related_documents"""
+    mine, permit = create_mine_and_permit()
+    amendment = permit.permit_amendments[0]
+    now_identity = NOWApplicationIdentityFactory(mine=mine)
+    amendment.now_application_identity = now_identity
+    amendment.save()
+    
+    now_app = now_identity.now_application
+
+    # Create a draft doc (latest timestamp)
+    draft_date = datetime.utcnow()
+    draft_doc = create_now_document(now_app, mine, 'PMT', created_at=draft_date)
+
+    # Create an issued doc (earlier timestamp)
+    issued_date = datetime.utcnow() - timedelta(days=1)
+    issued_doc_guid = uuid.uuid4()
+    issued_doc_xref = create_now_document(now_app, mine, 'PMT', created_at=issued_date, document_manager_guid=issued_doc_guid)
+
+    # Link issued doc to amendment.related_documents
+    PermitAmendmentDocumentFactory(
+        permit_amendment=amendment,
+        document_manager_guid=issued_doc_guid,
+        document_name="Issued Permit.pdf"
+    )
+
+    # Should return issued_doc_xref even though draft_doc is newer
+    result = get_final_issued_permit_document(amendment)
+    assert result.mine_document_guid == issued_doc_xref.mine_document_guid
+
+def test_get_final_issued_permit_document_multiple_issued(db_session):
+    """Test returns latest issued document if multiple match"""
+    mine, permit = create_mine_and_permit()
+    amendment = permit.permit_amendments[0]
+    now_identity = NOWApplicationIdentityFactory(mine=mine)
+    amendment.now_application_identity = now_identity
+    amendment.save()
+    
+    now_app = now_identity.now_application
+
+    # Issued doc 1
+    date1 = datetime.utcnow() - timedelta(days=2)
+    guid1 = uuid.uuid4()
+    xref1 = create_now_document(now_app, mine, 'PMT', created_at=date1, document_manager_guid=guid1)
+    PermitAmendmentDocumentFactory(permit_amendment=amendment, document_manager_guid=guid1)
+
+    # Issued doc 2 (Latest)
+    date2 = datetime.utcnow() - timedelta(days=1)
+    guid2 = uuid.uuid4()
+    xref2 = create_now_document(now_app, mine, 'PMT', created_at=date2, document_manager_guid=guid2)
+    PermitAmendmentDocumentFactory(permit_amendment=amendment, document_manager_guid=guid2)
+
+    # Should return xref2
+    result = get_final_issued_permit_document(amendment)
+    assert result.mine_document_guid == xref2.mine_document_guid


### PR DESCRIPTION
## Objective 

[MDS-6731](https://bcmines.atlassian.net/browse/MDS-6731)

Currently, when indexing now permit conditions for search, we associate it with `amendment.now_application_documents[0].mine_document` which may not always be correct depending on the order of when the documents were generated/updated. This PR ensures we link the condition to the latest generated NoW application document ('PMT', 'PMA' codes), that are part of the issued permit (related_documents).

Also modified the bulk index command to add a `dry-run` option which lets you view the export as a csv so it can be verified before updating the search index