### PR TITLE
[MDS-6796] - NoW issue permit wrong status

### DIFF
--- a/services/core-api/app/api/now_applications/resources/now_application_status_resource.py
+++ b/services/core-api/app/api/now_applications/resources/now_application_status_resource.py
@@ -79,264 +79,267 @@ class NOWApplicationStatusResource(Resource, UserMixin):
         if now_application_status_code is None or current_status == now_application_status_code:
             return 200
 
-        # Handle approved status
-        if now_application_status_code == 'AIA':
-            permit = Permit.find_by_now_application_guid(application_guid)
-            if not permit:
-                raise NotFound('No permit found for this application.')
+        try:
+            # Handle approved status
+            if now_application_status_code == 'AIA':
+                permit = Permit.find_by_now_application_guid(application_guid)
+                if not permit:
+                    raise NotFound('No permit found for this application.')
 
-            permit_amendment = PermitAmendment.find_by_now_application_guid(application_guid)
-            if not permit_amendment:
-                raise NotFound('No permit amendment found for this application.')
+                permit_amendment = PermitAmendment.find_by_now_application_guid(application_guid)
+                if not permit_amendment:
+                    raise NotFound('No permit amendment found for this application.')
 
-            # Validate the application contacts and the issue date
-            for contact in now_application_identity.now_application.contacts:
-                if contact.mine_party_appt_type_code != 'PMT' and contact.mine_party_appt_type_code != 'MMG':
-                    continue
+                # Validate the application contacts and the issue date
+                for contact in now_application_identity.now_application.contacts:
+                    if contact.mine_party_appt_type_code != 'PMT' and contact.mine_party_appt_type_code != 'MMG':
+                        continue
 
