### PR TITLE
[MDS-6861] - VFCBC Failed Requests Logging

### DIFF
--- a/services/core-api/app/api/now_submissions/resources/application_list_resource.py
+++ b/services/core-api/app/api/now_submissions/resources/application_list_resource.py
@@ -114,6 +114,10 @@ class ApplicationListResource(Resource, UserMixin):
     @api.marshal_with(APPLICATION, code=201)
     def post(self):
         current_app.logger.debug('Attempting to load application')
+
+        current_app.logger.info("*****VFCBC Raw Request Body*****")
+        current_app.logger.info(request.get_data(as_text=True))
+
         current_app.logger.info("*****VFCBC Request Payload*****")
         current_app.logger.info(request.json)
         try:


### PR DESCRIPTION
## Objective 

Through Simen's testing he found that the API should be fine accepting all unicode characters.  He theorized that a malformed JSON payload may be the culprit in causing the failure (possibly an extra ") somewhere.  This is just adding logging for the full request in order to inspect the failure with more detail.

[MDS-6861](https://bcmines.atlassian.net/browse/MDS-6861)

_Why are you making this change? Provide a short explanation and/or screenshots_
