### PR TITLE
[MDS-6803] Debounce global search

### DIFF
--- a/services/common/src/constants/API.ts
+++ b/services/common/src/constants/API.ts
@@ -139,7 +139,7 @@ export const REPORT_ERROR = `/report-error`;
 export const EPIC_INFO = (mineGuid) => `/mines/${mineGuid}/epic`;
 
 // Search
-export const SEARCH = (params) => (params ? `/search?${queryString.stringify(params)}` : "/search");
+export const SEARCH = (params) => (params ? `/search?${queryString.stringify(params, { arrayFormat: 'comma' })}` : "/search");
 export const SEARCH_OPTIONS = "/search/options";
 export const SIMPLE_SEARCH = "/search/simple";
 

--- a/services/core-api/app/api/search/search/global_search_service.py
+++ b/services/core-api/app/api/search/search/global_search_service.py
@@ -1,12 +1,20 @@
 """Global search service for executing searches against Elasticsearch."""
 
+import json
+
 import regex
+from app.api.search.elasticsearch.elastic_search_service import ElasticSearchService
 from flask import current_app
 
-from app.api.search.elasticsearch.elastic_search_service import ElasticSearchService
-from .search_constants import TYPE_TO_INDEX, ES_AGGREGATIONS, FACET_KEYS, FILTER_PARAMS, SEARCH_FIELDS
-from .search_filters import build_filter_clauses
+from .search_constants import (
+    ES_AGGREGATIONS,
+    FACET_KEYS,
+    FILTER_PARAMS,
+    SEARCH_FIELDS,
+    TYPE_TO_INDEX,
+)
 from .search_facets import extract_facets
+from .search_filters import build_filter_clauses
 from .search_transformers import transform_es_results
 
 
@@ -136,6 +144,7 @@ class GlobalSearchService:
             query = build_search_query(search_term, filter_clauses)
 
             current_app.logger.info(f"Searching ES indices: {','.join(indices)} for: {search_term}")
+            current_app.logger.info(f"ES Query: {json.dumps(query)}")
 
             es_results = ElasticSearchService.search(','.join(set(indices)), query, size=size)
             hits = es_results['hits']['hits']

