### PR TITLE
[MDS-6198] Separated docman and flower into separate containers when running app locally

### DIFF
--- a/docker-compose.M1.yaml
+++ b/docker-compose.M1.yaml
@@ -56,7 +56,6 @@ services:
     build:
       context: services/postgres
       dockerfile: Dockerfile
-      platform: linux/amd64
     environment:
       - POSTGRES_USER=mds
       - POSTGRES_PASSWORD=test
@@ -330,21 +329,35 @@ services:
       - document_manager_celery
       - tusd
     env_file: ./services/document-manager/backend/.env
+  flower:
+    restart: always
+    container_name: flower
+    build:
+      context: services/document-manager/backend
+    entrypoint: celery -A app.tasks.celery flower --basic_auth=flower:flower
+    ports:
+      - 5555:5555
+    volumes:
+      - ./services/document-manager/backend:/app
+    depends_on:
+      - postgres
+      - redis
+    env_file: ./services/document-manager/backend/.env
 
   document_manager_celery:
     restart: always
     container_name: document_manager_celery
+    entrypoint: celery -A app.tasks.celery worker --loglevel=info --logfile=/tmp/celery/celery.log --pidfile=/tmp/celery/celery.pid --concurrency=3 -n document_manager_service@%h
+
     build:
       context: services/document-manager/backend
-    entrypoint: ./celery.sh
-    ports:
-      - 5555:5555
     volumes:
       - ./services/document-manager/backend:/app
       - document_manager_logs:/var/log/document-manager
     depends_on:
       - postgres
       - redis
+      - flower
       - tusd
     env_file: ./services/document-manager/backend/.env
 

--- a/docker-compose.M1.yaml
+++ b/docker-compose.M1.yaml
@@ -347,7 +347,7 @@ services:
   document_manager_celery:
     restart: always
     container_name: document_manager_celery
-    entrypoint: celery -A app.tasks.celery worker --loglevel=info --logfile=/tmp/celery/celery.log --pidfile=/tmp/celery/celery.pid --concurrency=3 -n document_manager_service@%h
+    entrypoint: celery -A app.tasks.celery worker --loglevel=info --pidfile=/tmp/celery/celery.pid --concurrency=3 -n document_manager_service@%h
 
     build:
       context: services/document-manager/backend

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -307,6 +307,7 @@ services:
     env_file: ./services/filesystem-provider/.env
 
   ####################### DOCUMENT_MANAGER_BACKEND Definition #######################
+
   document_manager_backend:
     restart: always
     container_name: document_manager_backend
@@ -325,19 +326,33 @@ services:
       - tusd
     env_file: ./services/document-manager/backend/.env
 
+  flower:
+    restart: always
+    container_name: flower
+    build:
+      context: services/document-manager/backend
+    entrypoint: celery -A app.tasks.celery flower --basic_auth=flower:flower
+    ports:
+      - 5555:5555
+    volumes:
+      - ./services/document-manager/backend:/app
+    depends_on:
+      - postgres
+      - redis
+    env_file: ./services/document-manager/backend/.env
+
   document_manager_celery:
     restart: always
     container_name: document_manager_celery
     build:
       context: services/document-manager/backend
-    entrypoint: ./celery.sh
-    ports:
-      - 5555:5555
+    entrypoint: celery -A app.tasks.celery worker --loglevel=info --logfile=/tmp/celery/celery.log --pidfile=/tmp/celery/celery.pid --concurrency=3 -n document_manager_service@%h
     volumes:
       - ./services/document-manager/backend:/app
       - document_manager_logs:/var/log/document-manager
     depends_on:
       - postgres
+      - flower
       - redis
       - tusd
     env_file: ./services/document-manager/backend/.env

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -346,7 +346,7 @@ services:
     container_name: document_manager_celery
     build:
       context: services/document-manager/backend
-    entrypoint: celery -A app.tasks.celery worker --loglevel=info --logfile=/tmp/celery/celery.log --pidfile=/tmp/celery/celery.pid --concurrency=3 -n document_manager_service@%h
+    entrypoint: celery -A app.tasks.celery worker --loglevel=info --pidfile=/tmp/celery/celery.pid --concurrency=3 -n document_manager_service@%h
     volumes:
       - ./services/document-manager/backend:/app
       - document_manager_logs:/var/log/document-manager

--- a/services/document-manager/backend/.env-example
+++ b/services/document-manager/backend/.env-example
@@ -56,7 +56,7 @@ CLIENT_ID=
 CLIENT_SECRET=
 GRANT_TYPE=
 
-CELERY_REST_API_URL=http://document_manager_celery:5555
+CELERY_REST_API_URL=http://flower:5555
 
 FLOWER_USER=flower
 FLOWER_USER_PASSWORD=flower

--- a/services/document-manager/backend/app/config.py
+++ b/services/document-manager/backend/app/config.py
@@ -2,7 +2,7 @@ import logging
 import os
 import traceback
 
-from flask import current_app
+from flask import current_app, has_request_context
 from opentelemetry import trace
 
 
@@ -12,7 +12,7 @@ class CustomFormatter(logging.Formatter):
         def get_key_cloak_client_id():
             try:
                 # Check if the request is a valid HTTP request
