### PR TITLE
[CHORE] Fix Local M1 Deployments

### DIFF
--- a/docker-compose.M1.yaml
+++ b/docker-compose.M1.yaml
@@ -167,7 +167,7 @@ services:
       - certs:/certs
     depends_on:
       - flyway
-      - nris_backend
+      # - nris_backend
       - document_manager_backend
       - tusd
       - filesystem_provider
@@ -179,7 +179,7 @@ services:
       - keycloak
       - core_api_celery
     healthcheck:
-      test: ["CMD", "curl", "localhost:5000/health"]
+      test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:5000/health')\""]
       interval: 5s
       timeout: 5s
       retries: 5
@@ -260,38 +260,38 @@ services:
       retries: 5
 
   ####################### NRIS_BACKEND Definition #######################
-  nris_backend:
-    restart: always
-    container_name: nris_python
-    build:
-      context: services/nris-api/backend
-    ports:
-      - 5500:5500
-    volumes:
-      - ./services/nris-api/backend:/app
-    depends_on:
-      - flyway
-      - redis
-      - nris_migrate
-    env_file: ./services/nris-api/backend/.env
-    healthcheck:
-      test: ["CMD", "curl", "localhost:5500/health"]
-      interval: 5s
-      timeout: 5s
-      retries: 5
+  # nris_backend:
+  #   restart: always
+  #   container_name: nris_python
+  #   build:
+  #     context: services/nris-api/backend
+  #   ports:
+  #     - 5500:5500
+  #   volumes:
+  #     - ./services/nris-api/backend:/app
+  #   depends_on:
+  #     - flyway
+  #     - redis
+  #     - nris_migrate
+  #   env_file: ./services/nris-api/backend/.env
+  #   healthcheck:
+  #     test: ["CMD", "curl", "localhost:5500/health"]
+  #     interval: 5s
+  #     timeout: 5s
+  #     retries: 5
 
-  nris_migrate:
-    restart: on-failure
-    container_name: nris_migrate
-    build:
-      dockerfile: Dockerfile.migrate
-      context: services/nris-api/backend
-    volumes:
-      - ./services/nris-api/backend:/app
-    depends_on:
-      - flyway
-      - redis
-    env_file: ./services/nris-api/backend/.env
+  # nris_migrate:
+  #   restart: on-failure
+  #   container_name: nris_migrate
+  #   build:
+  #     dockerfile: Dockerfile.migrate
+  #     context: services/nris-api/backend
+  #   volumes:
+  #     - ./services/nris-api/backend:/app
+  #   depends_on:
+  #     - flyway
+  #     - redis
+  #   env_file: ./services/nris-api/backend/.env
 
   ####################### TUSD Definition #######################
   tusd:
@@ -305,7 +305,6 @@ services:
   ####################### Syncfusion Filesystem Provider Definition #######################
   filesystem_provider:
     container_name: filesystem_provider
-    platform: linux/amd64
     build:
       context: services/filesystem-provider
     ports:

--- a/docker-compose.M1.yaml
+++ b/docker-compose.M1.yaml
@@ -167,7 +167,6 @@ services:
       - certs:/certs
     depends_on:
       - flyway
-      # - nris_backend
       - document_manager_backend
       - tusd
       - filesystem_provider

--- a/otel-collector-config.yaml
+++ b/otel-collector-config.yaml
@@ -8,8 +8,8 @@ processors:
   batch:
 
 exporters:
-  jaeger:
-    endpoint: jaeger:14250
+  otlp:
+    endpoint: jaeger:4317
     tls:
       insecure: true # https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configtls/README.md
 
@@ -28,4 +28,4 @@ service:
     traces:
       receivers: [otlp]
       processors: [batch]
-      exporters: [jaeger]
+      exporters: [otlp]

--- a/services/core-api/tests/factories.py
+++ b/services/core-api/tests/factories.py
@@ -546,7 +546,7 @@ class MineVerifiedStatusFactory(BaseFactory):
     healthy_ind = factory.Faker('boolean', chance_of_getting_true=50)
     verifying_user = factory.Faker('name')
     verifying_timestamp = TODAY
-    update_user = factory.Faker('name')
+    update_user = 'system'
     update_timestamp = TODAY
 
 
