### PR TITLE
[MDS-6854] Mine reports fixes

### DIFF
--- a/services/common/src/components/permits/ViewPermit.tsx
+++ b/services/common/src/components/permits/ViewPermit.tsx
@@ -304,7 +304,7 @@ const ViewPermit: FC = () => {
   ) : null;
 
   return (
-    <div className="fixed-tabs-container">
+    <div className="fixed-tabs-container permit-tabs-container">
       <CommonPageHeader
         entityLabel={permit?.permit_no ?? ""}
         entityType="Permit"

--- a/services/common/src/interfaces/reports/mineReportParams.interface.ts
+++ b/services/common/src/interfaces/reports/mineReportParams.interface.ts
@@ -12,6 +12,7 @@ export interface MineReportParams {
   status?: string[];
   sort_field?: string;
   sort_dir?: string;
+  sort_overdue?: boolean | string;
   mine_reports_type?: string | string[];
   permit_guid?: string;
   page?: string;

--- a/services/common/src/tests/permits/__snapshots__/ViewPermit.spec.tsx.snap
+++ b/services/common/src/tests/permits/__snapshots__/ViewPermit.spec.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`ViewPermit renders properly 1`] = `
 <div
-  class="fixed-tabs-container"
+  class="fixed-tabs-container permit-tabs-container"
 >
   <div
     class="common-page"

--- a/services/core-api/app/api/mines/reports/models/mine_report.py
+++ b/services/core-api/app/api/mines/reports/models/mine_report.py
@@ -137,6 +137,20 @@ class MineReport(SoftDeleteMixin, AuditMixin, Base):
                 due_dt >= april_1_2025 and
                 self.mine_report_status_code == 'NON')
 
+    @is_overdue.expression
+    def is_overdue(cls):
+        from sqlalchemy import case
+        april_1_2025 = date(2025, 4, 1)
+        return case(
+            (and_(
+                cls.due_date.isnot(None),
+                cls.due_date < func.now(),
+                cls.due_date >= april_1_2025,
+                cls.mine_report_status_code == 'NON'
+            ), True),
+            else_=False
+        )
+
     @hybrid_property
     def report_type(self):
         return "PRR" if self.permit_condition_category_code or self.mine_report_permit_requirement_id else "CRR"

--- a/services/core-api/app/api/mines/reports/report_helpers.py
+++ b/services/core-api/app/api/mines/reports/report_helpers.py
@@ -144,6 +144,9 @@ class ReportFilterHelper:
 
         filtered_query = apply_filters(query, conditions)
 
+        if args.get('sort_overdue'):
+            filtered_query = filtered_query.order_by(desc(MineReport.is_overdue))
+
         if args['sort_field'] == 'mine_report_status_code' or args['sort_field'] == 'mine_report_status':
             if args['sort_dir'] == 'asc':
                 filtered_query = filtered_query.order_by(

--- a/services/core-api/app/api/mines/reports/report_helpers.py
+++ b/services/core-api/app/api/mines/reports/report_helpers.py
@@ -63,13 +63,13 @@ class ReportFilterHelper:
 
         if args["report_type"] or (args['sort_field'] and sort_models[
             args['sort_field']] in ['MineReportCategoryXref', 'MineReportDefinition'] and not mine_guid):
-            query = query.join(
+            query = query.outerjoin(
                 MineReportDefinition, MineReport.mine_report_definition_id ==
                                       MineReportDefinition.mine_report_definition_id)
-            query = query.join(
+            query = query.outerjoin(
                 MineReportCategoryXref, MineReportDefinition.mine_report_definition_id ==
                                         MineReportCategoryXref.mine_report_definition_id)
-            query = query.join(
+            query = query.outerjoin(
                 MineReportCategory, MineReportCategoryXref.mine_report_category ==
                                     MineReportCategory.mine_report_category)
 
@@ -80,9 +80,12 @@ class ReportFilterHelper:
             conditions.append(ReportFilterHelper.build_filter('Mine', 'mine_region', 'in', args["region"]))
 
         if args["report_type"]:
-            conditions.append(
-                ReportFilterHelper.build_filter('MineReportCategoryXref', 'mine_report_category', 'in',
-                                                args["report_type"]))
+            query = query.filter(
+                or_(
+                    MineReportCategoryXref.mine_report_category.in_(args["report_type"]),
+                    MineReport.permit_condition_category_code.in_(args["report_type"])
+                )
+            )
 
         if args["report_name"]:
             report_name = args["report_name"][0]

--- a/services/core-api/app/api/mines/reports/report_helpers.py
+++ b/services/core-api/app/api/mines/reports/report_helpers.py
@@ -7,7 +7,7 @@ from app.api.mines.reports.models.mine_report import MineReport
 from app.api.mines.reports.models.mine_report_category import MineReportCategory
 from app.api.mines.reports.models.mine_report_category_xref import MineReportCategoryXref
 from app.api.mines.reports.models.mine_report_definition import MineReportDefinition
-from sqlalchemy import case
+from sqlalchemy import case, or_, and_
 from app.api.mines.permits.permit_conditions.models.permit_condition_category import PermitConditionCategory
 from app.api.mines.reports.models.mine_report_permit_requirement import MineReportPermitRequirement
 from app.api.mines.permits.permit.models.permit import Permit
@@ -141,6 +141,20 @@ class ReportFilterHelper:
 
         if args.get('permit_guid'):
             query = query.filter(MineReport.permit_guid == args["permit_guid"])
+
+        if args.get('is_upcoming_view'):
+            from datetime import date
+            upcoming_window_end = args.get('upcoming_window_end', date.today())
+            query = query.filter(
+                or_(
+                    MineReport.is_overdue == True,
+                    and_(
+                        MineReport.due_date >= date.today(),
+                        MineReport.due_date <= upcoming_window_end,
+                        MineReport.mine_report_status_code == 'NON'
+                    )
+                )
+            )
 
         filtered_query = apply_filters(query, conditions)
 

--- a/services/core-api/app/api/mines/reports/resources/mine_reports.py
+++ b/services/core-api/app/api/mines/reports/resources/mine_reports.py
@@ -146,11 +146,9 @@ class MineReportListResource(Resource, UserMixin):
             else:
                 end_date = date.today() + timedelta(days=365)
 
-            # Enforce due date to be strictly in the future within the window, unless caller already set
-            if not args['due_date_after']:
-                args['due_date_after'] = date.today().isoformat()
-            if not args['due_date_before']:
-                args['due_date_before'] = end_date.isoformat()
+            # Set an explicit upcoming view flag for report_helpers to process
+            args['is_upcoming_view'] = True
+            args['upcoming_window_end'] = end_date
 
             # If no explicit report types provided, default to CRR + PRR for upcoming
             if not requested_types:

--- a/services/core-api/app/api/mines/reports/resources/mine_reports.py
+++ b/services/core-api/app/api/mines/reports/resources/mine_reports.py
@@ -115,6 +115,7 @@ class MineReportListResource(Resource, UserMixin):
             'major': request.args.get('major', type=str),
             'region': request.args.getlist('region', type=str),
             'permit_guid': request.args.get('permit_guid', type=str),
+            'sort_overdue': request.args.get('sort_overdue', type=str) == "true",
         }
 
         mrd_category = request.args.get('mine_report_definition_category')

--- a/services/core-api/tests/reports/resource/test_mine_reports_resource.py
+++ b/services/core-api/tests/reports/resource/test_mine_reports_resource.py
@@ -404,7 +404,7 @@ def test_get_upcoming_reports_for_mine(test_client, db_session, auth_headers):
     past_due = MineReportFactory(
         mine=mine,
         mine_report_submissions=0,
-        due_date=today - timedelta(days=1),  # yesterday → should be excluded when upcoming=true
+        due_date=today - timedelta(days=1),  # yesterday → should be included when upcoming=true
         received_date=None,
     )
     far_future = MineReportFactory(
@@ -426,7 +426,7 @@ def test_get_upcoming_reports_for_mine(test_client, db_session, auth_headers):
 
     assert str(in_window_1.mine_report_guid) in returned
     assert str(in_window_2.mine_report_guid) in returned
-    assert str(past_due.mine_report_guid) not in returned
+    assert str(past_due.mine_report_guid) in returned
     assert str(far_future.mine_report_guid) not in returned
 
 

--- a/services/core-web/src/styles/components/ScrollSideMenuWrapper.scss
+++ b/services/core-web/src/styles/components/ScrollSideMenuWrapper.scss
@@ -134,3 +134,13 @@
     }
 
 }
+
+.permit-tabs-container .fixed-tabs-tabs {
+    &>.ant-tabs-nav {
+        top: 154px !important;
+    }
+
+    &>.ant-tabs-content-holder {
+        margin-top: 154px;
+    }
+}

--- a/services/core-web/src/tests/components/mine/Permit/__snapshots__/PermitConditions.spec.tsx.snap
+++ b/services/core-web/src/tests/components/mine/Permit/__snapshots__/PermitConditions.spec.tsx.snap
@@ -3,7 +3,7 @@
 exports[`PermitConditions renders properly 1`] = `
 <div>
   <div
-    class="fixed-tabs-container"
+    class="fixed-tabs-container permit-tabs-container"
   >
     <div
       class="common-page"

--- a/services/minespace-web/src/components/dashboard/mine/MineDashboard.tsx
+++ b/services/minespace-web/src/components/dashboard/mine/MineDashboard.tsx
@@ -16,7 +16,7 @@ import { useFeatureFlag } from "@mds/common/providers/featureFlags/useFeatureFla
 import { Feature } from "@mds/common/utils";
 import {
   fetchMineReportStats,
-  getOverdueReportsCountByMineGuid,
+  getMineReportStatsByMineGuid,
 } from "@mds/common/redux/slices/mineReportStatsSlice";
 
 const MineDashboard: FC = () => {
@@ -58,7 +58,11 @@ const MineDashboard: FC = () => {
     }
   }, [id]);
 
