### PR TITLE
[MDS-6728] Generate list of recuring crr reports

### DIFF
--- a/migrations/sql/V2026.02.18.10.59__add_yearly_type_to_mine_report_due_date_type.sql
+++ b/migrations/sql/V2026.02.18.10.59__add_yearly_type_to_mine_report_due_date_type.sql
@@ -1,0 +1,2 @@
+INSERT INTO mine_report_due_date_type (mine_report_due_date_type, description, active_ind, create_user, update_user)
+VALUES ('YRL', 'Reports due yearly', true, 'system-mds', 'system-mds');

--- a/services/common/src/redux/slices/complianceReportsSlice.ts
+++ b/services/common/src/redux/slices/complianceReportsSlice.ts
@@ -74,7 +74,7 @@ const complianceReportSlice = createAppSlice({
         thunkApi.dispatch(showLoading());
         const resp = await CustomAxios({
           errorToastMessage: "Failed to load compliance reports",
-        }).get(`${ENVIRONMENT.apiUrl}${API.MINE_REPORT_DEFINITIONS(searchParams ?? {})}`, headers);
+        }).get(`${ENVIRONMENT.apiUrl}${API.MINE_REPORT_DEFINITIONS({ ...searchParams, active_ind: [true] })}`, headers);
         thunkApi.dispatch(hideLoading());
         return resp.data;
       },

--- a/services/core-api/app/api/mines/reports/models/mine_report.py
+++ b/services/core-api/app/api/mines/reports/models/mine_report.py
@@ -31,12 +31,13 @@ from app.config import Config
 from app.extensions import db
 from flask import current_app
 from pytz import timezone as pytz_timezone
-from sqlalchemy import and_, desc, func, literal, select
+from sqlalchemy import and_, desc, func, literal, select, exists, or_
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import validates
 from sqlalchemy.schema import FetchedValue
+from typing import Self
 
 
 class MineReport(SoftDeleteMixin, AuditMixin, Base):
@@ -470,6 +471,58 @@ class MineReport(SoftDeleteMixin, AuditMixin, Base):
         )
         
         return mine_report
+
+    @classmethod
+    def get_all_recurring_crr_reports(cls) -> list[Self]:
+        from app.api.mines.reports.models.mine_report_definition import MineReportDefinition
+        from app.api.mines.permits.permit.models.mine_permit_xref import MinePermitXref
+        from app.api.mines.permits.permit.models.permit import Permit
+        from app.api.mines.reports.models.mine_report_category_xref import MineReportCategoryXref
+        from app.api.mines.tailings.models.tailings import MineTailingsStorageFacility
+
+        # Check to see if mine report's mine has an active permit
+        active_permit_exists = exists().where(
+            and_(
+                MinePermitXref.mine_guid == cls.mine_guid,
+                MinePermitXref.permit_id == Permit.permit_id,
+                Permit.deleted_ind == False,
+            )
+        )
+
+        # Check to see if mine report definition has TSF category
+        definition_has_tsf = exists().where(
+            and_(
+                MineReportCategoryXref.mine_report_definition_id
+                == cls.mine_report_definition_id,
+                MineReportCategoryXref.mine_report_category == "TSF",
+            )
+        )
+
+        # Check to see if mine has a tailings storage facility
+        tsf_exists = exists().where(
+            MineTailingsStorageFacility.mine_guid == cls.mine_guid
+        )
+
+        return (
+            cls.query
+            .join(
+                MineReportDefinition,
+                cls.mine_report_definition_id
+                == MineReportDefinition.mine_report_definition_id,
+            )
+            .filter(
+                cls.deleted_ind == False,
+                cls.due_date != None,
+                MineReportDefinition.active_ind.is_(True),
+                MineReportDefinition.mine_report_due_date_type.in_(["FIS", "YRL"]),
+                active_permit_exists,
+                or_(
+                    ~definition_has_tsf,
+                    tsf_exists,
+                ),
+            )
+            .all()
+        )
 
     @validates('mine_report_definition_id')
     def validate_mine_report_definition_id(self, key, mine_report_definition_id):