@@ -620,8 +620,8 @@ class MineIncidentNoteFactory(BaseFactory):
     mine_incident_note_guid = GUID
     mine_incident_guid = factory.SelfAttribute('mine_incident.mine_incident_guid')
     content = factory.Faker('sentence')
-    create_user = factory.Faker('name')
-    update_user = factory.Faker('name')
+    create_user = 'system'
+    update_user = 'system'
     create_timestamp = TODAY
     update_timestamp = TODAY
     deleted_ind = False

--- a/services/filesystem-provider/Dockerfile
+++ b/services/filesystem-provider/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update \
     supervisor \
     procps
 
-RUN ln -s /lib/x86_64-linux-gnu/libdl-2.24.so /lib/x86_64-linux-gnu/libdl.so
+RUN ln -s /lib/x86_64-linux-gnu/libdl-2.24.so /lib/x86_64-linux-gnu/libdl.so || true
     # install System.Drawing native dependencies
 RUN apt-get update && apt-get install -y --allow-unauthenticated libgdiplus libc6-dev libx11-dev
 RUN ln -s libgdiplus.so gdiplus.dll

--- a/services/permits/docker-compose.yaml
+++ b/services/permits/docker-compose.yaml
@@ -67,7 +67,7 @@ services:
   create_certs:
     tty: true
     container_name: create_certs
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.12.1
+    image: elasticsearch:8.12.1
     command: >
       bash -c '
       ### 1. Create CA and certificates for elasticsearch.
@@ -113,7 +113,7 @@ services:
       retries: 120
 
   elasticsearch:
-    image: "docker.elastic.co/elasticsearch/elasticsearch:8.12.1"
+    image: "elasticsearch:8.12.1"
     container_name: elasticsearch
     ports:
       - 9200:9200


### PR DESCRIPTION
## Objective 

_Why are you making this change? Provide a short explanation and/or screenshots_

While doing a local deployment of the full backend for the first time, I ran into several issues that needed to be resolved. Anyone deploying on an Apple M1  that wipes their cached images and uses the latest configs (does a 'clean slate' deployment) would also run into these issues. 

These changes resolve those issues, such that both `make be` and `make be-minimal` complete successfully and all backend services spin up without issue.

Below is a summary of each service I encountered an issue with, and the steps taken to resolve the issue. 

### NRIS Service
_Affects: M1 Builds Only_
**Background / Issue:**
   - The `nris_backend` and `nris_migrate` services were active in `docker-compose.M1.yaml` and listed as `depends_on` for backend. 
   - This caused `make be` to attempt to build and run NRIS locally, which is not viable for two reasons: 
     - (1) the service connects to an external BC Government Oracle database via a wallet/certificate that requires coordination with the NRIS admin team - it is not reachable locally without this; 
     - (2) the Oracle Instant Client bundled in the Dockerfile is x86-only (linux.x64), with no ARM64 build available.

**Steps to Reproduce:** 
- Run `make be` on M1 - build fails due to `cx_Oracle` requiring `pkg_resources` during pip wheel build (a side effect of `setuptools>=78.1.1`). 

**Changes made:**
  - `docker-compose.M1.yaml`: commented out `nris_backend` and `nris_migrat` service definitions                                                                             
  - `docker-compose.M1.yaml`: removed `nris_backend` from backend's `depends_on`
 
**Result:** 
- `make be` no longer attempts to build or start NRIS.

  ---
### Filesystem-Provider Service    
_Affects: All Builds_                                            
**Background / Issue:**
- The `filesystem_provider` service had platform: `linux/amd64` set in `docker-compose.M1.yaml`, forcing the build to run under Rosetta emulation. 
  - This caused `dotnet restore` to hang during build. 
  - This is a known symptom of Rosetta's network stack stalling on outbound TCP connections during build. 
- The `mcr.microsoft.com/dotnet/sdk:7.0` image (the image already being used) has native ARM64 support, making the emulation flag unnecessary.
- Additionally, the Dockerfile contained a symlink command targeting an x86-specific path 
  (`/lib/x86_64-linux-gnu/libdl-2.24.so`) that does not exist on ARM64, causing the build to fail if `platform: linux/amd64` is removed.                                           
                  