-                # A mine can only have one active mine manager and a permit can only have one active permittee
-                current_apt = MinePartyAppointment.find_current_appointments(
-                    permit_id=permit.permit_id
-                    if contact.mine_party_appt_type_code == 'PMT' else None,
-                    mine_guid=now_application_identity.mine.mine_guid
-                    if contact.mine_party_appt_type_code == 'MMG' else None,
-                    mine_party_appt_type_code=contact.mine_party_appt_type_code)
-                if len(current_apt) > 1:
-                    raise BadRequest(
-                        'This mine has more than one mine manager. Resolve this and try again.'
-                        if contact.mine_party_appt_type_code == 'MMG' else
-                        'This permit has more than one permittee. Resolve this and try again.')
-
-                # Validate that the issue date is not before the most recent amendment's issue date
-                amendments = [
-                    amendment for amendment in permit.permit_amendments if amendment
-                    and amendment.issue_date and amendment.permit_amendment_status_code != 'DFT'
-                ]
-                if amendments:
-                    latest_amendment = max(amendments, key=attrgetter('issue_date'))
-                    if latest_amendment and latest_amendment.issue_date > issue_date.date():
-                        raise BadRequest(
-                            f'Cannot set the issue date of permit {permit.permit_no} before the issue date of its most recent amendment, dated {latest_amendment.issue_date}.'
-                        )
-
-                # Validate that the issue date is not before the appointment's start date
-                if len(current_apt) == 1 and current_apt[0].start_date > issue_date.date():
-                    raise BadRequest(
-                        f'Cannot set the issue date prior to the start date of {current_apt[0].start_date}.'
-                    )
-
-            # Move the permit out of draft (draft status on permit indicates that the permit amendment is the first/original)
-            if permit.permit_status_code == 'D':
-                permit.permit_status_code = 'O'
-                permit_amendment.permit_amendment_status_code = 'ACT'
-                permit_amendment.permit_amendment_type_code = 'OGP'
-
-            if permit_amendment.permit_amendment_status_code == 'DFT':
-                permit_amendment.permit_amendment_status_code = 'ACT'
-
-            if permit_amendment.permit_amendment_status_code != 'ACT':
-                raise AssertionError('The permit status was not set to Active.')
-
-            # update permit conditions to not require review
-            permit_amendment.update_permit_condition_status("COM")
-
-            # set exemption fee status code
-            now_site_property = now_application_identity.now_application.site_property
-            is_exploration = permit.permit_no[1] == "X" or permit.is_exploration
-            Permit.validate_exemption_fee_status(
-                is_exploration, permit.permit_status_code, permit.permit_prefix, [
-                    detail.mine_disturbance_code
-                    for detail in now_site_property.mine_type_detail if detail.mine_disturbance_code
-                ], now_site_property.mine_tenure_type_code, exemption_fee_status_code)
-            permit.exemption_fee_status_code = exemption_fee_status_code
-            permit.exemption_fee_status_note = exemption_fee_status_note
-
-            permit.save()
-
-            permit_amendment.issue_date = issue_date
-            permit_amendment.authorization_end_date = auth_end_date
-            permit_amendment.description = description
-
-            # Transfer reclamation security data from the application to the permit
-            permit_amendment.liability_adjustment = now_application_identity.now_application.liability_adjustment
-            permit_amendment.security_received_date = now_application_identity.now_application.security_received_date
-            permit_amendment.security_not_required = now_application_identity.now_application.security_not_required
-            permit_amendment.security_not_required_reason = now_application_identity.now_application.security_not_required_reason
-            permit_amendment.save()
-
-            # transfer site_properties to permit
-            def get_disturbance_codes(site_property):
-                return [
-                    detail.mine_disturbance_code for detail in site_property.mine_type_detail
-                    if detail.mine_disturbance_code
-                ]
-
-            def get_commodity_codes(site_property):
-                return [
-                    detail.mine_commodity_code for detail in site_property.mine_type_detail
-                    if detail.mine_commodity_code
-                ]
-
-            def create_site_property_for_permit(mine_guid, permit_guid, site_property):
-                permit_site_property = MineType.create(
-                    now_application_identity.mine_guid,
-                    site_property.mine_tenure_type_code,
-                    permit_guid=permit.permit_guid)
-
-                for detail in [
-                        detail for detail in site_property.mine_type_detail
-                        if detail.mine_disturbance_code
-                ]:
-                    MineTypeDetail.create(
-                        permit_site_property, mine_disturbance_code=detail.mine_disturbance_code)
-
-                for detail in [
-                        detail for detail in site_property.mine_type_detail
-                        if detail.mine_commodity_code
-                ]:
-                    MineTypeDetail.create(
-                        permit_site_property, mine_commodity_code=detail.mine_commodity_code)
-
-                return permit_site_property
-
-            if now_site_property:
-                permit_site_property = MineType.find_by_permit_guid(
-                    permit.permit_guid, now_application_identity.mine.mine_guid)
-
-                if not permit_site_property:
-                    # create site property that is linked to a permit
-                    permit_site_property = create_site_property_for_permit(
-                        now_application_identity.mine_guid, permit.permit_guid, now_site_property)
-                    permit_site_property.save()
-                else:
-                    is_site_property_updated = False
-                    now_disturbances = get_disturbance_codes(now_site_property)
-                    now_commodities = get_commodity_codes(now_site_property)
-                    permit_disturbances = get_disturbance_codes(permit_site_property)
-                    permit_commodities = get_commodity_codes(permit_site_property)
-
-                    def check_if_equal(list_1, list_2):
-                        if len(list_1) != len(list_2):
-                            return False
-                        return sorted(list_1) == sorted(list_2)
-
-                    if permit_site_property.mine_tenure_type_code != now_site_property.mine_tenure_type_code or not check_if_equal(
-                            now_disturbances, permit_disturbances) or not check_if_equal(
-                                now_commodities, permit_commodities):
-                        is_site_property_updated = True
-
-                    if is_site_property_updated:
-                        permit_site_property.expire_record(commit=False)
-                        db.session.add(permit_site_property)
-                        new_permit_site_property = create_site_property_for_permit(
-                            now_application_identity.mine_guid, permit.permit_guid,
-                            now_site_property)
-                        db.session.add(new_permit_site_property)
-                        db.session.commit()
-
-            # End all Tenure Holder, Land Owner, and Mine Operator appointments that are not present on current assignments and are linked to this permit
-            only_one_contact_of_type_allowed = ['PMT', 'MMG']
-            multiple_contact_type_allowed = ['THD', 'LDO', 'MOR']
-            mine_party_appointments = MinePartyAppointment.find_current_appointments(
-                mine_party_appt_type_code=multiple_contact_type_allowed, permit_id=permit.permit_id)
-            filtered_contacts = [
-                c for c in now_application_identity.now_application.contacts
-                if c.mine_party_appt_type_code in multiple_contact_type_allowed
-            ]
-            for apt in mine_party_appointments:
-                if apt.permit_id and not next(
-                    (contact
-                     for contact in filtered_contacts if contact.party_guid == apt.party_guid),
-                        None):
-                    apt.end_date = permit_amendment.issue_date - timedelta(days=1)
-                    db.session.add(apt)
-            db.session.commit()
-
-            # Create contacts
-            user_info = self.get_user_info()
-            for contact in now_application_identity.now_application.contacts:
-                if contact.mine_party_appt_type_code in ['PMT', 'MMG', 'THD', 'LDO', 'MOR']:
-                    new_appt_needed = False
+                    # A mine can only have one active mine manager and a permit can only have one active permittee
                     current_apt = MinePartyAppointment.find_current_appointments(
-                        permit_id=permit.permit_id if contact.mine_party_appt_type_code
-                        in PERMIT_LINKED_CONTACT_TYPES else None,
+                        permit_id=permit.permit_id
+                        if contact.mine_party_appt_type_code == 'PMT' else None,
                         mine_guid=now_application_identity.mine.mine_guid
                         if contact.mine_party_appt_type_code == 'MMG' else None,
                         mine_party_appt_type_code=contact.mine_party_appt_type_code)
