### PR TITLE
[MDS-6737] Only show reports for latest permit amendment in interface

### DIFF
--- a/services/core-api/app/api/mines/reports/report_helpers.py
+++ b/services/core-api/app/api/mines/reports/report_helpers.py
@@ -1,17 +1,27 @@
 # report_helpers.py
-from sqlalchemy import asc, desc
-from sqlalchemy_filters import apply_sort, apply_pagination, apply_filters
+import uuid
 
 from app.api.mines.mine.models.mine import Mine
+from app.api.mines.permits.permit.models.permit import Permit
+from app.api.mines.permits.permit_amendment.models.permit_amendment import (
+    PermitAmendment,
+)
+from app.api.mines.permits.permit_conditions.models.permit_condition_category import (
+    PermitConditionCategory,
+)
 from app.api.mines.reports.models.mine_report import MineReport
 from app.api.mines.reports.models.mine_report_category import MineReportCategory
-from app.api.mines.reports.models.mine_report_category_xref import MineReportCategoryXref
+from app.api.mines.reports.models.mine_report_category_xref import (
+    MineReportCategoryXref,
+)
 from app.api.mines.reports.models.mine_report_definition import MineReportDefinition
-from sqlalchemy import case, or_, and_
-from app.api.mines.permits.permit_conditions.models.permit_condition_category import PermitConditionCategory
-from app.api.mines.reports.models.mine_report_permit_requirement import MineReportPermitRequirement
-from app.api.mines.permits.permit.models.permit import Permit
-import uuid
+from app.api.mines.reports.models.mine_report_permit_requirement import (
+    MineReportPermitRequirement,
+)
+from app.extensions import db
+from sqlalchemy import and_, asc, case, desc, func, or_
+from sqlalchemy_filters import apply_filters, apply_pagination, apply_sort
+
 
 def is_guid(value) -> bool:
     try:
@@ -24,6 +34,155 @@ class ReportFilterHelper:
     @classmethod
     def build_filter(cls, model, field, op, argfield):
         return {'model': model, 'field': field, 'op': op, 'value': argfield}
+
+    @staticmethod
+    def _filter_latest_permit_amendment_prr(query):
+        latest_amendments = (
+            db.session.query(
+                PermitAmendment.permit_id.label('permit_id'),
+                func.max(PermitAmendment.issue_date).label('latest_issue_date'),
+            )
+            .filter(
+                PermitAmendment.deleted_ind == False,
+                PermitAmendment.permit_amendment_status_code != 'DFT',
+            )
+            .group_by(PermitAmendment.permit_id)
+            .subquery()
+        )
+
+        latest_amendment_ids = (
+            db.session.query(
+                PermitAmendment.permit_amendment_id.label('latest_permit_amendment_id'),
+                PermitAmendment.permit_id.label('permit_id'),
+            )
+            .join(
+                latest_amendments,
+                and_(
+                    PermitAmendment.permit_id == latest_amendments.c.permit_id,
+                    PermitAmendment.issue_date == latest_amendments.c.latest_issue_date,
+                )
+            )
+            .filter(
+                PermitAmendment.deleted_ind == False,
+                PermitAmendment.permit_amendment_status_code != 'DFT',
+            )
+            .subquery()
+        )
+
+        filtered_query = (
+            query
+                .outerjoin(MineReport.mine_report_permit_requirement)
+                .outerjoin(MineReport.permit_condition_category)
+                .outerjoin(latest_amendment_ids, MineReport.permit_id == latest_amendment_ids.c.permit_id)
+        )
+
+        return filtered_query.filter(
+            or_(
+                MineReport.mine_report_definition_id.isnot(None),
+                MineReportPermitRequirement.permit_amendment_id == latest_amendment_ids.c.latest_permit_amendment_id,
+                PermitConditionCategory.permit_amendment_id == latest_amendment_ids.c.latest_permit_amendment_id,
+            )
+        )
+
+    @staticmethod
+    def _get_alg_permit_amendment_ids(permit_guid=None):
+        """
+        Get permit_amendment_ids from ALG permits (latest amendment by issue_date).
+        Only returns amendments from permits where the latest amendment is type ALG.
+        """
+        # Subquery: latest issue_date per permit
+        latest_issue_date_subq = (
+            db.session.query(
+                PermitAmendment.permit_id,
+                func.max(PermitAmendment.issue_date).label('max_issue_date'),
+            )
+            .filter(
+                PermitAmendment.deleted_ind == False,
+                PermitAmendment.permit_amendment_status_code != 'DFT',
+            )
+            .group_by(PermitAmendment.permit_id)
+            .subquery()
+        )
+
+        # Get permits where latest amendment is ALG
+        alg_permit_ids_subq = (
+            db.session.query(PermitAmendment.permit_id)
+            .join(latest_issue_date_subq, and_(
+                PermitAmendment.permit_id == latest_issue_date_subq.c.permit_id,
+                PermitAmendment.issue_date == latest_issue_date_subq.c.max_issue_date,
+            ))
+            .filter(
+                PermitAmendment.deleted_ind == False,
+                PermitAmendment.permit_amendment_type_code == 'ALG',
+            )
+            .subquery()
+        )
+
+        # Get the latest amendment ID per (permit_id, mine_guid) for ALG permits
+        latest_per_mine_subq = (
+            db.session.query(
+                PermitAmendment.permit_id,
+                PermitAmendment.mine_guid,
+                func.max(PermitAmendment.issue_date).label('max_issue_date'),
+            )
+            .filter(
+                PermitAmendment.permit_id.in_(alg_permit_ids_subq),
+                PermitAmendment.deleted_ind == False,
+                PermitAmendment.permit_amendment_status_code != 'DFT',
+            )
+            .group_by(PermitAmendment.permit_id, PermitAmendment.mine_guid)
+            .subquery()
+        )
+
+        query = (
+            db.session.query(PermitAmendment.permit_amendment_id)
+            .join(latest_per_mine_subq, and_(
+                PermitAmendment.permit_id == latest_per_mine_subq.c.permit_id,
+                PermitAmendment.mine_guid == latest_per_mine_subq.c.mine_guid,
+                PermitAmendment.issue_date == latest_per_mine_subq.c.max_issue_date,
+            ))
+            .filter(PermitAmendment.deleted_ind == False)
+        )
+
+        if permit_guid:
+            permit = Permit.find_by_permit_guid(permit_guid)
+            if not permit:
+                return None
+            query = query.filter(PermitAmendment.permit_id == permit.permit_id)
+
+        return query.subquery()
+
+    @staticmethod
+    def get_filtered_requirements(current_date, permit_guid=None):
+        """
+        Get active PRR requirements from ALG permits only.
+        Returns the latest amendment's requirements per (permit_id, mine_guid).
+        """
+        alg_amendment_ids = ReportFilterHelper._get_alg_permit_amendment_ids(permit_guid)
+        if alg_amendment_ids is None:
+            return [], {'status': 'error', 'reason': 'permit not found'}
+
+        valid_pa = MineReportPermitRequirement.permit_amendment_is_validated()
+
+        requirements = (
+            MineReportPermitRequirement.query
+            .filter_by(deleted_ind=False, active_ind=True)
+            .filter(valid_pa)
+            .filter(MineReportPermitRequirement.initial_due_date.isnot(None))
+            .filter(MineReportPermitRequirement.permit_amendment_id.in_(alg_amendment_ids))
+            .filter(
+                or_(
+                    MineReportPermitRequirement.due_date_period_months > 0,  # recurring
+                    and_(  # single reports with future due date
+                        MineReportPermitRequirement.due_date_period_months == 0,
+                        MineReportPermitRequirement.initial_due_date >= current_date,
+                    )
+                )
+            )
+            .all()
+        )
+
+        return requirements, None
 
     @staticmethod
     def apply_filters_and_pagination(query, args, mine_guid=None):
