### PR TITLE
[MDS-6847] - BUG - Unable to submit final incident report

### DIFF
--- a/services/core-api/app/api/services/email_service.py
+++ b/services/core-api/app/api/services/email_service.py
@@ -241,6 +241,8 @@ class EmailService():
             return tracking_records
 
         for recipient_email in recipients:
+            if not recipient_email:
+                continue
             tracking_record = EmailTracking.create(
                 recipient_email=recipient_email,
                 recipient_type=recipient_type,
@@ -287,6 +289,15 @@ class EmailService():
         elif is_not_prod and not Config.EMAIL_RECIPIENT_OVERRIDE:
             current_app.logger.info(
                 'Not sending email: Recipient override must be set when not in prod environment!')
+            return
+
+        # Filter out None or empty string recipients
+        recipients = [r for r in (recipients or []) if r]
+        cc = [c for c in (cc or []) if c]
+        bcc = [b for b in (bcc or []) if b]
+
+        if not recipients and not cc and not bcc:
+            current_app.logger.info('Not sending email: No valid recipients found.')
             return
 
         original_recipients = recipients
@@ -410,6 +421,15 @@ class EmailService():
         elif is_not_prod and not Config.EMAIL_RECIPIENT_OVERRIDE:
             current_app.logger.info(
                 'Not sending email: Recipient override must be set when not in prod environment!')
+            return
+
+        # Filter out None or empty string recipients
+        recipients = [r for r in (recipients or []) if r]
+        cc = [c for c in (cc or []) if c]
+        bcc = [b for b in (bcc or []) if b]
+
+        if not recipients and not cc and not bcc:
+            current_app.logger.info('Not sending email: No valid recipients found.')
             return
 
         original_recipients = recipients


### PR DESCRIPTION
When submitting a final incident report and there was no inspector added in the `Inspector reported to  (optional)` field, the system was adding a None type recipient to the recipients list.  This was causing a failure in the email_tracking table due to the recipient being required.

Added filters to the send_email and send_template_email functions to remove None types from recipient lists and added a check for None types before the email tracking record is created.

## Objective 

[MDS-6847](https://bcmines.atlassian.net/browse/MDS-6847)

_Why are you making this change? Provide a short explanation and/or screenshots_
