### PR TITLE
[CHORE] added feature flag exception list to static content loader

### DIFF
--- a/services/common/src/redux/reducers/staticContentReducer.js
+++ b/services/common/src/redux/reducers/staticContentReducer.js
@@ -1,5 +1,6 @@
 import * as actionTypes from "@mds/common/constants/actionTypes";
 import { STATIC_CONTENT } from "@mds/common/constants/reducerTypes";
+import { isFeatureEnabled, Feature } from "@mds/common/utils/featureFlag";
 
 /**
  * @file staticContentReducer.js
@@ -173,11 +174,17 @@ export const getProjectDecisionPackageStatusCodes = (state) =>
 export const getMunicipalityOptions = (state) => state[STATIC_CONTENT].municipalityOptions;
 export const getNoticeOfWorkTierOptions = (state) => state[STATIC_CONTENT].noticeOfWorkTierOptions;
 
-const isStaticContentLoaded = (state) =>
-  Object.keys(state)
+const isStaticContentLoaded = (state) => {
+  const staticContentExceptions = [];
+  if (!isFeatureEnabled(Feature.NOTICE_OF_WORK_TIER)) {
+    staticContentExceptions.push("noticeOfWorkTierOptions");
+  }
+
+  return Object.keys(state)
     // eslint-disable-next-line no-prototype-builtins
-    .filter((p) => state.hasOwnProperty(p) && Array.isArray(state[p]))
+    .filter((p) => state.hasOwnProperty(p) && Array.isArray(state[p]) && !staticContentExceptions.includes(p))
     .every((p) => state[p].length > 0);
+};
 
 export const getStaticContentLoadingIsComplete = (state) =>
   isStaticContentLoaded(state[STATIC_CONTENT]);


### PR DESCRIPTION
## Objective 

As the feature flagged notice_of_work_tier section is turned off in prod, it therefore never loads the static content and still expects it.  Added an exception list based on the feature flag to not require it if it's off.

_Why are you making this change? Provide a short explanation and/or screenshots_
