### PR TITLE
[MDS-6743] Global Search: Move indexing of mine party appointments to separate index

### DIFF
--- a/services/pgsync/schema.json
+++ b/services/pgsync/schema.json
@@ -195,37 +195,27 @@
                 "email",
                 "phone_no",
                 "deleted_ind"
-            ],
-            "children": [
-                {
-                    "table": "mine_party_appt",
-                    "columns": [
-                        "mine_party_appt_guid",
-                        "mine_party_appt_id",
-                        "mine_guid",
-                        "mine_party_appt_type_code",
-                        "start_date",
-                        "end_date",
-                        "status",
-                        "mine_party_acknowledgement_status",
-                        "permit_id",
-                        "mine_tailings_storage_facility_guid",
-                        "deleted_ind"
-                    ],
-                    "label": "mine_party_appointments",
-                    "relationship": {
-                        "type": "one_to_many",
-                        "variant": "object",
-                        "foreign_key": {
-                            "child": [
-                                "party_guid"
-                            ],
-                            "parent": [
-                                "party_guid"
-                            ]
-                        }
-                    }
-                }
+            ]
+        }
+    },
+    {
+        "database": "mds",
+        "index": "party_appointments",
+        "nodes": {
+            "table": "mine_party_appt",
+            "columns": [
+                "mine_party_appt_guid",
+                "mine_party_appt_id",
+                "party_guid",
+                "mine_guid",
+                "mine_party_appt_type_code",
+                "start_date",
+                "end_date",
+                "status",
+                "mine_party_acknowledgement_status",
+                "permit_id",
+                "mine_tailings_storage_facility_guid",
+                "deleted_ind"
             ]
         }
     },


### PR DESCRIPTION
## Objective 

[MDS-6743](https://bcmines.atlassian.net/browse/MDS-6743)

Index mine party appointments separately as we're hitting an error when indexing them as children of a party in Openshift.

<img width="731" height="71" alt="image" src="https://github.com/user-attachments/assets/7b9ae39f-158d-480f-810e-cc2f1a06e735" />
