### PR TITLE
[MDS-6908] Fix PGSync DevOps Workflows

### DIFF
--- a/.github/workflows/pgsync.build.dev.yaml
+++ b/.github/workflows/pgsync.build.dev.yaml
@@ -6,7 +6,7 @@ on:
     branches:
       - develop
     paths:
-      - services/pgsync/**
+      - services/pgsync/*
       - .github/workflows/pgsync.build.dev.yaml
 
 env:

--- a/.github/workflows/pgsync.build.dev.yaml
+++ b/.github/workflows/pgsync.build.dev.yaml
@@ -31,3 +31,11 @@ jobs:
       - name: Push
         run: |
           docker push --all-tags ${{ secrets.CLUSTER_REGISTRY }}/${{ secrets.NS_TOOLS }}/${{ env.NAME }}
+
+      - name: Setup SSH Agent
+        uses: ./.github/actions/setup-ssh
+        with:
+          ssh-private-key: ${{ secrets.GITOPS_REPO_DEPLOY_KEY }}
+
+      - name: Commit and Push
+        run: ./gitops/commit.sh ${{ env.NAME }} dev dev ${{ github.actor }} permits

--- a/.github/workflows/pgsync.build.dev.yaml
+++ b/.github/workflows/pgsync.build.dev.yaml
@@ -6,6 +6,7 @@ on:
     branches:
       - develop
     paths:
+      - services/pgsync/**
       - .github/workflows/pgsync.build.dev.yaml
 
 env:

--- a/.github/workflows/pgsync.deploy.prod.yaml
+++ b/.github/workflows/pgsync.deploy.prod.yaml
@@ -64,5 +64,7 @@ jobs:
     needs: [trigger-gitops]
     if: always() && (needs.trigger-gitops.result == 'failure')
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
       - name: Notification
-        run: ./gitops/watch-deployment.sh pgsync prod ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} 1
+        run: ./gitops/notify_discord.sh pgsync prod ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} 1 mds-permits-prod

--- a/.github/workflows/pgsync.deploy.prod.yaml
+++ b/.github/workflows/pgsync.deploy.prod.yaml
@@ -30,7 +30,7 @@ jobs:
 
   trigger-gitops:
     runs-on: ubuntu-24.04
-    timeout-minutes: 10
+    timeout-minutes: 15
     needs: promote-image
     steps:
       - name: Checkout
@@ -42,8 +42,9 @@ jobs:
           ssh-private-key: ${{ secrets.GITOPS_REPO_DEPLOY_KEY }}
 
       - name: Git Ops Push
-        run: ./gitops/commit.sh ${{ env.IMAGE }} test prod ${{ github.actor }}
+        run: ./gitops/commit.sh ${{ env.IMAGE }} test prod ${{ github.actor }} permits
       - name: Install oc
+        if: ${{ env.NEEDS_ROLLOUT=='true' }}
         uses: redhat-actions/openshift-tools-installer@v1
         with:
           oc: "4.7"
@@ -52,9 +53,11 @@ jobs:
         with:
           version: v2.7.9 # optional
       - name: oc login
+        if: ${{ env.NEEDS_ROLLOUT=='true' }}
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
-        run: ./gitops/watch-deployment.sh pgsync prod ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGO_CD_CLI_JWT }}
+        if: ${{ env.NEEDS_ROLLOUT=='true' }}
+        run: ./gitops/watch-deployment.sh pgsync prod ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGO_CD_CLI_JWT }} mds-permits-prod false
 
   run-if-failed:
     runs-on: ubuntu-24.04

--- a/.github/workflows/pgsync.deploy.test.yaml
+++ b/.github/workflows/pgsync.deploy.test.yaml
@@ -64,5 +64,7 @@ jobs:
     needs: [trigger-gitops]
     if: always() && (needs.trigger-gitops.result == 'failure')
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
       - name: Notification
-        run: ./gitops/watch-deployment.sh pgsync test ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} 1
+        run: ./gitops/notify_discord.sh pgsync test ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} 1 mds-permits-test

--- a/.github/workflows/pgsync.deploy.test.yaml
+++ b/.github/workflows/pgsync.deploy.test.yaml
@@ -54,7 +54,7 @@ jobs:
       - name: oc login
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
-        run: ./gitops/watch-deployment.sh pgsync test ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGO_CD_CLI_JWT }}
+        run: ./gitops/watch-deployment.sh pgsync test ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGO_CD_CLI_JWT }} mds-permits-test
 
   run-if-failed:
     runs-on: ubuntu-24.04

--- a/.github/workflows/pgsync.deploy.test.yaml
+++ b/.github/workflows/pgsync.deploy.test.yaml
@@ -57,7 +57,7 @@ jobs:
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
         if: ${{ env.NEEDS_ROLLOUT=='true' }}
-        run: ./gitops/watch-deployment.sh pgsync test ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGO_CD_CLI_JWT }} mds-permits-test
+        run: ./gitops/watch-deployment.sh pgsync test ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGO_CD_CLI_JWT }} mds-permits-test false
 
   run-if-failed:
     runs-on: ubuntu-24.04

--- a/.github/workflows/pgsync.deploy.test.yaml
+++ b/.github/workflows/pgsync.deploy.test.yaml
@@ -42,7 +42,7 @@ jobs:
           ssh-private-key: ${{ secrets.GITOPS_REPO_DEPLOY_KEY }}
 
       - name: Git Ops Push
-        run: ./gitops/commit.sh ${{ env.IMAGE }} dev test ${{ github.actor }}
+        run: ./gitops/commit.sh ${{ env.IMAGE }} dev test ${{ github.actor }} permits
       - name: Install oc
         uses: redhat-actions/openshift-tools-installer@v1
         with:

--- a/.github/workflows/pgsync.deploy.test.yaml
+++ b/.github/workflows/pgsync.deploy.test.yaml
@@ -30,7 +30,7 @@ jobs:
 
   trigger-gitops:
     runs-on: ubuntu-24.04
-    timeout-minutes: 10
+    timeout-minutes: 15
     needs: promote-image
     steps:
       - name: Checkout
@@ -44,6 +44,7 @@ jobs:
       - name: Git Ops Push
         run: ./gitops/commit.sh ${{ env.IMAGE }} dev test ${{ github.actor }} permits
       - name: Install oc
+        if: ${{ env.NEEDS_ROLLOUT=='true' }}
         uses: redhat-actions/openshift-tools-installer@v1
         with:
           oc: "4.7"
@@ -52,8 +53,10 @@ jobs:
         with:
           version: v2.7.9 # optional
       - name: oc login
+        if: ${{ env.NEEDS_ROLLOUT=='true' }}
         run: oc login --token=${{ secrets.BUILD_TOKEN }} --server=${{ secrets.CLUSTER_API }}
       - name: Notification
+        if: ${{ env.NEEDS_ROLLOUT=='true' }}
         run: ./gitops/watch-deployment.sh pgsync test ${{ github.sha }} ${{ secrets.DISCORD_DEPLOYMENT_WEBHOOK }} ${{ secrets.ARGOCD_SERVER }} ${{ secrets.ARGO_CD_CLI_JWT }} mds-permits-test
 
   run-if-failed:

--- a/gitops/commit.sh
+++ b/gitops/commit.sh
@@ -5,6 +5,7 @@ TARGET_APP=${1?"Enter App Name !"}
 SOURCE_ENV=${2?"Enter Source Env Name !"}
 TARGET_ENV=${3?"Enter Target Env Name !"}
 ACTOR_NAME=${4?"Enter Actor Name !"}
+GITOPS_APP_DIR=${5:-}
 
 MDS_GIT_HASH=$(git rev-parse --verify HEAD)
 REPO_URL="https://github.com/bcgov/mds/commit"
@@ -35,6 +36,25 @@ function commit() {
     fi
 }
 
+function get_overlay_dir() {
+    local env=$1
+    if [ -n "$GITOPS_APP_DIR" ]; then
+        echo "$GITOPS_APP_DIR/overlays/$env/$TARGET_APP"
+    else
+        echo "$TARGET_APP/overlays/$env"
+    fi
+}
+
+function validate_patch_path() {
+    local path_pattern=$1
+    local matches
+    matches=$(ls $path_pattern 2>/dev/null)
+    if [ -z "$matches" ]; then
+        echo "ERROR: No deployment patch file found matching: $path_pattern" >&2
+        exit 1
+    fi
+}
+
 if [ ! -d $REPO_LOCATION/gitops/tenant-gitops-4c2ba9 ]; then
     git clone git@github.com:bcgov-c/tenant-gitops-4c2ba9.git $REPO_LOCATION/gitops/tenant-gitops-4c2ba9
 fi
@@ -47,17 +67,23 @@ cd $REPO_LOCATION/gitops/tenant-gitops-4c2ba9
 if [ $TARGET_ENV == 'dev' ]; then
     echo "$TARGET_ENV Environment, updating git hash in deployment env vars"
 
+    TARGET_PATCH="$(get_overlay_dir $TARGET_ENV)/*deployment.patch.yaml"
+    validate_patch_path "$TARGET_PATCH"
     # Replace the commit sha in env vars in overlay patch
-    sed -i "s^git-commit.*^git-commit-$MDS_GIT_HASH^" $TARGET_APP/overlays/$TARGET_ENV/*deployment.patch.yaml
+    sed -i "s^git-commit.*^git-commit-$MDS_GIT_HASH^" $TARGET_PATCH
     commit "[$TARGET_APP] Pushed to $TARGET_ENV by $ACTOR_NAME - $REPO_URL/$MDS_GIT_HASH"
 else
     echo "$TARGET_ENV Environment, Trigger deployment by promoting image from $SOURCE_ENV env"
     # copy git has from dev into test / prod overlay patch!
     # promotion of images are based off the same git hash!
-    MDS_GIT_HASH=$(cat $TARGET_APP/overlays/$SOURCE_ENV/*deployment.patch.yaml | grep git-commit -m1 | cut -f2 -d ":" | xargs | cut -d "-" -f 3)
+    SOURCE_PATCH="$(get_overlay_dir $SOURCE_ENV)/*deployment.patch.yaml"
+    TARGET_PATCH="$(get_overlay_dir $TARGET_ENV)/*deployment.patch.yaml"
+    validate_patch_path "$SOURCE_PATCH"
+    validate_patch_path "$TARGET_PATCH"
+    MDS_GIT_HASH=$(cat $SOURCE_PATCH | grep git-commit -m1 | cut -f2 -d ":" | xargs | cut -d "-" -f 3)
     echo
     # Replace the commit sha in env vars in overlay patch
-    sed -i "s^git-commit.*^git-commit-$MDS_GIT_HASH^" $TARGET_APP/overlays/$TARGET_ENV/*deployment.patch.yaml
+    sed -i "s^git-commit.*^git-commit-$MDS_GIT_HASH^" $TARGET_PATCH
     commit "[$TARGET_APP] Pushed from $SOURCE_ENV to $TARGET_ENV by $ACTOR_NAME - $REPO_URL/$MDS_GIT_HASH"
 
 fi

--- a/gitops/notify_discord.sh
+++ b/gitops/notify_discord.sh
@@ -6,6 +6,7 @@ ENV=${2?"Enter ENV Name !"}
 GIT_SHA=${3?"Enter GIT SHA of commit!"}
 DISCORD_URL=${4?"Enter DISCORD Webhook!"}
 SUCCESS=${5?"Success-0 or Fail-1?"}
+ARGOCD_APP=${6:-"mds-$TARGET_APP-$ENV"}
 
 if [ $SUCCESS == 0 ]; then
     MSG_COLOR=65280
@@ -25,7 +26,7 @@ curl -X POST -H 'Content-Type: application/json' --data \
     "embeds": [
         {
             "title": "'"Argo CD: $TARGET_APP"'",
-            "description": "'"Deployment $MSG - $TARGET_APP - $ENV [click here](https://argocd-shared.apps.silver.devops.gov.bc.ca/applications/mds-$TARGET_APP-$ENV)"'",
+            "description": "'"Deployment $MSG - $TARGET_APP - $ENV [click here](https://argocd-shared.apps.silver.devops.gov.bc.ca/applications/$ARGOCD_APP)"'",
             "color": "'"$MSG_COLOR"'"
         },
         {

--- a/gitops/watch-deployment.sh
+++ b/gitops/watch-deployment.sh
@@ -35,7 +35,7 @@ fi
 
 echo "Target Revision is achieved $CURRENT_REVISION"
 
-echo "Watching rollout of new revision! "
+echo "Watching rollout of new revision "
 kubectl rollout status -w deploy/$TARGET_APP -n 4c2ba9-$ENV
 
 ROLLOUT_STATUS=$?

--- a/gitops/watch-deployment.sh
+++ b/gitops/watch-deployment.sh
@@ -8,6 +8,7 @@ DISCORD_DEPLOYMENT_WEBHOOK=${4?"Enter DISCORD_DEPLOYMENT_WEBHOOK!"}
 ARGOCD_SERVER=${5?"Enter ARGOCD_SERVER!"}
 ARGOCD_AUTH_TOKEN=${6?"Enter ARGOCD_AUTH_TOKEN!"}
 ARGOCD_APP=${7:-"mds-$TARGET_APP-$ENV"}
+ARGOCD_WAIT=${8:-true}
 
 REPO_LOCATION=$(git rev-parse --show-toplevel)
 
@@ -28,7 +29,9 @@ echo "Watching for new revision of $TARGET_APP to be rolled out"
 echo "Waiting for $TARGET_APP to sync and be in healthy state"
 
 argocd app sync $ARGOCD_APP --grpc-web --server $ARGOCD_SERVER --auth-token $ARGOCD_AUTH_TOKEN
-argocd app wait $ARGOCD_APP --grpc-web --server $ARGOCD_SERVER --auth-token $ARGOCD_AUTH_TOKEN
+if [ "$ARGOCD_WAIT" == "true" ]; then
+    argocd app wait $ARGOCD_APP --grpc-web --server $ARGOCD_SERVER --auth-token $ARGOCD_AUTH_TOKEN
+fi
 
 echo "Target Revision is achieved $CURRENT_REVISION"
 

--- a/gitops/watch-deployment.sh
+++ b/gitops/watch-deployment.sh
@@ -7,6 +7,7 @@ GIT_SHA=${3?"Enter GIT SHA of commit!"}
 DISCORD_DEPLOYMENT_WEBHOOK=${4?"Enter DISCORD_DEPLOYMENT_WEBHOOK!"}
 ARGOCD_SERVER=${5?"Enter ARGOCD_SERVER!"}
 ARGOCD_AUTH_TOKEN=${6?"Enter ARGOCD_AUTH_TOKEN!"}
+ARGOCD_APP=${7:-"mds-$TARGET_APP-$ENV"}
 
 REPO_LOCATION=$(git rev-parse --show-toplevel)
 
@@ -26,9 +27,8 @@ echo -e "\n"
 echo "Watching for new revision of $TARGET_APP to be rolled out"
 echo "Waiting for $TARGET_APP to sync and be in healthy state"
 
-APP="mds-$TARGET_APP-$ENV"
-argocd app sync $APP --server $ARGOCD_SERVER --auth-token $ARGOCD_AUTH_TOKEN
-argocd app wait $APP --server $ARGOCD_SERVER --auth-token $ARGOCD_AUTH_TOKEN
+argocd app sync $ARGOCD_APP --grpc-web --server $ARGOCD_SERVER --auth-token $ARGOCD_AUTH_TOKEN
+argocd app wait $ARGOCD_APP --grpc-web --server $ARGOCD_SERVER --auth-token $ARGOCD_AUTH_TOKEN
 
 echo "Target Revision is achieved $CURRENT_REVISION"
 


### PR DESCRIPTION
## Objective 

[MDS-6908](https://bcmines.atlassian.net/browse/MDS-6908)

_Why are you making this change? Provide a short explanation and/or screenshots_

The **PGSync - Promote Test** and **PGSync - Promote PROD** GitHub Actions workflows were both non-functional, as PGSync is deployed as part of the Permits service in ArgoCD (`mds-permits-*`) rather than having its own top-level GitOps directory. This created a structural mismatch with the shared scripts used by all other services. Subsequent compounding issues caused every workflow run to fail at different stages, all of which have been resolved in this PR.

**Key Points:**
- The root cause was that the shared `commit.sh` script constructed the GitOps file paths assumed a `{APP}/overlays/{ENV}/` structure, while PGSync's actual path in the GitOps repo was `permits/overlays/{ENV}/pgsync/`
- Additionally, `pgsync.build.dev.yaml` was missing the GitOps update step present in all other dev build workflows, meaning the dev overlay was permanently stuck at `git-commit-placeholder` and could never be promoted to test.
- `pgsync.deploy.test.yaml` was missing `NEEDS_ROLLOUT` conditions on the Notification step, causing it to run unconditionally and hang on every run, including when there was nothing to deploy.      
- `watch-deployment.sh` constructed the ArgoCD app name as `mds-pgsync-test`, which does not exist. 
  - PGSync is managed under `mds-permits-test`
- `argocd app wait` on the full permits app caused indefinite hangs due to pre-existing unhealthy resources unrelated to PGSync, making it appear as though PGSync did not deploy successfully when it actually did.
- The `run-if-failed` job in both pgsync workflows was completely non-functional - it was missing a checkout step, calling the wrong script (`watch-deployment.sh` instead of `notify_discord.sh`), and passing insufficient arguments.
- `notify_discord.sh` hardcoded the ArgoCD link as `mds-{APP}-{ENV}`, producing a broken link for any bundled service like PGSync.

_Note that all the changes made are backwards compatible, no existing calls have been broken._

**Changes Made:**
- `gitops/commit.sh`: Added optional argument `GITOPS_APP_DIR`. When provided, resolves GitOps paths as `{GITOPS_APP_DIR}/overlays/{ENV}/{APP}/` instead of the default. 
  - Added `get_overlay_dir()` and `validate_patch_path()` helper functions for cleaner path handling and fast, understandable failure messages.
- `gitops/watch-deployment.sh`: Added optional argument `ARGOCD_APP` (ArgoCD app name override) and `ARGOCD_WAIT` (skips `argocd app wait` when false). 
  - Added `--grpc-web` flag to all ArgoCD CLI calls to silence related warnings.
- `gitops/notify_discord.sh`: Added optional argument `ARGOCD_APP` and updated the ArgoCD embed link to use it. 
- `pgsync.build.dev.yaml`: Added SSH agent setup and GitOps push step to write the real commit hash to the dev overlay on each build. 
  - Added `services/pgsync/**` to the push path trigger.
- `pgsync.deploy.test.yaml`: Passed permits as GITOPS_APP_DIR to commit.sh.
  - Added `NEEDS_ROLLOUT` conditions to **Install oc**,  **oc login**, and **Notification** steps. 
  - Bumped `timeout-minutes` from 10 to 15. 
  - Passed `mds-permits-test` as ArgoCD app override and false for `ARGOCD_WAIT` to `watch-deployment.sh`. 
  - Fixed `run-if-failed`: added checkout step, replaced `watch-deployment.sh` with `notify_discord.sh`, passed `mds-permits-test` as ArgoCD app override.
- `pgsync.deploy.prod.yaml`: Same changes as test workflow with prod-appropriate values.