### PR TITLE
[MDS-6859] Fix Orgbook ID (Business Number) Not Displaying

### DIFF
--- a/services/core-api/app/api/search/search/search_transformers.py
+++ b/services/core-api/app/api/search/search/search_transformers.py
@@ -64,7 +64,7 @@ def prepare_party_source(source):
     
     prepared = dict(source)
     prepared['name'] = f"{first_name} {party_name}".strip() if first_name else party_name
-    prepared['party_orgbook_entity'] = None
+    prepared['party_orgbook_entity'] = source.get('party_orgbook_entity') #.get() returns None by default
     prepared['business_role_appts'] = []
     prepared['mine_party_appt'] = transformed_appts
     prepared['address'] = []

--- a/services/core-api/tests/search/test_search_transformers.py
+++ b/services/core-api/tests/search/test_search_transformers.py
@@ -79,7 +79,8 @@ class TestPreparePartySources:
             'party_name': 'Doe',
             'party_type_code': 'PER',
             'email': 'john.doe@example.com',
-            'phone_no': '555-1234'
+            'phone_no': '555-1234',
+            'party_orgbook_entity': {'registration_id': 'BC123456'}
         }
         
         result = prepare_party_source(source)
@@ -89,9 +90,17 @@ class TestPreparePartySources:
         assert result['first_name'] == 'John'
         assert result['party_name'] == 'Doe'
         assert result['email'] == 'john.doe@example.com'
-        assert result['party_orgbook_entity'] is None
+        assert result['party_orgbook_entity'] == {'registration_id': 'BC123456'}
         assert result['business_role_appts'] == []
         assert result['address'] == []
+    
+    def test_prepare_party_source_without_orgbook_entity(self):
+        source = {} 
+
+        result = prepare_party_source(source)
+
+        assert result['party_orgbook_entity'] is None
+
 
     def test_prepare_party_source_organization(self):
         source = {

--- a/services/pgsync/schema.json
+++ b/services/pgsync/schema.json
@@ -195,6 +195,27 @@
                 "email",
                 "phone_no",
                 "deleted_ind"
+            ],
+            "children": [
+                {
+                    "table": "party_orgbook_entity",
+                    "columns": [
+                        "registration_id"
+                    ],
+                    "label": "party_orgbook_entity",
+                    "relationship": {
+                        "type": "one_to_one",
+                        "variant": "object",
+                        "foreign_key": {
+                            "child": [
+                                "party_guid"
+                            ],
+                            "parent": [
+                                "party_guid"
+                            ]
+                        }
+                    }
+                }
             ]
         }
     },


### PR DESCRIPTION
## Objective 

- Fix a bug where a verified mine's Orgbook Business Number was not displaying in the 'Add Bond' modal

[MDS-6859](https://bcmines.atlassian.net/browse/MDS-6859)

_Why are you making this change? Provide a short explanation and/or screenshots_

It was noted that in the 'Add Bond' modal on the Securities page in Core, a verified mine's Orgbook Business Number was not being displayed:

<img width="1139" height="566" alt="image" src="https://github.com/user-attachments/assets/d38aad75-83c9-4de1-8069-f7b5be0e1a66" />


This PR fixes this behavior, now correctly displaying the ID:

<img width="1087" height="538" alt="image" src="https://github.com/user-attachments/assets/377c16df-c595-49c6-bfa5-c5f82652084d" />
