### PR TITLE
[MDS-6741] - View Mine Report Definition Button Does Nothing

### DIFF
--- a/services/core-web/src/components/admin/complianceCodes/AddReportDefinitionForm.tsx
+++ b/services/core-web/src/components/admin/complianceCodes/AddReportDefinitionForm.tsx
@@ -118,7 +118,7 @@ const AddReportDefinitionForm: FC<{
 
       <div className="ant-modal-footer">
         <RenderCancelButton />
-        {isEditMode ? <RenderSubmitButton buttonText="Save Report" disableOnClean={false} /> : null}
+        <RenderSubmitButton buttonText="Save Report" disableOnClean={false} />
       </div>
     </FormWrapper>
   );

--- a/services/core-web/src/components/admin/complianceCodes/AddReportDefinitionForm.tsx
+++ b/services/core-web/src/components/admin/complianceCodes/AddReportDefinitionForm.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { FC } from "react";
 import FormWrapper from "@mds/common/components/forms/FormWrapper";
 import { ADD_REPORT_DEFINITION } from "@/constants/forms";
 import { Col, Row, Typography } from "antd";
@@ -12,10 +12,16 @@ import RenderCancelButton from "@mds/common/components/forms/RenderCancelButton"
 import RenderSubmitButton from "@mds/common/components/forms/RenderSubmitButton";
 import { maxLength, required, requiredRadioButton } from "@mds/common/redux/utils/Validate";
 import { Field } from "@mds/common/components/forms/form";
+import { IMineReportDefinition } from "@mds/common/interfaces";
 
 const { Title, Paragraph } = Typography;
 
-const AddReportDefinitionForm = ({ handleSubmit, isModal = false }) => {
+const AddReportDefinitionForm: FC<{
+  handleSubmit?: (values: Partial<IMineReportDefinition>) => void | Promise<void>;
+  isModal?: boolean;
+  isEditMode?: boolean;
+  initialValues?: Partial<IMineReportDefinition>;
+}> = ({ handleSubmit, isModal = false, isEditMode = true, initialValues = {} }) => {
   const mineReportDueDateTypes = useAppSelector(getMineReportDueDateTypes);
 
   const dueDatePeriodMonthsOptions = [
@@ -25,7 +31,14 @@ const AddReportDefinitionForm = ({ handleSubmit, isModal = false }) => {
   ];
 
   return (
-    <FormWrapper name={ADD_REPORT_DEFINITION} onSubmit={handleSubmit} isModal={isModal}>
+    <FormWrapper
+      name={ADD_REPORT_DEFINITION}
+      onSubmit={handleSubmit}
+      isModal={isModal}
+      isEditMode={isEditMode}
+      initialValues={initialValues}
+      reduxFormConfig={{ destroyOnUnmount: true }}
+    >
       <Title level={3}>Report Details</Title>
       <Field
         required
@@ -105,7 +118,7 @@ const AddReportDefinitionForm = ({ handleSubmit, isModal = false }) => {
 
       <div className="ant-modal-footer">
         <RenderCancelButton />
-        <RenderSubmitButton buttonText="Save Report" disableOnClean={false} />
+        {isEditMode ? <RenderSubmitButton buttonText="Save Report" disableOnClean={false} /> : null}
       </div>
     </FormWrapper>
   );

--- a/services/core-web/src/components/admin/complianceCodes/ComplianceReportManagement.tsx
+++ b/services/core-web/src/components/admin/complianceCodes/ComplianceReportManagement.tsx
@@ -1,5 +1,5 @@
 import React, { FC, useEffect, useState } from "react";
-import { Button, Input, Row, Typography } from "antd";
+import { Button, Input, notification, Row, Typography } from "antd";
 import queryString from "query-string";
 import PlusOutlined from "@ant-design/icons/PlusOutlined";
 import CoreTable from "@mds/common/components/common/CoreTable";
@@ -115,7 +115,32 @@ const ComplianceReportManagement: FC = () => {
   };
 
   const openViewModal = (record) => {
-    console.log("record", record);
+    const reportDefinition = reportDefinitions.find(
+      (r) => r.mine_report_definition_guid === record.mine_report_definition_guid
+    );
+    if (!reportDefinition) {
+      notification.error({
+        message: "Error",
+        description: "Report definition not found",
+      });
+    }
+    console.log("reportDefinition", reportDefinition);
+    record.compliance_articles = [reportDefinition.compliance_articles[0]];
+    dispatch(
+      openModal({
+        props: {
+          title: `View Report`,
+          isEditMode: false,
+          initialValues: {
+            ...reportDefinition,
+            mine_report_due_date_type_code: reportDefinition.mine_report_due_date_type,
+            mine_report_due_date_months: reportDefinition.due_date_period_months,
+            report_type: reportDefinition.is_prr_only ? "PRR" : "CRR",
+          },
+        },
+        content: AddReportDefinitionForm,
+      })
+    );
   };
 
   const actions = [

--- a/services/core-web/src/components/admin/complianceCodes/ComplianceReportManagement.tsx
+++ b/services/core-web/src/components/admin/complianceCodes/ComplianceReportManagement.tsx
@@ -1,5 +1,5 @@
 import React, { FC, useEffect, useState } from "react";
-import { Button, Input, notification, Row, Typography } from "antd";
+import { Button, Input, Row, Typography } from "antd";
 import queryString from "query-string";
 import PlusOutlined from "@ant-design/icons/PlusOutlined";
 import CoreTable from "@mds/common/components/common/CoreTable";
@@ -115,27 +115,17 @@ const ComplianceReportManagement: FC = () => {
   };
 
   const openViewModal = (record) => {
-    const reportDefinition = reportDefinitions.find(
-      (r) => r.mine_report_definition_guid === record.mine_report_definition_guid
-    );
-    if (!reportDefinition) {
-      notification.error({
-        message: "Error",
-        description: "Report definition not found",
-      });
-      return;
-    }
-    record.compliance_articles = [reportDefinition.compliance_articles[0]];
+    record.compliance_articles = [record.compliance_articles[0]];
     dispatch(
       openModal({
         props: {
           title: `View Report`,
           isEditMode: false,
           initialValues: {
-            ...reportDefinition,
-            mine_report_due_date_type_code: reportDefinition.mine_report_due_date_type,
-            mine_report_due_date_months: reportDefinition.due_date_period_months,
-            report_type: reportDefinition.is_prr_only ? "PRR" : "CRR",
+            ...record,
+            mine_report_due_date_type_code: record.mine_report_due_date_type,
+            mine_report_due_date_months: record.due_date_period_months,
+            report_type: record.is_prr_only ? "PRR" : "CRR",
           },
         },
         content: AddReportDefinitionForm,

--- a/services/core-web/src/components/admin/complianceCodes/ComplianceReportManagement.tsx
+++ b/services/core-web/src/components/admin/complianceCodes/ComplianceReportManagement.tsx
@@ -123,8 +123,8 @@ const ComplianceReportManagement: FC = () => {
         message: "Error",
         description: "Report definition not found",
       });
+      return;
     }
-    console.log("reportDefinition", reportDefinition);
     record.compliance_articles = [reportDefinition.compliance_articles[0]];
     dispatch(
       openModal({


### PR DESCRIPTION
It seems we never implemented the view modal for viewing a mine report definition.  Converted the existing create modal to have an optional view only mode

## Objective 

[MDS-6741](https://bcmines.atlassian.net/browse/MDS-6741)

<img width="2142" height="1175" alt="image" src="https://github.com/user-attachments/assets/d2d6d93b-ed03-4445-a682-d09a33a6e220" />
