### PR TITLE
[MDS-6761] Fix for signature not being able to change

### DIFF
--- a/services/core-web/package.json
+++ b/services/core-web/package.json
@@ -27,7 +27,7 @@
     "enzyme": "3.11.0",
     "enzyme-adapter-react-16": "1.15.8",
     "filepond": "4.30.4",
-    "filepond-plugin-file-encode": "2.1.10",
+    "filepond-plugin-file-encode": "2.1.14",
     "filepond-plugin-file-validate-size": "2.2.8",
     "filepond-plugin-file-validate-type": "1.2.8",
     "filepond-plugin-get-file": "1.1.0",

--- a/services/core-web/src/components/Forms/parties/PartySignatureUpload.js
+++ b/services/core-web/src/components/Forms/parties/PartySignatureUpload.js
@@ -32,11 +32,13 @@ registerPlugin(
 );
 
 export const PartySignatureUpload = (props) => {
-  const [files, setFiles] = useState([]);
+  const [files, setFiles] = useState(() => {
+    return props.signature ? [props.signature] : [];
+  });
 
   return (
     <FilePond
-      files={props.signature ? [props.signature] : files}
+      files={files}
       allowImagePreview
       allowRevert
       labelIdle='<strong>Drag & Drop your files or <span class="filepond--label-action">Browse</span></strong><br>
@@ -44,7 +46,17 @@ export const PartySignatureUpload = (props) => {
       acceptedFileTypes={Object.values(IMAGE)}
       onupdatefiles={(fileItems) => {
         const item = fileItems && fileItems[0];
-        props.onFileChange(item ? item.getFileEncodeDataURL() : null);
+        let encoded = null;
+        if (item) {
+          try {
+            encoded = item.getFileEncodeDataURL();
+          } catch (error) {
+            console.error("Failed to get encoded file:", error);
+            encoded = null;
+          }
+        }
+
+        props.onFileChange(encoded);
         setFiles(fileItems);
       }}
       labelButtonDownloadItem="Download signature"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2908,7 +2908,7 @@ __metadata:
     eslint-plugin-react: 7.37.1
     file-loader: 6.2.0
     filepond: 4.30.4
-    filepond-plugin-file-encode: 2.1.10
+    filepond-plugin-file-encode: 2.1.14
     filepond-plugin-file-validate-size: 2.2.8
     filepond-plugin-file-validate-type: 1.2.8
     filepond-plugin-get-file: 1.1.0
@@ -10976,12 +10976,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"filepond-plugin-file-encode@npm:2.1.10":
-  version: 2.1.10
-  resolution: "filepond-plugin-file-encode@npm:2.1.10"
+"filepond-plugin-file-encode@npm:2.1.14":
+  version: 2.1.14
+  resolution: "filepond-plugin-file-encode@npm:2.1.14"
   peerDependencies:
     filepond: ">=3.x <5.x"
-  checksum: eb51ca41c716898d636d1258611fb792687cfcc2b12dc455303d48f9dfbb47e16cc3c22d2c82132c179d5031b679ed755c39145b53e54e6f21be2849fcc89691
+  checksum: 6a0a4c74c95840544776cc73be4f723215b67c16d91e5852281fac11e9ab281b6693be7a65917a16fa66e79635ab51bf5ab03a7d0f1de286f9b25c34cb93bbe1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Objective 

[MDS-6761](https://bcmines.atlassian.net/browse/MDS-6761)

- Updated filepond-plugin-file-encode to version 2.1.14 to fix this error 

`can't access property "data", base64Cache[item.id] is undefined` 

I found only PartySignatureUpload file uses this library. I tried testing some other file upload areas too just in case and didn't notice any breaking bugs from version upgrade.

-  Adjusted how the FilePond file property is feed data in the PartySignatureUpload file.