-                if current_app and hasattr(current_app, 'extensions'):
+                if current_app and hasattr(current_app, 'extensions') and has_request_context():
                     from app.extensions import getJwtManager
                     from flask import request
 
@@ -24,6 +24,7 @@ class CustomFormatter(logging.Formatter):
             except Exception as e:
                 #print error only when there is a major error with implementation of getJwtManager()
                 print(traceback.format_exc())
+
 
             return None
 
@@ -130,10 +131,16 @@ class Config(object):
 
     FLASK_LOGGING_LEVEL = os.environ.get('FLASK_LOGGING_LEVEL',
                                          'INFO')  # ['DEBUG','INFO','WARN','ERROR','CRITICAL']
+    CELERY_LOGGING_LEVEL = os.environ.get('CELERY_LOGGING_LEVEL',
+                                          FLASK_LOGGING_LEVEL)  # ['DEBUG','INFO','WARN','ERROR','CRITICAL']
     WERKZEUG_LOGGING_LEVEL = os.environ.get('WERKZEUG_LOGGING_LEVEL',
                                             'CRITICAL')  # ['DEBUG','INFO','WARN','ERROR','CRITICAL']
     DISPLAY_WERKZEUG_LOG = os.environ.get('DISPLAY_WERKZEUG_LOG',
                                           True)
+
+    CELERYD_HIJACK_ROOT_LOGGER = False
+    CELERYD_LOG_FORMAT = '%(asctime)s %(levelname)s [%(name)s] [%(filename)s:%(lineno)d]'
+    CELERYD_TASK_LOG_FORMAT = '%(asctime)s %(levelname)s [%(name)s] [%(filename)s:%(lineno)d]'
     
     GEOMARK_URL_BASE = os.environ.get('GEOMARK_URL_BASE', 'https://test.apps.gov.bc.ca/pub/geomark')
     GEOMARK_SECRET_KEY = os.environ.get('GEOMARK_SECRET_KEY', None)
@@ -142,6 +149,7 @@ class Config(object):
 
     LOGGING_DICT_CONFIG = {
         'version': 1,
+        'disable_existing_loggers': False,
         'formatters': {
             'default': {
                 '()': CustomFormatter,
@@ -161,6 +169,21 @@ class Config(object):
             'handlers': ['console']
         },
         'loggers': {
+            'celery': {
+                'level': CELERY_LOGGING_LEVEL,
+                'handlers': ['console'],
+                'propagate': False
+            },
+            'celery.app.trace': {
+                'level': CELERY_LOGGING_LEVEL,
+                'handlers': ['console'],
+                'propagate': False
+            },
+            'celery.task': {
+                'level': CELERY_LOGGING_LEVEL,
+                'handlers': ['console'],
+                'propagate': False
+            },
             'werkzeug': {
                 'level': WERKZEUG_LOGGING_LEVEL,
                 'handlers': ['console'],

--- a/services/document-manager/backend/requirements.txt
+++ b/services/document-manager/backend/requirements.txt
@@ -32,17 +32,16 @@ zipstream==1.1.4
 stream-zip==0.0.67
 requests_toolbelt==1.0.0
 
-opentelemetry-distro==0.33b0
-opentelemetry-exporter-otlp==1.12.0
-opentelemetry-instrumentation-dbapi==0.33b0
-opentelemetry-instrumentation-logging==0.33b0
-opentelemetry-instrumentation-urllib==0.33b0
-opentelemetry-instrumentation-wsgi==0.33b0
-opentelemetry-instrumentation-celery==0.33b0
-opentelemetry-instrumentation-flask==0.33b0
-opentelemetry-instrumentation-redis==0.33b0
-opentelemetry-instrumentation-requests==0.33b0
-opentelemetry-instrumentation-sqlalchemy==0.33b0
-opentelemetry-instrumentation-urllib3==0.33b0
+opentelemetry-distro==0.62b0
+opentelemetry-exporter-otlp==1.41.0
+opentelemetry-instrumentation-dbapi==0.62b0
+opentelemetry-instrumentation-logging==0.62b0
+opentelemetry-instrumentation-urllib==0.62b0
+opentelemetry-instrumentation-wsgi==0.62b0
+opentelemetry-instrumentation-celery==0.62b0
+opentelemetry-instrumentation-flask==0.62b0
+opentelemetry-instrumentation-redis==0.62b0
+opentelemetry-instrumentation-requests==0.62b0
+opentelemetry-instrumentation-sqlalchemy==0.62b0
+opentelemetry-instrumentation-urllib3==0.62b0
 tornado>=6.4.1 # not directly required, pinned by Snyk to avoid a vulnerability
-setuptools>=78.1.1 # not directly required, pinned by Snyk to avoid a vulnerability


### PR DESCRIPTION
## Objective 

[MDS-6198](https://bcmines.atlassian.net/browse/MDS-6198)

Separated flower into a separate container when running the app locally. That way we'll be able to see the logs for both containers easily.

Also resolved a "No module named pkg_resources" error when building the docman image. Cause: the `opentelemetry` pulled in an outdated `setuptools` package

<img width="951" height="501" alt="image" src="https://github.com/user-attachments/assets/50e691bb-6a62-422e-a02b-495fc3f6028e" />