+                    if len(current_apt) > 1:
+                        raise BadRequest(
+                            'This mine has more than one mine manager. Resolve this and try again.'
+                            if contact.mine_party_appt_type_code == 'MMG' else
+                            'This permit has more than one permittee. Resolve this and try again.')
 
-                    # A mine can only have one active Mine Manager and a permit can only have one active Permittee
-                    if contact.mine_party_appt_type_code in only_one_contact_of_type_allowed:
-                        if len(current_apt) > 1:
+                    # Validate that the issue date is not before the most recent amendment's issue date
+                    amendments = [
+                        amendment for amendment in permit.permit_amendments if amendment
+                        and amendment.issue_date and amendment.permit_amendment_status_code != 'DFT'
+                    ]
+                    if amendments:
+                        latest_amendment = max(amendments, key=attrgetter('issue_date'))
+                        if latest_amendment and latest_amendment.issue_date > issue_date.date():
                             raise BadRequest(
-                                'This mine has more than one mine manager. Resolve this and try again.'
-                                if contact.mine_party_appt_type_code == 'MMG' else
-                                'This permit has more than one permittee. Resolve this and try again.'
+                                f'Cannot set the issue date of permit {permit.permit_no} before the issue date of its most recent amendment, dated {latest_amendment.issue_date}.'
                             )
 