@@ -144,6 +303,8 @@ class ReportFilterHelper:
 
         if args.get('permit_guid'):
             query = query.filter(MineReport.permit_guid == args["permit_guid"])
+
+        query = ReportFilterHelper._filter_latest_permit_amendment_prr(query)
 
         if args.get('is_upcoming_view'):
             from datetime import date

--- a/services/core-api/app/api/mines/reports/resources/mine_report_stats.py
+++ b/services/core-api/app/api/mines/reports/resources/mine_report_stats.py
@@ -1,6 +1,7 @@
 from datetime import date, datetime, timedelta
 
 from app.api.mines.mine.models.mine import Mine
+from app.api.mines.reports.report_helpers import ReportFilterHelper
 from app.api.mines.reports.models.mine_report import MineReport
 from app.api.mines.response_models import MINE_REPORT_STATS_MODEL
 from app.api.utils.access_decorators import (
@@ -37,11 +38,16 @@ class MineReportStatsResource(Resource, UserMixin):
         in_90_days = today + timedelta(days=90)
 
         # Overdue = due_date < today, due_date >= 2025-04-01, and status is NON (no latest submission)
-        overdue_reports = (
-            MineReport.query
-            .filter(
+        base_query = ReportFilterHelper._filter_latest_permit_amendment_prr(
+            MineReport.query.filter(
                 MineReport.mine_guid == mine_guid,
                 MineReport.deleted_ind == False,
+            )
+        )
+
+        overdue_reports = (
+            base_query
+            .filter(
                 MineReport.due_date != None,
                 MineReport.due_date >= april_1_2025,
                 MineReport.due_date < today,
@@ -52,10 +58,8 @@ class MineReportStatsResource(Resource, UserMixin):
 
         # Due in next 90 days = due_date between today and +90, and not yet submitted
         due_next_90_days = (
-            MineReport.query
+            base_query
             .filter(
-                MineReport.mine_guid == mine_guid,
-                MineReport.deleted_ind == False,
                 MineReport.due_date != None,
                 MineReport.due_date >= today,
                 MineReport.due_date <= in_90_days,

--- a/services/core-api/app/api/mines/reports/tasks.py
+++ b/services/core-api/app/api/mines/reports/tasks.py
@@ -1,14 +1,52 @@
-from app.api.mines.reports.models.mine_report_permit_requirement import MineReportPermitRequirement
+from collections import defaultdict
+from datetime import datetime
+
+from app.api.mines.mine.models.mine import Mine
 from app.api.mines.reports.models.mine_report import MineReport
 from app.api.mines.reports.models.mine_report_definition import MineReportDefinition
-from app.api.mines.mine.models.mine import Mine
+from app.api.mines.reports.report_helpers import ReportFilterHelper
+from app.api.utils.feature_flag import Feature, is_feature_enabled
 from app.extensions import db
 from app.tasks.celery import celery
-from celery import chain
-from datetime import datetime
 from dateutil.relativedelta import relativedelta
-from app.api.utils.feature_flag import Feature, is_feature_enabled
-from collections import defaultdict
+
+
+def _delete_relevant_permit_report_requests(requirements):
+    requirement_ids = [
+        requirement.mine_report_permit_requirement_id
+        for requirement in requirements
+    ]
+
+    if not requirement_ids:
+        return 0
+
+    existing_report_requests = MineReport.query.filter(
+        MineReport.mine_report_permit_requirement_id.in_(requirement_ids),
+        MineReport.deleted_ind == False,
+        MineReport.mine_report_status_code == 'NON',
+    ).all()
+
+    for report_request in existing_report_requests:
+        report_request.delete(commit=False)
+
+    db.session.commit()
+    return len(existing_report_requests)
+
+
+def _latest_permit_amendment_authorization_has_passed(requirement, current_date):
+    from app.api.mines.permits.permit_amendment.models.permit_amendment import (
+        PermitAmendment,
+    )
+
+    permit_amendment = PermitAmendment.find_by_permit_amendment_id(requirement.permit_amendment_id)
+    if not permit_amendment:
+        return False
+
+    latest_permit_amendment = PermitAmendment.find_last_amendment_by_permit_id(permit_amendment.permit_id)
+    if not latest_permit_amendment or not latest_permit_amendment.authorization_end_date:
+        return False
+
+    return latest_permit_amendment.authorization_end_date < current_date
 
 def _calculate_missing_due_dates(requirement, existing_due_dates, current_date, one_year_from_now):
     """Calculate which due dates need new reports created."""
@@ -75,6 +113,10 @@ def _create_report_for_due_date(requirement, due_date):
 def _process_single_requirement(requirement, current_date, one_year_from_now):
     """Process a single requirement and create missing reports."""
     print(f"Processing requirement: {requirement.report_name} (ID: {requirement.mine_report_permit_requirement_id})")
+
+    if _latest_permit_amendment_authorization_has_passed(requirement, current_date):
+        print("  Skipping - latest permit amendment authorization end date has passed")
+        return 0, 0
     
     if not requirement.initial_due_date:
         print("  Skipping - no initial due date")
@@ -172,7 +214,7 @@ def _process_crr_reports(mine, mine_report_definition, reports, current_date, on
     return created_count, failed_count
 
 @celery.task()
-def create_new_recurring_report_requests():
+def create_new_recurring_report_requests(permit_guid=None, regenerate=False):
     """
     Create new recurring report requests based on permit requirements.
     This task finds all recurring requirements and creates missing reports
@@ -184,20 +226,27 @@ def create_new_recurring_report_requests():
     
     print("Starting creation of recurring report requests...")
     current_date = datetime.now().date()
-    
-    recurring_requirements = MineReportPermitRequirement.get_all_recurring()
-    print(f"Found {len(recurring_requirements)} recurring report requirements")
-    single_requirements = MineReportPermitRequirement.get_all_single_reports(current_date)
-    print(f"Found {len(single_requirements)} single report requirements")
 
-    all_requirements = recurring_requirements + single_requirements
+    requirements, error = ReportFilterHelper.get_filtered_requirements(current_date, permit_guid=permit_guid)
+    if error:
+        return error
+
+    if permit_guid:
+        print(f"Filtering report request generation to permit guid: {permit_guid}")
+
+    print(f"Found {len(requirements)} report requirements")
     
     one_year_from_now = current_date + relativedelta(years=1)
+    total_deleted = 0
+
+    if regenerate:
+        total_deleted = _delete_relevant_permit_report_requests(requirements)
+        print(f"Deleted {total_deleted} existing permit report requests before regeneration")
     
     total_created = 0
     failed_requirements = []
     
-    for requirement in all_requirements:
+    for requirement in requirements:
         created_count, failed_count = _process_single_requirement(
             requirement, current_date, one_year_from_now
         )
@@ -219,6 +268,7 @@ def create_new_recurring_report_requests():
             print(f"  - Requirement ID {failed['requirement_id']} ({failed['report_name']}): {failed['failed_count']} failed reports")
     
     return {
+        'total_deleted': total_deleted,
         'total_created': total_created,
         'failed_requirements': failed_requirements
     }

--- a/services/core-api/app/commands.py
+++ b/services/core-api/app/commands.py
@@ -159,6 +159,22 @@ def register_commands(app):
             create_new_recurring_crr_report_requests()
             print("celery job started: create_new_recurring_crr_report_requests")
 
+    @app.cli.command('regenerate_report_requests_for_permit')
+    @click.argument('permit_guid')
+    def regenerate_report_requests_for_permit(permit_guid):
+        from app import auth
+        from app.api.mines.reports.tasks import create_new_recurring_report_requests
+
+        auth.apply_security = False
+
+        with current_app.app_context():
+            result = create_new_recurring_report_requests(permit_guid=permit_guid, regenerate=True)
+
+            if result.get('status') == 'error':
+                raise click.ClickException(result['reason'])
+
+            print(result)
+
     @app.cli.command('revoke_mines_act_permit_vc_and_offer_newest')
     @click.argument('credential_exchange_id')
     @click.argument('permit_guid')

--- a/services/core-api/tests/api/test_permit_search_service.py
+++ b/services/core-api/tests/api/test_permit_search_service.py
@@ -19,6 +19,16 @@ def mock_oauth_session():
         session_instance.fetch_token.return_value = {'access_token': 'test_token'}
         yield session_instance
 
+
+@pytest.fixture(autouse=True)
+def mock_oidc_configuration():
+    with patch('app.api.search.search.permit_search_service.requests.get') as mock_get:
+        response = MagicMock()
+        response.raise_for_status.return_value = None
+        response.json.return_value = {'token_endpoint': 'https://example.com/token'}
+        mock_get.return_value = response
+        yield mock_get
+
 def test_permit_search_success(mock_oauth_session):
     search_term = {'query': 'test', 'filters': {'type': 'permit'}}
     expected_response = {'total': 1, 'results': [{'id': '1'}]}

--- a/services/core-api/tests/cli/test_cli.py
+++ b/services/core-api/tests/cli/test_cli.py
@@ -1,4 +1,14 @@
 import pytest
+from unittest import mock
+from flask import Flask
+
+from app.commands import register_commands
+
+
+def _cli_runner():
+    app = Flask(__name__)
+    register_commands(app)
+    return app.test_cli_runner()
 
 
 @pytest.mark.skip(reason='not successing on first test suite run')
@@ -6,3 +16,24 @@ def test_create_mines_cli(test_client, cli_runner):
     result = cli_runner.invoke(args=['create-data', '10', 'False'])
     assert result.exit_code == 0
     assert "Created" in result.output
+
+
+@mock.patch('app.api.mines.reports.tasks.create_new_recurring_report_requests')
+def test_regenerate_report_requests_for_permit_cli(mock_create_report_requests):
+    mock_create_report_requests.return_value = {'total_deleted': 1, 'total_created': 2, 'failed_requirements': []}
+
+    result = _cli_runner().invoke(args=['regenerate_report_requests_for_permit', 'permit-guid'])
+
+    assert result.exit_code == 0
+    assert "'total_created': 2" in result.output
+    mock_create_report_requests.assert_called_once_with(permit_guid='permit-guid', regenerate=True)
+
+
+@mock.patch('app.api.mines.reports.tasks.create_new_recurring_report_requests')
+def test_regenerate_report_requests_for_permit_cli_handles_unknown_permit(mock_create_report_requests):
+    mock_create_report_requests.return_value = {'status': 'error', 'reason': 'permit not found'}
+
+    result = _cli_runner().invoke(args=['regenerate_report_requests_for_permit', 'missing-permit-guid'])
+
+    assert result.exit_code != 0
+    assert 'permit not found' in result.output

--- a/services/core-api/tests/permits/permit_extraction/resources/test_permit_condition_extraction_resource.py
+++ b/services/core-api/tests/permits/permit_extraction/resources/test_permit_condition_extraction_resource.py
@@ -77,7 +77,9 @@ def test_post_permit_condition_fails_with_invalid_permit_amendment(test_client, 
 
 @responses.activate
 @mock.patch('app.api.mines.permits.permit_extraction.resources.permit_condition_extraction_resource.poll_update_permit_extraction_status.delay')
-def test_post_permit_condition_extraction(delay, test_client, auth_headers, pc_test_data, db_session):
+@mock.patch('app.api.search.search.permit_search_service._get_oidc_configuration')
+def test_post_permit_condition_extraction(mock_oidc_config, delay, test_client, auth_headers, pc_test_data, db_session):
+    mock_oidc_config.return_value = {'token_endpoint': 'https://test.loginproxy.gov.bc.ca/auth/realms/standard/protocol/openid-connect/token'}
     delay.return_value = mock.Mock(id='123')
 
     amendment, amendment_document = pc_test_data

--- a/services/core-api/tests/permits/permit_extraction/resources/test_permit_condition_extraction_resource.py
+++ b/services/core-api/tests/permits/permit_extraction/resources/test_permit_condition_extraction_resource.py
@@ -77,9 +77,7 @@ def test_post_permit_condition_fails_with_invalid_permit_amendment(test_client, 
 
 @responses.activate
 @mock.patch('app.api.mines.permits.permit_extraction.resources.permit_condition_extraction_resource.poll_update_permit_extraction_status.delay')
-@mock.patch('app.api.search.search.permit_search_service._get_oidc_configuration')
 def test_post_permit_condition_extraction(mock_oidc_config, delay, test_client, auth_headers, pc_test_data, db_session):
-    mock_oidc_config.return_value = {'token_endpoint': 'https://test.loginproxy.gov.bc.ca/auth/realms/standard/protocol/openid-connect/token'}
     delay.return_value = mock.Mock(id='123')
 
     amendment, amendment_document = pc_test_data

--- a/services/core-api/tests/permits/permit_extraction/resources/test_permit_condition_extraction_resource.py
+++ b/services/core-api/tests/permits/permit_extraction/resources/test_permit_condition_extraction_resource.py
@@ -77,7 +77,7 @@ def test_post_permit_condition_fails_with_invalid_permit_amendment(test_client, 
 
 @responses.activate
 @mock.patch('app.api.mines.permits.permit_extraction.resources.permit_condition_extraction_resource.poll_update_permit_extraction_status.delay')
-def test_post_permit_condition_extraction(mock_oidc_config, delay, test_client, auth_headers, pc_test_data, db_session):
+def test_post_permit_condition_extraction(delay, test_client, auth_headers, pc_test_data, db_session):
     delay.return_value = mock.Mock(id='123')
 
     amendment, amendment_document = pc_test_data

--- a/services/core-api/tests/reports/resource/test_mine_report_stats_resource.py
+++ b/services/core-api/tests/reports/resource/test_mine_report_stats_resource.py
@@ -7,8 +7,10 @@ from tests.factories import (
     MineFactory,
     MinePermitXrefFactory,
     MineReportFactory,
+    MineReportPermitRequirementFactory,
     MineReportSubmissionFactory,
     PermitFactory,
+    create_mine_and_permit,
 )
 
 
@@ -131,3 +133,59 @@ def test_overdue_threshold_april_1_boundary(test_client, db_session, auth_header
 
     assert resp.status_code == 200
     assert data['overdue_reports'] == 1
+
+
+def test_report_stats_only_include_latest_permit_required_reports(test_client, db_session, auth_headers):
+    today = datetime.now(pytz_timezone('US/Pacific')).date()
+    mine, permit = create_mine_and_permit(mine_kwargs={"mine_reports": 0}, num_permit_amendments=2)
+    # Set distinct issue_dates so the filter can determine the latest amendment
+    for i, amendment in enumerate(permit.permit_amendments):
+        amendment.issue_date = today - timedelta(days=10 - i)
+    db_session.flush()
+    latest_amendment = max(permit.permit_amendments, key=lambda amendment: amendment.issue_date)
+    previous_amendment = min(permit.permit_amendments, key=lambda amendment: amendment.issue_date)
+
+    latest_requirement = MineReportPermitRequirementFactory(
+        permit_amendment=latest_amendment,
+        report_name="Latest Stats PRR",
+        due_date_period_months=0,
+        initial_due_date=today + timedelta(days=10),
+        active_ind=True,
+        deleted_ind=False,
+    )
+    previous_requirement = MineReportPermitRequirementFactory(
+        permit_amendment=previous_amendment,
+        report_name="Old Stats PRR",
+        due_date_period_months=0,
+        initial_due_date=today + timedelta(days=10),
+        active_ind=True,
+        deleted_ind=False,
+    )
+
+    MineReportFactory(
+        mine=mine,
+        permit=permit,
+        mine_report_definition_id=None,
+        mine_report_permit_requirement=latest_requirement,
+        due_date=today + timedelta(days=10),
+        received_date=None,
+        mine_report_submissions=0,
+    )
+    MineReportFactory(
+        mine=mine,
+        permit=permit,
+        mine_report_definition_id=None,
+        mine_report_permit_requirement=previous_requirement,
+        due_date=today - timedelta(days=1),
+        received_date=None,
+        mine_report_submissions=0,
+    )
+
+    resp = test_client.get(
+        f"/mines/{mine.mine_guid}/reports/stats", headers=auth_headers['full_auth_header']
+    )
+    data = json.loads(resp.data.decode())
+
+    assert resp.status_code == 200
+    assert data['overdue_reports'] == 0
+    assert data['due_next_90_days'] == 1

--- a/services/core-api/tests/reports/resource/test_mine_reports_resource.py
+++ b/services/core-api/tests/reports/resource/test_mine_reports_resource.py
@@ -7,7 +7,13 @@ from app.api.mines.mine.models.mine import Mine
 from app.api.mines.reports.models.mine_report_definition import MineReportDefinition
 from flask import current_app
 from pytz import timezone as pytz_timezone
-from tests.factories import MineFactory, MineReportFactory, MineReportSubmissionFactory
+from tests.factories import (
+    MineFactory,
+    MineReportFactory,
+    MineReportPermitRequirementFactory,
+    MineReportSubmissionFactory,
+    create_mine_and_permit,
+)
 
 THREE_REPORTS = 3
 ONE_REPORT = 1
@@ -73,14 +79,57 @@ def test_get_code_required_reports_for_mine(test_client, db_session, auth_header
 
 
 def test_get_permit_required_reports_for_mine(test_client, db_session, auth_headers):
-    mine = MineFactory(mine_reports=THREE_REPORTS)
-    mine_reports = MineReportFactory(mine=mine, permit_required_reports=True)
+    mine, permit = create_mine_and_permit(mine_kwargs={"mine_reports": 0}, num_permit_amendments=2)
+    # Set distinct issue_dates so the filter can determine the latest amendment
+    today = date.today()
+    for i, amendment in enumerate(permit.permit_amendments):
+        amendment.issue_date = today - timedelta(days=10 - i)
+    db_session.flush()
+    latest_amendment = max(permit.permit_amendments, key=lambda amendment: amendment.issue_date)
+    previous_amendment = min(permit.permit_amendments, key=lambda amendment: amendment.issue_date)
+
+    latest_requirement = MineReportPermitRequirementFactory(
+        permit_amendment=latest_amendment,
+        report_name="Latest PRR",
+        due_date_period_months=0,
+        initial_due_date=date.today() + timedelta(days=10),
+        active_ind=True,
+        deleted_ind=False,
+    )
+    previous_requirement = MineReportPermitRequirementFactory(
+        permit_amendment=previous_amendment,
+        report_name="Old PRR",
+        due_date_period_months=0,
+        initial_due_date=date.today() + timedelta(days=10),
+        active_ind=True,
+        deleted_ind=False,
+    )
+
+    MineReportFactory(
+        mine=mine,
+        permit=permit,
+        mine_report_definition_id=None,
+        mine_report_permit_requirement=latest_requirement,
+        due_date=date.today() + timedelta(days=10),
+        mine_report_submissions=0,
+    )
+    MineReportFactory(
+        mine=mine,
+        permit=permit,
+        mine_report_definition_id=None,
+        mine_report_permit_requirement=previous_requirement,
+        due_date=date.today() + timedelta(days=10),
+        mine_report_submissions=0,
+    )
+
     get_resp = test_client.get(
         f'/mines/{mine.mine_guid}/reports?mine_reports_type={MINE_REPORT_TYPE["PERMIT REQUIRED REPORTS"]}',
         headers=auth_headers['full_auth_header'])
     get_data = json.loads(get_resp.data.decode())
+
     assert len(get_data['records']) == 1
     assert get_resp.status_code == 200
+    assert get_data['records'][0]['mine_report_permit_requirement_id'] == latest_requirement.mine_report_permit_requirement_id
 
 
 def test_get_a_report_for_a_mine(test_client, db_session, auth_headers):
@@ -346,7 +395,7 @@ def test_delete_mine_report(test_client, db_session, auth_headers):
 
 def test_get_prr_and_crr_reports_for_mine(test_client, db_session, auth_headers):
     # Create a mine with no reports, then add one CRR (non-TSF) and one PRR
-    mine = MineFactory(mine_reports=0)
+    mine, permit = create_mine_and_permit(mine_kwargs={"mine_reports": 0}, num_permit_amendments=1)
 
     # Pick a non-TSF code-required report definition to avoid TAR filtering
     defs = MineReportDefinition.get_all()
@@ -356,7 +405,22 @@ def test_get_prr_and_crr_reports_for_mine(test_client, db_session, auth_headers)
 
     # Create CRR (has definition) and PRR (no definition) reports
     MineReportFactory(mine=mine, mine_report_definition_id=non_tsf_def.mine_report_definition_id)
-    MineReportFactory(mine=mine, permit_required_reports=True)
+    requirement = MineReportPermitRequirementFactory(
+        permit_amendment=permit.permit_amendments[0],
+        report_name="Current PRR",
+        due_date_period_months=0,
+        initial_due_date=date.today() + timedelta(days=10),
+        active_ind=True,
+        deleted_ind=False,
+    )
+    MineReportFactory(
+        mine=mine,
+        permit=permit,
+        mine_report_definition_id=None,
+        mine_report_permit_requirement=requirement,
+        due_date=date.today() + timedelta(days=10),
+        mine_report_submissions=0,
+    )
 
     # Request only CRR
     get_resp = test_client.get(
@@ -428,6 +492,65 @@ def test_get_upcoming_reports_for_mine(test_client, db_session, auth_headers):
     assert str(in_window_2.mine_report_guid) in returned
     assert str(past_due.mine_report_guid) in returned
     assert str(far_future.mine_report_guid) not in returned
+
+
+def test_get_upcoming_reports_for_mine_only_shows_latest_permit_required_reports(test_client, db_session, auth_headers):
+    today = date.today()
+    mine, permit = create_mine_and_permit(mine_kwargs={"mine_reports": 0}, num_permit_amendments=2)
+    # Set distinct issue_dates so the filter can determine the latest amendment
+    for i, amendment in enumerate(permit.permit_amendments):
+        amendment.issue_date = today - timedelta(days=10 - i)
+    db_session.flush()
+    latest_amendment = max(permit.permit_amendments, key=lambda amendment: amendment.issue_date)
+    previous_amendment = min(permit.permit_amendments, key=lambda amendment: amendment.issue_date)
+
+    latest_requirement = MineReportPermitRequirementFactory(
+        permit_amendment=latest_amendment,
+        report_name="Latest Upcoming PRR",
+        due_date_period_months=0,
+        initial_due_date=today + timedelta(days=10),
+        active_ind=True,
+        deleted_ind=False,
+    )
+    previous_requirement = MineReportPermitRequirementFactory(
+        permit_amendment=previous_amendment,
+        report_name="Old Upcoming PRR",
+        due_date_period_months=0,
+        initial_due_date=today + timedelta(days=10),
+        active_ind=True,
+        deleted_ind=False,
+    )
+
+    latest_report = MineReportFactory(
+        mine=mine,
+        permit=permit,
+        mine_report_definition_id=None,
+        mine_report_permit_requirement=latest_requirement,
+        due_date=today + timedelta(days=10),
+        received_date=None,
+        mine_report_submissions=0,
+    )
+    old_report = MineReportFactory(
+        mine=mine,
+        permit=permit,
+        mine_report_definition_id=None,
+        mine_report_permit_requirement=previous_requirement,
+        due_date=today + timedelta(days=10),
+        received_date=None,
+        mine_report_submissions=0,
+    )
+
+    resp = test_client.get(
+        f"/mines/{mine.mine_guid}/reports?upcoming=true&time_range=90d&mine_reports_type=PRR",
+        headers=auth_headers["full_auth_header"],
+    )
+
+    assert resp.status_code == 200
+    data = json.loads(resp.data.decode())
+    returned = {r["mine_report_guid"] for r in data["records"]}
+
+    assert str(latest_report.mine_report_guid) in returned
+    assert str(old_report.mine_report_guid) not in returned
 
 
 def test_get_pending_reports_for_mine_status_filter(test_client, db_session, auth_headers):

--- a/services/core-api/tests/reports/resource/test_reports_resource.py
+++ b/services/core-api/tests/reports/resource/test_reports_resource.py
@@ -2,7 +2,12 @@ import json
 import uuid
 from datetime import datetime, timedelta
 
-from tests.factories import MineFactory
+from tests.factories import (
+    MineFactory,
+    MineReportFactory,
+    MineReportPermitRequirementFactory,
+    create_mine_and_permit,
+)
 
 THREE_REPORTS = 3
 ONE_REPORT = 1
@@ -69,3 +74,57 @@ def test_get_reports(test_client, db_session, auth_headers):
 
         assert (start_date <= received_date)
         assert (received_date <= end_date)
+
+
+def test_get_reports_only_shows_latest_permit_required_reports(test_client, db_session, auth_headers):
+    mine, permit = create_mine_and_permit(mine_kwargs={"mine_reports": 0}, num_permit_amendments=2)
+    # Set distinct issue_dates so the filter can determine the latest amendment
+    today = datetime.today().date()
+    for i, amendment in enumerate(permit.permit_amendments):
+        amendment.issue_date = today - timedelta(days=10 - i)
+    db_session.flush()
+    latest_amendment = max(permit.permit_amendments, key=lambda amendment: amendment.issue_date)
+    previous_amendment = min(permit.permit_amendments, key=lambda amendment: amendment.issue_date)
+
+    latest_requirement = MineReportPermitRequirementFactory(
+        permit_amendment=latest_amendment,
+        report_name="Latest Global PRR",
+        due_date_period_months=0,
+        initial_due_date=datetime.today().date() + timedelta(days=10),
+        active_ind=True,
+        deleted_ind=False,
+    )
+    previous_requirement = MineReportPermitRequirementFactory(
+        permit_amendment=previous_amendment,
+        report_name="Old Global PRR",
+        due_date_period_months=0,
+        initial_due_date=datetime.today().date() + timedelta(days=10),
+        active_ind=True,
+        deleted_ind=False,
+    )
+
+    latest_report = MineReportFactory(
+        mine=mine,
+        permit=permit,
+        mine_report_definition_id=None,
+        mine_report_permit_requirement=latest_requirement,
+        due_date=datetime.today().date() + timedelta(days=10),
+        mine_report_submissions=0,
+    )
+    old_report = MineReportFactory(
+        mine=mine,
+        permit=permit,
+        mine_report_definition_id=None,
+        mine_report_permit_requirement=previous_requirement,
+        due_date=datetime.today().date() + timedelta(days=10),
+        mine_report_submissions=0,
+    )
+
+    get_resp = test_client.get(
+        f'/mines/reports?search={mine.mine_name}', headers=auth_headers['full_auth_header'])
+    get_data = json.loads(get_resp.data.decode())
+    returned = {report['mine_report_guid'] for report in get_data['records']}
+
+    assert get_resp.status_code == 200
+    assert str(latest_report.mine_report_guid) in returned
+    assert str(old_report.mine_report_guid) not in returned

--- a/services/core-api/tests/reports/test_report_tasks.py
+++ b/services/core-api/tests/reports/test_report_tasks.py
@@ -11,6 +11,7 @@ from app.api.mines.reports.models.mine_report_definition import MineReportDefini
 from tests.factories import (
     MineReportPermitRequirementFactory,
     MineReportFactory,
+    PermitAmendmentFactory,
     create_mine_and_permit,
     MineFactory,
     ComplianceArticleFactory,
@@ -30,6 +31,8 @@ def setup_recurring_requirements(db_session):
     """Set up test data with a mine, permit, and recurring report requirements."""
     mine, permit = create_mine_and_permit(num_permit_amendments=1)
     permit_amendment = permit.permit_amendments[0]
+    permit_amendment.permit_amendment_type_code = 'ALG'
+    permit_amendment.save()
     today = date.today()
     
     quarterly_requirement = MineReportPermitRequirementFactory(
@@ -314,9 +317,9 @@ class TestCreateNewRecurringReportRequests:
             report_due_date = report.due_date.date()
             assert report_due_date <= max_date, f"Report due date {report_due_date} should not be after {max_date}"
     
-    @mock.patch('app.api.mines.reports.tasks.MineReportPermitRequirement.get_all_recurring')
-    def test_task_with_no_recurring_requirements(self, mock_get_all_recurring, db_session):
-        mock_get_all_recurring.return_value = []
+    @mock.patch('app.api.mines.reports.tasks.ReportFilterHelper.get_filtered_requirements')
+    def test_task_with_no_recurring_requirements(self, mock_get_filtered_requirements, db_session):
+        mock_get_filtered_requirements.return_value = ([], None)
         
         result = create_new_recurring_report_requests()
         
@@ -362,6 +365,338 @@ class TestCreateNewRecurringReportRequests:
             expected_year = report.due_date.year - 1 if report.due_date.month <= 3 else report.due_date.year
             assert report.submission_year == expected_year
             assert report.mine_report_status_code == 'NON' # Report Requested
+
+    @mock.patch('app.api.mines.reports.tasks.is_feature_enabled', return_value=True)
+    def test_task_can_filter_to_a_single_permit(self, _mock_feature_flag, db_session):
+        first_mine, first_permit = create_mine_and_permit(num_permit_amendments=1)
+        second_mine, second_permit = create_mine_and_permit(num_permit_amendments=1)
+        today = date.today()
+
+        first_permit.permit_amendments[0].permit_amendment_type_code = 'ALG'
+        first_permit.permit_amendments[0].save()
+        second_permit.permit_amendments[0].permit_amendment_type_code = 'ALG'
+        second_permit.permit_amendments[0].save()
+
+        first_requirement = MineReportPermitRequirementFactory(
+            permit_amendment=first_permit.permit_amendments[0],
+            report_name="First Permit Report",
+            due_date_period_months=3,
+            initial_due_date=today - relativedelta(months=6),
+            active_ind=True,
+            deleted_ind=False,
+        )
+        second_requirement = MineReportPermitRequirementFactory(
+            permit_amendment=second_permit.permit_amendments[0],
+            report_name="Second Permit Report",
+            due_date_period_months=3,
+            initial_due_date=today - relativedelta(months=6),
+            active_ind=True,
+            deleted_ind=False,
+        )
+
+        result = create_new_recurring_report_requests(permit_guid=first_permit.permit_guid)
+
+        first_reports = MineReport.query.filter_by(
+            mine_report_permit_requirement_id=first_requirement.mine_report_permit_requirement_id,
+            deleted_ind=False,
+        ).count()
+        second_reports = MineReport.query.filter_by(
+            mine_report_permit_requirement_id=second_requirement.mine_report_permit_requirement_id,
+            deleted_ind=False,
+        ).count()
+
+        assert result['total_created'] > 0
+        assert result['total_deleted'] == 0
+        assert first_reports > 0
+        assert second_reports == 0
+
+    @mock.patch('app.api.mines.reports.tasks.is_feature_enabled', return_value=True)
+    def test_task_fully_regenerates_existing_report_requests_for_a_single_permit(self, _mock_feature_flag, db_session):
+        first_mine, first_permit = create_mine_and_permit(num_permit_amendments=1)
+        second_mine, second_permit = create_mine_and_permit(num_permit_amendments=1)
+        today = date.today()
+
+        first_permit.permit_amendments[0].permit_amendment_type_code = 'ALG'
+        first_permit.permit_amendments[0].save()
+        second_permit.permit_amendments[0].permit_amendment_type_code = 'ALG'
+        second_permit.permit_amendments[0].save()
+
+        first_requirement = MineReportPermitRequirementFactory(
+            permit_amendment=first_permit.permit_amendments[0],
+            report_name="First Permit One-time Report",
+            due_date_period_months=0,
+            initial_due_date=today + relativedelta(months=3),
+            active_ind=True,
+            deleted_ind=False,
+        )
+        second_requirement = MineReportPermitRequirementFactory(
+            permit_amendment=second_permit.permit_amendments[0],
+            report_name="Second Permit One-time Report",
+            due_date_period_months=0,
+            initial_due_date=today + relativedelta(months=3),
+            active_ind=True,
+            deleted_ind=False,
+        )
+
+        MineReportFactory(
+            mine=first_mine,
+            permit=first_permit,
+            mine_report_permit_requirement=first_requirement,
+            due_date=first_requirement.initial_due_date,
+            deleted_ind=False,
+            mine_report_submissions=0,
+        )
+        MineReportFactory(
+            mine=second_mine,
+            permit=second_permit,
+            mine_report_permit_requirement=second_requirement,
+            due_date=second_requirement.initial_due_date,
+            deleted_ind=False,
+            mine_report_submissions=0,
+        )
+
+        result = create_new_recurring_report_requests(permit_guid=first_permit.permit_guid, regenerate=True)
+
+        first_active_reports = MineReport.query.filter_by(
+            mine_report_permit_requirement_id=first_requirement.mine_report_permit_requirement_id,
+            deleted_ind=False,
+        ).count()
+        first_deleted_reports = MineReport.query.filter_by(
+            mine_report_permit_requirement_id=first_requirement.mine_report_permit_requirement_id,
+            deleted_ind=True,
+        ).count()
+        second_active_reports = MineReport.query.filter_by(
+            mine_report_permit_requirement_id=second_requirement.mine_report_permit_requirement_id,
+            deleted_ind=False,
+        ).count()
+        second_deleted_reports = MineReport.query.filter_by(
+            mine_report_permit_requirement_id=second_requirement.mine_report_permit_requirement_id,
+            deleted_ind=True,
+        ).count()
+
+        assert result['total_deleted'] == 1
+        assert result['total_created'] == 1
+        assert first_active_reports == 1
+        assert first_deleted_reports == 1
+        assert second_active_reports == 1
+        assert second_deleted_reports == 0
+
+    @mock.patch('app.api.mines.reports.tasks.is_feature_enabled', return_value=True)
+    def test_task_filter_does_not_delete_existing_reports_without_regeneration(self, _mock_feature_flag, db_session):
+        mine, permit = create_mine_and_permit(num_permit_amendments=1)
+        today = date.today()
+
+        permit.permit_amendments[0].permit_amendment_type_code = 'ALG'
+        permit.permit_amendments[0].save()
+
+        requirement = MineReportPermitRequirementFactory(
+            permit_amendment=permit.permit_amendments[0],
+            report_name="One-time Report",
+            due_date_period_months=0,
+            initial_due_date=today + relativedelta(months=3),
+            active_ind=True,
+            deleted_ind=False,
+        )
+
+        MineReportFactory(
+            mine=mine,
+            permit=permit,
+            mine_report_permit_requirement=requirement,
+            due_date=requirement.initial_due_date,
+            deleted_ind=False,
+            mine_report_submissions=0,
+        )
+
+        result = create_new_recurring_report_requests(permit_guid=permit.permit_guid)
+
+        active_reports = MineReport.query.filter_by(
+            mine_report_permit_requirement_id=requirement.mine_report_permit_requirement_id,
+            deleted_ind=False,
+        ).count()
+        deleted_reports = MineReport.query.filter_by(
+            mine_report_permit_requirement_id=requirement.mine_report_permit_requirement_id,
+            deleted_ind=True,
+        ).count()
+
+        assert result['total_deleted'] == 0
+        assert result['total_created'] == 0
+        assert active_reports == 1
+        assert deleted_reports == 0
+
+    @mock.patch('app.api.mines.reports.tasks.is_feature_enabled', return_value=True)
+    def test_task_only_uses_latest_validated_requirements_per_mine_for_amalgamated_permits(self, _mock_feature_flag, db_session):
+        first_mine, permit = create_mine_and_permit(num_permit_amendments=0)
+        second_mine = MineFactory()
+        permit._all_mines.append(second_mine)
+        today = date.today()
+
+        first_mine_original_amendment = PermitAmendmentFactory(
+            permit=permit,
+            mine=first_mine,
+            issue_date=today - relativedelta(months=3),
+            permit_amendment_type_code='AMD',
+        )
+        first_mine_latest_amendment = PermitAmendmentFactory(
+            permit=permit,
+            mine=first_mine,
+            issue_date=today - relativedelta(months=2),
+            permit_amendment_type_code='AMD',
+        )
+        second_mine_amalgamated_amendment = PermitAmendmentFactory(
+            permit=permit,
+            mine=second_mine,
+            issue_date=today - relativedelta(months=1),
+            permit_amendment_type_code='ALG',
+        )
+
+        stale_requirement = MineReportPermitRequirementFactory(
+            permit_amendment=first_mine_original_amendment,
+            report_name="Stale Mine 1 Report",
+            due_date_period_months=0,
+            initial_due_date=today + relativedelta(months=3),
+            active_ind=True,
+            deleted_ind=False,
+        )
+        latest_first_mine_requirement = MineReportPermitRequirementFactory(
+            permit_amendment=first_mine_latest_amendment,
+            report_name="Latest Mine 1 Report",
+            due_date_period_months=0,
+            initial_due_date=today + relativedelta(months=3),
+            active_ind=True,
+            deleted_ind=False,
+        )
+        second_mine_requirement = MineReportPermitRequirementFactory(
+            permit_amendment=second_mine_amalgamated_amendment,
+            report_name="Latest Mine 2 Report",
+            due_date_period_months=0,
+            initial_due_date=today + relativedelta(months=3),
+            active_ind=True,
+            deleted_ind=False,
+        )
+
+        result = create_new_recurring_report_requests()
+
+        stale_reports = MineReport.query.filter_by(
+            mine_report_permit_requirement_id=stale_requirement.mine_report_permit_requirement_id,
+            deleted_ind=False,
+        ).count()
+        latest_first_mine_reports = MineReport.query.filter_by(
+            mine_report_permit_requirement_id=latest_first_mine_requirement.mine_report_permit_requirement_id,
+            deleted_ind=False,
+        ).count()
+        second_mine_reports = MineReport.query.filter_by(
+            mine_report_permit_requirement_id=second_mine_requirement.mine_report_permit_requirement_id,
+            deleted_ind=False,
+        ).count()
+
+        assert result['total_created'] == 2
+        assert stale_reports == 0
+        assert latest_first_mine_reports == 1
+        assert second_mine_reports == 1
+
+    @mock.patch('app.api.mines.reports.tasks.is_feature_enabled', return_value=True)
+    def test_task_skips_creation_when_latest_authorization_end_date_has_passed(self, _mock_feature_flag, db_session):
+        _mine, permit = create_mine_and_permit(num_permit_amendments=2)
+        today = date.today()
+        latest_permit_amendment = max(
+            permit._all_permit_amendments,
+            key=lambda permit_amendment: permit_amendment.permit_amendment_id,
+        )
+        older_permit_amendment = min(
+            permit._all_permit_amendments,
+            key=lambda permit_amendment: permit_amendment.permit_amendment_id,
+        )
+
+        older_permit_amendment.authorization_end_date = today + relativedelta(days=30)
+        older_permit_amendment.permit_amendment_type_code = 'AMD'
+        older_permit_amendment.save()
+        latest_permit_amendment.authorization_end_date = today - relativedelta(days=1)
+        latest_permit_amendment.permit_amendment_type_code = 'ALG'
+        latest_permit_amendment.save()
+
+        requirement = MineReportPermitRequirementFactory(
+            permit_amendment=older_permit_amendment,
+            report_name="Expired Authorization Report",
+            due_date_period_months=0,
+            initial_due_date=today + relativedelta(months=3),
+            active_ind=True,
+            deleted_ind=False,
+        )
+
+        result = create_new_recurring_report_requests(permit_guid=permit.permit_guid)
+
+        reports = MineReport.query.filter_by(
+            mine_report_permit_requirement_id=requirement.mine_report_permit_requirement_id,
+            deleted_ind=False,
+        ).count()
+
+        assert result['total_created'] == 0
+        assert result['total_deleted'] == 0
+        assert reports == 0
+
+    @mock.patch('app.api.mines.reports.tasks.is_feature_enabled', return_value=True)
+    def test_task_can_filter_to_a_permit_without_context_mine(self, _mock_feature_flag, db_session):
+        _mine, permit = create_mine_and_permit(num_permit_amendments=1)
+        permit._context_mine = None
+        today = date.today()
+
+        permit._all_permit_amendments[0].permit_amendment_type_code = 'ALG'
+        permit._all_permit_amendments[0].save()
+
+        requirement = MineReportPermitRequirementFactory(
+            permit_amendment=permit._all_permit_amendments[0],
+            report_name="Context-free Permit Report",
+            due_date_period_months=0,
+            initial_due_date=today + relativedelta(months=3),
+            active_ind=True,
+            deleted_ind=False,
+        )
+
+        result = create_new_recurring_report_requests(permit_guid=permit.permit_guid)
+
+        reports = MineReport.query.filter_by(
+            mine_report_permit_requirement_id=requirement.mine_report_permit_requirement_id,
+            deleted_ind=False,
+        ).count()
+
+        assert result['total_created'] == 1
+        assert result['total_deleted'] == 0
+        assert reports == 1
+
+    @mock.patch('app.api.mines.reports.tasks.is_feature_enabled', return_value=True)
+    def test_task_does_not_create_reports_when_latest_permit_amendment_is_not_amalgamated(self, _mock_feature_flag, db_session):
+        _mine, permit = create_mine_and_permit(num_permit_amendments=1)
+        today = date.today()
+
+        permit.permit_amendments[0].permit_amendment_type_code = 'AMD'
+        permit.permit_amendments[0].save()
+
+        requirement = MineReportPermitRequirementFactory(
+            permit_amendment=permit.permit_amendments[0],
+            report_name="Non Amalgamated Report",
+            due_date_period_months=0,
+            initial_due_date=today + relativedelta(months=3),
+            active_ind=True,
+            deleted_ind=False,
+        )
+
+        result = create_new_recurring_report_requests(permit_guid=permit.permit_guid)
+
+        reports = MineReport.query.filter_by(
+            mine_report_permit_requirement_id=requirement.mine_report_permit_requirement_id,
+            deleted_ind=False,
+        ).count()
+
+        assert result['total_created'] == 0
+        assert result['total_deleted'] == 0
+        assert reports == 0
+
+    @mock.patch('app.api.mines.reports.tasks.is_feature_enabled', return_value=True)
+    @mock.patch('app.api.mines.permits.permit.models.permit.Permit.find_by_permit_guid', return_value=None)
+    def test_task_returns_error_for_unknown_permit_filter(self, _mock_find_permit, _mock_feature_flag):
+        result = create_new_recurring_report_requests(permit_guid='missing-permit-guid')
+
+        assert result == {'status': 'error', 'reason': 'permit not found'}
 
 
 # CRR report test

--- a/services/core-web/src/components/mine/Reports/MineReportInfo.tsx
+++ b/services/core-web/src/components/mine/Reports/MineReportInfo.tsx
@@ -208,9 +208,9 @@ export const MineReportInfo: FC = () => {
       <div className="center">
         <ResponsivePagination
           onPageChange={onPageChange}
-          currentPage={Number(pageData.current_page)}
-          pageTotal={Number(pageData.total)}
-          itemsPerPage={Number(pageData.items_per_page)}
+          currentPage={Number(pageData?.current_page)}
+          pageTotal={Number(pageData?.total)}
+          itemsPerPage={Number(pageData?.items_per_page)}
         />
       </div>
     </div>


### PR DESCRIPTION
## Objective 

[MDS-6737](https://bcmines.atlassian.net/browse/MDS-6737)

This PR updates the reporting list view in core to
- Only create Report Requests for the latest validated permit required report requirements to the mine IF the latest permit type is AMALGAMATED
- Only show the report requirements for the permit amendment with the latest issue date
- Stop creating the report requirements if the permit authorization date for the latest permit amendment has passed

Also added a utility command to regenerate the report requests for a permit, which made testing it a whole lot easier