--- a/services/core-api/app/api/search/search/search_constants.py
+++ b/services/core-api/app/api/search/search/search_constants.py
@@ -40,8 +40,6 @@ SEARCH_FIELDS = [
     "document_name^2",
     # Description fields
     "description",
-    # Catch-all
-    "*"
 ]
 
 FACET_KEYS = [

--- a/services/core-api/app/api/search/search/simple_search_service.py
+++ b/services/core-api/app/api/search/search/simple_search_service.py
@@ -5,6 +5,7 @@ Business logic for simple search functionality.
 Separated from the REST resource layer for better testability and maintainability.
 """
 
+import json
 import logging
 import traceback
 
@@ -170,7 +171,7 @@ class SimpleSearchService:
         search_results = []
         
         try:
-            current_app.logger.info(f"ES Query: {query}")
+            current_app.logger.info(f"ES Query: {json.dumps(query)}")
             es_results = ElasticSearchService.search(indices_string, query, size=30)
             hits = es_results['hits']['hits']
             current_app.logger.info(f"ES returned {len(hits)} hits")

--- a/services/core-web/src/components/search/GlobalSearch/GlobalSearch.tsx
+++ b/services/core-web/src/components/search/GlobalSearch/GlobalSearch.tsx
@@ -237,9 +237,27 @@ const GlobalSearch: React.FC<GlobalSearchProps> = ({
   }, [searchResults]);
 
   const handleViewAll = () => {
-    saveRecentSearch(searchTerm);
+    if (searchTerm) {
+      saveRecentSearch(searchTerm);
+    }
     handleClose();
-    history.push(router.SEARCH_RESULTS.dynamicRoute({ q: searchTerm }));
+    
+    // Map filter keys to search results page tab keys
+    const filterToTabMap: Record<string, string> = {
+      mine: "mine",
+      contact: "people",
+      organization: "organization",
+      permit: "permit",
+      explosives_permit: "explosives_permit",
+      now_application: "now_application",
+      nod: "notice_of_departure",
+      document: "document",
+    };
+    
+    // Get tab from first active filter if any
+    const tab = activeFilters.length > 0 ? filterToTabMap[activeFilters[0]] : null;
+    
+    history.push(router.SEARCH_RESULTS.dynamicRoute({ q: searchTerm || "*", t: tab }));
   };
 
   const handleQuickAction = (route: string) => {
@@ -282,7 +300,7 @@ const GlobalSearch: React.FC<GlobalSearchProps> = ({
           })}
           <div className="global-search-results__view-all">
             <Button type="link" block onClick={handleViewAll} className="global-search-results__view-all-btn">
-              View all results for "{searchTerm}"
+              {searchTerm ? `View all results for "${searchTerm}"` : "View all results"}
             </Button>
           </div>
         </div>

--- a/services/core-web/src/components/search/GlobalSearch/GlobalSearch.tsx
+++ b/services/core-web/src/components/search/GlobalSearch/GlobalSearch.tsx
@@ -3,6 +3,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { useHistory, useLocation } from "react-router-dom";
 import { Modal, Input, Typography, Button, List, Space, Row, Divider, Tag } from "antd";
 import { SearchOutlined } from "@ant-design/icons";
+import debounce from "lodash/debounce";
 import { fetchSearchBarResults, selectSearchBarResults, selectSearchBarFacets } from "@mds/common/redux/slices/searchSlice";
 import * as router from "@/constants/routes";
 import { ISearchResult, ISimpleSearchResult } from "@mds/common/interfaces";
@@ -30,7 +31,7 @@ const GlobalSearch: React.FC<GlobalSearchProps> = ({
 }) => {
   const [isModalVisible, setIsModalVisible] = useState(false);
   const [searchTerm, setSearchTerm] = useState("");
-  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [selectedIndex, setSelectedIndex] = useState(-1);
   const [activeFilters, setActiveFilters] = useState<string[]>([]);
   const [scopeToMine, setScopeToMine] = useState(false);
   const [quickFilter, setQuickFilter] = useState<string | null>(null);
@@ -47,11 +48,11 @@ const GlobalSearch: React.FC<GlobalSearchProps> = ({
 
   const { recentSearches, saveRecentSearch, removeRecentSearch } = useRecentSearches();
 
-  const handleSearch = useCallback(
-    (term: string, filters: string[], mineGuid: string | null) => {
+  const performSearch = useCallback(
+    (term: string, filters: string[], mineGuid: string | null, currentQuickFilter: string | null) => {
       const effectiveTerm = term || "*";
       if (effectiveTerm.length > 0) {
-        const derivedTypes = getSearchTypes(filters, quickFilter);
+        const derivedTypes = getSearchTypes(filters, currentQuickFilter);
         // If no filters are selected, explicitly send all search types to allow 1-char search
         const allTypes = Object.values(SEARCH_TYPE_CONFIG).flatMap((c) => c.types);
 
@@ -62,7 +63,27 @@ const GlobalSearch: React.FC<GlobalSearchProps> = ({
         }));
       }
     },
-    [dispatch, quickFilter]
+    [dispatch]
+  );
+
+  const debouncedSearch = useMemo(
+    () => debounce((term: string, filters: string[], mineGuid: string | null, currentQuickFilter: string | null) => {
+      performSearch(term, filters, mineGuid, currentQuickFilter);
+    }, 300),
+    [performSearch]
+  );
+
+  useEffect(() => {
+    return () => {
+      debouncedSearch.cancel();
+    };
+  }, [debouncedSearch]);
+
+  const handleSearch = useCallback(
+    (term: string, filters: string[], mineGuid: string | null) => {
+      debouncedSearch(term, filters, mineGuid, quickFilter);
+    },
+    [debouncedSearch, quickFilter]
   );
 
   const handleOpen = () => {
@@ -73,7 +94,7 @@ const GlobalSearch: React.FC<GlobalSearchProps> = ({
   const handleClose = useCallback(() => {
     setIsModalVisible(false);
     setSearchTerm("");
-    setSelectedIndex(0);
+    setSelectedIndex(-1);
     setActiveFilters([]);
     setScopeToMine(false);
     setQuickFilter(null);
@@ -104,7 +125,7 @@ const GlobalSearch: React.FC<GlobalSearchProps> = ({
     const value = e.target.value;
 
     setSearchTerm(value);
-    setSelectedIndex(0);
+    setSelectedIndex(-1);
     if (value.length > 0) {
       handleSearch(value, activeFilters, getMineGuidForSearch());
     }
@@ -115,7 +136,7 @@ const GlobalSearch: React.FC<GlobalSearchProps> = ({
       ? activeFilters.filter((f) => f !== filterKey)
       : [...activeFilters, filterKey];
     setActiveFilters(newFilters);
-    setSelectedIndex(0);
+    setSelectedIndex(-1);
     if (searchTerm.length > 0 || newFilters.length > 0) {
       handleSearch(searchTerm, newFilters, getMineGuidForSearch());
     }
@@ -160,12 +181,8 @@ const GlobalSearch: React.FC<GlobalSearchProps> = ({
   };
 
   const handleEnter = () => {
-    if (searchResults?.length > 0) {
+    if (selectedIndex >= 0 && searchResults?.length > 0) {
       navigateToResult(searchResults[selectedIndex]);
-    } else if (searchTerm.length > 0) {
-      saveRecentSearch(searchTerm);
-      handleClose();
-      history.push(router.SEARCH_RESULTS.dynamicRoute({ q: searchTerm }));
     }
   };
 
@@ -179,15 +196,19 @@ const GlobalSearch: React.FC<GlobalSearchProps> = ({
     switch (e.key) {
       case "ArrowDown":
         e.preventDefault();
-        setSelectedIndex((prev) => (prev + 1) % (totalItems || 1));
+        if (totalItems > 0) {
+          setSelectedIndex((prev) => (prev < 0 ? 0 : (prev + 1) % totalItems));
+        }
         break;
       case "ArrowUp":
         e.preventDefault();
-        setSelectedIndex((prev) => (prev - 1 + (totalItems || 1)) % (totalItems || 1));
+        if (totalItems > 0) {
+          setSelectedIndex((prev) => (prev < 0 ? totalItems - 1 : (prev - 1 + totalItems) % totalItems));
+        }
         break;
       case "Enter":
         e.preventDefault();
-        if (!searchTerm && recentSearches.length > 0) {
+        if (!searchTerm && recentSearches.length > 0 && selectedIndex >= 0) {
           handleRecentSearchClick(recentSearches[selectedIndex]);
         } else {
           handleEnter();

--- a/services/core-web/src/components/search/SearchResultsTabs.tsx
+++ b/services/core-web/src/components/search/SearchResultsTabs.tsx
@@ -27,6 +27,18 @@ interface SearchResultsTabsProps {
     nodResults: any[];
     nods: any[];
     totalResults: number;
+    facetCounts: {
+      mine: number;
+      party: number;
+      person: number;
+      organization: number;
+      permit: number;
+      explosives_permit: number;
+      now_application: number;
+      notice_of_departure: number;
+      mine_documents: number;
+      permit_documents: number;
+    };
   };
 }
 
@@ -47,19 +59,16 @@ export const SearchResultsTabs: React.FC<SearchResultsTabsProps> = ({
   results,
 }) => {
   const {
-    mines,
     mineResults,
     peopleResults,
     organizationResults,
     permitResults,
     documentResults,
     explosivesPermitResults,
-    explosivesPermits,
     nowApplicationResults,
-    nowApplications,
     nodResults,
-    nods,
     totalResults,
+    facetCounts,
   } = results;
 
   const explosivesColumns = [
@@ -92,7 +101,7 @@ export const SearchResultsTabs: React.FC<SearchResultsTabsProps> = ({
         <>
           {mineResults.length > 0 && (
             <MineResultsTable
-              header={`Mines (${mineResults.length})`}
+              header={`Mines (${facetCounts.mine})`}
               highlightRegex={highlightRegex}
               query={query}
               searchResults={mineResults}
@@ -101,7 +110,7 @@ export const SearchResultsTabs: React.FC<SearchResultsTabsProps> = ({
           )}
           {peopleResults.length > 0 && (
             <ContactResultsTable
-              header={`People (${peopleResults.length})`}
+              header={`People (${facetCounts.person})`}
               highlightRegex={highlightRegex}
               query={query}
               searchResults={peopleResults}
@@ -111,7 +120,7 @@ export const SearchResultsTabs: React.FC<SearchResultsTabsProps> = ({
           )}
           {organizationResults.length > 0 && (
             <ContactResultsTable
-              header={`Organizations (${organizationResults.length})`}
+              header={`Organizations (${facetCounts.organization})`}
               highlightRegex={highlightRegex}
               query={query}
               searchResults={organizationResults}
@@ -121,14 +130,14 @@ export const SearchResultsTabs: React.FC<SearchResultsTabsProps> = ({
           )}
           {permitResults.length > 0 && (
             <PermitResultsTable
-              header={`Permits (${permitResults.length})`}
+              header={`Permits (${facetCounts.permit})`}
               highlightRegex={highlightRegex}
               searchResults={permitResults}
             />
           )}
           {explosivesPermitResults.length > 0 && (
             <GenericResultsTable
-              header={`Explosives Permits (${explosivesPermitResults.length})`}
+              header={`Explosives Permits (${facetCounts.explosives_permit})`}
               searchResults={explosivesPermitResults}
               highlightRegex={highlightRegex}
               getRecordKey={(record: any) => record.explosives_permit_guid}
@@ -137,7 +146,7 @@ export const SearchResultsTabs: React.FC<SearchResultsTabsProps> = ({
           )}
           {nowApplicationResults.length > 0 && (
             <GenericResultsTable
-              header={`Notices of Work (${nowApplicationResults.length})`}
+              header={`Notices of Work (${facetCounts.now_application})`}
               searchResults={nowApplicationResults}
               highlightRegex={highlightRegex}
               getRecordKey={(record: any) => record.now_application_guid}
@@ -146,7 +155,7 @@ export const SearchResultsTabs: React.FC<SearchResultsTabsProps> = ({
           )}
           {nodResults.length > 0 && (
             <GenericResultsTable
-              header={`Notices of Departure (${nodResults.length})`}
+              header={`Notices of Departure (${facetCounts.notice_of_departure})`}
               searchResults={nodResults}
               highlightRegex={highlightRegex}
               getRecordKey={(record: any) => record.nod_guid}
@@ -155,7 +164,7 @@ export const SearchResultsTabs: React.FC<SearchResultsTabsProps> = ({
           )}
           {documentResults.length > 0 && (
             <DocumentResultsTable
-              header={`Documents (${documentResults.length})`}
+              header={`Documents (${facetCounts.mine_documents + facetCounts.permit_documents})`}
               highlightRegex={highlightRegex}
               searchResults={documentResults}
             />
@@ -165,7 +174,7 @@ export const SearchResultsTabs: React.FC<SearchResultsTabsProps> = ({
     },
     {
       key: "mine",
-      label: `Mines (${mines.length})`,
+      label: `Mines (${facetCounts.mine})`,
       children: mineResults.length === 0 ? renderEmptyState() : (
         <MineResultsTable
           header=""
@@ -178,7 +187,7 @@ export const SearchResultsTabs: React.FC<SearchResultsTabsProps> = ({
     },
     {
       key: "people",
-      label: `People (${peopleResults.length})`,
+      label: `People (${facetCounts.person})`,
       children: peopleResults.length === 0 ? renderEmptyState() : (
         <ContactResultsTable
           header=""
@@ -192,7 +201,7 @@ export const SearchResultsTabs: React.FC<SearchResultsTabsProps> = ({
     },
     {
       key: "organization",
-      label: `Organizations (${organizationResults.length})`,
+      label: `Organizations (${facetCounts.organization})`,
       children: organizationResults.length === 0 ? renderEmptyState() : (
         <ContactResultsTable
           header=""
@@ -206,7 +215,7 @@ export const SearchResultsTabs: React.FC<SearchResultsTabsProps> = ({
     },
     {
       key: "permit",
-      label: `Permits (${results.permitResults.length})`,
+      label: `Permits (${facetCounts.permit})`,
       children: permitResults.length === 0 ? renderEmptyState() : (
         <PermitResultsTable
           header=""
@@ -217,7 +226,7 @@ export const SearchResultsTabs: React.FC<SearchResultsTabsProps> = ({
     },
     {
       key: "explosives_permit",
-      label: `Explosives (${explosivesPermits.length})`,
+      label: `Explosives (${facetCounts.explosives_permit})`,
       children: explosivesPermitResults.length === 0 ? renderEmptyState() : (
         <GenericResultsTable
           header=""
@@ -230,7 +239,7 @@ export const SearchResultsTabs: React.FC<SearchResultsTabsProps> = ({
     },
     {
       key: "now_application",
-      label: `NoW (${nowApplications.length})`,
+      label: `NoW (${facetCounts.now_application})`,
       children: nowApplicationResults.length === 0 ? renderEmptyState() : (
         <GenericResultsTable
           header=""
@@ -243,7 +252,7 @@ export const SearchResultsTabs: React.FC<SearchResultsTabsProps> = ({
     },
     {
       key: "notice_of_departure",
-      label: `NODs (${nods.length})`,
+      label: `NODs (${facetCounts.notice_of_departure})`,
       children: nodResults.length === 0 ? renderEmptyState() : (
         <GenericResultsTable
           header=""
@@ -256,7 +265,7 @@ export const SearchResultsTabs: React.FC<SearchResultsTabsProps> = ({
     },
     {
       key: "document",
-      label: `Documents (${documentResults.length})`,
+      label: `Documents (${facetCounts.mine_documents + facetCounts.permit_documents})`,
       children: documentResults.length === 0 ? renderEmptyState() : (
         <DocumentResultsTable
           header=""

--- a/services/core-web/src/components/search/SearchResultsV2.tsx
+++ b/services/core-web/src/components/search/SearchResultsV2.tsx
@@ -61,9 +61,17 @@ export const SearchResults: React.FC = () => {
                 <div className="search-results-v2__result-count">
                   <Text type="secondary">
                     {results.totalResults === 0 ? (
-                      <>No results for "<strong>{params.q}</strong>"{hasActiveFilters && " (filtered)"}</>
+                      params.q === "*" ? (
+                        <>No results found{hasActiveFilters && " (filtered)"}</>
+                      ) : (
+                        <>No results for "<strong>{params.q}</strong>"{hasActiveFilters && " (filtered)"}</>
+                      )
                     ) : (
-                      <>Showing <strong>{results.totalResults}</strong> results for "<strong>{params.q}</strong>"{hasActiveFilters && " (filtered)"}</>
+                      params.q === "*" ? (
+                        <>Showing <strong>{results.totalResults}</strong> results{hasActiveFilters && " (filtered)"}</>
+                      ) : (
+                        <>Showing <strong>{results.totalResults}</strong> results for "<strong>{params.q}</strong>"{hasActiveFilters && " (filtered)"}</>
+                      )
                     )}
                   </Text>
                 </div>

--- a/services/core-web/src/components/search/useSearchResults.ts
+++ b/services/core-web/src/components/search/useSearchResults.ts
@@ -11,6 +11,7 @@ import {
 } from "@mds/common/redux/slices/searchSlice";
 import { getPartyRelationshipTypeHash } from "@mds/common/redux/selectors/staticContentSelectors";
 import * as router from "@/constants/routes";
+import { RECENT_SEARCHES_KEY, MAX_RECENT_SEARCHES } from "./GlobalSearch/utils/searchConfig";
 
 export interface SearchParams {
   q?: string;
@@ -139,18 +140,34 @@ export const useSearchResults = () => {
     }
   }, [searchOptions.length, dispatch]);
 
+  const saveRecentSearch = useCallback((term: string) => {
+    if (!term.trim()) return;
+    try {
+      const stored = localStorage.getItem(RECENT_SEARCHES_KEY);
+      const existing = stored ? JSON.parse(stored) : [];
+      const updated = [term, ...existing.filter((s: string) => s !== term)].slice(0, MAX_RECENT_SEARCHES);
+      localStorage.setItem(RECENT_SEARCHES_KEY, JSON.stringify(updated));
+    } catch {
+      // Ignore localStorage errors
+    }
+  }, []);
+
   useEffect(() => {
     const parsedParams = queryString.parse(location.search);
     const { q, t } = parsedParams;
     if (q) {
       setParams({ q: q as string, t: t as string });
-      setSearchInputValue(q as string);
+      // Don't show "*" in the search input - it's just used for "show all"
+      setSearchInputValue(q === "*" ? "" : q as string);
       setIsSearching(true);
+      if (q !== "*") {
+        saveRecentSearch(q as string);
+      }
       const { types, filters: enhancedFilters } = mapTabToSearchType(t as string, selectedFilters);
       const apiFilters = getFiltersForApi(enhancedFilters);
       dispatch(fetchSearchResults({ searchTerm: q as string, searchTypes: types, filters: apiFilters }));
     }
-  }, [location.search, dispatch, mapTabToSearchType, getFiltersForApi]);
+  }, [location.search, dispatch, mapTabToSearchType, getFiltersForApi, saveRecentSearch]);
 
   useEffect(() => {
     if (searchResults) {
@@ -178,8 +195,44 @@ export const useSearchResults = () => {
   const nowApplicationResults = nowApplications.map((item: any) => item.result).filter(Boolean);
   const nodResults = nods.map((item: any) => item.result).filter(Boolean);
 
-  const totalResults = mines.length + parties.length + permits.length + mineDocuments.length + permitDocuments.length +
-    explosivesPermits.length + nowApplications.length + nods.length;
+  // Calculate total using facet counts when available (more accurate than capped array lengths)
+  const typeFacets = searchFacets?.type || [];
+  const partyTypeFacets = searchFacets?.party_type || [];
+  
+  const getFacetCount = (typeKey: string) => {
+    const facet = typeFacets.find((f: any) => f.key === typeKey);
+    return facet?.count || 0;
+  };
+  
+  const getPartyTypeFacetCount = (typeKey: string) => {
+    const facet = partyTypeFacets.find((f: any) => f.key === typeKey);
+    return facet?.count || 0;
+  };
+
+  // Use facet counts if available, otherwise fall back to array lengths
+  // Note: party_type facets use "Person"/"Organization" keys, not "PER"/"ORG"
+  const facetCounts = {
+    mine: getFacetCount('mine') || mines.length,
+    party: getFacetCount('party') || parties.length,
+    person: getPartyTypeFacetCount('Person') || peopleResults.length,
+    organization: getPartyTypeFacetCount('Organization') || organizationResults.length,
+    permit: getFacetCount('permit') || permits.length,
+    explosives_permit: getFacetCount('explosives_permit') || explosivesPermits.length,
+    now_application: getFacetCount('now_application') || nowApplications.length,
+    notice_of_departure: getFacetCount('notice_of_departure') || nods.length,
+    mine_documents: getFacetCount('mine_documents') || mineDocuments.length,
+    permit_documents: getFacetCount('permit_documents') || permitDocuments.length,
+  };
+
+  // Calculate total: sum all type facets, but replace 'party' with person+organization to avoid double counting
+  const totalResults = typeFacets.length > 0
+    ? typeFacets.reduce((sum: number, f: any) => {
+        // Skip 'party' since we count person and organization separately
+        if (f.key === 'party') return sum;
+        return sum + (f.count || 0);
+      }, 0) + facetCounts.person + facetCounts.organization
+    : mines.length + parties.length + permits.length + mineDocuments.length + permitDocuments.length +
+      explosivesPermits.length + nowApplications.length + nods.length;
 
   const hasActiveFilters = Object.keys(selectedFilters).length > 0;
 
@@ -211,6 +264,7 @@ export const useSearchResults = () => {
       nodResults,
       nods,
       totalResults,
+      facetCounts,
     },
   };
 };

--- a/services/core-web/src/styles/components/GlobalSearch.scss
+++ b/services/core-web/src/styles/components/GlobalSearch.scss
@@ -9,10 +9,11 @@
   }
 
   &__input {
-    border-bottom: 1px solid #f0f0f0;
+    border: none;
+    border-bottom: 2px solid $violet;
     border-radius: 0;
-    height: 60px; // Increased height to prevent "squished" look
-    padding: 0 16px; // Horizontal padding to match other elements
+    height: 60px;
+    padding: 0 16px;
     display: flex;
     align-items: center;
 
@@ -20,7 +21,7 @@
       font-size: 16px;
       height: 100%;
     }
-    
+
     .ant-input-prefix {
       margin-right: 12px;
     }

--- a/services/core-web/src/styles/components/SearchResultItem.scss
+++ b/services/core-web/src/styles/components/SearchResultItem.scss
@@ -50,7 +50,7 @@
   }
 
   &__title {
-    font-weight: 500;
+    font-weight: 400;
     display: inline;
   }
 

--- a/services/core-web/src/tests/components/search/GlobalSearch.spec.tsx
+++ b/services/core-web/src/tests/components/search/GlobalSearch.spec.tsx
@@ -5,6 +5,9 @@ import { ReduxWrapper } from "@mds/common/tests/utils/ReduxWrapper";
 import GlobalSearch from "@/components/search/GlobalSearch/GlobalSearch";
 import { searchReducerType } from "@mds/common/redux/slices/searchSlice";
 import { SIMPLE_SEARCH_RESULTS, SIMPLE_SEARCH_FACETS } from "@mds/common/tests/mocks/searchMockData";
+import * as searchSlice from "@mds/common/redux/slices/searchSlice";
+
+const mockFetchSearchBarResults = jest.spyOn(searchSlice, "fetchSearchBarResults");
 
 const getDefaultState = () => ({
   [searchReducerType]: {
@@ -63,7 +66,12 @@ const getModalInput = () => {
 describe("GlobalSearch", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.useFakeTimers();
     localStorage.clear();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
   });
 
   describe("Rendering", () => {
@@ -182,8 +190,10 @@ describe("GlobalSearch", () => {
         fireEvent.keyDown(document, { key: "k", metaKey: true });
       });
 
-      // Wait a bit and confirm modal did not open
-      await new Promise(resolve => setTimeout(resolve, 100));
+      // Advance fake timers and confirm modal did not open
+      await act(async () => {
+        jest.advanceTimersByTime(100);
+      });
       expect(document.querySelector('.global-search-modal')).not.toBeInTheDocument();
     });
 
@@ -210,6 +220,7 @@ describe("GlobalSearch", () => {
 
   describe("Search Input", () => {
     it("updates search term on input change", async () => {
+      jest.useRealTimers();
       renderGlobalSearch({ enableShortcut: true });
 
       await openModalViaKeyboard();
@@ -225,6 +236,7 @@ describe("GlobalSearch", () => {
     });
 
     it("clears input when clear icon is clicked", async () => {
+      jest.useRealTimers();
       renderGlobalSearch({ enableShortcut: true });
 
       await openModalViaKeyboard();
@@ -246,6 +258,153 @@ describe("GlobalSearch", () => {
         });
         expect(input!.value).toBe("");
       }
+    });
+  });
+
+  describe("Debounced Search", () => {
+    it("does not dispatch search immediately on input change", async () => {
+      renderGlobalSearch({ enableShortcut: true });
+
+      await act(async () => {
+        fireEvent.keyDown(document, { key: "k", metaKey: true });
+        jest.advanceTimersByTime(100);
+      });
+
+      const input = getModalInput();
+      expect(input).toBeTruthy();
+
+      mockFetchSearchBarResults.mockClear();
+
+      await act(async () => {
+        fireEvent.change(input!, { target: { value: "t" } });
+      });
+
+      // Should not have dispatched immediately
+      expect(mockFetchSearchBarResults).not.toHaveBeenCalled();
+    });
+
+    it("dispatches search after debounce delay (300ms)", async () => {
+      renderGlobalSearch({ enableShortcut: true });
+
+      await act(async () => {
+        fireEvent.keyDown(document, { key: "k", metaKey: true });
+        jest.advanceTimersByTime(100);
+      });
+
+      const input = getModalInput();
+      expect(input).toBeTruthy();
+
+      mockFetchSearchBarResults.mockClear();
+
+      await act(async () => {
+        fireEvent.change(input!, { target: { value: "test" } });
+      });
+
+      // Not dispatched yet
+      expect(mockFetchSearchBarResults).not.toHaveBeenCalled();
+
+      // Advance past debounce delay
+      await act(async () => {
+        jest.advanceTimersByTime(300);
+      });
+
+      // Now should have been called
+      expect(mockFetchSearchBarResults).toHaveBeenCalledTimes(1);
+      expect(mockFetchSearchBarResults).toHaveBeenCalledWith(
+        expect.objectContaining({
+          searchTerm: "test",
+        })
+      );
+    });
+
+    it("only dispatches once for rapid keystrokes", async () => {
+      renderGlobalSearch({ enableShortcut: true });
+
+      await act(async () => {
+        fireEvent.keyDown(document, { key: "k", metaKey: true });
+        jest.advanceTimersByTime(100);
+      });
+
+      const input = getModalInput();
+      expect(input).toBeTruthy();
+
+      mockFetchSearchBarResults.mockClear();
+
+      // Simulate rapid typing
+      await act(async () => {
+        fireEvent.change(input!, { target: { value: "t" } });
+        jest.advanceTimersByTime(50);
+        fireEvent.change(input!, { target: { value: "te" } });
+        jest.advanceTimersByTime(50);
+        fireEvent.change(input!, { target: { value: "tes" } });
+        jest.advanceTimersByTime(50);
+        fireEvent.change(input!, { target: { value: "test" } });
+      });
+
+      // Not dispatched yet (still within debounce window)
+      expect(mockFetchSearchBarResults).not.toHaveBeenCalled();
+
+      // Advance past debounce delay
+      await act(async () => {
+        jest.advanceTimersByTime(300);
+      });
+
+      // Should only dispatch once with final value
+      expect(mockFetchSearchBarResults).toHaveBeenCalledTimes(1);
+      expect(mockFetchSearchBarResults).toHaveBeenCalledWith(
+        expect.objectContaining({
+          searchTerm: "test",
+        })
+      );
+    });
+
+    it("resets debounce timer on new input", async () => {
+      renderGlobalSearch({ enableShortcut: true });
+
+      await act(async () => {
+        fireEvent.keyDown(document, { key: "k", metaKey: true });
+        jest.advanceTimersByTime(100);
+      });
+
+      const input = getModalInput();
+      expect(input).toBeTruthy();
+
+      mockFetchSearchBarResults.mockClear();
+
+      await act(async () => {
+        fireEvent.change(input!, { target: { value: "test" } });
+      });
+
+      // Wait 200ms (less than 300ms debounce)
+      await act(async () => {
+        jest.advanceTimersByTime(200);
+      });
+
+      // Type more - should reset the timer
+      await act(async () => {
+        fireEvent.change(input!, { target: { value: "testing" } });
+      });
+
+      // Wait another 200ms (total 400ms from first keystroke, but only 200ms from last)
+      await act(async () => {
+        jest.advanceTimersByTime(200);
+      });
+
+      // Should still not have fired because timer was reset
+      expect(mockFetchSearchBarResults).not.toHaveBeenCalled();
+
+      // Wait another 100ms to complete the debounce from last keystroke
+      await act(async () => {
+        jest.advanceTimersByTime(100);
+      });
+
+      // Now should fire with the latest value
+      expect(mockFetchSearchBarResults).toHaveBeenCalledTimes(1);
+      expect(mockFetchSearchBarResults).toHaveBeenCalledWith(
+        expect.objectContaining({
+          searchTerm: "testing",
+        })
+      );
     });
   });
 
@@ -306,7 +465,7 @@ describe("GlobalSearch", () => {
       expect(document.querySelector('.global-search-modal')).toBeInTheDocument();
     });
 
-    it("handles Enter key in empty state", async () => {
+    it("handles Enter key with no selection - modal stays open", async () => {
       renderGlobalSearch({ enableShortcut: true });
 
       await openModalViaKeyboard();
@@ -320,10 +479,8 @@ describe("GlobalSearch", () => {
         fireEvent.keyDown(input!, { key: "Enter" });
       });
 
-      // Enter with search term should close modal and navigate
-      await waitFor(() => {
-        expect(document.querySelector('.global-search-modal')).not.toBeInTheDocument();
-      });
+      // Enter with no selection should keep modal open
+      expect(document.querySelector('.global-search-modal')).toBeInTheDocument();
     });
   });
 
@@ -486,7 +643,7 @@ describe("GlobalSearch", () => {
   });
 
   describe("Result Click Navigation", () => {
-    it("closes modal when navigating via search term submission", async () => {
+    it("keeps modal open when Enter is pressed with no selection", async () => {
       renderGlobalSearch({ enableShortcut: true });
 
       await openModalViaKeyboard();
@@ -496,15 +653,13 @@ describe("GlobalSearch", () => {
         fireEvent.change(input!, { target: { value: "test mine" } });
       });
 
-      // Submit search via Enter
+      // Press Enter without selecting a result
       await act(async () => {
         fireEvent.keyDown(input!, { key: "Enter" });
       });
 
-      // Modal should close after submission
-      await waitFor(() => {
-        expect(document.querySelector('.global-search-modal')).not.toBeInTheDocument();
-      });
+      // Modal should stay open since no result is selected
+      expect(document.querySelector('.global-search-modal')).toBeInTheDocument();
     });
   });
 

--- a/services/core-web/src/tests/components/search/SearchResultsTabs.spec.tsx
+++ b/services/core-web/src/tests/components/search/SearchResultsTabs.spec.tsx
@@ -3,6 +3,19 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { SearchResultsTabs } from "@/components/search/SearchResultsTabs";
 
+const emptyFacetCounts = {
+  mine: 0,
+  party: 0,
+  person: 0,
+  organization: 0,
+  permit: 0,
+  explosives_permit: 0,
+  now_application: 0,
+  notice_of_departure: 0,
+  mine_documents: 0,
+  permit_documents: 0,
+};
+
 const emptyResults = {
   mines: [],
   mineResults: [],
@@ -17,6 +30,7 @@ const emptyResults = {
   nodResults: [],
   nods: [],
   totalResults: 0,
+  facetCounts: emptyFacetCounts,
 };
 
 const defaultProps = {

--- a/services/core-web/src/tests/components/search/SearchResultsV2.spec.tsx
+++ b/services/core-web/src/tests/components/search/SearchResultsV2.spec.tsx
@@ -217,11 +217,21 @@ describe("SearchResultsV2 Integration Tests", () => {
         notice_of_departure: [],
       };
 
+      const facetsWithTypeCounts = {
+        ...SEARCH_FACETS,
+        type: [
+          { key: "mine", count: 5 },
+          { key: "party", count: 3 },
+          { key: "permit", count: 2 },
+        ],
+      };
+
       const customState = {
         ...getDefaultState(),
         [searchReducerType]: {
           ...getDefaultState()[searchReducerType],
           searchResults: resultsWithCounts,
+          searchFacets: facetsWithTypeCounts,
         },
       };
 
@@ -259,11 +269,17 @@ describe("SearchResultsV2 Integration Tests", () => {
         notice_of_departure: [],
       };
 
+      const emptyFacets = {
+        ...SEARCH_FACETS,
+        type: [],
+      };
+
       const customState = {
         ...getDefaultState(),
         [searchReducerType]: {
           ...getDefaultState()[searchReducerType],
           searchResults: emptyResults,
+          searchFacets: emptyFacets,
         },
       };
 
@@ -284,11 +300,17 @@ describe("SearchResultsV2 Integration Tests", () => {
         notice_of_departure: [],
       };
 
+      const emptyFacets = {
+        ...SEARCH_FACETS,
+        type: [],
+      };
+
       const customState = {
         ...getDefaultState(),
         [searchReducerType]: {
           ...getDefaultState()[searchReducerType],
           searchResults: emptyResults,
+          searchFacets: emptyFacets,
         },
       };
 

--- a/services/core-web/src/tests/components/search/__snapshots__/SearchResultsV2.spec.tsx.snap
+++ b/services/core-web/src/tests/components/search/__snapshots__/SearchResultsV2.spec.tsx.snap
@@ -1487,7 +1487,11 @@ exports[`SearchResultsV2 Integration Tests Snapshots matches snapshot with no re
               <span
                 class="ant-typography ant-typography-secondary"
               >
-                No results for "
+                Showing 
+                <strong>
+                  238
+                </strong>
+                 results for "
                 <strong>
                   test
                 </strong>
@@ -1520,7 +1524,7 @@ exports[`SearchResultsV2 Integration Tests Snapshots matches snapshot with no re
                         role="tab"
                         tabindex="0"
                       >
-                        All (0)
+                        All (238)
                       </div>
                     </div>
                     <div
@@ -1535,7 +1539,7 @@ exports[`SearchResultsV2 Integration Tests Snapshots matches snapshot with no re
                         role="tab"
                         tabindex="0"
                       >
-                        Mines (0)
+                        Mines (50)
                       </div>
                     </div>
                     <div
@@ -1580,7 +1584,7 @@ exports[`SearchResultsV2 Integration Tests Snapshots matches snapshot with no re
                         role="tab"
                         tabindex="0"
                       >
-                        Permits (0)
+                        Permits (45)
                       </div>
                     </div>
                     <div
@@ -1595,7 +1599,7 @@ exports[`SearchResultsV2 Integration Tests Snapshots matches snapshot with no re
                         role="tab"
                         tabindex="0"
                       >
-                        Explosives (0)
+                        Explosives (28)
                       </div>
                     </div>
                     <div
@@ -1610,7 +1614,7 @@ exports[`SearchResultsV2 Integration Tests Snapshots matches snapshot with no re
                         role="tab"
                         tabindex="0"
                       >
-                        NoW (0)
+                        NoW (38)
                       </div>
                     </div>
                     <div
@@ -1625,7 +1629,7 @@ exports[`SearchResultsV2 Integration Tests Snapshots matches snapshot with no re
                         role="tab"
                         tabindex="0"
                       >
-                        NODs (0)
+                        NODs (20)
                       </div>
                     </div>
                     <div
@@ -1640,7 +1644,7 @@ exports[`SearchResultsV2 Integration Tests Snapshots matches snapshot with no re
                         role="tab"
                         tabindex="0"
                       >
-                        Documents (0)
+                        Documents (57)
                       </div>
                     </div>
                     <div
@@ -1697,56 +1701,7 @@ exports[`SearchResultsV2 Integration Tests Snapshots matches snapshot with no re
                     id="rc-tabs-test-panel-all"
                     role="tabpanel"
                     tabindex="0"
-                  >
-                    <div
-                      class="ant-empty ant-empty-normal search-results-v2__empty-state"
-                    >
-                      <div
-                        class="ant-empty-image"
-                      >
-                        <svg
-                          class="ant-empty-img-simple"
-                          height="41"
-                          viewBox="0 0 64 41"
-                          width="64"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <g
-                            fill="none"
-                            fill-rule="evenodd"
-                            transform="translate(0 1)"
-                          >
-                            <ellipse
-                              class="ant-empty-img-simple-ellipse"
-                              cx="32"
-                              cy="33"
-                              rx="32"
-                              ry="7"
-                            />
-                            <g
-                              class="ant-empty-img-simple-g"
-                              fill-rule="nonzero"
-                            >
-                              <path
-                                d="M55 12.76L44.854 1.258C44.367.474 43.656 0 42.907 0H21.093c-.749 0-1.46.474-1.947 1.257L9 12.761V22h46v-9.24z"
-                              />
-                              <path
-                                class="ant-empty-img-simple-path"
-                                d="M41.613 15.931c0-1.605.994-2.93 2.227-2.931H55v18.137C55 33.26 53.68 35 52.05 35h-40.1C10.32 35 9 33.259 9 31.137V13h11.16c1.233 0 2.227 1.323 2.227 2.928v.022c0 1.605 1.005 2.901 2.237 2.901h14.752c1.232 0 2.237-1.308 2.237-2.913v-.007z"
-                              />
-                            </g>
-                          </g>
-                        </svg>
-                      </div>
-                      <div
-                        class="ant-empty-description"
-                      >
-                        <span>
-                          No results in this category
-                        </span>
-                      </div>
-                    </div>
-                  </div>
+                  />
                 </div>
               </div>
             </div>
@@ -3247,7 +3202,7 @@ exports[`SearchResultsV2 Integration Tests Snapshots matches snapshot with searc
               >
                 Showing 
                 <strong>
-                  9
+                  239
                 </strong>
                  results for "
                 <strong>
@@ -3282,7 +3237,7 @@ exports[`SearchResultsV2 Integration Tests Snapshots matches snapshot with searc
                         role="tab"
                         tabindex="0"
                       >
-                        All (9)
+                        All (239)
                       </div>
                     </div>
                     <div
@@ -3297,7 +3252,7 @@ exports[`SearchResultsV2 Integration Tests Snapshots matches snapshot with searc
                         role="tab"
                         tabindex="0"
                       >
-                        Mines (2)
+                        Mines (50)
                       </div>
                     </div>
                     <div
@@ -3342,7 +3297,7 @@ exports[`SearchResultsV2 Integration Tests Snapshots matches snapshot with searc
                         role="tab"
                         tabindex="0"
                       >
-                        Permits (1)
+                        Permits (45)
                       </div>
                     </div>
                     <div
@@ -3357,7 +3312,7 @@ exports[`SearchResultsV2 Integration Tests Snapshots matches snapshot with searc
                         role="tab"
                         tabindex="0"
                       >
-                        Explosives (1)
+                        Explosives (28)
                       </div>
                     </div>
                     <div
@@ -3372,7 +3327,7 @@ exports[`SearchResultsV2 Integration Tests Snapshots matches snapshot with searc
                         role="tab"
                         tabindex="0"
                       >
-                        NoW (1)
+                        NoW (38)
                       </div>
                     </div>
                     <div
@@ -3387,7 +3342,7 @@ exports[`SearchResultsV2 Integration Tests Snapshots matches snapshot with searc
                         role="tab"
                         tabindex="0"
                       >
-                        NODs (1)
+                        NODs (20)
                       </div>
                     </div>
                     <div
@@ -3402,7 +3357,7 @@ exports[`SearchResultsV2 Integration Tests Snapshots matches snapshot with searc
                         role="tab"
                         tabindex="0"
                       >
-                        Documents (0)
+                        Documents (57)
                       </div>
                     </div>
                     <div
@@ -3685,7 +3640,7 @@ exports[`SearchResultsV2 Integration Tests Snapshots matches snapshot with searc
                       class="padding-lg--bottom"
                     >
                       <h2>
-                        Permits (1)
+                        Permits (45)
                       </h2>
                       <div
                         class="ant-divider ant-divider-horizontal"
@@ -3852,7 +3807,7 @@ exports[`SearchResultsV2 Integration Tests Snapshots matches snapshot with searc
                         style="font-size: 16px;"
                       >
                         <strong>
-                          Notices of Departure (1)
+                          Notices of Departure (20)
                         </strong>
                       </span>
                     </div>


### PR DESCRIPTION
## Objective 

[MDS-6803](https://bcmines.atlassian.net/browse/MDS-6803)

This PR fixes a couple of issues noticed during testing of the new global search feature

- Added a debounce to global search to avoid searches on each keystroke
- Don't navigate to the first search result if you still have focus in the search bar
- Fix facet count not always being correct
- Fix text on "View All" button when search is empty
- Tweak styling of search modal
- Added some logging to help debug connection issue for longer searches

