### PR TITLE
[MDS-6743] Added schema.json to pgsync dockerfile build

### DIFF
--- a/services/pgsync/Dockerfile
+++ b/services/pgsync/Dockerfile
@@ -7,6 +7,7 @@ WORKDIR /app
 USER root
 
 COPY start.sh /app/start.sh
+COPY schema.json /config/schema.json
 RUN chmod +x /app/start.sh
 RUN chmod 777 /app
 


### PR DESCRIPTION
## Objective 

[MDS-6743](https://bcmines.atlassian.net/browse/MDS-6743)

`schema.json` is what defines what data is being synced between postgres and elasticsearch for search usage. Locally it's being mounted as a volume, but it does need to be bundled with the image when pushed to OpenShift