### PR TITLE
[MDS-6742] fix to view report details in compliance articles page

### DIFF
--- a/services/core-web/src/components/admin/complianceCodes/ComplianceCodeViewEditForm.tsx
+++ b/services/core-web/src/components/admin/complianceCodes/ComplianceCodeViewEditForm.tsx
@@ -90,6 +90,7 @@ const ComplianceCodeViewEditForm: FC<{
         onSubmit={handleSubmit}
         isEditMode={isEditMode}
         isModal={true}
+        forceRedux={true}
       >
         <Steps current={currentStep}>
           {steps.map((step) => (

--- a/services/core-web/src/components/admin/complianceCodes/ReportEditForm.tsx
+++ b/services/core-web/src/components/admin/complianceCodes/ReportEditForm.tsx
@@ -48,10 +48,10 @@ export const ReportEditForm = (props: ReportEditProps) => {
   const renderReports = ({ fields }) => (
     <Row style={{ width: "100%" }}>
       {fields.map((report, index) => {
-        const reportData = formValues.reports && formValues.reports[index];
+        const reportData = formValues?.reports && formValues?.reports[index];
         const reportDefinition =
           mineReportDefinitionOptions?.find(
-            (d) => d?.mine_report_definition_guid === reportData.mine_report_definition_guid
+            (d) => d?.mine_report_definition_guid === reportData?.mine_report_definition_guid
           ) || {} as IMineReportDefinition;
         const reportWCompliance = {
           ...reportDefinition,


### PR DESCRIPTION
## Objective 

[MDS-6742](https://bcmines.atlassian.net/browse/MDS-6742)

- Fix to make report details show up in the **View Health, Safety and Reclamation Code** modal
- The `ReportEditForm` component that is setup in the `ComplianceCodeViewEditForm` component always seems to return null for it's form values. I found that in the `FormWrapper` component the setup of the initial values is determined by the below conditional

```
  const initialValues = useSelector((state) => {
    if (!isEditMode && forceRedux) {
      return getFormValues(props.name)(state);
    }
    return props.initialValues;
  });
```

In this situation the `isEditMode` value is always false so `!isEditMode` results in true, and by default `forceRedux` is false. So it seems to never call the `getFormValues` portion. The fix was to add `forceRedux` as a prop to the `FormWrapper` component call in the `CompliaceCodeViewEditForm` component

<img width="2542" height="1119" alt="image" src="https://github.com/user-attachments/assets/e93e3b0f-85a9-4733-a406-c359612278ad" />