--- a/services/core-api/app/api/mines/reports/resources/mine_report_definition_list_resource.py
+++ b/services/core-api/app/api/mines/reports/resources/mine_report_definition_list_resource.py
@@ -130,5 +130,3 @@ class MineReportDefinitionListResource(Resource, UserMixin):
                                                              data.get('report_type'),
                                                              data.get('is_common'))
         return mine_report_definition, 201
-
-

--- a/services/core-api/app/api/mines/reports/resources/mine_reports.py
+++ b/services/core-api/app/api/mines/reports/resources/mine_reports.py
@@ -159,8 +159,19 @@ class MineReportListResource(Resource, UserMixin):
                 }
 
         # Base query; ordering is applied via ReportFilterHelper
-        query = MineReport.query.filter_by(mine_guid=mine_guid, deleted_ind=False)
-
+        query = (
+            MineReport.query
+            .outerjoin(MineReportDefinition)
+            .filter(
+                MineReport.mine_guid == mine_guid,
+                MineReport.deleted_ind == False,
+                or_(
+                    MineReport.mine_report_definition_id.is_(None),
+                    MineReportDefinition.active_ind.is_(True),
+                )
+            )
+        )
+        
         if requested_types:
             conditions = []
 

--- a/services/core-api/app/api/mines/reports/resources/reports_resource.py
+++ b/services/core-api/app/api/mines/reports/resources/reports_resource.py
@@ -65,7 +65,17 @@ class ReportsResource(Resource, UserMixin):
             'region': request.args.getlist('region', type=str),
         }
 
-        query = MineReport.query.filter_by(deleted_ind=False)
+        query = (
+            MineReport.query
+            .outerjoin(MineReportDefinition)
+            .filter(
+                MineReport.deleted_ind == False,
+                or_(
+                    MineReport.mine_report_definition_id.is_(None),
+                    MineReportDefinition.active_ind.is_(True),
+                )
+            )
+        )
 
         records, pagination_details = ReportFilterHelper.apply_filters_and_pagination(query, args)
         if not records:

--- a/services/core-api/app/api/mines/reports/tasks.py
+++ b/services/core-api/app/api/mines/reports/tasks.py
@@ -1,11 +1,13 @@
 from app.api.mines.reports.models.mine_report_permit_requirement import MineReportPermitRequirement
 from app.api.mines.reports.models.mine_report import MineReport
+from app.api.mines.reports.models.mine_report_definition import MineReportDefinition
+from app.api.mines.mine.models.mine import Mine
 from app.extensions import db
 from app.tasks.celery import celery
 from datetime import datetime
 from dateutil.relativedelta import relativedelta
 from app.api.utils.feature_flag import Feature, is_feature_enabled
-
+from collections import defaultdict
 
 def _calculate_missing_due_dates(requirement, existing_due_dates, current_date, one_year_from_now):
     """Calculate which due dates need new reports created."""
