### PR TITLE
[MDS-6760] - NRIS orders intake fix

### DIFF
--- a/services/nris-api/backend/app/nris/etl/nris_etl.py
+++ b/services/nris-api/backend/app/nris/etl/nris_etl.py
@@ -362,6 +362,10 @@ def _save_stop_order(stop_order, inspected_location):
         noncompliance_permit = _save_order_noncompliance_permit(order_permit)
         stop_detail.noncompliance_permits.append(noncompliance_permit)
 
+    for order_condition in stop_order.findall('order_conditions'):
+        noncompliance_permit = _save_order_noncompliance_condition(order_condition)
+        stop_detail.noncompliance_permits.append(noncompliance_permit)
+
     for attachment in stop_order.findall('attachment'):
         _save_document(attachment, stop_detail=stop_detail)
 
@@ -395,6 +399,20 @@ def _save_order_noncompliance_permit(order_permit):
     noncompliance_permit.section_text = _parse_element_text(permit_section_text)
 
     return noncompliance_permit
+
+
+def _save_order_noncompliance_condition(order_condition):
+    noncompliance_permit = NonCompliancePermit()
+
+    pc_number = order_condition.find('pc_number')
+    pc_text = order_condition.find('pc_text')
+
+    noncompliance_permit.section_number = _parse_element_text(pc_number)
+    noncompliance_permit.section_title = ""
+    noncompliance_permit.section_text = _parse_element_text(pc_text)
+
+    return noncompliance_permit
+
 
 
 def _save_order_noncompliance_legislation(order_legislation):


### PR DESCRIPTION
## Objective 

Some orders were missing from our system, but do exist in NRIS.  Using a spreadsheet with a list of missing orders I was able to examine the differences in the xml data to determine why certain ones were being dropped.  

It was discovered that the relevant missing records had the pertinent data nested under a different field than our script was set up to parse.  We have always checked for orders related to inspections by parsing the <order_permits> tag, but these records had that data under an <order_conditions> tag.

The solution was to include the <order_conditions> tag in the parsing and include a helper to assist with that data intake.

Below is an AI generated summary of the findings:

1. Unparsed Permit Conditions (8 records): Currently, our api only extracts permit information if the XML uses the <order_permits> tag. However, 8 of the missing records actually use the <order_conditions> tag instead (containing <pc_number> and <pc_text>). Because this tag is ignored, these orders are saved without their permit condition details.
No Orders in XML (23 records): The remaining 23 missing records (e.g., Record 241275) actually do not contain any <stop_orders> elements natively in their XML. For example, Record 241275 is a Desktop Inspection observing historical disturbances and no enforcement actions or orders were issued. Thus, nris_etl.py correctly skips creating OrderStopDetail records.
 
2. nris_etl.py only extracts permit information if the XML uses the <order_permits> tag. However, 8 of the missing records actually use the <order_conditions> tag instead (containing <pc_number> and <pc_text>). Because this tag is ignored, these orders are saved without their permit condition details.

[MDS-6760](https://bcmines.atlassian.net/browse/MDS-6760)

_Why are you making this change? Provide a short explanation and/or screenshots_
