### PR TITLE
[MDS-6746] - Make project summary editable in changes requested status

### DIFF
--- a/services/common/src/components/project/ProjectDescriptionTab.tsx
+++ b/services/common/src/components/project/ProjectDescriptionTab.tsx
@@ -358,11 +358,12 @@ const ProjectDescriptionTab = () => {
   ]);
 
   const handleViewProjectDescriptionClicked = () => {
+    const isEditableStatus = !['DFT', 'CHR'].includes(project.project_summary.status_code)
     const url = GLOBAL_ROUTES?.EDIT_PROJECT_SUMMARY.dynamicRoute(
       project.project_summary.project_guid,
       project.project_summary.project_summary_guid,
       "basic-information",
-      true
+      isEditableStatus
     );
     history.push(url);
   };


### PR DESCRIPTION
## Objective 

The link to view the project description while in a 'Changes Requested' status, directed the user to the view only version of the page.  Updated it to direct to the correct version based on the current status of the project description.

[MDS-6746](https://bcmines.atlassian.net/browse/MDS-6746)