@@ -39,6 +41,26 @@ def _calculate_missing_due_dates(requirement, existing_due_dates, current_date, 
 
     return missing_due_dates
 
+def _calculate_missing_crr_report_due_dates(mine_report_due_date_type, existing_due_dates, current_date, one_year_from_now):
+    missing_due_dates = []
+    latest_existing_due_date= max(existing_due_dates) if existing_due_dates else None
+
+    if latest_existing_due_date:
+        if mine_report_due_date_type == "YRL":
+            next_due_date = current_date.replace(month=1,day=31)
+        elif mine_report_due_date_type == "FIS":
+            next_due_date = current_date.replace(month=3, day=31)
+    else:
+        return missing_due_dates
+
+    # Roll forward a year if next due date is in the past
+    if next_due_date < current_date:
+        next_due_date += relativedelta(years=1)
+
+    if next_due_date not in existing_due_dates:
+        missing_due_dates.append(next_due_date)
+
+    return missing_due_dates
 
 def _create_report_for_due_date(requirement, due_date):
     """Create a single mine report for the given due date."""
@@ -94,6 +116,59 @@ def _process_single_requirement(requirement, current_date, one_year_from_now):
     print(f"  Successfully created {created_count} reports for this requirement")
     return created_count, failed_count
 
+def _process_crr_reports(mine, mine_report_definition, reports, current_date, one_year_from_now):
+    """Process a mine's existing crr reports of the given mine report definition type and create any missing reports"""
+
+    print(f"Processing {mine_report_definition.report_name} reports for the mine: {mine.mine_name}")
+    
+    existing_due_dates = set()
+    for report in reports:
+        dd = report.due_date
+        if isinstance(dd, datetime):
+            dd = dd.date()
+        existing_due_dates.add(dd)
+    
+    missing_due_dates = _calculate_missing_crr_report_due_dates(
+        mine_report_definition.mine_report_due_date_type, existing_due_dates, current_date, one_year_from_now
+    )
+
+    print(f"  Need to create {len(missing_due_dates)} new CRR reports")
+
+    # Create missing reports
+    created_count = 0
+    failed_count = 0
+
+    for due_date in missing_due_dates:
+        try:
+            new_mine_report = MineReport.create(
+                mine_report_definition_id=mine_report_definition.mine_report_definition_id,
+                mine_guid=mine.mine_guid,
+                due_date=due_date,  # Use the passed-in due date
+                received_date=None, # Not received yet
+                submission_year=None,  # Will be set when submitted
+                description_comment=None,  # Will be set when submitted
+                submitter_name="",  # Will be set when submitted
+                permit_id=None,     # CRR reports don't use this
+                permit_condition_category_code=None,
+                mine_report_permit_requirement_id=None, #CRR reports don't use this
+                submitter_email="",  # Will be set when submitted
+                add_to_session=True,
+                system_created=True
+            )
+
+            new_mine_report.submission_year = due_date.year
+            new_mine_report.save()
+            db.session.commit()
+
+            created_count += 1
+            print(f"    Created report due {due_date}")
+        except Exception as e:
+            print(f"    Error creating report for due date {due_date}: {str(e)}")
+            db.session.rollback()
+            failed_count += 1
+    
+    print(f"  Successfully created {created_count} {mine_report_definition.report_name} reports for this mine")
+    return created_count, failed_count
 
 @celery.task()
 def create_new_recurring_report_requests():
@@ -106,7 +181,6 @@ def create_new_recurring_report_requests():
         print("Task exiting early - feature flag is disabled")
         return {"status": "skipped", "reason": "feature flag disabled"} 
     
-    print("Starting creation of recurring report requests...")
     current_date = datetime.now().date()
     
     recurring_requirements = MineReportPermitRequirement.get_all_recurring()
@@ -145,4 +219,65 @@ def create_new_recurring_report_requests():
     return {
         'total_created': total_created,
         'failed_requirements': failed_requirements
+    }
+
+@celery.task()
+def create_new_recurring_crr_report_requests():
+    """
+    Create new recurring report requests based on existing CRR reports.
+    This task finds all recurring CRR reports and creates missing reports
+    for the next year, ensuring no duplicates are created.
+    """
+    if not is_feature_enabled(Feature.RECURRING_REPORTS):
+        print("Task exiting early - feature flag is disabled")
+        return {"status": "skipped", "reason": "feature flag disabled"} 
+    
+    current_date = datetime.now().date()
+    one_year_from_now = current_date + relativedelta(years=1)
+
+    recurring_reports = MineReport.get_all_recurring_crr_reports()
+    print(f"Found {len(recurring_reports)} recurring CRR reports")
+
+    # Group reports by mine then by mine report definition ID 
+    grouped_recurring_reports = defaultdict(lambda: defaultdict(list))
+    for report in recurring_reports:
+        grouped_recurring_reports[report.mine_guid][report.mine_report_definition_id].append(report)
+    
+    total_created = 0
+    failed_report_requests= []
+
+    for mine_guid, mine_report_definitions in grouped_recurring_reports.items():
+        mine = Mine.find_by_mine_guid(mine_guid)
+        if not mine:
+            print(f"No mine found for mine guid: {mine_guid}")
+            continue
+        for mine_report_definition_id, reports in mine_report_definitions.items():    
+            mine_report_definition = MineReportDefinition.find_by_mine_report_definition_id(mine_report_definition_id)
+            if not mine_report_definition:
+                print(f"No MineReportDefinition found for id: {mine_report_definition_id}")
+                continue
+
+            created_count, failed_count = _process_crr_reports(
+            mine, mine_report_definition, reports, current_date, one_year_from_now
+            )
+            
+            total_created += created_count
+        
+            if failed_count > 0:
+                failed_report_requests.append({
+                    'mine_name': mine.mine_name,
+                    'mine_report_definition_report_name': mine_report_definition.report_name,
+                    'failed_count': failed_count
+                })
+
+    print(f"\nCompleted! Total CRR reports created: {total_created}")
+    
+    if failed_report_requests:
+        print("\nWarning: Some report requests had failures:")
+        for failed in failed_report_requests:
+            print(f"  - Mine Report of definition ({failed['mine_report_definition_report_name']}) belonging to the mine {failed['mine_name']}: {failed['failed_count']} failed reports")
+    
+    return {
+        'total_created': total_created,
+        'failed_report_requests': failed_report_requests
     }

--- a/services/core-api/app/api/mines/reports/tasks.py
+++ b/services/core-api/app/api/mines/reports/tasks.py
@@ -181,6 +181,7 @@ def create_new_recurring_report_requests():
         print("Task exiting early - feature flag is disabled")
         return {"status": "skipped", "reason": "feature flag disabled"} 
     
+    print("Starting creation of recurring report requests...")
     current_date = datetime.now().date()
     
     recurring_requirements = MineReportPermitRequirement.get_all_recurring()
@@ -232,6 +233,7 @@ def create_new_recurring_crr_report_requests():
         print("Task exiting early - feature flag is disabled")
         return {"status": "skipped", "reason": "feature flag disabled"} 
     
+    print("Starting creation of recurring CRR report requests...")
     current_date = datetime.now().date()
     one_year_from_now = current_date + relativedelta(years=1)
 

--- a/services/core-api/app/commands.py
+++ b/services/core-api/app/commands.py
@@ -149,12 +149,15 @@ def register_commands(app):
     @app.cli.command('create_new_recurring_report_requests')
     def create_new_recurring_report_requests():
         from app import auth
-        from app.api.mines.reports.tasks import create_new_recurring_report_requests
+        from app.api.mines.reports.tasks import create_new_recurring_report_requests, create_new_recurring_crr_report_requests
         auth.apply_security = False
 
         with current_app.app_context():
             create_new_recurring_report_requests()
             print("celery job started: create_new_recurring_report_requests")
+
+            create_new_recurring_crr_report_requests()
+            print("celery job started: create_new_recurring_crr_report_requests")
 
     @app.cli.command('revoke_mines_act_permit_vc_and_offer_newest')
     @click.argument('credential_exchange_id')

--- a/services/core-api/tests/reports/test_report_tasks.py
+++ b/services/core-api/tests/reports/test_report_tasks.py
@@ -4,14 +4,16 @@ from datetime import datetime, date
 from dateutil.relativedelta import relativedelta
 
 from app.api.mines.reports.tasks import create_new_recurring_report_requests
+from app.api.mines.reports.tasks import create_new_recurring_crr_report_requests
 from app.api.mines.reports.models.mine_report import MineReport
 from app.api.mines.reports.models.mine_report_permit_requirement import MineReportPermitRequirement
+from app.api.mines.reports.models.mine_report_definition import MineReportDefinition
 from tests.factories import (
     MineReportPermitRequirementFactory,
     MineReportFactory,
-    create_mine_and_permit
+    create_mine_and_permit,
+    MineFactory,
 )
-
 
 @pytest.fixture(scope="function")
 def db_session(db_session):
@@ -65,6 +67,43 @@ def setup_recurring_requirements(db_session):
     }
 
 
