### PR TITLE
[MDS-6881] Relaxed permit required reports filter

### DIFF
--- a/services/core-api/app/api/mines/reports/report_helpers.py
+++ b/services/core-api/app/api/mines/reports/report_helpers.py
@@ -79,8 +79,10 @@ class ReportFilterHelper:
         return filtered_query.filter(
             or_(
                 MineReport.mine_report_definition_id.isnot(None),
+                MineReport.mine_report_status_code != 'NON',
                 MineReportPermitRequirement.permit_amendment_id == latest_amendment_ids.c.latest_permit_amendment_id,
                 PermitConditionCategory.permit_amendment_id == latest_amendment_ids.c.latest_permit_amendment_id,
+                PermitConditionCategory.permit_amendment_id.is_(None),
             )
         )
 

--- a/services/core-api/app/api/mines/reports/report_helpers.py
+++ b/services/core-api/app/api/mines/reports/report_helpers.py
@@ -80,9 +80,20 @@ class ReportFilterHelper:
             or_(
                 MineReport.mine_report_definition_id.isnot(None),
                 MineReport.mine_report_status_code != 'NON',
-                MineReportPermitRequirement.permit_amendment_id == latest_amendment_ids.c.latest_permit_amendment_id,
-                PermitConditionCategory.permit_amendment_id == latest_amendment_ids.c.latest_permit_amendment_id,
-                PermitConditionCategory.permit_amendment_id.is_(None),
+                and_(
+                    MineReport.mine_report_permit_requirement_id.isnot(None),
+                    MineReportPermitRequirement.permit_amendment_id == latest_amendment_ids.c.latest_permit_amendment_id
+                ),
+                # New Categories: must match latest amendment
+                and_(
+                    MineReport.permit_condition_category_code.isnot(None),
+                    PermitConditionCategory.permit_amendment_id == latest_amendment_ids.c.latest_permit_amendment_id
+                ),
+                # Legacy Standard Categories: no amendment ID, but must have a category code
+                and_(
+                    MineReport.permit_condition_category_code.isnot(None),
+                    PermitConditionCategory.permit_amendment_id.is_(None)
+                )
             )
         )
 


### PR DESCRIPTION
## Objective 

It looks like the recent update to filter reports was a bit too restrictive.  It was filtering permit required reports to only those associated with the latest permit amendment.

relaxed the filter in 
services/core-api/app/api/mines/reports/report_helpers.py
 to:

- Always show Code Required Reports (CRR).
- Show historical PRR submissions (any report with a status other than 'NON').
- Show legacy standard PRR requirements (where permit_amendment_id is null).
- Strictly filter unsubmitted PRR requirements (status 'NON') to only those associated with the latest permit amendment.

[MDS-6881](https://bcmines.atlassian.net/browse/MDS-6881)

_Why are you making this change? Provide a short explanation and/or screenshots_
