### PR TITLE
[MDS-6745] Sending emails when EMA auths in project description

### DIFF
--- a/services/core-api/app/api/projects/project/models/project.py
+++ b/services/core-api/app/api/projects/project/models/project.py
@@ -199,7 +199,7 @@ class Project(AuditMixin, Base):
     
     def has_ema_auths(self):
         if self.project_summary:
-            ema_types = ProjectSummaryAuthorizationType.get_by_group_id("ENVIRONMENTAL_MANAGEMENT_ACT")
+            ema_types = ProjectSummaryAuthorizationType.get_by_group_id("ENVIRONMENTAL_MANAGMENT_ACT")
             ema_type_codes = {type.project_summary_authorization_type for type in ema_types}
             return any(auth_type in ema_type_codes for auth_type in self.project_summary.authorization_types)
         return False

--- a/services/core-api/app/templates/email/projects/minespace_project_summary_email.html
+++ b/services/core-api/app/templates/email/projects/minespace_project_summary_email.html
@@ -2,10 +2,10 @@
 {% from "email/_components/email_macros.html" import paragraph, button_link, inline_link %}
 
 {% set brand = 'minespace' %}
-{% set title = message %}
+{% set page_title = message %}
 
 {% block content %}
-{{ paragraph('A project description has been submitted for ' + mine.mine_name + ' (Mine no: ' + mine.mine_no + ') in
+{{ paragraph('Project description data has been submitted for ' + mine.mine_name + ' (Mine no: ' + mine.mine_no + ') in
 Minespace. The Major Mines Office will be in contact with you regarding your submission.', margin_top=16, brand=brand)
 }}
 


### PR DESCRIPTION
## Objective 
- there was a typo in the database. There still is, but there was, too
- my spelling was too good so it was getting wrong results (not getting list of EMA auth types)
- made spelling consistent with database

[MDS-6745](https://bcmines.atlassian.net/browse/MDS-6745)
[MDS-6744](https://bcmines.atlassian.net/browse/MDS-6744)

_Why are you making this change? Provide a short explanation and/or screenshots_