+@pytest.fixture(params=["YRL", "FIS"])
+def setup_crr_environment(request, db_session):
+    today = date.today()
+
+    mine = MineFactory()
+
+    due_type = request.param
+
+    if due_type == "YRL":
+        expected_month = 1
+        expected_day = 31
+    elif due_type == "FIS":
+        expected_month = 3
+        expected_day = 31
+
+    mine_report_definition = MineReportDefinition(
+        report_name=f"CRR {due_type} Report",
+        active_ind=True,
+        mine_report_due_date_type=due_type,
+        description=f"CRR {due_type} definition",
+        is_common=True,
+        is_prr_only=False,
+    )
+
+    db_session.add(mine_report_definition)
+    db_session.commit()
+
+    yield {
+        "mine": mine,
+        "definition": mine_report_definition,
+        "today": today,
+        "due_type": due_type,
+        "expected_month": expected_month,
+        "expected_day": expected_day
+    }
+
+
 @pytest.fixture
 def setup_with_existing_reports(setup_recurring_requirements):
     data = setup_recurring_requirements
@@ -93,6 +132,7 @@ def setup_with_existing_reports(setup_recurring_requirements):
     yield data
 
 
+# PRR report tests
 class TestCreateNewRecurringReportRequests:
     
     def test_task_creates_missing_reports_for_next_year(self, setup_recurring_requirements):
