### PR TITLE
[CHORE] - fix core web ts errors

### DIFF
--- a/services/common/src/components/tailings/EditTsfAppointmentForm.tsx
+++ b/services/common/src/components/tailings/EditTsfAppointmentForm.tsx
@@ -38,23 +38,21 @@ const EditTsfAppointmentForm: FC<EditTsfProps> = ({
     const partyTitle = useAppSelector(getPartyRelationshipTitle(partyAppointment.mine_party_appt_type_code))
 
     const onSubmit = (values) => {
-        dispatch(updatePartyRelationship({ data: values })).then((resp) => {
-            if (resp?.data) {
-                const mineGuid = partyAppointment.mine_guid;
+        dispatch(updatePartyRelationship({ data: values })).unwrap().then(() => {
+            const mineGuid = partyAppointment.mine_guid;
 
-                Promise.all([
-                    dispatch(fetchTailingsStorageFacility({ mineGuid, tsfGuid })),
-                    dispatch(
-                        fetchPartyRelationships({
-                            mine_guid: mineGuid,
-                            relationships: "party",
-                            mine_tailings_storage_facility_guid: tsfGuid,
-                        })
-                    )
-                ]);
-                if (isModal) {
-                    dispatch(closeModal());
-                }
+            Promise.all([
+                dispatch(fetchTailingsStorageFacility({ mineGuid, tsfGuid })),
+                dispatch(
+                    fetchPartyRelationships({
+                        mine_guid: mineGuid,
+                        relationships: "party",
+                        mine_tailings_storage_facility_guid: tsfGuid,
+                    })
+                )
+            ]);
+            if (isModal) {
+                dispatch(closeModal());
             }
         });
     };

--- a/services/common/src/components/tailings/EngineerOfRecord.tsx
+++ b/services/common/src/components/tailings/EngineerOfRecord.tsx
@@ -45,7 +45,7 @@ export const EngineerOfRecord: FC<EngineerOfRecordProps> = (props) => {
 
   const { addContactModalConfig } = useContext(TailingsContext);
   const tsfFormName = FORM.ADD_TAILINGS_STORAGE_FACILITY;
-  const partyRelationships: IMinePartyAppt[] = useAppSelector(getPartyRelationships);
+  const partyRelationships = useAppSelector(getPartyRelationships) as unknown as IMinePartyAppt[];
   const mine: IMine = useAppSelector(getMineById(mineGuid));
 
   const formValues = useAppSelector(getFormValues(tsfFormName)) as ITailingsStorageFacilityForm;

--- a/services/common/src/interfaces/party/partyAppt.interface.ts
+++ b/services/common/src/interfaces/party/partyAppt.interface.ts
@@ -6,4 +6,6 @@ export interface IPartyAppt extends IAddPartyAppointment {
   update_user?: string;
   party: IParty;
   documents?: IMineDocument[];
+  status?: string;
+  mine_party_acknowledgement_status?: string;
 }

--- a/services/core-web/src/components/common/PartySelectField.tsx
+++ b/services/core-web/src/components/common/PartySelectField.tsx
@@ -20,7 +20,7 @@ import { FormContext } from "@mds/common/components/forms/FormWrapper";
 interface IPartySelectOption {
   value: string | undefined,
   originalValue?: IParty,
-  label: JSX.Element
+  label: React.ReactNode
 };
 
 const renderAddPartyFooter = (showAddParty, partyLabel) => (

--- a/services/core-web/src/components/mine/ContactInfo/PartyRelationships/InactiveContact.tsx
+++ b/services/core-web/src/components/mine/ContactInfo/PartyRelationships/InactiveContact.tsx
@@ -18,16 +18,14 @@ export const InactiveContact: FC<InactiveContactProps> = ({
 }) => {
   const [redirectToProfile, setRedirectToProfile] = useState(false);
 
-  useEffect(() => {
-    if (redirectToProfile) {
-      return (
-        <Redirect
-          to={router.RELATIONSHIP_PROFILE.dynamicRoute(mine.mine_guid, partyRelationshipTypeCode)}
-          push
-        />
-      );
-    }
-  }, []);
+  if (redirectToProfile) {
+    return (
+      <Redirect
+        to={router.RELATIONSHIP_PROFILE.dynamicRoute(mine.mine_guid, partyRelationshipTypeCode)}
+        push
+      />
+    );
+  }
 
   return (
     <Card

--- a/services/core-web/src/components/modalContent/EditPartyModal.tsx
+++ b/services/core-web/src/components/modalContent/EditPartyModal.tsx
@@ -6,7 +6,7 @@ import EditFullPartyForm, {
 import moment from "moment";
 import { formatDate } from "@common/utils/helpers";
 import { useAppSelector } from "@mds/common/redux/rootState";
-import { IParty } from "@mds/common/interfaces";
+import { IParty, ItemMap } from "@mds/common/interfaces";
 
 interface EditPartyProps {
   onSubmit: () => any;
@@ -14,9 +14,9 @@ interface EditPartyProps {
 }
 
 export const EditPartyModal: FC<EditPartyProps> = ({ onSubmit, partyGuid }) => {
-  const parties = useAppSelector(getParties) as IParty[];
+  const parties = useAppSelector(getParties) as ItemMap<IParty>;
   const partyFromStore = parties[partyGuid];
-  const party: EditFullPartyFormValues = partyFromStore ? { ...partyFromStore } : null;
+  const party = partyFromStore ? ({ ...partyFromStore } as EditFullPartyFormValues) : null;
   const today = moment().utc();
   const sortedBusinessRoleAppts = [...(party?.business_role_appts ?? [])].sort(
     (a, b) => b.party_business_role_appt_id - a.party_business_role_appt_id

--- a/services/minespace-web/src/components/pages/MinespaceAccessRequest.tsx
+++ b/services/minespace-web/src/components/pages/MinespaceAccessRequest.tsx
@@ -1,4 +1,5 @@
 import React, { FC, useEffect, useMemo } from "react";
+import moment from "moment";
 import { arrayPush, arrayRemove, Field, getFormValues } from "@mds/common/components/forms/form";
 import FormWrapper from "@mds/common/components/forms/FormWrapper";
 import RenderField from "@mds/common/components/forms/RenderField";
@@ -279,7 +280,9 @@ const MinespaceAccessRequest: FC = () => {
         </Typography.Paragraph>
         <Typography.Paragraph>
           Submitted on:{" "}
-          {new Date(currentUserAccessRequest.access_request.submitted_timestamp).toLocaleString()}
+          {moment(currentUserAccessRequest.access_request.submitted_timestamp).format(
+            "M/D/YYYY, h:mm:ss A"
+          )}
         </Typography.Paragraph>
       </div>
     );

--- a/services/minespace-web/src/setupTests.js
+++ b/services/minespace-web/src/setupTests.js
@@ -3,6 +3,10 @@ import Adapter from "enzyme-adapter-react-16";
 import path from "path";
 import server from "@/tests/server";
 import "@testing-library/jest-dom";
+import moment from "moment-timezone";
+
+process.env.TZ = "UTC";
+moment.tz.setDefault("UTC");
 
 beforeAll(() => {
   server.listen({ onUnhandledRequest: "warn" });


### PR DESCRIPTION
## Summary of Changes

This PR focuses on resolving recurring TypeScript errors and stabilizing snapshot tests that were inconsistently updating in different environments.

### 1. MineSpace Snapshot Stabilization
Snapshots in the MineSpace-web service were frequently updating locally due to environment-specific locale and timezone differences (specifically regarding date formatting).
- **Core Environment Fix**: Standardized the test environment in `minespace-web/src/setupTests.js` by forcing `UTC` as the default timezone for both the Node process and `moment`.
- **Deterministic Formatting**: Replaced non-deterministic `Date.prototype.toLocaleString()` calls with explicit `moment().format()` in `MinespaceAccessRequest.tsx`. This ensures that date strings are rendered consistently regardless of the local developer locale.

### 2. Core-web & Common TypeScript/Logic Cleanup
Resolved several TypeScript errors and React best-practice violations in `core-web` and `@mds/common` services.
- **Async Handling**: Refactored `EditTsfAppointmentForm.tsx` to use `.unwrap()` on dispatched actions for more robust asynchronous result handling.
- **Type Safety**: 
    - Extended the `IPartyAppt` interface with missing `status` and `mine_party_acknowledgement_status` fields.
    - Resolved selector type mismatches in `EngineerOfRecord.tsx` and `EditPartyModal.tsx` by adding appropriate type mapping for `getParties` and `getPartyRelationships`.
    - Updated `PartySelectField.tsx` to use `React.ReactNode` for labels to improve component compatibility.
- **React Logic Fix**: Corrected a logic error in `InactiveContact.tsx` by moving a `<Redirect />` component out of a `useEffect` hook and into the main render block.
