### PR TITLE
[MDS-6886] Files with versions in bulk download are not downloading

### DIFF
--- a/services/common/src/components/documents/DocumentTable.tsx
+++ b/services/common/src/components/documents/DocumentTable.tsx
@@ -102,6 +102,15 @@ export const DocumentTable: FC<DocumentTableProps> = ({
     setDocuments(parseDocuments(props.documents ?? []));
   }, [props.documents]);
 
+  const normalizeSelectedRows = (selectedRows: MineDocument[]) => {
+    const latestByDocManager = new Map<string, MineDocument>();
+    documents.forEach((doc) => {
+      latestByDocManager.set(doc.document_manager_guid, doc);
+    });
+
+    return selectedRows.map((row) => latestByDocManager.get(row.document_manager_guid) ?? row)
+  };
+
   const openArchiveModal = (docs: MineDocument[]) => {
     const mineGuid = docs[0].mine_guid;
     dispatch(
@@ -312,8 +321,9 @@ export const DocumentTable: FC<DocumentTableProps> = ({
     </Row>;
   };
 
-  const handleRowSelectionChange = (value) => {
-    setRowSelection(value);
+  const handleRowSelectionChange = (selectedRows) => {
+    const normalized = normalizeSelectedRows(selectedRows);
+    setRowSelection(normalized);
   };
 
   const rowSelectionObject: any = {


### PR DESCRIPTION
## Objective 

[MDS-6886](https://bcmines.atlassian.net/browse/MDS-6886)

- Found out for files with versions when it comes to bulk download row selection it selects the original version of the file and not the latest. This also meant when our code tries to put together a list of document_manager_guids to send to the back end the files with versions would always have their document_manager_guid filtered out because the object does not have the property `is_latest_version` so it always just defaults to false for that conditional check.

- Adding logic to normalize row selection for bulk downloads to make sure files with versions will have their latest selected and not the original version.
