### PR TITLE
[CHORE] - Fixed Axios Upgrade

### DIFF
--- a/services/common/src/redux/customAxios.js
+++ b/services/common/src/redux/customAxios.js
@@ -50,7 +50,9 @@ CustomAxios = ({
   suppressErrorNotification = false,
   successToastMessage = undefined,
 } = {}) => {
-  const instance = axios.create();
+  const instance = axios.create({
+    adapter: ['xhr', 'http']
+  });
 
   instance.interceptors.response.use(
     (response) => {

--- a/services/common/src/redux/customAxios.js
+++ b/services/common/src/redux/customAxios.js
@@ -51,7 +51,7 @@ CustomAxios = ({
   successToastMessage = undefined,
 } = {}) => {
   const instance = axios.create({
-    adapter: ['xhr', 'http']
+    adapter: process.env.NODE_ENV === "test" ? undefined : ['xhr', 'http']
   });
 
   instance.interceptors.response.use(

--- a/services/core-web/package.json
+++ b/services/core-web/package.json
@@ -18,7 +18,7 @@
     "@reduxjs/toolkit": "2.0.1",
     "antd": "4.24.10",
     "array-move": "3.0.1",
-    "axios": "1.8.3",
+    "axios": "1.13.5",
     "axios-mock-adapter": "1.17.0",
     "core-js": "3.38.1",
     "date-fns": "2.28.0",

--- a/services/minespace-web/package.json
+++ b/services/minespace-web/package.json
@@ -13,7 +13,7 @@
     "@react-keycloak/web": "^3.4.0",
     "@reduxjs/toolkit": "2.0.1",
     "antd": "4.24.10",
-    "axios": "1.8.3",
+    "axios": "1.13.5",
     "axios-mock-adapter": "1.17.0",
     "core-js": "3.38.1",
     "dotenv": "16.4.5",

--- a/services/minespace-web/runner/server.js
+++ b/services/minespace-web/runner/server.js
@@ -1,6 +1,6 @@
 const express = require("express");
 const cacheControl = require("express-cache-controller");
-const dotenv = require("dotenv").config("./env");
+const dotenv = require("dotenv").config({ path: "./env" });
 const expressStaticGzip = require("express-static-gzip");
 const helmet = require("helmet");
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11369,20 +11369,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"form-data@npm:^4.0.0, form-data@npm:~4.0.4":
-  version: 4.0.5
-  resolution: "form-data@npm:4.0.5"
-  dependencies:
-    asynckit: ^0.4.0
-    combined-stream: ^1.0.8
-    es-set-tostringtag: ^2.1.0
-    hasown: ^2.0.2
-    mime-types: ^2.1.12
-  checksum: af8328413c16d0cded5fccc975a44d227c5120fd46a9e81de8acf619d43ed838414cc6d7792195b30b248f76a65246949a129a4dadd148721948f90cd6d4fb69
-  languageName: node
-  linkType: hard
-
-"form-data@npm:^4.0.5":
+"form-data@npm:^4.0.0, form-data@npm:^4.0.5, form-data@npm:~4.0.4":
   version: 4.0.5
   resolution: "form-data@npm:4.0.5"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2991,7 +2991,7 @@ __metadata:
     antd: 4.24.10
     array-move: 3.0.1
     autoprefixer: 10.4.20
-    axios: 1.8.3
+    axios: 1.13.5
     axios-mock-adapter: 1.17.0
     clean-webpack-plugin: 4.0.0
     copy-webpack-plugin: 12.0.2
@@ -3139,7 +3139,7 @@ __metadata:
     acorn: 6.4.1
     antd: 4.24.10
     autoprefixer: 10.4.20
-    axios: 1.8.3
+    axios: 1.13.5
     axios-mock-adapter: 1.17.0
     clean-webpack-plugin: 4.0.0
     copy-webpack-plugin: 12.0.2
@@ -6621,14 +6621,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:1.8.3":
-  version: 1.8.3
-  resolution: "axios@npm:1.8.3"
+"axios@npm:1.13.5":
+  version: 1.13.5
+  resolution: "axios@npm:1.13.5"
   dependencies:
-    follow-redirects: ^1.15.6
-    form-data: ^4.0.0
+    follow-redirects: ^1.15.11
+    form-data: ^4.0.5
     proxy-from-env: ^1.1.0
-  checksum: 85fc8ad7d968e43ea9da5513310637d29654b181411012ee14cc0a4b3662782e6c81ac25eea40b5684f86ed2d8a01fa6fc20b9b48c4da14ef4eaee848fea43bc
+  checksum: 985024c4a32f837053f198f02a308fd6f8bfb4053a2f21e39e37992bc6d06917f008679c36b3e7f0f0c9060c85ffe37c61e58d2ac662595d68dc1b89cef78de8
   languageName: node
   linkType: hard
 
@@ -11297,7 +11297,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.0.0, follow-redirects@npm:^1.14.0, follow-redirects@npm:^1.15.6":
+"follow-redirects@npm:^1.0.0, follow-redirects@npm:^1.14.0, follow-redirects@npm:^1.15.11":
   version: 1.15.11
   resolution: "follow-redirects@npm:1.15.11"
   peerDependenciesMeta:
@@ -11370,6 +11370,19 @@ __metadata:
   linkType: hard
 
 "form-data@npm:^4.0.0, form-data@npm:~4.0.4":
+  version: 4.0.5
+  resolution: "form-data@npm:4.0.5"
+  dependencies:
+    asynckit: ^0.4.0
+    combined-stream: ^1.0.8
+    es-set-tostringtag: ^2.1.0
+    hasown: ^2.0.2
+    mime-types: ^2.1.12
+  checksum: af8328413c16d0cded5fccc975a44d227c5120fd46a9e81de8acf619d43ed838414cc6d7792195b30b248f76a65246949a129a4dadd148721948f90cd6d4fb69
+  languageName: node
+  linkType: hard
+
+"form-data@npm:^4.0.5":
   version: 4.0.5
   resolution: "form-data@npm:4.0.5"
   dependencies:


### PR DESCRIPTION
Snyk keeps wanting to upgrade Axios, but it introduces breaking changes for cypress testing as it changes the way it makes calls there.  This PR does that upgrade and makes sure we include both adapter types needed in the customAxios implementation.

This also contains a fix to the dot-env error causing a crash on dev in openshift.