-                        # If there is a current appointment and it does not match the proposed appointment, end the current and create a new one
-                        if len(current_apt
-                               ) == 1 and current_apt[0].party_guid != contact.party_guid:
-                            new_appt_needed = True
-                            current_apt[0].end_date = permit_amendment.issue_date - timedelta(
-                                days=1)
-                            db.session.add_all(current_apt)
+                    # Validate that the issue date is not before the appointment's start date
+                    if len(current_apt) == 1 and current_apt[0].start_date > issue_date.date():
+                        raise BadRequest(
+                            f'Cannot set the issue date prior to the start date of {current_apt[0].start_date}.'
+                        )
+
+                # Move the permit out of draft (draft status on permit indicates that the permit amendment is the first/original)
+                if permit.permit_status_code == 'D':
+                    permit.permit_status_code = 'O'
+                    permit_amendment.permit_amendment_status_code = 'ACT'
+                    permit_amendment.permit_amendment_type_code = 'OGP'
+
+                if permit_amendment.permit_amendment_status_code == 'DFT':
+                    permit_amendment.permit_amendment_status_code = 'ACT'
+
+                if permit_amendment.permit_amendment_status_code != 'ACT':
+                    raise AssertionError('The permit status was not set to Active.')
+
+                # update permit conditions to not require review
+                permit_amendment.update_permit_condition_status("COM")
+
+                # set exemption fee status code
+                now_site_property = now_application_identity.now_application.site_property
+                is_exploration = permit.permit_no[1] == "X" or permit.is_exploration
+                Permit.validate_exemption_fee_status(
+                    is_exploration, permit.permit_status_code, permit.permit_prefix, [
+                        detail.mine_disturbance_code
+                        for detail in now_site_property.mine_type_detail if detail.mine_disturbance_code
+                    ], now_site_property.mine_tenure_type_code, exemption_fee_status_code)
+                permit.exemption_fee_status_code = exemption_fee_status_code
+                permit.exemption_fee_status_note = exemption_fee_status_note
+
+                permit.save(commit=False)
+
+                permit_amendment.issue_date = issue_date
+                permit_amendment.authorization_end_date = auth_end_date
+                permit_amendment.description = description
+
+                # Transfer reclamation security data from the application to the permit
+                permit_amendment.liability_adjustment = now_application_identity.now_application.liability_adjustment
+                permit_amendment.security_received_date = now_application_identity.now_application.security_received_date
+                permit_amendment.security_not_required = now_application_identity.now_application.security_not_required
+                permit_amendment.security_not_required_reason = now_application_identity.now_application.security_not_required_reason
+                permit_amendment.save(commit=False)
+
+                # transfer site_properties to permit
+                def get_disturbance_codes(site_property):
+                    return [
+                        detail.mine_disturbance_code for detail in site_property.mine_type_detail
+                        if detail.mine_disturbance_code
+                    ]
+
+                def get_commodity_codes(site_property):
+                    return [
+                        detail.mine_commodity_code for detail in site_property.mine_type_detail
+                        if detail.mine_commodity_code
+                    ]
+
+                def create_site_property_for_permit(mine_guid, permit_guid, site_property):
+                    permit_site_property = MineType.create(
+                        now_application_identity.mine_guid,
+                        site_property.mine_tenure_type_code,
+                        permit_guid=permit.permit_guid)
+
+                    for detail in [
+                            detail for detail in site_property.mine_type_detail
+                            if detail.mine_disturbance_code
+                    ]:
+                        MineTypeDetail.create(
+                            permit_site_property, mine_disturbance_code=detail.mine_disturbance_code)
+
+                    for detail in [
+                            detail for detail in site_property.mine_type_detail
+                            if detail.mine_commodity_code
+                    ]:
+                        MineTypeDetail.create(
+                            permit_site_property, mine_commodity_code=detail.mine_commodity_code)
+
+                    return permit_site_property
+
+                if now_site_property:
+                    permit_site_property = MineType.find_by_permit_guid(
+                        permit.permit_guid, now_application_identity.mine.mine_guid)
+
+                    if not permit_site_property:
+                        # create site property that is linked to a permit
+                        permit_site_property = create_site_property_for_permit(
+                            now_application_identity.mine_guid, permit.permit_guid, now_site_property)
+                        permit_site_property.save(commit=False)
                     else:
-                        new_appt_needed = False if len(mine_party_appointments) > 0 and next(
-                            (apt for apt in mine_party_appointments
-                             if apt.party_guid == contact.party_guid), None) else True
+                        is_site_property_updated = False
+                        now_disturbances = get_disturbance_codes(now_site_property)
+                        now_commodities = get_commodity_codes(now_site_property)
+                        permit_disturbances = get_disturbance_codes(permit_site_property)
+                        permit_commodities = get_commodity_codes(permit_site_property)
 
-                    # If there is no current appointment, create a new one
-                    if len(current_apt) == 0:
-                        new_appt_needed = True
+                        def check_if_equal(list_1, list_2):
+                            if len(list_1) != len(list_2):
+                                return False
+                            return sorted(list_1) == sorted(list_2)
 
-                    # Create the new appointment, if necessary
-                    if new_appt_needed:
-                        new_mpa = MinePartyAppointment.create(
-                            mine=now_application_identity.mine
-                            if contact.mine_party_appt_type_code == 'MMG' else None,
-                            permit=permit if contact.mine_party_appt_type_code
+                        if permit_site_property.mine_tenure_type_code != now_site_property.mine_tenure_type_code or not check_if_equal(
+                                now_disturbances, permit_disturbances) or not check_if_equal(
+                                    now_commodities, permit_commodities):
+                            is_site_property_updated = True
+
+                        if is_site_property_updated:
+                            permit_site_property.expire_record(commit=False)
+                            db.session.add(permit_site_property)
+                            new_permit_site_property = create_site_property_for_permit(
+                                now_application_identity.mine_guid, permit.permit_guid,
+                                now_site_property)
+                            db.session.add(new_permit_site_property)
+
+                # End all Tenure Holder, Land Owner, and Mine Operator appointments that are not present on current assignments and are linked to this permit
+                only_one_contact_of_type_allowed = ['PMT', 'MMG']
+                multiple_contact_type_allowed = ['THD', 'LDO', 'MOR']
+                mine_party_appointments = MinePartyAppointment.find_current_appointments(
+                    mine_party_appt_type_code=multiple_contact_type_allowed, permit_id=permit.permit_id)
+                filtered_contacts = [
+                    c for c in now_application_identity.now_application.contacts
+                    if c.mine_party_appt_type_code in multiple_contact_type_allowed
+                ]
+                for apt in mine_party_appointments:
+                    if apt.permit_id and not next(
+                        (contact
+                         for contact in filtered_contacts if contact.party_guid == apt.party_guid),
+                            None):
+                        apt.end_date = permit_amendment.issue_date - timedelta(days=1)
+                        db.session.add(apt)
+                
+                # Create contacts
+                user_info = self.get_user_info()
+                for contact in now_application_identity.now_application.contacts:
+                    if contact.mine_party_appt_type_code in ['PMT', 'MMG', 'THD', 'LDO', 'MOR']:
+                        new_appt_needed = False
+                        current_apt = MinePartyAppointment.find_current_appointments(
+                            permit_id=permit.permit_id if contact.mine_party_appt_type_code
                             in PERMIT_LINKED_CONTACT_TYPES else None,
-                            party_guid=contact.party_guid,
-                            mine_party_appt_type_code=contact.mine_party_appt_type_code,
-                            start_date=permit_amendment.issue_date,
-                            end_date=None,
-                            processed_by=user_info)
-                        if contact.mine_party_appt_type_code in PERMIT_LINKED_CONTACT_TYPES:
-                            new_mpa.assign_related_guid(contact.mine_party_appt_type_code,
-                                                        permit.permit_guid)
-                        db.session.add(new_mpa)
+                            mine_guid=now_application_identity.mine.mine_guid
+                            if contact.mine_party_appt_type_code == 'MMG' else None,
+                            mine_party_appt_type_code=contact.mine_party_appt_type_code)
 
