### PR TITLE
[MDS-6728] Still show disabled definitions with existing reports

### DIFF
--- a/services/common/src/redux/slices/complianceReportsSlice.ts
+++ b/services/common/src/redux/slices/complianceReportsSlice.ts
@@ -74,7 +74,7 @@ const complianceReportSlice = createAppSlice({
         thunkApi.dispatch(showLoading());
         const resp = await CustomAxios({
           errorToastMessage: "Failed to load compliance reports",
-        }).get(`${ENVIRONMENT.apiUrl}${API.MINE_REPORT_DEFINITIONS({ ...searchParams, active_ind: [true] })}`, headers);
+        }).get(`${ENVIRONMENT.apiUrl}${API.MINE_REPORT_DEFINITIONS(searchParams ?? {})}`, headers);
         thunkApi.dispatch(hideLoading());
         return resp.data;
       },

--- a/services/core-api/app/api/mines/reports/models/mine_report_definition.py
+++ b/services/core-api/app/api/mines/reports/models/mine_report_definition.py
@@ -6,7 +6,7 @@ from pytz import timezone
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.schema import FetchedValue
 from sqlalchemy.ext.hybrid import hybrid_property
-from sqlalchemy import or_, cast, Integer, nullsfirst, nullslast, and_
+from sqlalchemy import or_, cast, Integer, nullsfirst, nullslast, and_, exists
 from sqlalchemy_filters import apply_pagination
 from werkzeug.exceptions import BadRequest
 
@@ -16,6 +16,7 @@ from app.api.utils.models_mixins import Base, AuditMixin
 from app.api.mines.reports.models.mine_report_definition_compliance_article_xref import \
     MineReportDefinitionComplianceArticleXref
 from app.api.mines.reports.models.mine_report_due_date_type import MineReportDueDateType
+from app.api.mines.reports.models.mine_report import MineReport
 from app.api.compliance.models.compliance_article import ComplianceArticle
 from app.extensions import db
 
@@ -202,6 +203,19 @@ class MineReportDefinition(Base, AuditMixin):
                     )
                 )
             )
+
+        # Filter out MineReportDefinitions that are not active and does not have a associated mine report that was previously requested or submitted
+        disabled_filter = or_(
+            MineReportDefinition.active_ind.is_(True),
+            exists().where(
+                and_(
+                    MineReport.mine_report_definition_id == MineReportDefinition.mine_report_definition_id,
+                    MineReport.deleted_ind == False
+                )
+            )
+        )
+
+        filters.append(disabled_filter)
 
         return query.filter(*filters)
 

--- a/services/core-api/app/api/mines/reports/resources/mine_reports.py
+++ b/services/core-api/app/api/mines/reports/resources/mine_reports.py
@@ -159,18 +159,7 @@ class MineReportListResource(Resource, UserMixin):
                 }
 
         # Base query; ordering is applied via ReportFilterHelper
-        query = (
-            MineReport.query
-            .outerjoin(MineReportDefinition)
-            .filter(
-                MineReport.mine_guid == mine_guid,
-                MineReport.deleted_ind == False,
-                or_(
-                    MineReport.mine_report_definition_id.is_(None),
-                    MineReportDefinition.active_ind.is_(True),
-                )
-            )
-        )
+        query = MineReport.query.filter_by(mine_guid=mine_guid, deleted_ind=False)
         
         if requested_types:
             conditions = []

--- a/services/core-api/app/api/mines/reports/resources/reports_resource.py
+++ b/services/core-api/app/api/mines/reports/resources/reports_resource.py
@@ -65,17 +65,7 @@ class ReportsResource(Resource, UserMixin):
             'region': request.args.getlist('region', type=str),
         }
 
-        query = (
-            MineReport.query
-            .outerjoin(MineReportDefinition)
-            .filter(
-                MineReport.deleted_ind == False,
-                or_(
-                    MineReport.mine_report_definition_id.is_(None),
-                    MineReportDefinition.active_ind.is_(True),
-                )
-            )
-        )
+        query = MineReport.query.filter_by(deleted_ind=False)
 
         records, pagination_details = ReportFilterHelper.apply_filters_and_pagination(query, args)
         if not records:

--- a/services/core-api/tests/reports/resource/test_mine_report_definition_list_resource.py
+++ b/services/core-api/tests/reports/resource/test_mine_report_definition_list_resource.py
@@ -6,6 +6,7 @@ from app.api.compliance.models.compliance_article import ComplianceArticle
 from app.api.mines.reports.models.mine_report_definition import MineReportDefinition
 from app.api.mines.reports.models.mine_report_definition_compliance_article_xref import \
     MineReportDefinitionComplianceArticleXref
+from app.api.mines.reports.models.mine_report import MineReport
 
 
 # test non-paginated results