-  const overdueReports = useSelector(getOverdueReportsCountByMineGuid(mine?.mine_guid));
+  const stats = useSelector(getMineReportStatsByMineGuid(mine?.mine_guid));
+  const overdueReports = stats?.overdue_reports ?? 0;
+  const dueNext90 = stats?.due_next_90_days ?? 0;
+  const reportsBadgeCount = Number(overdueReports) + Number(dueNext90);
+
   useEffect(() => {
     if (mine?.mine_guid && showReportStats) {
       dispatch(fetchMineReportStats(mine.mine_guid));
@@ -68,7 +72,7 @@ const MineDashboard: FC = () => {
   const dynamicRoute = (key: string) => {
     return MINE_DASHBOARD.dynamicRoute(mine?.mine_guid, key, "");
   };
-  const items = getMineDashboardRoutes(showApplications, overdueReports).map((item) => ({
+  const items = getMineDashboardRoutes(showApplications, reportsBadgeCount).map((item) => ({
     ...item,
     path: dynamicRoute(item.key),
   }));

--- a/services/minespace-web/src/components/dashboard/mine/MineDashboardRoutes.tsx
+++ b/services/minespace-web/src/components/dashboard/mine/MineDashboardRoutes.tsx
@@ -26,7 +26,7 @@ import {
   faUsers,
 } from "@fortawesome/pro-light-svg-icons";
 
-export const getMineDashboardRoutes = (showApplications, overdueReportsCount?: number) =>
+export const getMineDashboardRoutes = (showApplications, reportsBadgeCount?: number) =>
   [
     {
       key: "overview",
@@ -57,7 +57,7 @@ export const getMineDashboardRoutes = (showApplications, overdueReportsCount?: n
       label: "Reports",
       icon: (
         <Badge
-          count={overdueReportsCount}
+          count={reportsBadgeCount}
           overflowCount={99}
           showZero={false}
           style={{ backgroundColor: "#d9363e" }}

--- a/services/minespace-web/src/components/dashboard/mine/reports/ReportManagement.tsx
+++ b/services/minespace-web/src/components/dashboard/mine/reports/ReportManagement.tsx
@@ -85,6 +85,9 @@ const ReportManagement: FC = () => {
   const activePermits = stats?.active_permits ?? "";
   const reportsOverdue = stats?.overdue_reports ?? "";
   const reportsDueNext90 = stats?.due_next_90_days ?? "";
+  const upcomingReportsCount = stats
+    ? Number(stats.due_next_90_days || 0) + Number(stats.overdue_reports || 0)
+    : undefined;
 
   const openReport = (reportRecord: IMineReport, isEditMode: boolean) => {
     history.push(
@@ -251,7 +254,7 @@ const ReportManagement: FC = () => {
                       <Row gutter={8}>
                         <Col>Upcoming Reports</Col>
                         <Col>
-                          <Badge count={reportsDueNext90 ?? undefined} />
+                          <Badge count={upcomingReportsCount} />
                         </Col>
                       </Row>
                     ),

--- a/services/minespace-web/src/components/dashboard/mine/reports/ReportManagement.tsx
+++ b/services/minespace-web/src/components/dashboard/mine/reports/ReportManagement.tsx
@@ -46,6 +46,7 @@ const defaultParams: MineReportParams = {
     Strings.MINE_REPORTS_TYPE.codeRequiredReports,
     Strings.MINE_REPORTS_TYPE.permitRequiredReports,
   ],
+  sort_overdue: true,
 };
 
 const ReportManagement: FC = () => {

--- a/services/minespace-web/src/components/dashboard/mine/reports/UpcomingReports.tsx
+++ b/services/minespace-web/src/components/dashboard/mine/reports/UpcomingReports.tsx
@@ -44,7 +44,7 @@ const UpcomingReports: FC<UpcomingReportsProps> = ({ mineGuid, openReport }) => 
             Strings.MINE_REPORTS_TYPE.codeRequiredReports,
             Strings.MINE_REPORTS_TYPE.permitRequiredReports,
           ],
-          params: { page, per_page: REPORTS_PAGE_SIZE, time_range: range },
+          params: { page, per_page: REPORTS_PAGE_SIZE, time_range: range, sort_overdue: true },
         })
       )
     ).then(() => setIsLoaded(true));

--- a/services/minespace-web/src/styles/components/ScrollSideMenuWrapper.scss
+++ b/services/minespace-web/src/styles/components/ScrollSideMenuWrapper.scss
@@ -127,3 +127,13 @@
     }
   }
 }
+
+.permit-tabs-container .fixed-tabs-tabs {
+  &>.ant-tabs-nav {
+    top: 154px !important;
+  }
+
+  &>.ant-tabs-content-holder {
+    margin-top: 154px;
+  }
+}

--- a/services/minespace-web/src/tests/components/dashboard/mine/reports/__snapshots__/ReportManagement.spec.tsx.snap
+++ b/services/minespace-web/src/tests/components/dashboard/mine/reports/__snapshots__/ReportManagement.spec.tsx.snap
@@ -269,7 +269,7 @@ exports[`ReportManagement renders and matches snapshot 1`] = `
                         <sup
                           class="ant-scroll-number ant-badge-count"
                           data-show="true"
-                          title="5"
+                          title="9"
                         >
                           <span
                             class="ant-scroll-number-only"
@@ -278,7 +278,7 @@ exports[`ReportManagement renders and matches snapshot 1`] = `
                             <span
                               class="ant-scroll-number-only-unit current"
                             >
-                              5
+                              9
                             </span>
                           </span>
                         </sup>

--- a/services/minespace-web/src/tests/components/project/informationRequirementsTablePage/__snapshots__/InformationRequirementsTablePage.spec.tsx.snap
+++ b/services/minespace-web/src/tests/components/project/informationRequirementsTablePage/__snapshots__/InformationRequirementsTablePage.spec.tsx.snap
@@ -353,6 +353,7 @@ exports[`InformationRequirementsTablePage renders properly 1`] = `
                       </div>
                       <div
                         class="ant-tabs-ink-bar ant-tabs-ink-bar-animated"
+                        style="top: 0px; height: 0px;"
                       />
                     </div>
                   </div>

--- a/services/minespace-web/src/tests/components/project/informationRequirementsTablePage/__snapshots__/InformationRequirementsTablePage.spec.tsx.snap
+++ b/services/minespace-web/src/tests/components/project/informationRequirementsTablePage/__snapshots__/InformationRequirementsTablePage.spec.tsx.snap
@@ -353,7 +353,6 @@ exports[`InformationRequirementsTablePage renders properly 1`] = `
                       </div>
                       <div
                         class="ant-tabs-ink-bar ant-tabs-ink-bar-animated"
-                        style="top: 0px; height: 0px;"
                       />
                     </div>
                   </div>


### PR DESCRIPTION
## Objective 

Fix various bugs related to mine reports and permits:

MS: overdue is no longer at top of table
- Updated filtering here to handle overdue reports a bit better (added an is_overdue expression in addition to the hybrid property to make the db search for this better)

MS: upcoming reports no longer includes overdue reports
- We had explicitly kept future due dates from this list, but have added them in

MS: received reports are showing in upcoming reports
- Filtered out reports that have already been received here.

MS: Permit Overview page - can't see the permit conditions page (header overlap?)
- Fixed a CSS issue where the permit tabs were being pushed down further than they should and overlapping

MS; Filter name title to Permit Condition Category (issue if cond cat+rep name selected when trying to find CRR)
- The database was inadvertantly filtering out PRRs from the results here due to the types of joins we were using.  A full join with the Code-Required definition tables caused PRRs to be excluded.  Updated to an outer join to prevent this and refined some logic.

MS; the upcoming reports counter on the tab is off because it doesn't include Overdue reports (check again once overdue reports are back)
- Updated the counter to include overdue (also updated the counter on the dashboard "Reports" item.

[MDS-6854](https://bcmines.atlassian.net/browse/MDS-6854)

_Why are you making this change? Provide a short explanation and/or screenshots_
