### PR TITLE
[FIX] Fix issue with title/page_title

### DIFF
--- a/services/core-api/app/api/email_preview/resources/email_preview_resource.py
+++ b/services/core-api/app/api/email_preview/resources/email_preview_resource.py
@@ -254,8 +254,9 @@ class EmailPreviewResource(Resource, UserMixin):
                 }
                 return {**base_data, **template_data}
             elif 'section' in template_name:
+                message = 'The status of the Application for the project Mine Life Extension Project for Copper Mountain Mine has been updated to Withdrawn.'
                 template_data = {
-                    'message': 'Project Section Submitted for Review',
+                    'message': message,
                     'project': {
                         'mine_name': 'Copper Mountain Mine',
                         'mine_no': 'CU003',

--- a/services/core-api/app/templates/email/incident/minespace_awaiting_incident_final_report_email.html
+++ b/services/core-api/app/templates/email/incident/minespace_awaiting_incident_final_report_email.html
@@ -2,7 +2,7 @@
 {% from "email/_components/email_macros.html" import paragraph, button_link, info_block %}
 
 {% set brand = 'minespace' %}
-{% set title = 'An incident status has changed to "Awaiting Final Report"' %}
+{% set page_title = 'An incident status has changed to "Awaiting Final Report"' %}
 
 {% block content %}
 {{ paragraph('You can view this incident and see its current status by visiting Minespace.', align='center',

--- a/services/core-api/app/templates/email/incident/minespace_final_report_received_incident_email.html
+++ b/services/core-api/app/templates/email/incident/minespace_final_report_received_incident_email.html
@@ -2,7 +2,7 @@
 {% from "email/_components/email_macros.html" import paragraph, button_link, info_block %}
 
 {% set brand = 'minespace' %}
-{% set title = 'A final incident report has been submitted' %}
+{% set page_title = 'A final incident report has been submitted' %}
 
 {% block content %}
 {{ paragraph(mine.mine_name + ' (Mine no: ' + mine.mine_no + ') has had a final report submitted for the incident (' +

--- a/services/core-api/app/templates/email/mine_party_appt/minespace_new_eor_email.html
+++ b/services/core-api/app/templates/email/mine_party_appt/minespace_new_eor_email.html
@@ -2,7 +2,7 @@
 {% from "email/_components/email_macros.html" import paragraph, button_link, inline_link, info_block %}
 
 {% set brand = 'minespace' %}
-{% set title = 'New Engineer of Record for ' + tsf_name + ' at ' + mine.mine_name + ' has been assigned.' %}
+{% set page_title = 'New Engineer of Record for ' + tsf_name + ' at ' + mine.mine_name + ' has been assigned.' %}
 
 {% block content %}
 {{ paragraph('As of ' + start_date + ', a new Engineer of Record, ' + party.first_name + ' ' + party.last_name + ', has

--- a/services/core-api/app/templates/email/projects/minespace_project_section_email.html
+++ b/services/core-api/app/templates/email/projects/minespace_project_section_email.html
@@ -2,7 +2,7 @@
 {% from "email/_components/email_macros.html" import paragraph, button_link, info_block %}
 
 {% set brand = 'minespace' %}
-{% set title = message %}
+{% set page_title = message %}
 
 {% block content %}
 {{ paragraph(info_block('Mine Name', project.mine_name) +

--- a/services/core-api/app/templates/email/report/ms_new_report_requested_email.html
+++ b/services/core-api/app/templates/email/report/ms_new_report_requested_email.html
@@ -2,7 +2,7 @@
 {% from "email/_components/email_macros.html" import paragraph, button_link, info_block, inline_link %}
 
 {% set brand = 'minespace' %}
-{% set title = 'A report has been requested in MineSpace' %}
+{% set page_title = 'A report has been requested in MineSpace' %}
 
 {% block content %}
 {{ paragraph('To view more information about this submission please ' + inline_link(minespace_login_link, 'log into the


### PR DESCRIPTION
## Objective 
- some templates had a `set title = x` when the email_base.html file expects `set page_title = x`
- so the title was not being outputted in the email
- made it so that it sends the correct parameter name
