### PR TITLE
[MDS-6802] - Tier History Date Fix

### DIFF
--- a/services/core-api/app/api/utils/models_mixins.py
+++ b/services/core-api/app/api/utils/models_mixins.py
@@ -509,7 +509,7 @@ class HistoryMixin(object):
         if self.versions:
             hs = list(map(lambda version: {
                 'updated_by': version.update_user,
-                'updated_at': version.update_timestamp,
+                'updated_at': dt_to_str(version.update_timestamp),
                 'changeset': list(map(lambda key: json.loads(json.dumps({
                     'field_name': key,
                     'from': dt_to_str(version.changeset[key][0]),


### PR DESCRIPTION
## Objective 

[MDS-6802](https://bcmines.atlassian.net/browse/MDS-6802)

## Description
This PR resolves an issue in the now tier History Modal where timestamps were displaying an incorrect time, shifted by the local timezone offset.
**Root Cause:**
The backend `HistoryMixin` (which provides the history trail) was exposing UTC timestamps in its JSON payload without providing the timezone offset suffix. The frontend received `2026-04-08T20:42:00` and parsed it locally, incorrectly resolving it as `8:42 PM` local time rather than extracting the local equivalent from UTC.

**Fix:**
Wrapped the `updated_at` mapping in `models_mixins.py` with the existing `dt_to_str` helper. This ensures the output string adheres to ISO8601 formatting and includes the `+00:00` UTC offset indicator, allowing `moment.js` to parse it correctly into the user's local timezone.

**Side Effects Analysis:**
The `HistoryMixin` is also utilized by Tailings Storage Facilities (TSFs) and Dams. 
- *Why it's safe*: The frontend components for TSFs and Dams (`TailingsDiffModal.tsx` and `DiffTable.tsx`) run the `updated_at` API output through a `formatDate` helper rather than `formatDateTime`. The `formatDate` helper forces strict parsing against the `"YYYY-MM-DD"` format. This hard-strips out the time and ignores the new `+00:00` suffix. As a result, there are **zero visual side effects** on existing TSF or Dam history tables. 

---

## Manual Test Plan

- [ ] Log in as a Core user.
- [ ] Navigate to an active Notice of Work (NOW) application.
- [ ] Update the tier allocation to trigger a new entry in the tier history logs.
- [ ] Open the tier history modal.
- [ ] Verify that the recorded timestamp accurately reflects your current local time, completely eliminating the 6-hour offset gap.
- [ ] Navigate to the Tailings Storage Facility (TSF) tab of a mine that has TSF history.
- [ ] Open the TSF history/diff modal.
- [ ] Verify the history table renders without errors and the date accurately falls back to `MMM DD YYYY` (e.g., `Apr 08 2026`) without displaying the time.

