### PR TITLE
[MDS-6892] Active Permit Count Bugfix

### DIFF
--- a/services/core-api/app/api/mines/reports/resources/mine_report_stats.py
+++ b/services/core-api/app/api/mines/reports/resources/mine_report_stats.py
@@ -15,13 +15,12 @@ from flask_restx import Resource
 from pytz import timezone
 from werkzeug.exceptions import NotFound
 
-
 class MineReportStatsResource(Resource, UserMixin):
     @api.marshal_with(MINE_REPORT_STATS_MODEL, code=200)
     @requires_any_of([VIEW_ALL, MINESPACE_PROPONENT])
     def get(self, mine_guid):
         """Return stats for the given mine:
-        - active_permits: count of non-draft permits associated with the mine
+        - active_permits: count of non-draft, non-closed status permits associated with the mine
         - overdue_reports: due_date before today AND on/after 2025-04-01 (this is when report submissions became mandatory through Minespace) AND not yet submitted
         - due_next_90_days: due_date within [today, today+90] AND not yet submitted
         """
@@ -30,7 +29,7 @@ class MineReportStatsResource(Resource, UserMixin):
             raise NotFound('Mine not found')
 
         # Active permits are those surfaced by Mine.mine_permit (excludes drafts)
-        active_permits = len(mine.mine_permit_numbers)
+        active_permits = len([permit for permit in mine.mine_permit if permit.permit_status_code != 'C'])
 
         # Compute 'today' in Pacific Time to evaluate overdue and upcoming windows
         today = datetime.now(timezone('US/Pacific')).date()

--- a/services/core-api/tests/reports/resource/test_mine_report_stats_resource.py
+++ b/services/core-api/tests/reports/resource/test_mine_report_stats_resource.py
@@ -14,13 +14,15 @@ from tests.factories import (
 )
 
 
-def test_report_stats_active_permits_excludes_drafts(test_client, db_session, auth_headers):
+def test_report_stats_active_permits_excludes_inactive_permits(test_client, db_session, auth_headers):
     mine = MineFactory(mine_reports=0, minimal=True)
 
     p_draft = PermitFactory(permit_status_code='D')
     p_open = PermitFactory(permit_status_code='O')
+    p_closed = PermitFactory(permit_status_code='C') 
     MinePermitXrefFactory(permit=p_draft, mine=mine)
     MinePermitXrefFactory(permit=p_open, mine=mine)
+    MinePermitXrefFactory(permit=p_closed, mine=mine)
 
     resp = test_client.get(
         f"/mines/{mine.mine_guid}/reports/stats", headers=auth_headers['full_auth_header']


### PR DESCRIPTION
## Objective 

- Updated the logic that calculates a mine's active permit count to include a check for `permit_status = 'C'`, so the `active_permits` value accurately reflects both the number of non-draft permits, as well as non-closed permits
- Test file updated with the same logic

**_Note:_** Active permit filtering is currently split across two layers, `mine.mine_permit` excludes drafts (`permit_status == 'D'`), and the stats resource modified in this PR then excludes closed permits (`permit_status == 'C'`). Consolidating this logic into `mine.py` was considered but rejected, as `mine_permit` is used elsewhere in the codebase where closed permits should still be visible. The active permit definition was intentionally kept local to the stats calculation.  

[MDS-6892](https://bcmines.atlassian.net/browse/MDS-6892)

_Why are you making this change? Provide a short explanation and/or screenshots_

- It was noticed that the `active_permit` count for a mine did not accurately reflect how many open permits a mine had, instead it only filtered out the total number of non-draft permits (and kept included 'Closed' status permits)