### PR TITLE
[MDS-6802] - Added the rationale to the tier history table.

### DIFF
--- a/services/core-web/src/components/modalContent/NOWTierHistoryModal.tsx
+++ b/services/core-web/src/components/modalContent/NOWTierHistoryModal.tsx
@@ -1,5 +1,5 @@
 import React, { FC, useEffect, useState } from "react";
-import { Button, Table } from "antd";
+import { Button, Table, Tooltip } from "antd";
 import { useAppDispatch, useAppSelector } from "@mds/common/redux/rootState";
 import { fetchNoticeOfWorkApplicationTierHistory } from "@mds/common/redux/actionCreators/noticeOfWorkActionCreator";
 import { formatDateTime } from "@mds/common/redux/utils/helpers";
@@ -45,13 +45,33 @@ export const NOWTierHistoryModal: FC<NOWTierHistoryModalProps> = (props) => {
       key: "changeset",
       render: (changeset) => {
         const tierChange = changeset.find((c) => c.field_name === "notice_of_work_tier_code");
+        const descriptionChange = changeset.find((c) => c.field_name === "description");
         if (tierChange) {
-           const from = tierOptionsHash[tierChange.from] || Strings.EMPTY_FIELD;
-           const to = tierOptionsHash[tierChange.to] || Strings.EMPTY_FIELD;
-           const suffix = !tierChange.from ? " (initial intake)" : "";
-           return `Changed from ${from} to ${to}${suffix}`;
+          const from = tierOptionsHash[tierChange.from] || Strings.EMPTY_FIELD;
+          const to = tierOptionsHash[tierChange.to] || Strings.EMPTY_FIELD;
+          const suffix = !tierChange.from ? " (initial intake)" : "";
+          return `Changed from ${from} to ${to}${suffix}`;
+        }
+        if (descriptionChange) {
+          return "Rationale updated";
         }
         return "No tier change recorded";
+      },
+    },
+    {
+      title: "Rationale",
+      dataIndex: "changeset",
+      key: "rationale",
+      render: (changeset) => {
+        const descriptionChange = changeset.find((c) => c.field_name === "description");
+        const rationale = descriptionChange?.to || Strings.EMPTY_FIELD;
+        return (
+          <Tooltip title={rationale} placement="topLeft">
+            <div className="ellipsis-text nowrap" style={{ maxWidth: 200 }}>
+              {rationale}
+            </div>
+          </Tooltip>
+        );
       },
     },
   ];

--- a/services/core-web/src/tests/components/modalContent/NOWTierHistoryModal.spec.tsx
+++ b/services/core-web/src/tests/components/modalContent/NOWTierHistoryModal.spec.tsx
@@ -87,4 +87,26 @@ describe("NOWTierHistoryModal", () => {
 
     expect(await screen.findByText("No tier change recorded")).toBeInTheDocument();
   });
+
+  it("renders properly with only description change", async () => {
+    const descriptionChangeHistory = [
+      {
+        updated_by: "User 3",
+        updated_at: "2023-01-03T12:00:00Z",
+        changeset: [{ field_name: "description", from: "old", to: "new rationale" }],
+      },
+    ];
+    (NOW_ACTIONS.fetchNoticeOfWorkApplicationTierHistory as jest.Mock).mockReturnValue(() =>
+      Promise.resolve({ data: descriptionChangeHistory })
+    );
+
+    render(
+      <ReduxWrapper initialState={initialState}>
+        <NOWTierHistoryModal {...props} />
+      </ReduxWrapper>
+    );
+
+    expect(await screen.findByText("Rationale updated")).toBeInTheDocument();
+    expect(await screen.findByText("new rationale")).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Objective 

This PR enhances the Notice of Work Tier History Modal by displaying the rationale (description) entered during tier updates. It also improves the UI by truncating long rationale text and providing a tooltip for better readability.

[MDS-6802](https://bcmines.atlassian.net/browse/MDS-6802)


Key Changes
- New "Rationale" Column: Added to the Tier History table to show the high-level description/rationale for each change.
- Smart Change Labels: Updated the "Change" column to display "Rationale updated" when only the description is modified (since we can't put changed from tier x to tier x), ensuring all updates are clearly reflected in the history.
UI Enhancements:
Implemented ellipsis truncation for the rationale text to preserve modal space.
Added an Ant Design Tooltip that displays the full rationale on hover or click.

<img width="884" height="685" alt="image" src="https://github.com/user-attachments/assets/46d32316-653e-4c6b-8887-cdf7ad237307" />