+                        # A mine can only have one active Mine Manager and a permit can only have one active Permittee
+                        if contact.mine_party_appt_type_code in only_one_contact_of_type_allowed:
+                            if len(current_apt) > 1:
+                                raise BadRequest(
+                                    'This mine has more than one mine manager. Resolve this and try again.'
+                                    if contact.mine_party_appt_type_code == 'MMG' else
+                                    'This permit has more than one permittee. Resolve this and try again.'
+                                )
+
+                            # If there is a current appointment and it does not match the proposed appointment, end the current and create a new one
+                            if len(current_apt
+                                   ) == 1 and current_apt[0].party_guid != contact.party_guid:
+                                new_appt_needed = True
+                                current_apt[0].end_date = permit_amendment.issue_date - timedelta(
+                                    days=1)
+                                db.session.add_all(current_apt)
+                        else:
+                            new_appt_needed = False if len(mine_party_appointments) > 0 and next(
+                                (apt for apt in mine_party_appointments
+                                 if apt.party_guid == contact.party_guid), None) else True
+
+                        # If there is no current appointment, create a new one
+                        if len(current_apt) == 0:
+                            new_appt_needed = True
+
+                        # Create the new appointment, if necessary
+                        if new_appt_needed:
+                            new_mpa = MinePartyAppointment.create(
+                                mine=now_application_identity.mine
+                                if contact.mine_party_appt_type_code == 'MMG' else None,
+                                permit=permit if contact.mine_party_appt_type_code
+                                in PERMIT_LINKED_CONTACT_TYPES else None,
+                                party_guid=contact.party_guid,
+                                mine_party_appt_type_code=contact.mine_party_appt_type_code,
+                                start_date=permit_amendment.issue_date,
+                                end_date=None,
+                                processed_by=user_info)
+                            if contact.mine_party_appt_type_code in PERMIT_LINKED_CONTACT_TYPES:
+                                new_mpa.assign_related_guid(contact.mine_party_appt_type_code,
+                                                            permit.permit_guid)
+                            db.session.add(new_mpa)
+
+                export_and_index_permit_amendments.delay([permit_amendment.permit_amendment_guid])
+
+                # Issue verifiable credential to OrgBook (currently, a non-blocking operation)
+                try:
+                    OrgBookIssuerService().issue_permit_amendment_vc(permit_amendment)
+                except AssertionError as e:
+                    current_app.logger.info('VC not issued due to unsuccessful status code')
+                    current_app.logger.debug(str(e))
+                except Exception as ex:
+                    current_app.logger.warning('VC not issued due to unknown error')
+                    current_app.logger.info(str(ex))
+
+            # Handle rejected and withdrawn statuses
+            elif now_application_status_code in ['REJ', 'WDN', 'NPR']:
+                for progress in now_application_identity.now_application.application_progress:
+                    if progress.end_date is None or (progress.end_date is not None and
+                                                     progress.end_date > datetime.now(tz=timezone.utc)):
+                        progress.end_date = datetime.now(tz=timezone.utc)
+                for delay in now_application_identity.application_delays:
+                    if delay.end_date is None or (delay.end_date is not None
+                                                  and delay.end_date > datetime.now(tz=timezone.utc)):
+                        delay.end_date = datetime.now(tz=timezone.utc)
+
+            # Update the status code
+            now_application_identity.now_application.decision_by_user_date = datetime.utcnow()
+            now_application_identity.now_application.status_updated_date = datetime.utcnow()
+            now_application_identity.now_application.previous_application_status_code = current_status
+            now_application_identity.now_application.now_application_status_code = now_application_status_code
+            now_application_identity.now_application.status_reason = status_reason
+
+            now_application_identity.save(commit=False)
             db.session.commit()
+        except Exception as e:
+            db.session.rollback()
+            current_app.logger.error(str(e))
+            raise e
 