**Steps to Reproduce:** 
- Run `make be` on M1 - `dotnet restore` hangs indefinitely with zero output.

**Changes made:**                                                                         
  - `docker-compose.M1.yaml`: removed `platform: linux/amd64` from the `filesystem_provider` service definition                                                                          
  - `services/filesystem-provider/Dockerfile`: appended `|| true` to the libdl symlink line to make it non-fatal on ARM64 (no impact on x86 systems)                                                     
                                                                                          
**Result:**
- `filesystem_provider` service builds and starts successfully on ARM64.
                                                                                          
**Note:** The `|| true` change affects *all* platforms, but on x86 the symlink command  already silently creates a dangling symlink (the source file `libdl-2.24.so` no longer exists as a standalone file on modern Debian). The `|| true` has no practical effect on x86 builds. The `platform: linux/amd64` removal is M1-specific.

  ---
### OpenTelemetry Collector (Jaeger Exporter Removed)
_Affects: All Builds_                                                                                  
**Background / Issue:**
- The `otelcollector` service used `image: otel/opentelemetry-collector` (unpinned latest) and `otel-collector-config.yaml` configured a jaeger exporter. 
- The jaeger exporter was removed from both the `core` and `contrib OTel` collector distributions in recent versions, in favour of sending traces to Jaeger via the standard `otlp` exporter (Jaeger has supported OTLP natively since v1.35). 
- With an unpinned image, a recent pull picked up a version that no longer includes the exporter, causing the collector to crash on startup with a config parse error.

**Steps to Reproduce:** 
- Run `make be`- `mds-otelcollector-1` exits immediately with: `'exporters' unknown type: "jaeger"`.
                                                                                          
**Changes made:**  
- `otel-collector-config.yaml`: replaced `jaeger exporter` (pointing to `jaeger:14250`) with `otlp exporter` pointing to `jaeger:4317` (Jaeger's OTLP gRPC port)                         
- `otel-collector-config.yaml`: updated the traces pipeline to reference otlp instead of `jaeger`

**Result:**
- OTel collector starts and stays running. Traces flow from backend services → collector → Jaeger as before.

  ---
### MDS Backend Healthcheck
_Affects: All Builds_
**Background / Issue:**
- The backend service healthcheck in `docker-compose.M1.yaml` used `["CMD", "curl", 
  "localhost:5000/health"]`. 
- The `core-api` Dockerfile is based on `python:3.11.14-slim`, which does not include curl. 
- Every healthcheck invocation failed with `exec: "curl": executable file not found in $PATH`, permanently marking the container unhealthy despite  the service running correctly.

**Steps to Reproduce:** 
- Run `make be` - `mds_backend` shows as (unhealthy) in `docker ps` indefinitely (the backend pod remains up and does function correctly).
                                                                                          
**Changes made:** 
- `docker-compose.M1.yaml`: replaced curl healthcheck with `CMD-SHELL` using Python's built-in `urllib.request`, which is guaranteed available in any Python container

**Result:**
- `mds_backend` correctly transitions to healthy after startup.                                   

---
### Seed DB Data Factory Fix
 _Affects: All Builds_                                                                            
**Background / Issue:**
- `make seeddb` failed with `psycopg2.errors.StringDataRightTruncation: value too long for type character varying(60)`.
- The AuditMixin defines `create_user` and `update_user` as `String(60)`, which is appropriate for real IDIR usernames.
- However, two test factories (_MineVerifiedStatusFactory_ and _MineIncidentNoteFactory_) were using            
  `factory.Faker('name')` for these fields, which generates full person names that can exceed 60 characters.

**Steps to Reproduce:**
- Run `make seeddb` - command fails after some time with `psycopg2.errors.StringDataRightTruncation: value too long for type character varying(60)`.

**Changes made:**                                                                         
  - `services/core-api/tests/factories.py`: changed `update_user` from `factory.Faker('name')` to `'system'`             
  - `services/core-api/tests/factories.py`: changed `create_user` and `update_user` from `factory.Faker('name')` to `'system'`
                                                     
**Result:**
- `make seeddb` completes successfully. 
- _Note:_`'system'` matches the value `get_user_username()` returns in non-request context (CLI commands), and aligns with existing test assertions in the codebase.