### PR TITLE
[MDS-6798] - Update Mine Contacts

### DIFF
--- a/services/core-web/src/components/mine/ContactInfo/ViewPartyRelationships.tsx
+++ b/services/core-web/src/components/mine/ContactInfo/ViewPartyRelationships.tsx
@@ -340,6 +340,7 @@ export const ViewPartyRelationships: FC<ViewPartyRelationshipsProps> = ({ mine }
           openEditPartyRelationshipModal={openEditPartyRelationshipModal}
           onSubmitEditPartyRelationship={onSubmitEditPartyRelationship}
           isEditable
+          editPermission={USER_ROLES.role_edit_parties}
         />
       </Col>
     );

--- a/services/core-web/src/components/mine/Summary/MineSummary.tsx
+++ b/services/core-web/src/components/mine/Summary/MineSummary.tsx
@@ -10,6 +10,7 @@ import { getMines } from "@mds/common/redux/selectors/mineSelectors";
 import { getUnformattedPermits } from "@mds/common/redux/selectors/permitSelectors";
 import * as String from "@mds/common/constants/strings";
 import * as router from "@/constants/routes";
+import { USER_ROLES } from "@mds/common/constants/environment";
 import PermitCard from "@/components/mine/Permit/MinePermitCard";
 import { TSFCard } from "@/components/mine/Tailings/MineTSFCard";
 import { DOC, OVERDUEDOC } from "@/constants/assets";
@@ -38,6 +39,7 @@ const renderPartyRelationship = (mine, permits, partyRelationship, partyRelation
         partyRelationship={partyRelationship}
         partyRelationshipTitle={partyRelationshipTitle}
         compact
+        editPermission={USER_ROLES.role_edit_parties}
       />
     </Col>
   );


### PR DESCRIPTION
## Objective 
Users were unable to update mine contacts because the "Update" button was not showing up on the contact cards.

A recent update to the cards (made by me) neglected to included the permission prop the decided whether or not to show the update button based on the user's role.  As such, the button was not displayed for anyone.  
Fixed the prop drilling to reinstate the button.

[MDS-6798](https://bcmines.atlassian.net/browse/MDS-6798)

<img width="1565" height="1037" alt="image" src="https://github.com/user-attachments/assets/2cfe8136-0400-42d8-9381-4ba261597b92" />
