### PR TITLE
[MDS-6717] Avoid mine reports with multiple "is_latest" submissions

### DIFF
--- a/migrations/sql/V2025.12.03.01.26__mine_report_single_is_latest.sql
+++ b/migrations/sql/V2025.12.03.01.26__mine_report_single_is_latest.sql
@@ -1,0 +1,17 @@
+-- Clean up existing duplicate is_latest=TRUE records
+-- Keep only the most recent submission as latest for each mine_report_id
+UPDATE mine_report_submission 
+SET is_latest = FALSE 
+WHERE mine_report_submission_id NOT IN (
+    SELECT MAX(mine_report_submission_id) 
+    FROM mine_report_submission 
+    WHERE is_latest = TRUE 
+    GROUP BY mine_report_id
+) 
+AND is_latest = TRUE;
+
+-- Create a unique partial index to enforce only one is_latest=TRUE per mine_report_id
+-- This prevents race conditions at the database level
+CREATE UNIQUE INDEX IF NOT EXISTS idx_mine_report_submission_one_latest 
+ON mine_report_submission(mine_report_id) 
+WHERE is_latest = TRUE;

--- a/services/core-api/app/api/mines/reports/resources/mine_report_submission_resource.py
+++ b/services/core-api/app/api/mines/reports/resources/mine_report_submission_resource.py
@@ -273,16 +273,18 @@ class ReportSubmissionResource(Resource, UserMixin):
             submitter_name=data.get('submitter_name', None)
         )
 
-        mine_report_contacts = self.get_mine_report_submission_contacts(
-            contacts, mine_report_id, report_submission.mine_report_submission_id)
-        report_submission.mine_report_contacts = mine_report_contacts
-
         # Mark previous submission as not latest BEFORE saving new one to reduce race condition window
         if previous_submission:
             previous_submission.is_latest = False
             previous_submission.save()
         
         report_submission.save()
+        
+        mine_report_contacts = self.get_mine_report_submission_contacts(
+            contacts, mine_report_id, report_submission.mine_report_submission_id)
+        if mine_report_contacts:
+            report_submission.mine_report_contacts = mine_report_contacts
+            report_submission.save()
 
         if create_initial_report:
             mine_report.send_crr_and_prr_add_notification_email(is_proponent, report_type)

--- a/services/core-api/app/api/mines/reports/resources/mine_report_submission_resource.py
+++ b/services/core-api/app/api/mines/reports/resources/mine_report_submission_resource.py
@@ -161,9 +161,11 @@ class ReportSubmissionResource(Resource, UserMixin):
             submitter_name=getattr(previous_submission, "submitter_name"),
         )
         
-        report_submission.save()
+        # Mark previous submission as not latest BEFORE saving new one to reduce race condition window
         previous_submission.is_latest = False
         previous_submission.save()
+        
+        report_submission.save()
         return report_submission
 
     @api.expect(parser)
@@ -245,10 +247,11 @@ class ReportSubmissionResource(Resource, UserMixin):
         create_timestamp = None
         create_user = None
         previous_submission = None
-        if not is_proponent and not is_first_submission:
+        if not is_first_submission:
             previous_submission = MineReportSubmission.find_latest_by_mine_report_guid(str(mine_report_guid))
-            create_timestamp = getattr(previous_submission, 'create_timestamp')
-            create_user = getattr(previous_submission, 'create_user')
+            if previous_submission:
+                create_timestamp = getattr(previous_submission, 'create_timestamp')
+                create_user = getattr(previous_submission, 'create_user')
 
         report_submission = MineReportSubmission(
             create_timestamp=create_timestamp,
@@ -274,10 +277,12 @@ class ReportSubmissionResource(Resource, UserMixin):
             contacts, mine_report_id, report_submission.mine_report_submission_id)
         report_submission.mine_report_contacts = mine_report_contacts
 
-        report_submission.save()
+        # Mark previous submission as not latest BEFORE saving new one to reduce race condition window
         if previous_submission:
             previous_submission.is_latest = False
             previous_submission.save()
+        
+        report_submission.save()
 
         if create_initial_report:
             mine_report.send_crr_and_prr_add_notification_email(is_proponent, report_type)


### PR DESCRIPTION
## Objective 
- query blowing up because multiple results were returned when one was expected
- migration: clean up data, and enforce at database level only one "is_latest" submission
- code: close race conditions (a couple offending records were  at the same second) and also close loophole (another was months apart but it was an issue with the user being MS proponent)

[MDS-6717](https://bcmines.atlassian.net/browse/MDS-6717)
