### PR TITLE
[MDS-6814] - Can't Assign Project Lead

### DIFF
--- a/services/core-api/app/api/projects/project_summary/models/project_summary.py
+++ b/services/core-api/app/api/projects/project_summary/models/project_summary.py
@@ -1434,6 +1434,9 @@ class ProjectSummary(SoftDeleteMixin, AuditMixin, Base):
         cc = [MDS_EMAIL]
         minespace_recipients = [contact.email for contact in self.contacts if contact.is_primary]
 
+        ministry_recipients = [email for email in ministry_recipients if email]
+        minespace_recipients = [email for email in minespace_recipients if email]
+
         ministry_template = "email/projects/ministry_project_summary_email.html"
         minespace_template = "email/projects/minespace_project_summary_email.html"
         subject = f'Project Description Notification for {mine.mine_name}'
@@ -1460,16 +1463,17 @@ class ProjectSummary(SoftDeleteMixin, AuditMixin, Base):
             "ema_auth_link": f'{Config.EMA_AUTH_LINK}',
         }
 
-        EmailService.send_template_email(
-            subject,
-            ministry_recipients,
-            ministry_template,
-            ministry_context,
-            cc=cc,
-            reference_id=self.project_summary_guid,
-            reference_table='project_summary'
-        )
-        if send_ms_email:
+        if ministry_recipients:
+            EmailService.send_template_email(
+                subject,
+                ministry_recipients,
+                ministry_template,
+                ministry_context,
+                cc=cc,
+                reference_id=self.project_summary_guid,
+                reference_table='project_summary'
+            )
+        if send_ms_email and minespace_recipients:
             EmailService.send_template_email(
                 subject,
                 minespace_recipients,

--- a/services/core-api/tests/projects/project_summaries/resources/test_project_summary_emails.py
+++ b/services/core-api/tests/projects/project_summaries/resources/test_project_summary_emails.py
@@ -1,4 +1,6 @@
-from tests.factories import ProjectSummaryFactory
+from tests.factories import ProjectSummaryFactory, PartyFactory, ProjectSummaryAuthorizationFactory
+from app.api.projects.project_summary.models.project_summary import ProjectSummary
+from app.api.projects.project.models.project import Project
 from app.api.constants import MDS_EMAIL
 from app.config import Config
 
@@ -7,10 +9,14 @@ from unittest.mock import patch, mock_open, call, ANY
 @patch("app.api.services.email_service.EmailService.send_template_email")
 @patch("builtins.open", mock_open(read_data='email content'))
 
-def test_sub_to_asg(mock_send_template_email, test_client, db_session, auth_headers):
+@patch("app.api.projects.project.models.project.Project.has_mines_act_auths", return_value=True)
+def test_sub_to_asg(mock_has_mines_act_auths, mock_send_template_email, test_client, db_session, auth_headers):
     project_summary = ProjectSummaryFactory(set_status_code='SUB')
 
     # TODO: ams_authorizations and documents should both have documents in order to test document emails
+
+    party = PartyFactory(person=True)
+    party.save()
 
     updated_project_summary_title = 'Test Project Title - Updated'
     data = {}
@@ -23,12 +29,14 @@ def test_sub_to_asg(mock_send_template_email, test_client, db_session, auth_head
     data['project_summary_description'] = project_summary.project_summary_description
     data['status_code'] = 'ASG'
     data['is_historic'] = False
+    data['project_lead_party_guid'] = party.party_guid
 
     put_resp = test_client.put(
         f'/projects/{project_summary.project.project_guid}/project-summaries/{project_summary.project_summary_guid}',
         headers=auth_headers['full_auth_header'],
         json=data
     )
+    
     ministry_context = {
             "project_summary": {
                 "project_summary_description": project_summary.project_summary_description,


### PR DESCRIPTION
When assigning a project lead that didn't have an email address, the system would error out rather than complete the task.  This was happening because we were sending a 'None' value to CHES which would fail.

Implemented a step to filter out None values from both recipients arrays and added a check before both the ministry and proponent sends to make sure there is at least 1 valid email in that list before starting the send.

## Objective 

[MDS-6814](https://bcmines.atlassian.net/browse/MDS-6814)

_Why are you making this change? Provide a short explanation and/or screenshots_
