### PR TITLE
[MDS-6832] Fix pre_pool ping

### DIFF
--- a/services/core-api/app/config.py
+++ b/services/core-api/app/config.py
@@ -146,7 +146,6 @@ class Config(object):
     # SqlAlchemy config
     SQLALCHEMY_DATABASE_URI = DB_URL
     SQLALCHEMY_TRACK_MODIFICATIONS = False
-    SQLALCHEMY_ENGINE_OPTIONS = {"pool_pre_ping": True}
     SQLALCHEMY_WARN_20 = True
 
     JWT_OIDC_WELL_KNOWN_CONFIG = os.environ.get(
@@ -198,7 +197,7 @@ class Config(object):
     RESTPLUS_JSON = {'indent': None, 'separators': (',', ':')}
     COMPRESS_LEVEL = 9
     SQLALCHEMY_TRACK_MODIFICATIONS = False
-    SQLALCHEMY_ENGINE_OPTIONS = {'pool_timeout': 300, 'max_overflow': 20}
+    SQLALCHEMY_ENGINE_OPTIONS = {'pool_timeout': 300, 'max_overflow': 20, 'pool_pre_ping': True}
 
     # Flagsmith
     FLAGSMITH_URL = os.environ.get('FLAGSMITH_URL',


### PR DESCRIPTION
## Objective 

[MDS-6832](https://bcmines.atlassian.net/browse/MDS-6832)

Enabling `pool_pre_ping` for our sqlalchemy <-> postgres connection as an attempt to resolve some of the crash-loop backoffs that are happening. After increasing memory limits, some pods still seem to restart with a slightly different error

<img width="1276" height="115" alt="image" src="https://github.com/user-attachments/assets/43173a3d-450e-4c32-91a7-525c0ab4741e" />

Background: https://stackoverflow.com/questions/55457069/how-to-fix-operationalerror-psycopg2-operationalerror-server-closed-the-conn
