### PR TITLE
[MDS-6885] [MS] Remove Major Mine Alert Banner for PRP's

### DIFF
--- a/docker-compose.M1.yaml
+++ b/docker-compose.M1.yaml
@@ -53,10 +53,10 @@ services:
     restart: always
     container_name: mds_postgres
     user: postgres
+    platform: linux/amd64
     build:
       context: services/postgres
       dockerfile: Dockerfile
-      platform: linux/amd64
     environment:
       - POSTGRES_USER=mds
       - POSTGRES_PASSWORD=test

--- a/services/common/src/components/reports/ReportGetStarted.tsx
+++ b/services/common/src/components/reports/ReportGetStarted.tsx
@@ -1,4 +1,4 @@
-import { Alert, Button, Col, Row, Typography } from "antd";
+import { Button, Col, Row, Typography } from "antd";
 import React, { FC, ReactNode, useEffect, useState } from "react";
 import { Field, getFormValues, change } from "@mds/common/components/forms/form";
 import ArrowRightOutlined from "@ant-design/icons/ArrowRightOutlined";
@@ -13,10 +13,8 @@ import {
   MINE_REPORTS_ENUM,
   MineReportType,
   REPORT_TYPE_CODES,
-  SystemFlagEnum,
 } from "@mds/common/constants/enums";
 import { FORM } from "@mds/common/constants/forms";
-import { MMO_EMAIL } from "@mds/common/constants/strings";
 import { useAppDispatch, useAppSelector } from "@mds/common/redux/rootState";
 import {
   getReportDefinitionsLoaded,
@@ -134,24 +132,6 @@ const ReportGetStarted: FC<ReportGetStartedProps> = ({
             },
           ]}
         />
-        {system !== SystemFlagEnum.core &&
-          mine.major_mine_ind &&
-          formValues?.report_type === REPORT_TYPE_CODES.PRR && (
-            <Alert
-              description={
-                <>
-                  Please note that the Major Mines Office (MMO) is currently unable to receive
-                  permit-required reports through MineSpace. You must submit your permit-required
-                  report to the MMO general intake inbox at {MMO_EMAIL}. Please request assistance
-                  for transferring large files by contacting{" "}
-                  <a href={`mailto:${MMO_EMAIL}`}>{MMO_EMAIL}</a>
-                </>
-              }
-              type="warning"
-              showIcon
-              className="margin-small--bottom"
-            />
-          )}
         {formValues?.report_type === REPORT_TYPE_CODES.PRR && (
           <RenderPRRFields mineGuid={mine.mine_guid} />
         )}


### PR DESCRIPTION
## Objective 
- Remove the Alert/Banner that was displayed for major mines (`major_mine_ind = true`), warning them that MMO cannot receive Permit Required Reports (PRP's) through minespace
- **_NOTE:_** No snaps were updated, as the Alert component had never been rendered as part of the snap test, thus removing it did not change the `.snap` file
- Also resolved an error with the M1 docker-compose file, where the platform had been specified at the wrong level of the yaml file for the postgres service

[MDS-6885](https://bcmines.atlassian.net/browse/MDS-6885)

_Why are you making this change? Provide a short explanation and/or screenshots_

- See the below changes, showing the banner has been removed:
<img width="1135" height="825" alt="image" src="https://github.com/user-attachments/assets/b0359e87-de16-4fc7-a7b8-514f4fa207e5" />
