### PR TITLE
[MDS-6728] Changing crr report generation to use pagination

### DIFF
--- a/services/core-api/app/api/mines/reports/models/mine_report.py
+++ b/services/core-api/app/api/mines/reports/models/mine_report.py
@@ -473,7 +473,7 @@ class MineReport(SoftDeleteMixin, AuditMixin, Base):
         return mine_report
 
     @classmethod
-    def get_all_recurring_crr_reports(cls) -> list[Self]:
+    def get_all_recurring_crr_reports(cls):
         from app.api.mines.reports.models.mine_report_definition import MineReportDefinition
         from app.api.mines.permits.permit.models.mine_permit_xref import MinePermitXref
         from app.api.mines.permits.permit.models.permit import Permit
@@ -539,7 +539,6 @@ class MineReport(SoftDeleteMixin, AuditMixin, Base):
                 ),
                 has_non_expired_compliance_article,
             )
-            .all()
         )
 
     @validates('mine_report_definition_id')

--- a/services/core-api/app/api/mines/reports/tasks.py
+++ b/services/core-api/app/api/mines/reports/tasks.py
@@ -172,13 +172,6 @@ def _process_crr_reports(mine, mine_report_definition, reports, current_date, on
     return created_count, failed_count
 
 @celery.task()
-def create_new_recurring_report_requests_chain():
-    chain(
-        create_new_recurring_report_requests.s(),
-        create_new_recurring_crr_report_requests.si()
-    ).apply_async()
-
-@celery.task()
 def create_new_recurring_report_requests():
     """
     Create new recurring report requests based on permit requirements.
@@ -245,14 +238,27 @@ def create_new_recurring_crr_report_requests():
     current_date = datetime.now().date()
     one_year_from_now = current_date + relativedelta(years=1)
 
-    recurring_reports = MineReport.get_all_recurring_crr_reports()
-    print(f"Found {len(recurring_reports)} recurring CRR reports")
+    query = MineReport.get_all_recurring_crr_reports()
+    batch_size = 100
+    page = 1
+    found_recurring_reports = 0
 
     # Group reports by mine then by mine report definition ID 
     grouped_recurring_reports = defaultdict(lambda: defaultdict(list))
-    for report in recurring_reports:
-        grouped_recurring_reports[report.mine_guid][report.mine_report_definition_id].append(report)
+
+    while True:
+        pagination = query.paginate(page=page, per_page=batch_size, error_out=False)
+        if not pagination.items:
+            break
+
+        for report in pagination.items:
+            grouped_recurring_reports[report.mine_guid][report.mine_report_definition_id].append(report)
+            found_recurring_reports += 1
+
+        page += 1
     
+    print(f"Found {found_recurring_reports} recurring CRR reports")
+
     total_created = 0
     failed_report_requests= []
 

--- a/services/core-api/app/config.py
+++ b/services/core-api/app/config.py
@@ -287,9 +287,13 @@ class Config(object):
             'task': 'app.api.parties.party_appt.tasks.notify_and_update_expired_party_appointments',
             'schedule': crontab(minute="*/15"),
         },
-        'create_new_recurring_report_requests_chain': {
-            'task': 'app.api.mines.reports.tasks.create_new_recurring_report_requests_chain',
+        'create_new_recurring_report_requests': {
+            'task': 'app.api.mines.reports.tasks.create_new_recurring_report_requests',
             'schedule': crontab(hour="10", minute="0"),  # Run daily at 2am (10am UTC)
+        },
+        'create_new_recurring_crr_report_requests': {
+            'task': 'app.api.mines.reports.tasks.create_new_recurring_crr_report_requests',
+            'schedule': crontab(hour="11", minute="0"),  # Run daily at 3am (11am UTC)
         },
         'push_untp_map_data_to_publisher': {
             'task': 'app.api.verifiable_credentials.manager.push_untp_map_data_to_publisher',


### PR DESCRIPTION
## Objective 

[MDS-6728](https://bcmines.atlassian.net/browse/MDS-6728)

- Noticed in the logs that a SIGKILL error was showing up causing CRR report generation not to run
- Separated PRR and CRR report generation into their own tasks so they can run separately
- Adjusted CRR report generation query to use pagination
