### PR TITLE
[MDS-6843] Fix for specific prod mine report missing documents

### DIFF
--- a/migrations/sql/V2026.03.06.15.32__fix_specific_mine_report_missing_documents_bug.sql
+++ b/migrations/sql/V2026.03.06.15.32__fix_specific_mine_report_missing_documents_bug.sql
@@ -1,0 +1,6 @@
+  -- Fix incorrect is_latest flag for submission 9710 in production environment
+UPDATE mine_report_submission
+SET is_latest = TRUE
+WHERE mine_report_submission_id = 9710
+  AND mine_report_submission_guid = '8dc00a33-e2bc-4eea-961c-b9d5853f9cbe'
+  AND mine_report_id = 8334;


### PR DESCRIPTION
## Objective 

[MDS-6843](https://bcmines.atlassian.net/browse/MDS-6843)

Found out this specific mine report only has one associated record in the `mine_report_submission` table, and in that record the `is_latest` column for it is set to false (https://metabase-4c2ba9-prod.apps.silver.devops.gov.bc.ca/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7InR5cGUiOiJxdWVyeSIsInF1ZXJ5Ijp7InNvdXJjZS10YWJsZSI6Mzk5LCJmaWx0ZXIiOlsiPSIsWyJmaWVsZCIsNDI3OCxudWxsXSw4MzM0XX0sImRhdGFiYXNlIjoyfSwiZGlzcGxheSI6InRhYmxlIiwidmlzdWFsaXphdGlvbl9zZXR0aW5ncyI6e319).


<img width="2521" height="669" alt="image" src="https://github.com/user-attachments/assets/790601dd-54e9-4169-bf60-50a801cbfb59" />


 This can prevent documents from showing up for a mine report front end page. Normally when a `mine_report_submission` record has `is_latest` set to false this happens for a previous submission record and a new submission record would be created, however there was only this one record in the `mine_report_submission` table for this mine report. 
  
 I think what happened was when the user went to submit the mine report our backend saved the previous submission's `is_latest` to false, and before it could proceed to create the new submission the request failed. From what Kathleen mentioned the user did get an error during the submission and this might occurred around the time we did a push to prod.
