### PR TITLE
[MDS-6835] Show tier allocation for mx and cx now apps

### DIFF
--- a/services/common/src/interfaces/noticeOfWork.interface.ts
+++ b/services/common/src/interfaces/noticeOfWork.interface.ts
@@ -55,6 +55,8 @@ export interface INoticeOfWork {
   application_progress?: INoticeOfWorkApplicationProgress[];
   now_application_tier_code?: string;
   now_application_tier_description?: string;
+  now_application_tier_created_date?: string;
+  now_application_tier_updated_date?: string;
   application_type_code?: string;
   now_application_status_code?: string;
 }

--- a/services/core-api/app/api/now_applications/models/now_application_tier.py
+++ b/services/core-api/app/api/now_applications/models/now_application_tier.py
@@ -33,3 +33,7 @@ class NOWApplicationTier(AuditMixin, Base):
 
     def __repr__(self):
         return '<NOWApplicationTier %r>' % self.now_application_tier_id
+    
+    @classmethod
+    def find_by_id(cls, now_application_id):
+        return cls.query.filter_by(now_application_id=now_application_id).one_or_none()

--- a/services/core-api/app/api/now_applications/resources/now_application_list_proponent_resource.py
+++ b/services/core-api/app/api/now_applications/resources/now_application_list_proponent_resource.py
@@ -1,5 +1,6 @@
 from app.api.now_applications.models.applications_view import ApplicationsView
 from app.api.now_applications.models.now_application_progress import NOWApplicationProgress
+from app.api.now_applications.models.now_application_tier import NOWApplicationTier
 from app.api.now_applications.resources.now_application_base_list_resource import NowApplicationBaseListResource
 from app.api.mines.mine.models.mine import Mine
 from app.api.now_applications.response_models import NOW_VIEW_MODEL_PROPONENT
@@ -20,5 +21,11 @@ class NOWApplicationListProponentResource(NowApplicationBaseListResource):
         for now in now_application_views:
             now_application_id = now.now_application_id
             now_application_progress = NOWApplicationProgress.find_by_id(now_application_id)
+            now_application_tier = NOWApplicationTier.find_by_id(now_application_id)
             now.application_progress = now_application_progress
+            if now_application_tier:
+                now.now_application_tier_code = now_application_tier.notice_of_work_tier_code
+                now.now_application_tier_description = now_application_tier.description
+                now.now_application_tier_created_date = now_application_tier.create_timestamp
+                now.now_application_tier_updated_date = now_application_tier.update_timestamp
         return now_application_views

--- a/services/core-api/app/api/now_applications/resources/now_application_proponent_resource.py
+++ b/services/core-api/app/api/now_applications/resources/now_application_proponent_resource.py
@@ -1,6 +1,7 @@
 from flask_restx import Resource
 from app.api.now_applications.models.applications_view import ApplicationsView
 from app.api.now_applications.models.now_application_progress import NOWApplicationProgress
+from app.api.now_applications.models.now_application_tier import NOWApplicationTier
 from app.api.now_applications.response_models import NOW_VIEW_MODEL_PROPONENT
 from app.api.utils.access_decorators import requires_any_of, VIEW_ALL, MINESPACE_PROPONENT
 from app.api.utils.resources_mixins import UserMixin
@@ -19,4 +20,10 @@ class NOWApplicationProponentResource(Resource, UserMixin):
         now_application_id = now_application_view.now_application_id
         now_application_progress = NOWApplicationProgress.find_by_id(now_application_id)
         now_application_view.application_progress = now_application_progress
+        now_application_tier = NOWApplicationTier.find_by_id(now_application_id)
+        if now_application_tier:
+            now_application_view.now_application_tier_code = now_application_tier.notice_of_work_tier_code
+            now_application_view.now_application_tier_description = now_application_tier.description
+            now_application_view.now_application_tier_created_date = now_application_tier.create_timestamp
+            now_application_view.now_application_tier_updated_date = now_application_tier.update_timestamp
         return now_application_view

