### PR TITLE
[MDS-6715] - Special Characters in File Names

### DIFF
--- a/services/common/src/utils/fileUploadHelper.ts
+++ b/services/common/src/utils/fileUploadHelper.ts
@@ -11,14 +11,14 @@ import { retryOnFail } from "./retry";
 import { COMPLETE_MULTIPART_UPLOAD } from "../constants/API";
 import { ENVIRONMENT } from "../constants/environment";
 
-/**
- * Encodes the given metadata to be sent to the document manager.
- * @param metadata The metadata to encode
- * @returns The encoded metadata
- */
 const encodeUploadMetadata = (metadata: { [key: string]: string }) => {
   return Object.entries(metadata)
-    .map(([k, v]) => `${k} ${btoa(v)}`)
+    .map(([k, v]) => {
+      // Convert UTF-8 string to bytes, then to base64
+      const bytes = new TextEncoder().encode(v);
+      const binString = Array.from(bytes, (byte) => String.fromCodePoint(byte)).join("");
+      return `${k} ${btoa(binString)}`;
+    })
     .join(",");
 };
 
@@ -143,7 +143,7 @@ export class FileUploadHelper {
   private _createMultipartUpload = async (): Promise<MultipartDocumentUpload> => {
     const headers = createRequestHeader({
       "Upload-Length": `${this.file.size}`,
-      Filename: this.file.name,
+      Filename: encodeURIComponent(this.file.name),
       "Upload-Metadata": encodeUploadMetadata(this.config.metadata),
       "Upload-Protocol": "s3-multipart",
     });


### PR DESCRIPTION
Non latin-1 characters in a file name were being rejected by the uploader.  Updating the conversion of the metadata into base64 to first convert to bytes.
Also had to encode the headers to accomodate special characters.

## Objective 

[MDS-6715](https://bcmines.atlassian.net/browse/MDS-6715)

<img width="2138" height="1172" alt="image" src="https://github.com/user-attachments/assets/a9543dce-b0ba-42bb-bafb-53c294adfc79" />