@@ -318,3 +358,175 @@ class TestCreateNewRecurringReportRequests:
             assert report.received_date is None
             assert report.submission_year == report.due_date.year
             assert report.mine_report_status_code == 'NON' # Report Requested
+
+
+# CRR report test
+class TestCreateNewRecurringCRRReportRequests:
+
+    def test_creates_missing_recurring_crr_reports(self, setup_crr_environment):
+        data = setup_crr_environment
+        mine = data["mine"]
+        definition = data["definition"]
+        today = data["today"]
+
+        existing_due = today - relativedelta(months=6)
+
+        MineReportFactory(
+            mine=mine,
+            mine_report_definition_id=definition.mine_report_definition_id,
+            due_date=existing_due,
+            deleted_ind=False
+        )
+
+        result = create_new_recurring_crr_report_requests()
+
+        assert int(result["total_created"]) > 0
+        assert len(result["failed_report_requests"]) == 0
+
+        reports = MineReport.query.filter_by(
+            mine_guid=mine.mine_guid,
+            mine_report_definition_id=definition.mine_report_definition_id,
+            deleted_ind=False
+        ).all()
+
+        assert len(reports) > 1
+
+    def test_created_reports_have_correct_fixed_day_and_month_for_due_dates(self, setup_crr_environment):
+        data = setup_crr_environment
+        mine = data["mine"]
+        definition = data["definition"]
+        today = data["today"]
+        expected_month = data["expected_month"]
+        expected_day = data["expected_day"]
+
+        create_new_recurring_crr_report_requests()
+
+        reports = MineReport.query.filter_by(
+            mine_guid=mine.mine_guid,
+            mine_report_definition_id=definition.mine_report_definition_id,
+            deleted_ind=False
+        ).all()
+
+        # Assert all reports have the correct fixed day/month
+        for report in reports:
+            due_date = report.due_date.date()
+            assert due_date.month == expected_month
+            assert due_date.day == expected_day
+            assert due_date > today
+
+    def test_no_duplicate_due_dates(self, setup_crr_environment):
+        data = setup_crr_environment
+        mine = data["mine"]
+        definition = data["definition"]
+        today = data["today"]
+        expected_month = data["expected_month"]
+        expected_day = data["expected_day"]
+
+        last_year = today.year - 1
+
+        existing_due_date = date(last_year, expected_month, expected_day)
+
+        MineReportFactory(
+            mine=mine,
+            mine_report_definition_id=definition.mine_report_definition_id,
+            due_date=existing_due_date,
+            deleted_ind=False
+        )
+
+        create_new_recurring_crr_report_requests()
+
+        reports = MineReport.query.filter_by(
+            mine_guid=mine.mine_guid,
+            mine_report_definition_id=definition.mine_report_definition_id,
+            deleted_ind=False
+        ).all()
+
+        due_dates = [r.due_date.date() for r in reports]
+
+        assert len(due_dates) == len(set(due_dates))
+
+    def test_task_ignores_non_recurring_mine_report_due_date_types(self, db_session):
+        today = date.today()
+
+        mine = MineFactory()
+
+        non_recurring_definition = MineReportDefinition(
+            report_name="Non Recurring Report",
+            active_ind=True,
+            mine_report_due_date_type="EVT",
+            description=f"CRR test definition",
+            is_common=True,
+            is_prr_only=False,
+        )
+
+        db_session.add(non_recurring_definition)
+        db_session.commit()
+
+        MineReportFactory(
+            mine=mine,
+            mine_report_definition_id=non_recurring_definition.mine_report_definition_id,
+            due_date=today - relativedelta(years=1),
+            deleted_ind=False
+        )
+
+        result = create_new_recurring_crr_report_requests()
+
+        reports = MineReport.query.filter_by(
+            mine_guid=mine.mine_guid,
+            mine_report_definition_id=non_recurring_definition.mine_report_definition_id,
+            deleted_ind=False
+        ).all()
+
+        assert len(reports) == 1
+        assert result["total_created"] == 0
+
+    @mock.patch("app.api.mines.reports.models.mine_report.MineReport.create")
+    @mock.patch("app.api.mines.reports.tasks.Mine.find_by_mine_guid")
+    @mock.patch("app.api.mines.reports.tasks.MineReportDefinition.find_by_mine_report_definition_id")
+    def test_task_handles_creation_failure(self, mock_definition, mock_mine, mock_create, setup_crr_environment):
+        mock_create.side_effect = Exception("Simulated failure")
+
+        mock_mine.return_value = mock.Mock(mine_name="Test Mine", mine_guid="fake-guid")
+        mock_definition.return_value = mock.Mock(report_name="Test CRR Report", mine_report_definition_id="fake-id")
+
+        result = create_new_recurring_crr_report_requests()
+
+        assert "total_created" in result
+        assert "failed_report_requests" in result
+        assert len(result['failed_report_requests']) >= 0
+
+    def test_respects_one_year_horizon(self, setup_crr_environment):
+        data = setup_crr_environment
+        mine = data["mine"]
+        definition = data["definition"]
+        today = data["today"]
+        expected_month = data["expected_month"]
+        expected_day = data["expected_day"]
+
+        last_year = today.year - 1
+        existing_due_date = date(last_year, expected_month, expected_day)
+
+        MineReportFactory(
+            mine=mine,
+            mine_report_definition_id=definition.mine_report_definition_id,
+            due_date=existing_due_date,
+            deleted_ind=False
+        )
+
+        create_new_recurring_crr_report_requests()
+
+        max_allowed_date = today + relativedelta(years=1)
+
+        reports = MineReport.query.filter_by(
+            mine_guid=mine.mine_guid,
+            mine_report_definition_id=definition.mine_report_definition_id,
+            deleted_ind=False
+        ).all()
+
+        for report in reports:
+            due_date = report.due_date.date()
+
+            assert due_date.month == expected_month
+            assert due_date.day == expected_day
+
+            assert due_date <= max_allowed_date


### PR DESCRIPTION
## Objective 

[MDS-6728](https://bcmines.atlassian.net/browse/MDS-6728)

- Added CRR report generation for existing CRR recurring reports. Will run daily under the same cli command as the PRR report generation

- Added new mine_report_due_date_type called `YRL` to support the reports that have set due date on Jan 31st for the year.

- Made it so reports that are associated with a mine report definition that has `active_ind = false` to not show up in reports table.

- Mine report definitions with `active_ind = false` will no longer show up in the report name filter drop down and also the report name drop down when creating a report.


<img width="980" height="399" alt="image" src="https://github.com/user-attachments/assets/6ba5c57f-df9a-41e2-9142-9129cffd81d5" />

<img width="2254" height="334" alt="image" src="https://github.com/user-attachments/assets/c7d2736c-c2b2-4100-9170-4185153e1d78" />

<img width="879" height="873" alt="image" src="https://github.com/user-attachments/assets/5ebaeee3-1553-4ac3-9f3d-c880edfbcda8" />