--- a/services/core-api/app/api/now_applications/response_models.py
+++ b/services/core-api/app/api/now_applications/response_models.py
@@ -839,6 +839,14 @@ NOW_VIEW_MODEL_PROPONENT = api.model(
         fields.List(fields.Nested(IMPORTED_NOW_SUBMISSION_DOCUMENT), skip_none=True),
         'application_progress':
         fields.Nested(NOW_APPLICATION_PROGRESS, skip_none=True),
+        'now_application_tier_code':
+        fields.String,
+        'now_application_tier_description':
+        fields.String,
+        'now_application_tier_created_date':
+        Date,
+        'now_application_tier_updated_date':
+        Date,
     })
 
 PAGINATED_LIST = api.model(

--- a/services/minespace-web/src/components/dashboard/mine/projects/NoticeOfWorkTable.tsx
+++ b/services/minespace-web/src/components/dashboard/mine/projects/NoticeOfWorkTable.tsx
@@ -92,7 +92,7 @@ export const NoticeOfWorkTable: FC<NoticeOfWorkTableProps> = ({ isLoaded, applic
             key: "now_application_tier_code",
             dataIndex: "now_application_tier_code",
             width: "120px",
-            sorter: dateSorter("now_application_tier_code"),
+            sorter: (a, b) => (a.now_application_tier_code > b.now_application_tier_code ? -1 : 1),
             defaultSortOrder: "descend" as SortOrder,
             render: (text, record) => {
               const isExploration =

--- a/services/minespace-web/src/components/dashboard/mine/projects/NoticeOfWorkTable.tsx
+++ b/services/minespace-web/src/components/dashboard/mine/projects/NoticeOfWorkTable.tsx
@@ -35,6 +35,10 @@ const transformRowData = (applications: INoticeOfWork[]) =>
     document:
       application.application_documents?.length > 0 ? application.application_documents[0] : {},
     application_progress: application.application_progress,
+    now_application_tier_code: application.now_application_tier_code,
+    now_application_tier_description: application.now_application_tier_description,
+    now_application_tier_created_date: application.now_application_tier_created_date,
+    now_application_tier_updated_date: application.now_application_tier_updated_date,
     mine_guid: application.mine_guid,
     review_started:
       formatDate(
@@ -48,6 +52,11 @@ const transformRowData = (applications: INoticeOfWork[]) =>
 
 export const NoticeOfWorkTable: FC<NoticeOfWorkTableProps> = ({ isLoaded, applications }) => {
   const { isFeatureEnabled } = useFeatureFlag();
+  const hasTypeMineralOrCoal = applications.some(
+    (app) =>
+      app.notice_of_work_type_description === "Mineral" ||
+      app.notice_of_work_type_description === "Coal"
+  );
   const columns = [
     {
       title: "Number",
@@ -64,6 +73,41 @@ export const NoticeOfWorkTable: FC<NoticeOfWorkTableProps> = ({ isLoaded, applic
         a.notice_of_work_type_description > b.notice_of_work_type_description ? -1 : 1,
       render: (text) => <div title="Type">{text}</div>,
     },
+    ...(isFeatureEnabled(Feature.NOTICE_OF_WORK_TIER) && hasTypeMineralOrCoal
+      ? [
+          {
+            title: (
+              <div>
+                Tier
+                <Tooltip
+                  overlayClassName="minespace-tooltip"
+                  title="Tier applies only to mineral and coal exploration applications. It indicates 
+                the assigned review tier based on the application details"
+                >
+                  {" "}
+                  <InfoCircleOutlined className="info-tooltip icon-sm" />
+                </Tooltip>
+              </div>
+            ),
+            key: "now_application_tier_code",
+            dataIndex: "now_application_tier_code",
+            width: "120px",
+            sorter: dateSorter("now_application_tier_code"),
+            defaultSortOrder: "descend" as SortOrder,
+            render: (text, record) => {
+              const isExploration =
+                record?.notice_of_work_type_description === "Mineral" ||
+                record?.notice_of_work_type_description === "Coal";
+              const now_application_tier_code = record.now_application_tier_code;
+              return !isEmpty(now_application_tier_code) && isExploration ? (
+                <div title="Tier">{now_application_tier_code}</div>
+              ) : (
+                Strings.EMPTY_FIELD
+              );
+            },
+          },
+        ]
+      : []),
     {
       title: "Status",
       key: "now_application_status_description",

--- a/services/minespace-web/src/components/pages/NoticeOfWork/NoticeOfWorkOverviewTab.tsx
+++ b/services/minespace-web/src/components/pages/NoticeOfWork/NoticeOfWorkOverviewTab.tsx
@@ -1,14 +1,27 @@
 import React, { FC } from "react";
 import { useSelector } from "react-redux";
-import { Col, Row, Typography } from "antd";
+import { Col, Row, Typography, Alert, Button } from "antd";
 import { formatDate } from "@mds/common/redux/utils/helpers";
 import { EMPTY_FIELD, NOT_STARTED } from "@mds/common/constants/strings";
 
 import { getNOWProgress } from "@mds/common/redux/selectors/noticeOfWorkSelectors";
 import NoticeOfWorkStagesTable from "./NoticeOfWorkStagesTable";
+import { INoticeOfWork } from "@mds/common/interfaces";
+import { NOW_APPLICATION_TIER_EXPLAINATION_LINK } from "@/constants/strings";
+import { useFeatureFlag } from "@mds/common/providers/featureFlags/useFeatureFlag";
+import { Feature } from "@mds/common/utils";
 
-export const NoticeOfWorkOverviewTab: FC = () => {
+interface NoticeOfWorkOverviewTabProps {
+  noticeOfWork: INoticeOfWork;
+}
+
+export const NoticeOfWorkOverviewTab: FC<NoticeOfWorkOverviewTabProps> = ({ noticeOfWork }) => {
   const noticeOfWorkProgress = useSelector(getNOWProgress) ?? {};
+  const { isFeatureEnabled } = useFeatureFlag();
+  const isTypeMineralOrCoal = ["Mineral", "Coal"].includes(
+    noticeOfWork?.notice_of_work_type_description
+  );
+
   const nowApplicationStages = [
     {
       title: "Technical Review",
@@ -53,6 +66,44 @@ export const NoticeOfWorkOverviewTab: FC = () => {
   return (
     <Row gutter={[0, 16]}>
       <Col lg={{ span: 14 }} xl={{ span: 16 }}>
+        {isFeatureEnabled(Feature.NOTICE_OF_WORK_TIER) &&
+        isTypeMineralOrCoal &&
+        noticeOfWork?.now_application_tier_code ? (
+          <Alert
+            message=""
+            description={
+              <Row justify="space-between" align="middle">
+                <Col xs={24} md={18}>
+                  <p>
+                    <b>Assigned Tier: {noticeOfWork?.now_application_tier_code}</b>
+                    <br />
+                    This tier sets the target service timeline for review.
+                    <br />
+                    Assigned on: {noticeOfWork?.now_application_tier_created_date}
+                    <br />
+                    Last Updated on: {noticeOfWork?.now_application_tier_updated_date}
+                  </p>
+                </Col>
+                <Col xs={24} md={6} style={{ textAlign: "right" }}>
+                  <a
+                    href={NOW_APPLICATION_TIER_EXPLAINATION_LINK}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <Button>View tier details</Button>
+                  </a>
+                </Col>
+              </Row>
+            }
+            type="info"
+            style={{
+              backgroundColor: "#FFC943",
+              border: "1.5px solid #E8A302",
+              marginBottom: "20px",
+            }}
+            className="ant-alert-info ant-alert-info-custom-with-black-icon"
+          />
+        ) : null}
         <Typography.Title level={4}>Application Stages</Typography.Title>
         <Typography.Paragraph>
           Applications shown here were submitted through FrontCounter BC and cannot be edited in

--- a/services/minespace-web/src/components/pages/NoticeOfWork/NoticeOfWorkOverviewTab.tsx
+++ b/services/minespace-web/src/components/pages/NoticeOfWork/NoticeOfWorkOverviewTab.tsx
@@ -11,6 +11,8 @@ import { NOW_APPLICATION_TIER_EXPLAINATION_LINK } from "@/constants/strings";
 import { useFeatureFlag } from "@mds/common/providers/featureFlags/useFeatureFlag";
 import { Feature } from "@mds/common/utils";
 
+const { Paragraph } = Typography;
+
 interface NoticeOfWorkOverviewTabProps {
   noticeOfWork: INoticeOfWork;
 }
@@ -70,13 +72,13 @@ export const NoticeOfWorkOverviewTab: FC<NoticeOfWorkOverviewTabProps> = ({ noti
         isTypeMineralOrCoal &&
         noticeOfWork?.now_application_tier_code ? (
           <Alert
-            message=""
+            message={
+              <Paragraph strong>Assigned Tier: {noticeOfWork?.now_application_tier_code}</Paragraph>
+            }
             description={
               <Row justify="space-between" align="middle">
                 <Col xs={24} md={18}>
                   <p>
-                    <b>Assigned Tier: {noticeOfWork?.now_application_tier_code}</b>
-                    <br />
                     This tier sets the target service timeline for review.
                     <br />
                     Assigned on: {noticeOfWork?.now_application_tier_created_date}
@@ -96,12 +98,7 @@ export const NoticeOfWorkOverviewTab: FC<NoticeOfWorkOverviewTabProps> = ({ noti
               </Row>
             }
             type="info"
-            style={{
-              backgroundColor: "#FFC943",
-              border: "1.5px solid #E8A302",
-              marginBottom: "20px",
-            }}
-            className="ant-alert-info ant-alert-info-custom-with-black-icon"
+            className="margin-large--bottom"
           />
         ) : null}
         <Typography.Title level={4}>Application Stages</Typography.Title>

--- a/services/minespace-web/src/components/pages/NoticeOfWork/NoticeOfWorkPage.tsx
+++ b/services/minespace-web/src/components/pages/NoticeOfWork/NoticeOfWorkPage.tsx
@@ -59,7 +59,7 @@ const NoticeOfWorkPage: FC = () => {
       key: "overview",
       children: (
         <div className={pageClass}>
-          <NoticeOfWorkOverviewTab />
+          <NoticeOfWorkOverviewTab noticeOfWork={noticeOfWork} />
         </div>
       ),
     },

--- a/services/minespace-web/src/constants/strings.js
+++ b/services/minespace-web/src/constants/strings.js
@@ -30,3 +30,6 @@ export const EDITABLE_NOTICE_OF_DEPARTURE_STATUS = ["Pending Review", "Informati
 
 export const NOTICE_OF_DEPARTURE_DOWNLOAD_LINK =
   "https://www2.gov.bc.ca/gov/content/industry/mineral-exploration-mining/permitting/mines-act-permits/mines-act-departures-from-approval";
+
+export const NOW_APPLICATION_TIER_EXPLAINATION_LINK =
+  "https://www2.qa.gov.bc.ca/assets/gov/farming-natural-resources-and-industry/mineral-exploration-mining/documents/permitting/mine-exploration-and-discovery/mx_permitting_timelines.pdf?";


### PR DESCRIPTION
## Objective 

[MDS-6835](https://bcmines.atlassian.net/browse/MDS-6835)

-Add tier column with tool tip to minespace NoW table, setup behind tier feature flag. Made it so when a mine does not have a Mineral or Coal NoW application the Tier column will not show. When there is at least one Mineral or Coal NoW application Tier column will show and all other NoW application types will have "N/A" in the tier column.

-Add banner to minespace NoW view page, setup behind tier feature flag. Banner won't show until a tier is assigned to the NoW application

<img width="2503" height="620" alt="image" src="https://github.com/user-attachments/assets/e95e4983-4432-4f8b-b50a-2aa3c044bb03" />

<img width="2504" height="688" alt="image" src="https://github.com/user-attachments/assets/f346e520-47f6-44f3-9383-3736d3ac3658" />

<img width="1940" height="817" alt="image" src="https://github.com/user-attachments/assets/b4e2cdf7-6173-4484-a681-3709d62d6c9b" />
             
