### PR TITLE
[MDS-6794] Fixed blank page when viewing TSF / EOR in core and minespace

### DIFF
--- a/services/common/src/components/tailings/TailingsSummaryPage.tsx
+++ b/services/common/src/components/tailings/TailingsSummaryPage.tsx
@@ -284,6 +284,7 @@ export const TailingsSummaryPage: FC = () => {
             enableReinitialize: true,
             destroyOnUnmount: true,
           }}
+          forceRedux={true}
         >
           <Step key="basic-information">
             <BasicInformation


### PR DESCRIPTION
## Objective 

[MDS-6794](https://bcmines.atlassian.net/browse/MDS-6794)

This PR should fix an issue when you're trying to view a TSF EOR / QP / Dam in minespace/core (view mode). Issue: This form requires the old redux form dependency in "view" mode due to how it's set up.

<img width="669" height="298" alt="image" src="https://github.com/user-attachments/assets/b18518c3-7dfb-4f30-8f93-e227057b5ac2" />
