### PR TITLE
[CHORE] - Fix pgsync permission granting

### DIFF
--- a/migrations/sql/V2026.02.26.02.00__fix_pgsync_permissions.sql
+++ b/migrations/sql/V2026.02.26.02.00__fix_pgsync_permissions.sql
@@ -1,0 +1,10 @@
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT FROM pg_catalog.pg_roles
+        WHERE  rolname = 'pgsync') THEN
+        
+        ALTER DEFAULT PRIVILEGES FOR ROLE pgsync IN SCHEMA public GRANT SELECT ON TABLES TO mds;
+    END IF;
+END
+$$;


### PR DESCRIPTION
## Objective 

Figured out what was happening with this bug.  It's actually tied to the global search.
There's a new database trigger in place to update Elasticsearch when certain entities are created or updated.
This updates a particular materialized view that Elasticsearch uses to provide the results.,
This view is owned by the 'pgsync' user in the database.,
When we make a call from our application it uses the 'mds' user for it's connection
We create a new contact which invokes the trigger to update Elasticsearch under the current user ('mds'),
Since that user doesn't have ownership over that function, it fails

It looks like whenever the container restarts pgsync drops the table and recreates it which drops any granted privileges as well.
This migration will alter it so any time it creates the view it will grant that select privilege to mds.

