### PR TITLE
[CHORE] Remove drop from repeatable applications view

### DIFF
--- a/migrations/sql/R__applications_view.sql
+++ b/migrations/sql/R__applications_view.sql
@@ -1,6 +1,4 @@
 
-DROP VIEW IF EXISTS public.applications_view;
-
 CREATE OR REPLACE VIEW public.applications_view AS
 SELECT nid.now_application_guid,
     m.mine_guid,


### PR DESCRIPTION
The `now_application_gis_export_view` is referencing the `applications_view`, so when the `applications_view` is updated it was trying to drop itself completely and then create or replace itself.  However, because the `now_application_gis_export_view` is now dependent on it, the migration fails.

Removed the Drop at the top of the repeatable applications view.  It retains the `CREATE OR REPLACE` which will effectively update the view without hitting the contstraint where the gis view is dependent on it so it fails.

