### PR TITLE
[MDS-6849] - Fix compliance year on generated report requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ node_modules/
 pipeline/build/
 coverage/
 .idea/
+.agents/
 migrations/sql/afterMigrate__88__create_schema_users.sql
 __pycache__
 *.pytest_cache

--- a/migrations/sql/V2026.03.05.11.09__fix_report_compliance_year_2026_bug.sql
+++ b/migrations/sql/V2026.03.05.11.09__fix_report_compliance_year_2026_bug.sql
@@ -1,0 +1,8 @@
+-- Fix existing reports that have the incorrect compliance year
+-- Change compliance year to 2025 for reports due in Jan-Mar of 2026
+
+UPDATE mine_report
+SET submission_year = 2025
+WHERE submission_year = 2026 
+  AND EXTRACT(MONTH FROM due_date) <= 3
+  AND EXTRACT(YEAR FROM due_date) = 2026;

--- a/services/core-api/app/api/mines/reports/tasks.py
+++ b/services/core-api/app/api/mines/reports/tasks.py
@@ -66,7 +66,7 @@ def _calculate_missing_crr_report_due_dates(mine_report_due_date_type, existing_
 def _create_report_for_due_date(requirement, due_date):
     """Create a single mine report for the given due date."""
     mine_report = MineReport.create_from_permit_report_requirement(requirement, due_date)
-    mine_report.submission_year = due_date.year
+    mine_report.submission_year = due_date.year - 1 if due_date.month <= 3 else due_date.year
     mine_report.save()
     db.session.commit()
     return mine_report
@@ -157,7 +157,7 @@ def _process_crr_reports(mine, mine_report_definition, reports, current_date, on
                 system_created=True
             )
 
-            new_mine_report.submission_year = due_date.year
+            new_mine_report.submission_year = due_date.year - 1 if due_date.month <= 3 else due_date.year
             new_mine_report.save()
             db.session.commit()
 

--- a/services/core-api/tests/reports/test_report_tasks.py
+++ b/services/core-api/tests/reports/test_report_tasks.py
@@ -358,7 +358,9 @@ class TestCreateNewRecurringReportRequests:
             assert report.submitter_name == ""
             assert report.submitter_email == ""
             assert report.received_date is None
-            assert report.submission_year == report.due_date.year
+            
+            expected_year = report.due_date.year - 1 if report.due_date.month <= 3 else report.due_date.year
+            assert report.submission_year == expected_year
             assert report.mine_report_status_code == 'NON' # Report Requested
 
 


### PR DESCRIPTION
Previously all report requests were using the due date to determine the compliance year.  This PR updates it so that those reports with a due date between Jan. 1 and Mar. 31 will have a compliance year set to the previous year.
Also added a migration to adjust any already created report requests that match this same criteria.

## Objective 

[MDS-6849](https://bcmines.atlassian.net/browse/MDS-6849)

_Why are you making this change? Provide a short explanation and/or screenshots_