-            export_and_index_permit_amendments.delay([permit_amendment.permit_amendment_guid])
-
-            # Issue verifiable credential to OrgBook (currently, a non-blocking operation)
-            try:
-                OrgBookIssuerService().issue_permit_amendment_vc(permit_amendment)
-            except AssertionError as e:
-                current_app.logger.info('VC not issued due to unsuccessful status code')
-                current_app.logger.debug(str(e))
-            except Exception as ex:
-                current_app.logger.warning('VC not issued due to unknown error')
-                current_app.logger.info(str(ex))
-
-        # Handle rejected and withdrawn statuses
-        elif now_application_status_code in ['REJ', 'WDN', 'NPR']:
-            for progress in now_application_identity.now_application.application_progress:
-                if progress.end_date is None or (progress.end_date is not None and
-                                                 progress.end_date > datetime.now(tz=timezone.utc)):
-                    progress.end_date = datetime.now(tz=timezone.utc)
-            for delay in now_application_identity.application_delays:
-                if delay.end_date is None or (delay.end_date is not None
-                                              and delay.end_date > datetime.now(tz=timezone.utc)):
-                    delay.end_date = datetime.now(tz=timezone.utc)
-
-        # Update the status code
-        now_application_identity.now_application.decision_by_user_date = datetime.utcnow()
-        now_application_identity.now_application.status_updated_date = datetime.utcnow()
-        now_application_identity.now_application.previous_application_status_code = current_status
-        now_application_identity.now_application.now_application_status_code = now_application_status_code
-        now_application_identity.now_application.status_reason = status_reason
-
-        now_application_identity.save()
         return 200

--- a/services/core-api/app/api/parties/party_appt/models/mine_party_appt.py
+++ b/services/core-api/app/api/parties/party_appt/models/mine_party_appt.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta, date
 from enum import Enum
 from werkzeug.exceptions import BadRequest
 
-from sqlalchemy import and_, nullsfirst, nullslast
+from sqlalchemy import and_, or_, nullsfirst, nullslast
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.schema import FetchedValue
 
@@ -275,7 +275,10 @@ class MinePartyAppointment(SoftDeleteMixin, AuditMixin, DraftMixin, Base):
             built_query = cls.query.filter_by(
                 deleted_ind=False, mine_guid=mine_guid, status=MinePartyAppointmentStatus.active)
         else:
-            built_query = cls.query.filter_by(deleted_ind=False, mine_guid=mine_guid, end_date=None)
+            built_query = cls.query.filter(
+                cls.deleted_ind == False,
+                cls.mine_guid == mine_guid,
+                or_(cls.end_date == None, cls.end_date > datetime.utcnow().date()))
 
         if permit_id:
             built_query = built_query.filter_by(permit_id=permit_id)


### PR DESCRIPTION
A number of notice of work applications have gotten stuck in a previous status rather than moving to approved when the permit is being issued.  There was a two part issue.

1. The function in the backend that handles the updating of the now_application status is set up in a way that it goes through a bunch of steps and saves data at multiple points throughout.  This isn't ideal because if it saves one thing, and then has an error later, the first thing remains updated, but it never gets to the rest.  I've put together a fix to make sure all of the changes are transactional (so if anything fails, everything gets rolled back to it's state before the change).  That's why we ended up with a status that didn't match where the application was intended to be.,
3. We have a function called find_current_appointments which runs during that process which should fetch the mine manager.  However, it has a filter applied to it so it only fetches appointments with no end date.  In instances where a mine manager has an end date in the future, the system thinks there is no mine manager because the end_date has a value.  So, the first function then thinks there is no mine manager, and it follows the logic in place for new_appt_needed and tries to create a new appointment.  But, when it tries to do that, it conflicts with a database constraint that doesn't allow overlapping appointment ranges and it fails (which leads us to issue #1).

Made the update function transactional, and updated the `find_current_appointment` function transactional to prevent partial updates on errors.

## Objective 

[MDS-6796](https://bcmines.atlassian.net/browse/MDS-6796)

_Why are you making this change? Provide a short explanation and/or screenshots_
