### PR TITLE
[MDS-6108] Incidents file types

### DIFF
--- a/services/core-web/src/components/Forms/incidents/IncidentFormDocuments.tsx
+++ b/services/core-web/src/components/Forms/incidents/IncidentFormDocuments.tsx
@@ -71,7 +71,7 @@ const IncidentFormDocuments: FC<IncidentFormDocumentsProps> = ({
                 id={INITIAL_INCIDENT_DOCUMENTS_FORM_FIELD}
                 name={INITIAL_INCIDENT_DOCUMENTS_FORM_FIELD}
                 labelIdle='<strong>Drag & Drop your files or <span class="filepond--label-action">Browse</span></strong><br>
-              <div>Accepted filetypes: .kmz, .doc, .docx, .xlsx, .pdf, .msg, .png, .jpeg, .tiff, .hiec</div>'
+              <div>Accepted filetypes: .kmz, .doc, .docx, .xlsx, .pdf, .msg, .png, .jpeg, .tiff, .heic</div>'
                 onFileLoad={(document_name, document_manager_guid) =>
                   onFileLoad(
                     document_name,
@@ -107,7 +107,7 @@ const IncidentFormDocuments: FC<IncidentFormDocumentsProps> = ({
                 id={FINAL_REPORT_DOCUMENTS_FORM_FIELD}
                 name={FINAL_REPORT_DOCUMENTS_FORM_FIELD}
                 labelIdle='<strong>Drag & Drop your files or <span class="filepond--label-action">Browse</span></strong><br>
-              <div>Accepted filetypes: .kmz, .doc, .docx, .xlsx, .pdf, .msg, .png, .jpeg, .tiff, .hiec</div>'
+              <div>Accepted filetypes: .kmz, .doc, .docx, .xlsx, .pdf, .msg, .png, .jpeg, .tiff, .heic</div>'
                 onFileLoad={(document_name, document_manager_guid) =>
                   onFileLoad(
                     document_name,

--- a/services/core-web/src/components/Forms/incidents/IncidentFormInternalDocumentComments.tsx
+++ b/services/core-web/src/components/Forms/incidents/IncidentFormInternalDocumentComments.tsx
@@ -86,7 +86,7 @@ const IncidentFormInternalDocumentComments: FC<IncidentFormInternalDocumentComme
                       id={INTERNAL_MINISTRY_DOCUMENTS_FORM_FIELD}
                       name={INTERNAL_MINISTRY_DOCUMENTS_FORM_FIELD}
                       labelIdle='<strong>Drag & Drop your files or <span class="filepond--label-action">Browse</span></strong><br>
-                    <div>Accepted filetypes: .kmz, .doc, .docx, .xlsx, .pdf</div>'
+                    <div>Accepted filetypes: .kmz, .doc, .docx, .xlsx, .pdf, .msg, .png, .jpeg, .tiff, .heic</div>'
                       onFileLoad={(document_name, document_manager_guid) =>
                         onFileLoad(
                           document_name,

--- a/services/minespace-web/src/components/Forms/incidents/IncidentForm.js
+++ b/services/minespace-web/src/components/Forms/incidents/IncidentForm.js
@@ -645,7 +645,7 @@ const renderUploadInitialNotificationDocuments = (
               onRemoveFile={parentHandlers?.deleteDocument}
               mineGuid={match.params?.mineGuid}
               component={IncidentFileUpload}
-              labelIdle='<strong class="filepond--label-action">Drag & drop your files or Browse</strong><div>Accepted filetypes: .kmz .doc .docx .xlsx .pdf .msg .png .jpeg .tiff .hiec</div>'
+              labelIdle='<strong class="filepond--label-action">Drag & drop your files or Browse</strong><div>Accepted filetypes: .kmz .doc .docx .xlsx .pdf .msg .png .jpeg .tiff .heic</div>'
             />
           </Col>
         </>
@@ -718,7 +718,7 @@ const renderUploadInitialNotificationDocuments = (
                 onRemoveFile={parentHandlers?.deleteDocument}
                 mineGuid={match.params?.mineGuid}
                 component={IncidentFileUpload}
-                labelIdle='<strong class="filepond--label-action">Final Report Upload</strong><div>Accepted filetypes: .kmz .doc .docx .xlsx .pdf .msg .png .jpeg .tiff .hiec</div>'
+                labelIdle='<strong class="filepond--label-action">Final Report Upload</strong><div>Accepted filetypes: .kmz .doc .docx .xlsx .pdf .msg .png .jpeg .tiff .heic</div>'
               />
             </Col>
           </>


### PR DESCRIPTION
Quick patch to allow common file types for internal ministry documents on incidents.  Also fixed a couple incidents of a type on the .heic file type.
(Technically the other file types were already allowed, this just updates the text)

## Objective 

[MDS-6108](https://bcmines.atlassian.net/browse/MDS-6108)

_Why are you making this change? Provide a short explanation and/or screenshots_
