### PR TITLE
[MDS-6825] Fix for not specified radio button not being selected

### DIFF
--- a/services/common/src/components/permits/ReportPermitRequirementForm.tsx
+++ b/services/common/src/components/permits/ReportPermitRequirementForm.tsx
@@ -202,6 +202,7 @@ export const ReportPermitRequirementForm: FC<ReportPermitRequirementProps> = ({
     if (selectedRequirement) {
       return ({
         ...selectedRequirement,
+        cim_or_cpo: selectedRequirement.cim_or_cpo ?? "NONE",
         ...initialValues
       });
     }


### PR DESCRIPTION
## Objective 

[MDS-6825](https://bcmines.atlassian.net/browse/MDS-6825)

- Fix for `"Not Specified"` radio button not staying selected when a report requirement's Regulatory Authority was saved with that option.

- Found out the `cim_or_cpo` value passed to the radio buttons component is an empty string when `"Not Specified"` is saved as the Regulatory Authority option and that wouldn't match any of the options seen in the `REPORT_REGULATORY_AUTHORITY_CODES_HASH`
