### PR TITLE
[CHORE] Restore new status changes made to now applications since backup

### DIFF
--- a/migrations/sql/V2026.01.30.11.45__update_altered_nows_to_match_changes_since_backup.sql
+++ b/migrations/sql/V2026.01.30.11.45__update_altered_nows_to_match_changes_since_backup.sql
@@ -1,0 +1,10 @@
+-- This migration updates the now_application_status_code for specific now_application_id entries
+-- to reflect changes made since the last backup.
+
+UPDATE now_application SET now_application_status_code = 'CDI' WHERE now_application_id = 2718;
+UPDATE now_application SET now_application_status_code = 'CDI' WHERE now_application_id = 2758;
+UPDATE now_application SET now_application_status_code = 'RCO' WHERE now_application_id = 3004;
+UPDATE now_application SET now_application_status_code = 'CDI' WHERE now_application_id = 3273;
+UPDATE now_application SET now_application_status_code = 'REF' WHERE now_application_id = 3395;
+UPDATE now_application SET now_application_status_code = 'REF' WHERE now_application_id = 3427;
+UPDATE now_application SET now_application_status_code = 'GVD' WHERE now_application_id = 3614;


### PR DESCRIPTION
## Objective 

This is a patch to the previous migration that restored all now_application status codes to the state they were in at the time of the backup.
The records updated all receieved changes since that time, and this migration will restore those records to this current state after the previous data fix migration runs.

_Why are you making this change? Provide a short explanation and/or screenshots_