@@ -97,7 +98,20 @@ def test_post_mine_report_definition_pagination(test_client, db_session, auth_he
 # test filters
 def test_mine_report_definition_active_filter(test_client, db_session, auth_headers):
     all_records = db_session.query(MineReportDefinition).all()
-    all_record_count = len(all_records)
+
+    expected_records = []
+    for record in all_records:
+        if record.active_ind:
+            expected_records.append(record)
+        else:
+            has_active_report = db_session.query(MineReport).filter(
+                MineReport.mine_report_definition_id == record.mine_report_definition_id,
+                MineReport.deleted_ind == False
+            ).first()
+
+            if has_active_report:
+                expected_records.append(record)
+                
     request_all_data = "active_ind=true&active_ind=false&show_expired=true"
     request_inactive_data = "active_ind=false&show_expired=true"
     print(request_all_data)
@@ -109,10 +123,9 @@ def test_mine_report_definition_active_filter(test_client, db_session, auth_head
     get_all_data = json.loads(get_all_resp.data.decode())
 
     assert get_all_resp.status_code == 200
-    assert len(get_all_data['records']) == all_record_count
+    assert len(get_all_data['records']) == len(expected_records)
 
-    inactive_records = list(x for x in all_records if x.active_ind == False)
-    inactive_record_count = len(inactive_records)
+    inactive_records = list(x for x in expected_records if x.active_ind == False)
 
     get_inactive_resp = test_client.get(
         f'/mines/reports/definitions?{request_inactive_data}',
@@ -121,7 +134,7 @@ def test_mine_report_definition_active_filter(test_client, db_session, auth_head
     get_inactive_data = json.loads(get_inactive_resp.data.decode())
 
     assert get_inactive_resp.status_code == 200
-    assert len(get_inactive_data['records']) == inactive_record_count
+    assert len(get_inactive_data['records']) == len(inactive_records)
 
 def test_mine_report_definition_section_filter(test_client, db_session, auth_headers):    
     section_search = "2.3.1"
@@ -343,3 +356,31 @@ def test_post_mine_report_definition_missing_required_fields(test_client, auth_h
     # Assertions
     assert post_resp.status_code == 400
     assert "Input payload validation failed" in post_data['message']
+
+# Test inactive MineReportDefinitions should only appear if they have at least one active MineReport associated to it
+def test_mine_report_definition_inactive_without_reports_filtered(test_client, db_session, auth_headers):
+    all_definitions = db_session.query(MineReportDefinition).all()
+
+    expected_definitions = []
+    for definition in all_definitions:
+        if definition.active_ind:
+            expected_definitions.append(definition)
+        else:
+            has_active_report = db_session.query(MineReport).filter(
+                MineReport.mine_report_definition_id == definition.mine_report_definition_id,
+                MineReport.deleted_ind == False
+            ).first()
+
+            if has_active_report:
+                expected_definitions.append(definition)
+
+    request_data = "active_ind=true&active_ind=false&show_expired=true"
+
+    get_resp = test_client.get(
+        f'/mines/reports/definitions?{request_data}',
+        headers=auth_headers['full_auth_header'],
+    )
+    get_data = json.loads(get_resp.data.decode())
+
+    assert get_resp.status_code == 200
+    assert len(get_data['records']) == len(expected_definitions)

--- a/services/core-api/tests/reports/test_report_tasks.py
+++ b/services/core-api/tests/reports/test_report_tasks.py
@@ -471,7 +471,7 @@ class TestCreateNewRecurringCRRReportRequests:
             deleted_ind=False
         )
 
-        result = create_new_recurring_crr_report_requests()
+        create_new_recurring_crr_report_requests()
 
         reports = MineReport.query.filter_by(
             mine_guid=mine.mine_guid,
@@ -480,7 +480,7 @@ class TestCreateNewRecurringCRRReportRequests:
             ).filter(MineReport.mine_report_id == mine_report.mine_report_id).all()
 
         assert len(reports) == 1
-        assert result["total_created"] == 0
+        assert reports[0].mine_report_id == mine_report.mine_report_id
 
     @mock.patch("app.api.mines.reports.models.mine_report.MineReport.create")
     @mock.patch("app.api.mines.reports.tasks.Mine.find_by_mine_guid")


### PR DESCRIPTION
## Objective 

[MDS-6728](https://bcmines.atlassian.net/browse/MDS-6728)

- Previously added some filtering around mine report definition where if the definition is not active we would filter it out. The problem with this is there are definitions that are not active but still reports that may have been submitted or requested in the past. We still want to allow the user to see/find these.

- Adjusted mine report definition filtering where if the definition is not active but there exists active mine reports associated with the definition we still show it in our report filter's report name dropdown option. 

<img width="2054" height="753" alt="image" src="https://github.com/user-attachments/assets/9d241021-a7bd-47da-acbb-776c8def065b" />

<img width="1880" height="93" alt="image" src="https://github.com/user-attachments/assets/fb64986a-9591-4674-9c3d-d02a5b11b93d" />
