### PR TITLE
[FIX] Only send Major Mine Application Submitted email to MMO if there's a mines act auth

### DIFF
--- a/services/core-api/app/api/projects/major_mine_application/models/major_mine_application.py
+++ b/services/core-api/app/api/projects/major_mine_application/models/major_mine_application.py
@@ -92,7 +92,7 @@ class MajorMineApplication(SoftDeleteMixin, AuditMixin, Base):
             return None
 
     def send_mma_submit_email(self):        
-        core_recipients = [PERM_RECL_EMAIL]
+        core_recipients = [PERM_RECL_EMAIL] if self.project.has_mines_act_auths() else []
         project_lead_email = self.project.project_lead.email if self.project.project_lead else None
         if project_lead_email:
             core_recipients.append(project_lead_email)

--- a/services/core-api/tests/projects/major_mines_application/resources/test_application_emails.py
+++ b/services/core-api/tests/projects/major_mines_application/resources/test_application_emails.py
@@ -157,6 +157,7 @@ def test_send_mma_submit_email(mock_send_template_email, test_client,
         project_summary_authorization_type='MINES_ACT_PERMIT'
     )
     auth.save()
+    db_session.refresh(major_mine_application)
     assert major_mine_application.project.has_mines_act_auths() == True
     # Add various document types to test document grouping
     documents = [

--- a/services/core-api/tests/projects/major_mines_application/resources/test_application_emails.py
+++ b/services/core-api/tests/projects/major_mines_application/resources/test_application_emails.py
@@ -157,7 +157,7 @@ def test_send_mma_submit_email(mock_send_template_email, test_client,
         project_summary_authorization_type='MINES_ACT_PERMIT'
     )
     auth.save()
-    
+    assert major_mine_application.project.has_mines_act_auth() == True
     # Add various document types to test document grouping
     documents = [
         {

--- a/services/core-api/tests/projects/major_mines_application/resources/test_application_emails.py
+++ b/services/core-api/tests/projects/major_mines_application/resources/test_application_emails.py
@@ -152,13 +152,13 @@ def test_send_mma_submit_email(mock_send_template_email, test_client,
     major_mine_application = MajorMineApplicationFactory(status_code='DFT')
     
     project_summary = ProjectSummaryFactory(project=major_mine_application.project)
-    auth = ProjectSummaryAuthorizationFactory(
+    ProjectSummaryAuthorizationFactory(
         project_summary=project_summary,
         project_summary_authorization_type='MINES_ACT_PERMIT'
     )
-    auth.save()
+
     db_session.refresh(major_mine_application)
-    assert major_mine_application.project.has_mines_act_auths() == True
+
     # Add various document types to test document grouping
     documents = [
         {

--- a/services/core-api/tests/projects/major_mines_application/resources/test_application_emails.py
+++ b/services/core-api/tests/projects/major_mines_application/resources/test_application_emails.py
@@ -6,7 +6,7 @@ from app.api.activity.models.activity_notification import ActivityType, Activity
 from app.api.constants import MAJOR_MINES_OFFICE_EMAIL, PERM_RECL_EMAIL, PROJECT_EMA_EMAILS
 from app.api.utils.helpers import format_datetime_to_string, parse_status_code_to_text
 from app.config import Config
-from tests.factories import MajorMineApplicationFactory, PartyFactory
+from tests.factories import MajorMineApplicationFactory, PartyFactory, ProjectSummaryFactory, ProjectSummaryAuthorizationFactory
 
 pytz.timezone('Canada/Pacific')
 
@@ -150,6 +150,13 @@ def test_major_mine_application_notifications(mock_send_template_email, mock_tri
 def test_send_mma_submit_email(mock_send_template_email, test_client,
                                db_session, auth_headers):
     major_mine_application = MajorMineApplicationFactory(status_code='DFT')
+    
+    project_summary = ProjectSummaryFactory(project=major_mine_application.project)
+    auth = ProjectSummaryAuthorizationFactory(
+        project_summary=project_summary,
+        project_summary_authorization_type='MINES_ACT_PERMIT'
+    )
+    auth.save()
     
     # Add various document types to test document grouping
     documents = [

--- a/services/core-api/tests/projects/major_mines_application/resources/test_application_emails.py
+++ b/services/core-api/tests/projects/major_mines_application/resources/test_application_emails.py
@@ -152,11 +152,12 @@ def test_send_mma_submit_email(mock_send_template_email, test_client,
     major_mine_application = MajorMineApplicationFactory(status_code='DFT')
     
     project_summary = ProjectSummaryFactory(project=major_mine_application.project)
-    ProjectSummaryAuthorizationFactory(
+    auth = ProjectSummaryAuthorizationFactory(
         project_summary=project_summary,
         project_summary_authorization_type='MINES_ACT_PERMIT'
     )
 
+    auth.save()
     db_session.refresh(major_mine_application)
 
     # Add various document types to test document grouping

--- a/services/core-api/tests/projects/major_mines_application/resources/test_application_emails.py
+++ b/services/core-api/tests/projects/major_mines_application/resources/test_application_emails.py
@@ -157,7 +157,7 @@ def test_send_mma_submit_email(mock_send_template_email, test_client,
         project_summary_authorization_type='MINES_ACT_PERMIT'
     )
     auth.save()
-    assert major_mine_application.project.has_mines_act_auth() == True
+    assert major_mine_application.project.has_mines_act_auths() == True
     # Add various document types to test document grouping
     documents = [
         {

--- a/services/core-web/src/components/Forms/ExplosivesPermit/ExplosivesPermitFormNew.tsx
+++ b/services/core-web/src/components/Forms/ExplosivesPermit/ExplosivesPermitFormNew.tsx
@@ -467,7 +467,7 @@ export const ExplosivesPermitFormNew: FC<ExplosivesPermitFormProps &
                   placeholder="Select Mine Manager"
                   partyLabel="Mine Manager"
                   required={!isHistoric}
-                  validate={isHistoric ? [partyHasAddress(mineManagersDropdown, partyValidationMessage)] : [required, partyHasAddress(mineManagersDropdown, partyValidationMessage)]}
+                  validate={isHistoric ? [] : [required, partyHasAddress(mineManagersDropdown, partyValidationMessage)]}
                   component={renderConfig.SELECT}
                   data={mineManagersDropdown}
                   disabled={disabled}
@@ -481,7 +481,7 @@ export const ExplosivesPermitFormNew: FC<ExplosivesPermitFormProps &
                   component={renderConfig.SELECT}
                   placeholder="Select Permittee"
                   required
-                  validate={[required, partyHasAddress(permitteeDropdown, partyValidationMessage)]}
+                  validate={isHistoric ? [required] : [required, partyHasAddress(permitteeDropdown, partyValidationMessage)]}
                   data={permitteeDropdown}
                   disabled={disabled || !mines_permit_guid}
                 />


### PR DESCRIPTION
## Objective 
- was sending to permrecl if there were only EMA auths
