### PR TITLE
[CHORE] Allow users to navigate between SteppedForm pages

### DIFF
--- a/services/common/src/components/forms/SteppedForm.tsx
+++ b/services/common/src/components/forms/SteppedForm.tsx
@@ -1,12 +1,13 @@
 import React, { FC, ReactElement, useEffect, useState } from "react";
 import { useSelector, useDispatch } from "react-redux";
-import { getFormSyncErrors, getFormValues, submit } from "@mds/common/components/forms/form";
+import { getFormSyncErrors, getFormValues, isDirty, getFormMeta, reset, submit } from "@mds/common/components/forms/form";
 import { Button, Col, Menu, Popconfirm, Row, StepProps } from "antd";
 import LeftOutlined from "@ant-design/icons/LeftOutlined";
 import RightOutlined from "@ant-design/icons/RightOutlined";
 import { indexOf } from "lodash";
 import { flattenObject, formatUrlToUpperCaseString } from "@mds/common/redux/utils/helpers";
 import FormWrapper, { FormWrapperProps } from "./FormWrapper";
+import { cancelConfirmWrapper } from "./RenderCancelButton";
 
 interface SteppedFormProps extends Omit<FormWrapperProps, "onSubmit"> {
   children: Array<ReactElement<StepProps>>;
@@ -45,7 +46,7 @@ const SteppedForm: FC<SteppedFormProps> = ({
   cancelConfirmMessage,
   sectionChangeText = "Save & Continue",
   nextText = "Next",
-  disableTabsOnError = true,
+  disableTabsOnError = false,
   forceRedux,
   confirmOnSubmit = false,
   confirmSubmissionText = "",
@@ -59,6 +60,11 @@ const SteppedForm: FC<SteppedFormProps> = ({
   const formValues = useSelector(getFormValues(name));
   const formErrors = useSelector((state) => getFormSyncErrors(name)(state));
   const errors = Object.keys(flattenObject(formErrors));
+  const isFormDirty = useSelector(isDirty(name));
+  const meta = useSelector(getFormMeta(name));
+  // sometimes isFormDirty is false positive because of automatic changes to form values
+  // but if the fields are actually touched then the meta will not equal {}
+  const isFormTouched = Object.keys(meta).length > 0;
 
   useEffect(() => {
     setTabIndex(tabs.indexOf(activeTab));
@@ -72,11 +78,19 @@ const SteppedForm: FC<SteppedFormProps> = ({
 
   const handleTabClick = (tab) => {
     if (tabIndex !== tabs.indexOf(tab)) {
-      setTabIndex(indexOf(tabs, tab));
+      const changeTab = () => {
+        // use isFormDirty here because automatic changes have to be reset too
+        if (isFormDirty) {
+          dispatch(reset(name));
+        }
+        setTabIndex(indexOf(tabs, tab));
 
-      if (handleTabChange) {
-        handleTabChange(tab);
+        if (handleTabChange) {
+          handleTabChange(tab);
+        }
       }
+      // but isFormTouched here will avoid prompting user unnecessarily
+      cancelConfirmWrapper(changeTab, isEditMode && isFormTouched);
     }
   };
 

--- a/services/common/src/components/forms/SteppedForm.tsx
+++ b/services/common/src/components/forms/SteppedForm.tsx
@@ -1,6 +1,13 @@
 import React, { FC, ReactElement, useEffect, useState } from "react";
 import { useSelector, useDispatch } from "react-redux";
-import { getFormSyncErrors, getFormValues, isDirty, getFormMeta, reset, submit } from "@mds/common/components/forms/form";
+import {
+  getFormSyncErrors,
+  getFormValues,
+  isDirty,
+  getFormMeta,
+  reset,
+  submit,
+} from "@mds/common/components/forms/form";
 import { Button, Col, Menu, Popconfirm, Row, StepProps } from "antd";
 import LeftOutlined from "@ant-design/icons/LeftOutlined";
 import RightOutlined from "@ant-design/icons/RightOutlined";
@@ -88,7 +95,7 @@ const SteppedForm: FC<SteppedFormProps> = ({
         if (handleTabChange) {
           handleTabChange(tab);
         }
-      }
+      };
       // but isFormTouched here will avoid prompting user unnecessarily
       cancelConfirmWrapper(changeTab, isEditMode && isFormTouched);
     }
@@ -167,14 +174,14 @@ const SteppedForm: FC<SteppedFormProps> = ({
           <div className="stepped-form-form-container">
             <FormWrapper
               name={name}
-              onSubmit={() => { }}
+              onSubmit={() => {}}
               initialValues={initialValues}
               isEditMode={isEditMode}
               forceRedux={forceRedux}
               reduxFormConfig={
                 reduxFormConfig ?? {
                   touchOnBlur: true,
-                  touchOnChange: false,
+                  touchOnChange: true,
                   enableReinitialize: true,
                 }
               }
@@ -236,8 +243,9 @@ const SteppedForm: FC<SteppedFormProps> = ({
                   {nextText}
                 </Button>
               )}
-              {isEditMode && isLast && (
-                confirmOnSubmit ? (
+              {isEditMode &&
+                isLast &&
+                (confirmOnSubmit ? (
                   <Popconfirm
                     placement="topRight"
                     title={confirmSubmissionText}
@@ -245,10 +253,7 @@ const SteppedForm: FC<SteppedFormProps> = ({
                     okText={confirmSubmissionOkText}
                     cancelText={confirmSubmissionCancelText}
                   >
-                    <Button
-                      type="primary"
-                      disabled={isSubmitting}
-                    >
+                    <Button type="primary" disabled={isSubmitting}>
                       {submitText || "Submit"}
                     </Button>
                   </Popconfirm>
@@ -260,8 +265,7 @@ const SteppedForm: FC<SteppedFormProps> = ({
                   >
                     {submitText || "Submit"}
                   </Button>
-                )
-              )}
+                ))}
             </Row>
           </div>
         )}

--- a/services/common/src/components/forms/form.tsx
+++ b/services/common/src/components/forms/form.tsx
@@ -17,6 +17,7 @@ export {
     formValueSelector,
     getFormSubmitErrors,
     getFormSyncErrors,
+    getFormMeta,
     getFormValues,
     hasSubmitFailed,
     initialize,

--- a/services/common/src/components/projectSummary/AuthorizationsInvolved.tsx
+++ b/services/common/src/components/projectSummary/AuthorizationsInvolved.tsx
@@ -53,9 +53,19 @@ import { SystemFlagEnum } from "@mds/common/constants/enums";
 import { getSystemFlag } from "@mds/common/redux/selectors/authenticationSelectors";
 import { FormContext } from "../forms/FormWrapper";
 import { ProjectSummaryFormComponentProps } from "./ProjectSummaryForm";
-import { areAuthEnvFieldsDisabled, areDocumentFieldsDisabled, isDocumentDeletionEnabled } from "../projects/projectUtils";
+import {
+  areAuthEnvFieldsDisabled,
+  areDocumentFieldsDisabled,
+  isDocumentDeletionEnabled,
+} from "../projects/projectUtils";
 import { removeDocumentFromProjectSummary } from "@mds/common/redux/actionCreators/projectActionCreator";
-import { PROJECT_SUMMARY_DOCUMENT_TYPE_CODE_STATE, WATER_SUSTAINABILITY_ACT, ENVIRONMENTAL_MANAGMENT_ACT, WASTE_DISCHARGE_NEW_AUTHORIZATIONS_URL, WASTE_DISCHARGE_AMENDMENT_AUTHORIZATIONS_URL } from "@mds/common/constants/strings";
+import {
+  PROJECT_SUMMARY_DOCUMENT_TYPE_CODE_STATE,
+  WATER_SUSTAINABILITY_ACT,
+  ENVIRONMENTAL_MANAGMENT_ACT,
+  WASTE_DISCHARGE_NEW_AUTHORIZATIONS_URL,
+  WASTE_DISCHARGE_AMENDMENT_AUTHORIZATIONS_URL,
+} from "@mds/common/constants/strings";
 import { useAppDispatch } from "@mds/common/redux/rootState";
 
 const RenderEMAPermitCommonSections = ({ code, isAmendment, index, isDisabled }) => {
@@ -64,9 +74,8 @@ const RenderEMAPermitCommonSections = ({ code, isAmendment, index, isDisabled })
     ? "Additional Amendment Request Information"
     : "Purpose of Application";
   const authType = isAmendment ? "AMENDMENT" : "NEW";
-  const { authorizations, mine_guid, project_guid, project_summary_guid, status_code } = useSelector(
-    getFormValues(FORM.ADD_EDIT_PROJECT_SUMMARY)
-  ) as IProjectSummaryForm;
+  const { authorizations, mine_guid, project_guid, project_summary_guid, status_code } =
+    useSelector(getFormValues(FORM.ADD_EDIT_PROJECT_SUMMARY)) as IProjectSummaryForm;
   const systemFlag = useSelector(getSystemFlag);
   const codeAuthorizations = authorizations[code];
   const { AMENDMENT, NEW } = codeAuthorizations;
@@ -92,11 +101,16 @@ const RenderEMAPermitCommonSections = ({ code, isAmendment, index, isDisabled })
           project_guid,
           project_summary_guid,
           document.mine_document_guid
-        )).then(() => {
-          removeAmendmentDocument(tableDocuments.indexOf(document), document.category, document.document_manager_guid)
-        })
+        )
+      ).then(() => {
+        removeAmendmentDocument(
+          tableDocuments.indexOf(document),
+          document.category,
+          document.document_manager_guid
+        );
+      });
     }
-  }
+  };
 
   const removeAmendmentDocument = (
     amendmentDocumentsIndex: number,
@@ -335,9 +349,11 @@ const RenderEMAAmendFieldArray = ({ fields, code, isDisabled, isEditMode }) => {
                       </a>
                     </Typography.Text>
                   </Col>
-                  {isEditMode && !isDisabled && <Col>
-                    <Button onClick={() => handleRemoveAmendment(index)}>Cancel</Button>
-                  </Col>}
+                  {isEditMode && !isDisabled && (
+                    <Col>
+                      <Button onClick={() => handleRemoveAmendment(index)}>Cancel</Button>
+                    </Col>
+                  )}
                 </Row>
               }
               name="existing_permits_authorizations[0]"
@@ -401,7 +417,9 @@ const RenderEMAAmendFieldArray = ({ fields, code, isDisabled, isEditMode }) => {
 };
 
 const RenderEMAAuthCodeFormSection = ({ code, isDisabled }) => {
-  const { authorizations } = useSelector(getFormValues(FORM.ADD_EDIT_PROJECT_SUMMARY)) as IProjectSummaryForm;
+  const { authorizations } = useSelector(
+    getFormValues(FORM.ADD_EDIT_PROJECT_SUMMARY)
+  ) as IProjectSummaryForm;
   const codeAuthorizations = authorizations[code] ?? [];
   const hasAmendments = codeAuthorizations.AMENDMENT?.length > 0;
   const hasNew = codeAuthorizations.NEW?.length > 0;
@@ -459,14 +477,16 @@ const RenderEMAAuthCodeFormSection = ({ code, isDisabled }) => {
                         component={RenderEMAAmendFieldArray}
                         props={{ code, isDisabled, isEditMode }}
                       />
-                      {isEditMode && <Button
-                        disabled={isDisabled}
-                        onClick={addAmendment}
-                        icon={<PlusCircleFilled />}
-                        className="btn-sm-padding margin-large--bottom"
-                      >
-                        Add another amendment
-                      </Button>}
+                      {isEditMode && (
+                        <Button
+                          disabled={isDisabled}
+                          onClick={addAmendment}
+                          icon={<PlusCircleFilled />}
+                          className="btn-sm-padding margin-large--bottom"
+                        >
+                          Add another amendment
+                        </Button>
+                      )}
                     </Row>
                   )}
                 </>
@@ -487,7 +507,9 @@ const RenderEMAAuthCodeFormSection = ({ code, isDisabled }) => {
 
 const RenderMinesActPermitSelect = ({ isDisabled }) => {
   const dispatch = useDispatch();
-  const formValues = useSelector(getFormValues(FORM.ADD_EDIT_PROJECT_SUMMARY)) as IProjectSummaryForm;
+  const formValues = useSelector(
+    getFormValues(FORM.ADD_EDIT_PROJECT_SUMMARY)
+  ) as IProjectSummaryForm;
   const { mine_guid } = formValues;
   const permits = useSelector(getPermits);
   const permitDropdown = createDropDownList(permits, "permit_no", "permit_guid");
@@ -576,18 +598,26 @@ const RenderAuthCodeFormSection = ({ authorizationType, code, isDisabled }) => {
   );
 };
 
-export const AuthorizationsInvolved: FC<ProjectSummaryFormComponentProps> = ({ fieldsDisabled }) => {
+export const AuthorizationsInvolved: FC<ProjectSummaryFormComponentProps> = ({
+  fieldsDisabled,
+}) => {
   const dispatch = useDispatch();
   const transformedProjectSummaryAuthorizationTypes = useSelector(
     getTransformedProjectSummaryAuthorizationTypes
   );
   const { isEditMode } = useContext(FormContext);
   const amsAuthTypes = useSelector(getAmsAuthorizationTypes);
-  const formValues = useSelector(getFormValues(FORM.ADD_EDIT_PROJECT_SUMMARY)) as IProjectSummaryForm;
+  const formValues = useSelector(
+    getFormValues(FORM.ADD_EDIT_PROJECT_SUMMARY)
+  ) as IProjectSummaryForm;
 
   const systemFlag = useSelector(getSystemFlag);
   const isCore = systemFlag === SystemFlagEnum.core;
-  const envFieldsDisabled = areAuthEnvFieldsDisabled(systemFlag, formValues?.status_code, formValues?.confirmation_of_submission);
+  const envFieldsDisabled = areAuthEnvFieldsDisabled(
+    systemFlag,
+    formValues?.status_code,
+    formValues?.confirmation_of_submission
+  );
 
   const handleChange = (e, code) => {
     dispatch(touch(FORM.ADD_EDIT_PROJECT_SUMMARY, "authorizationTypes"));
@@ -632,21 +662,29 @@ export const AuthorizationsInvolved: FC<ProjectSummaryFormComponentProps> = ({ f
             {transformedProjectSummaryAuthorizationTypes.map((authorization) => {
               return (
                 <div key={authorization.code} className="margin-large--bottom">
-                  {(authorization.code === WATER_SUSTAINABILITY_ACT) && (<>
-                    <Typography.Title level={4}>Indicate any other required regulatory approvals.</Typography.Title>
-                    <Typography.Paragraph>
-                      Note: These related approvals are listed for <b>informational purposes only</b> and are <b>not submitted</b> through this application.
-                      However, by providing details about these applications, you help support a coordinated review process across ministries,
-                      which may positively impact review timelines and reduce delays.
-                    </Typography.Paragraph>
-                  </>)}
-                  <Typography.Title level={5}>{`${authorization.description} ${authorization.code === ENVIRONMENTAL_MANAGMENT_ACT ? "(EMA)" : ""}`}</Typography.Title>
+                  {authorization.code === WATER_SUSTAINABILITY_ACT && (
+                    <>
+                      <Typography.Title level={4}>
+                        Indicate any other required regulatory approvals.
+                      </Typography.Title>
+                      <Typography.Paragraph>
+                        Note: These related approvals are listed for{" "}
+                        <b>informational purposes only</b> and are <b>not submitted</b> through this
+                        application. However, by providing details about these applications, you
+                        help support a coordinated review process across ministries, which may
+                        positively impact review timelines and reduce delays.
+                      </Typography.Paragraph>
+                    </>
+                  )}
+                  <Typography.Title
+                    level={5}
+                  >{`${authorization.description} ${authorization.code === ENVIRONMENTAL_MANAGMENT_ACT ? "(EMA)" : ""}`}</Typography.Title>
                   {authorization.code === ENVIRONMENTAL_MANAGMENT_ACT && (
                     <Typography.Paragraph>
-                      For Registration and Changes to an Existing Registration under the EMA’s Municipal Wastewater Regulation,
-                      Hazardous Waste Regulation or Petroleum Storage and
-                      Distribution Facilities Storm Water Regulation: submit an application to the Ministry of Environment and Parks
-                      according to the {" "}
+                      For Registration and Changes to an Existing Registration under the EMA’s
+                      Municipal Wastewater Regulation, Hazardous Waste Regulation or Petroleum
+                      Storage and Distribution Facilities Storm Water Regulation: submit an
+                      application to the Ministry of Environment and Parks according to the{" "}
                       <Link
                         to={{ pathname: WASTE_DISCHARGE_NEW_AUTHORIZATIONS_URL }}
                         target="_blank"
@@ -681,7 +719,9 @@ export const AuthorizationsInvolved: FC<ProjectSummaryFormComponentProps> = ({ f
                               checked={checked}
                               onChange={(e) => handleChange(e, child.code)}
                             >
-                              <b className={!isEditMode ? "view-item-label" : ""}>{child.description}</b>
+                              <b className={!isEditMode ? "view-item-label" : ""}>
+                                {child.description}
+                              </b>
                             </Checkbox>
                             {checked && (
                               <>

--- a/services/common/src/components/projectSummary/AuthorizationsInvolved.tsx
+++ b/services/common/src/components/projectSummary/AuthorizationsInvolved.tsx
@@ -9,6 +9,7 @@ import {
   FieldArray,
   FormSection,
   getFormValues,
+  touch,
 } from "@mds/common/components/forms/form";
 import { Alert, Button, Checkbox, Col, Row, Tooltip, Typography } from "antd";
 import InfoCircleOutlined from "@ant-design/icons/InfoCircleOutlined";
@@ -413,6 +414,7 @@ const RenderEMAAuthCodeFormSection = ({ code, isDisabled }) => {
   };
 
   const handleChangeAuthType = (value, _newVal, prevVal, _fieldName) => {
+    dispatch(touch(FORM.ADD_EDIT_PROJECT_SUMMARY, `${code}.types`));
     permitTypes.forEach((type) => {
       if (value.includes(type) && !prevVal.includes(type)) {
         dispatch(arrayPush(FORM.ADD_EDIT_PROJECT_SUMMARY, `authorizations.${code}.${type}`, {}));
@@ -588,6 +590,7 @@ export const AuthorizationsInvolved: FC<ProjectSummaryFormComponentProps> = ({ f
   const envFieldsDisabled = areAuthEnvFieldsDisabled(systemFlag, formValues?.status_code, formValues?.confirmation_of_submission);
 
   const handleChange = (e, code) => {
+    dispatch(touch(FORM.ADD_EDIT_PROJECT_SUMMARY, "authorizationTypes"));
     if (e.target.checked) {
       let formVal;
       dispatch(arrayPush(FORM.ADD_EDIT_PROJECT_SUMMARY, `authorizationTypes`, code));

--- a/services/common/src/components/projectSummary/__snapshots__/AuthorizationsInvolved.spec.tsx.snap
+++ b/services/common/src/components/projectSummary/__snapshots__/AuthorizationsInvolved.spec.tsx.snap
@@ -512,7 +512,7 @@ exports[`AuthorizationsInvolved renders properly 1`] = `
                       <div
                         class="ant-typography"
                       >
-                        For Registration and Changes to an Existing Registration under the EMA’s Municipal Wastewater Regulation, Hazardous Waste Regulation or Petroleum Storage and Distribution Facilities Storm Water Regulation: submit an application to the Ministry of Environment and Parks according to the 
+                        For Registration and Changes to an Existing Registration under the EMA’s Municipal Wastewater Regulation, Hazardous Waste Regulation or Petroleum Storage and Distribution Facilities Storm Water Regulation: submit an application to the Ministry of Environment and Parks according to the
                          
                         <a
                           href="https://www2.gov.bc.ca/gov/content/environment/waste-management/waste-discharge-authorization/apply"
@@ -755,7 +755,8 @@ exports[`AuthorizationsInvolved renders properly 1`] = `
                       <div
                         class="ant-typography"
                       >
-                        Note: These related approvals are listed for 
+                        Note: These related approvals are listed for
+                         
                         <b>
                           informational purposes only
                         </b>


### PR DESCRIPTION
## Objective 
- this has been sitting in my git stash!
- it's... mostly tested? It could probably use more testing, if it's decided to implement it. Try it out, look for issues, before merging _for sure_

### How it works:
- the user is now ALLOWED to navigate between different pages on the SteppedForm
- it'll show a message like "are you sure you want to change pages, your changes will be discarded" if the user has made changes
- it was kind of annoying getting the "isDirty" property properly