### PR TITLE
[MDS-6897] Update UI for HSRC Clauses and Reports

### DIFF
--- a/services/core-web/src/components/admin/complianceCodes/AddReportDefinitionForm.tsx
+++ b/services/core-web/src/components/admin/complianceCodes/AddReportDefinitionForm.tsx
@@ -53,10 +53,9 @@ const AddReportDefinitionForm: FC<{
         component={RenderAutoSizeField}
         name="description"
         label="Description"
-        // labelSubtitle={(<p><i>A short, plain-language summary of what the report is and when it is required.
-        //   This text is shown to mines when they choose a report to submit in MineSpace.</i></p>)}
+        labelSubtitle={(<p><i>A short, plain-language summary of what the report is and when it is required.
+          This text is shown to mines when they choose a report to submit in MineSpace.</i></p>)}
         maximumCharacters={3000}
-        placeholder="A short, plain-language summary of what the report is and when it is required. This text is shown to mines when they choose a report to submit in MineSpace."
         validate={[required, maxLength(3000)]}
       />
       <Row gutter={16}>

--- a/services/core-web/src/components/admin/complianceCodes/AddReportDefinitionForm.tsx
+++ b/services/core-web/src/components/admin/complianceCodes/AddReportDefinitionForm.tsx
@@ -2,7 +2,6 @@ import React, { FC } from "react";
 import FormWrapper from "@mds/common/components/forms/FormWrapper";
 import { ADD_REPORT_DEFINITION } from "@/constants/forms";
 import { Col, Row, Typography } from "antd";
-import RenderField from "@mds/common/components/forms/RenderField";
 import RenderSelect from "@mds/common/components/forms/RenderSelect";
 import RenderRadioButtons from "@mds/common/components/forms/RenderRadioButtons";
 import RenderAutoSizeField from "@mds/common/components/forms/RenderAutoSizeField";
@@ -40,21 +39,25 @@ const AddReportDefinitionForm: FC<{
       reduxFormConfig={{ destroyOnUnmount: true }}
     >
       <Title level={3}>Report Details</Title>
+      <Typography.Text><i>The information entered here is displayed to mine proponents in MineSpace when they select and submit this report.</i></Typography.Text>
       <Field
         required
-        component={RenderField}
+        component={RenderAutoSizeField}
         name="report_name"
         label="Report Name"
-        validate={[required, maxLength(100)]}
+        validate={[required, maxLength(200)]}
+        maximumCharacters={200}
       />
       <Field
         required
         component={RenderAutoSizeField}
         name="description"
         label="Description"
-        maximumCharacter={300}
-        placeholder="Describe the report's definition / purpose for the mine proponent"
-        validate={[required, maxLength(300)]}
+        // labelSubtitle={(<p><i>A short, plain-language summary of what the report is and when it is required.
+        //   This text is shown to mines when they choose a report to submit in MineSpace.</i></p>)}
+        maximumCharacters={3000}
+        placeholder="A short, plain-language summary of what the report is and when it is required. This text is shown to mines when they choose a report to submit in MineSpace."
+        validate={[required, maxLength(3000)]}
       />
       <Row gutter={16}>
         <Col span={12}>
@@ -81,15 +84,13 @@ const AddReportDefinitionForm: FC<{
           />
         </Col>
       </Row>
-      <Paragraph strong className="margin-small--bottom">
-        Report Type
-      </Paragraph>
       <Field
         required
         isVertical={true}
         component={RenderRadioButtons}
         name="report_type"
-        label="What is the type of the report?"
+        label="Report Type"
+        labelSubtitle={(<p><i>This determines where the report appears in MineSpace and how mines are directed to submit it.</i></p>)}
         customOptions={[
           { label: `Code Required Report`, value: "CRR" },
           {
@@ -112,7 +113,8 @@ const AddReportDefinitionForm: FC<{
         required
         component={RenderRadioButtons}
         name="is_common"
-        label="Is this a common report"
+        label="Available as a common report?"
+        labelSubtitle={(<p><i>Common reports appear as quick-select options for mines when starting a new report submission in MineSpace.</i></p>)}
         validate={[requiredRadioButton]}
       />
 

--- a/services/core-web/src/components/admin/complianceCodes/ComplianceReportManagement.tsx
+++ b/services/core-web/src/components/admin/complianceCodes/ComplianceReportManagement.tsx
@@ -1,5 +1,5 @@
 import React, { FC, useEffect, useState } from "react";
-import { Button, Input, Row, Typography } from "antd";
+import { Alert, Button, Input, Row, Typography } from "antd";
 import queryString from "query-string";
 import PlusOutlined from "@ant-design/icons/PlusOutlined";
 import CoreTable from "@mds/common/components/common/CoreTable";
@@ -75,9 +75,9 @@ const ComplianceReportManagement: FC = () => {
 
     const sortParams = order
       ? {
-          sort_dir: order.replace("end", ""),
-          sort_field,
-        }
+        sort_dir: order.replace("end", ""),
+        sort_field,
+      }
       : {};
 
     const newParams = {
@@ -230,10 +230,17 @@ const ComplianceReportManagement: FC = () => {
 
   return (
     <div>
-      <Typography.Text>
-        Manage Code Required Reports that are associated to HSRC. Create a new report before adding
-        it to a code in Health, Safety and Reclamation Code page.
-      </Typography.Text>
+      <Typography.Paragraph>
+        Manage Code Required Reports that are associated to HSRC.
+      </Typography.Paragraph>
+      <Alert
+        message="Important - Create the report before adding a code clause"
+        showIcon
+        type="warning"
+        description="If an HSRC clause requires a report, you must create the report first.
+        Reports created here can then be selected when adding the clause in the Health, Safety and Reclamation Code table."
+      />
+      <br />
       <Row justify="end">
         <Button onClick={() => openAddModal()} type="primary" icon={<PlusOutlined />}>
           Create Report

--- a/services/core-web/src/components/admin/complianceCodes/HSRCEditForm.tsx
+++ b/services/core-web/src/components/admin/complianceCodes/HSRCEditForm.tsx
@@ -44,7 +44,7 @@ export const HSRCEditForm = (props: HSRCEditFormProps) => {
             showIcon
             type="warning"
             description="If this HSRC clause includes a reporting requirement, ensure the report has already been created.
-            Reports are managed seperately and must exist before they can be linked to a code clause."
+            Reports are managed separately and must exist before they can be linked to a code clause."
           />
         </Col>
       </Row >
@@ -124,8 +124,7 @@ export const HSRCEditForm = (props: HSRCEditFormProps) => {
           <Field
             name="description"
             label="Clause Heading"
-            placeholder="Enter the heading the appears above the clause text in the HSRC (for example: 'Acquisition of a mine')"
-            // labelSubtitle={(<p><i>Enter the heading the appears above the clause text in the HSRC (for example: 'Acquisition of a mine')</i></p>)}
+            labelSubtitle={(<p><i>Enter the heading the appears above the clause text in the HSRC (for example: 'Acquisition of a mine')</i></p>)}
             component={RenderAutoSizeField}
             required
             validate={[required, maxLength(80)]}
@@ -136,9 +135,8 @@ export const HSRCEditForm = (props: HSRCEditFormProps) => {
           <Field
             name="long_description"
             label="Clause Text"
-            placeholder="Enter the HSRC wording that applies to this specific section, subsection, paragraph, or subparagraph.This should reflect the wording of the Code, not a summary."
-            // labelSubtitle={(<p><i>Enter the HSRC wording that applies to this specific section, subsection, paragraph, or subparagraph.
-            // This should reflect the wording of the Code, not a summary."</i></p>)}
+            labelSubtitle={(<p><i>Enter the HSRC wording that applies to this specific section, subsection, paragraph, or subparagraph.
+              This should reflect the wording of the Code, not a summary.</i></p>)}
             component={RenderAutoSizeField}
             required
             validate={[required, maxLength(3000)]}

--- a/services/core-web/src/components/admin/complianceCodes/HSRCEditForm.tsx
+++ b/services/core-web/src/components/admin/complianceCodes/HSRCEditForm.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Field } from "@mds/common/components/forms/form";
-import { Row, Col, Typography } from "antd";
+import { Alert, Row, Col, Typography } from "antd";
 import {
   required,
   maxLength,
@@ -37,6 +37,18 @@ export const HSRCEditForm = (props: HSRCEditFormProps) => {
 
   return (
     <>
+      <Row gutter={[16, 16]} className="form-row-margin">
+        <Col span={24}>
+          <Alert
+            message="Before you continue"
+            showIcon
+            type="warning"
+            description="If this HSRC clause includes a reporting requirement, ensure the report has already been created.
+            Reports are managed seperately and must exist before they can be linked to a code clause."
+          />
+        </Col>
+      </Row >
+      <br />
       <Row gutter={[16, 16]} className="form-row-margin">
         <Col span={24}>
           <Typography.Text strong>HSRC Details</Typography.Text>
@@ -101,7 +113,7 @@ export const HSRCEditForm = (props: HSRCEditFormProps) => {
         <Col span={12}>
           <Field
             name="expiry_date"
-            label="Date Expire"
+            label="Expiry Date"
             component={RenderDate}
             placeholder="Select date"
           />
@@ -111,16 +123,22 @@ export const HSRCEditForm = (props: HSRCEditFormProps) => {
         <Col span={24}>
           <Field
             name="description"
-            label="Description"
-            component={RenderField}
+            label="Clause Heading"
+            placeholder="Enter the heading the appears above the clause text in the HSRC (for example: 'Acquisition of a mine')"
+            // labelSubtitle={(<p><i>Enter the heading the appears above the clause text in the HSRC (for example: 'Acquisition of a mine')</i></p>)}
+            component={RenderAutoSizeField}
             required
-            validate={[required, maxLength(100)]}
+            validate={[required, maxLength(80)]}
+            maximumCharacters={80}
           />
         </Col>
         <Col span={24}>
           <Field
             name="long_description"
-            label="Long Description"
+            label="Clause Text"
+            placeholder="Enter the HSRC wording that applies to this specific section, subsection, paragraph, or subparagraph.This should reflect the wording of the Code, not a summary."
+            // labelSubtitle={(<p><i>Enter the HSRC wording that applies to this specific section, subsection, paragraph, or subparagraph.
+            // This should reflect the wording of the Code, not a summary."</i></p>)}
             component={RenderAutoSizeField}
             required
             validate={[required, maxLength(3000)]}
@@ -128,12 +146,11 @@ export const HSRCEditForm = (props: HSRCEditFormProps) => {
           />
         </Col>
         <Col span={24}>
-          <Typography.Text strong>Regulatory Authority</Typography.Text>
-        </Col>
-        <Col span={24}>
           <Field
             name="cim_or_cpo"
-            label="Who is the report for?"
+            label="Regulatory Authority"
+            labelSubtitle={(<p><i>Select the regulatory authority that has statutory responsibility for this HSRC clause.
+              This is used to determine associated reporting and review requirements</i></p>)}
             component={RenderRadioButtons}
             required
             validate={[requiredRadioButton]}
@@ -161,9 +178,11 @@ export const HSRCEditForm = (props: HSRCEditFormProps) => {
         <Col span={24}>
           <Field
             name="help_reference_link"
-            label="Resource Information Link"
-            component={RenderField}
-            validate={[protocol]}
+            label="External Guidance Link"
+            labelSubtitle={(<p><i>Add a public web link to guidance or reference material that supports interpretation or application of this clause, if available.</i></p>)}
+            component={RenderAutoSizeField}
+            validate={[protocol, maxLength(2000)]}
+            maximumCharacters={2000}
           />
         </Col>
       </Row>

--- a/services/core-web/src/components/admin/complianceCodes/__snapshots__/ComplianceCodeViewEditForm.spec.tsx.snap
+++ b/services/core-web/src/components/admin/complianceCodes/__snapshots__/ComplianceCodeViewEditForm.spec.tsx.snap
@@ -77,6 +77,60 @@ exports[`ComplianceCodeViewEditForm renders properly 1`] = `
           class="ant-col ant-col-24"
           style="padding: 8px 8px 8px 8px;"
         >
+          <div
+            class="ant-alert ant-alert-warning ant-alert-with-description"
+            data-show="true"
+            role="alert"
+          >
+            <span
+              aria-label="exclamation-circle"
+              class="anticon anticon-exclamation-circle ant-alert-icon"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="exclamation-circle"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                />
+                <path
+                  d="M464 688a48 48 0 1096 0 48 48 0 10-96 0zm24-112h48c4.4 0 8-3.6 8-8V296c0-4.4-3.6-8-8-8h-48c-4.4 0-8 3.6-8 8v272c0 4.4 3.6 8 8 8z"
+                />
+              </svg>
+            </span>
+            <div
+              class="ant-alert-content"
+            >
+              <div
+                class="ant-alert-message"
+              >
+                Before you continue
+              </div>
+              <div
+                class="ant-alert-description"
+              >
+                If this HSRC clause includes a reporting requirement, ensure the report has already been created.
+            Reports are managed separately and must exist before they can be linked to a code clause.
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <br />
+      <div
+        class="ant-row form-row-margin"
+        style="margin: -8px -8px -8px -8px;"
+      >
+        <div
+          class="ant-col ant-col-24"
+          style="padding: 8px 8px 8px 8px;"
+        >
           <span
             class="ant-typography"
           >
@@ -532,7 +586,7 @@ exports[`ComplianceCodeViewEditForm renders properly 1`] = `
                   title=""
                 >
                   <div>
-                    Date Expire
+                    Expiry Date
                      
                     <span
                       class="form-item-optional"
@@ -637,7 +691,17 @@ exports[`ComplianceCodeViewEditForm renders properly 1`] = `
                   <div
                     style="width: 100%;"
                   >
-                    Description
+                    Clause Heading
+                    <br />
+                    <span
+                      class="label-subtitle"
+                    >
+                      <p>
+                        <i>
+                          Enter the heading the appears above the clause text in the HSRC (for example: 'Acquisition of a mine')
+                        </i>
+                      </p>
+                    </span>
                   </div>
                 </label>
               </div>
@@ -650,14 +714,23 @@ exports[`ComplianceCodeViewEditForm renders properly 1`] = `
                   <div
                     class="ant-form-item-control-input-content"
                   >
-                    <input
-                      aria-label="description"
+                    <textarea
                       class="ant-input"
-                      data-testid="description"
                       name="description"
-                      type="text"
-                      value=""
+                      style="height: 0px; resize: none; min-height: -12px;"
                     />
+                    <div
+                      class="ant-row ant-row-space-between form-item-help description-form-help"
+                    >
+                      <span>
+                        Maximum 80 characters
+                      </span>
+                      <span
+                        class="flex-end"
+                      >
+                        80 / 80
+                      </span>
+                    </div>
                   </div>
                 </div>
                 <div
@@ -698,7 +771,17 @@ exports[`ComplianceCodeViewEditForm renders properly 1`] = `
                   <div
                     style="width: 100%;"
                   >
-                    Long Description
+                    Clause Text
+                    <br />
+                    <span
+                      class="label-subtitle"
+                    >
+                      <p>
+                        <i>
+                          Enter the HSRC wording that applies to this specific section, subsection, paragraph, or subparagraph. This should reflect the wording of the Code, not a summary.
+                        </i>
+                      </p>
+                    </span>
                   </div>
                 </label>
               </div>
@@ -751,18 +834,6 @@ exports[`ComplianceCodeViewEditForm renders properly 1`] = `
           class="ant-col ant-col-24"
           style="padding: 8px 8px 8px 8px;"
         >
-          <span
-            class="ant-typography"
-          >
-            <strong>
-              Regulatory Authority
-            </strong>
-          </span>
-        </div>
-        <div
-          class="ant-col ant-col-24"
-          style="padding: 8px 8px 8px 8px;"
-        >
           <div
             class="ant-form-item ant-form-item-with-help"
           >
@@ -780,7 +851,17 @@ exports[`ComplianceCodeViewEditForm renders properly 1`] = `
                   <div
                     style="width: 100%;"
                   >
-                    Who is the report for?
+                    Regulatory Authority
+                    <br />
+                    <span
+                      class="label-subtitle"
+                    >
+                      <p>
+                        <i>
+                          Select the regulatory authority that has statutory responsibility for this HSRC clause. This is used to determine associated reporting and review requirements
+                        </i>
+                      </p>
+                    </span>
                   </div>
                 </label>
               </div>
@@ -915,12 +996,22 @@ exports[`ComplianceCodeViewEditForm renders properly 1`] = `
                   title=""
                 >
                   <div>
-                    Resource Information Link
+                    External Guidance Link
                      
                     <span
                       class="form-item-optional"
                     >
                        (optional)
+                    </span>
+                    <br />
+                    <span
+                      class="label-subtitle"
+                    >
+                      <p>
+                        <i>
+                          Add a public web link to guidance or reference material that supports interpretation or application of this clause, if available.
+                        </i>
+                      </p>
                     </span>
                   </div>
                 </label>
@@ -934,14 +1025,23 @@ exports[`ComplianceCodeViewEditForm renders properly 1`] = `
                   <div
                     class="ant-form-item-control-input-content"
                   >
-                    <input
-                      aria-label="help_reference_link"
+                    <textarea
                       class="ant-input"
-                      data-testid="help_reference_link"
                       name="help_reference_link"
-                      type="text"
-                      value=""
+                      style="height: 0px; resize: none; min-height: -12px;"
                     />
+                    <div
+                      class="ant-row ant-row-space-between form-item-help help_reference_link-form-help"
+                    >
+                      <span>
+                        Maximum 2000 characters
+                      </span>
+                      <span
+                        class="flex-end"
+                      >
+                        2000 / 2000
+                      </span>
+                    </div>
                   </div>
                 </div>
                 <div
@@ -1056,6 +1156,60 @@ exports[`ComplianceCodeViewEditForm renders properly 1`] = `
           </div>
         </div>
       </div>
+      <div
+        class="ant-row form-row-margin"
+        style="margin: -8px -8px -8px -8px;"
+      >
+        <div
+          class="ant-col ant-col-24"
+          style="padding: 8px 8px 8px 8px;"
+        >
+          <div
+            class="ant-alert ant-alert-warning ant-alert-with-description"
+            data-show="true"
+            role="alert"
+          >
+            <span
+              aria-label="exclamation-circle"
+              class="anticon anticon-exclamation-circle ant-alert-icon"
+              role="img"
+            >
+              <svg
+                aria-hidden="true"
+                data-icon="exclamation-circle"
+                fill="currentColor"
+                focusable="false"
+                height="1em"
+                viewBox="64 64 896 896"
+                width="1em"
+              >
+                <path
+                  d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                />
+                <path
+                  d="M464 688a48 48 0 1096 0 48 48 0 10-96 0zm24-112h48c4.4 0 8-3.6 8-8V296c0-4.4-3.6-8-8-8h-48c-4.4 0-8 3.6-8 8v272c0 4.4 3.6 8 8 8z"
+                />
+              </svg>
+            </span>
+            <div
+              class="ant-alert-content"
+            >
+              <div
+                class="ant-alert-message"
+              >
+                Before you continue
+              </div>
+              <div
+                class="ant-alert-description"
+              >
+                If this HSRC clause includes a reporting requirement, ensure the report has already been created.
+            Reports are managed separately and must exist before they can be linked to a code clause.
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <br />
       <div
         class="ant-row form-row-margin"
         style="margin: -8px -8px -8px -8px;"
@@ -1206,7 +1360,7 @@ exports[`ComplianceCodeViewEditForm renders properly 1`] = `
             <div
               class="ant-typography view-item-label"
             >
-              Date Expire
+              Expiry Date
             </div>
             <div
               class="ant-typography view-item-value"
@@ -1230,7 +1384,7 @@ exports[`ComplianceCodeViewEditForm renders properly 1`] = `
             <div
               class="ant-typography view-item-label"
             >
-              Description
+              Clause Heading
             </div>
             <div
               class="ant-typography view-item-value"
@@ -1249,7 +1403,7 @@ exports[`ComplianceCodeViewEditForm renders properly 1`] = `
             <div
               class="ant-typography view-item-label"
             >
-              Long Description
+              Clause Text
             </div>
             <div
               class="ant-typography view-item-value"
@@ -1257,18 +1411,6 @@ exports[`ComplianceCodeViewEditForm renders properly 1`] = `
               N/A
             </div>
           </div>
-        </div>
-        <div
-          class="ant-col ant-col-24"
-          style="padding: 8px 8px 8px 8px;"
-        >
-          <span
-            class="ant-typography"
-          >
-            <strong>
-              Regulatory Authority
-            </strong>
-          </span>
         </div>
         <div
           class="ant-col ant-col-24"
@@ -1292,8 +1434,18 @@ exports[`ComplianceCodeViewEditForm renders properly 1`] = `
                     class="view-item-label"
                   >
                     <div>
-                      Who is the report for?
+                      Regulatory Authority
                        
+                      <br />
+                      <span
+                        class="label-subtitle"
+                      >
+                        <p>
+                          <i>
+                            Select the regulatory authority that has statutory responsibility for this HSRC clause. This is used to determine associated reporting and review requirements
+                          </i>
+                        </p>
+                      </span>
                     </div>
                   </div>
                 </label>
@@ -1411,7 +1563,7 @@ exports[`ComplianceCodeViewEditForm renders properly 1`] = `
             <div
               class="ant-typography view-item-label"
             >
-              Resource Information Link
+              External Guidance Link
             </div>
             <div
               class="ant-typography view-item-value"

--- a/services/core-web/src/components/admin/complianceCodes/__snapshots__/ComplianceReportManagement.spec.tsx.snap
+++ b/services/core-web/src/components/admin/complianceCodes/__snapshots__/ComplianceReportManagement.spec.tsx.snap
@@ -156,11 +156,55 @@ exports[`ComplianceReportManagement renders properly 1`] = `
         Health, Safety and Reclamation Code Report
       </h2>
       <div>
-        <span
+        <div
           class="ant-typography"
         >
-          Manage Code Required Reports that are associated to HSRC. Create a new report before adding it to a code in Health, Safety and Reclamation Code page.
-        </span>
+          Manage Code Required Reports that are associated to HSRC.
+        </div>
+        <div
+          class="ant-alert ant-alert-warning ant-alert-with-description"
+          data-show="true"
+          role="alert"
+        >
+          <span
+            aria-label="exclamation-circle"
+            class="anticon anticon-exclamation-circle ant-alert-icon"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="exclamation-circle"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+              />
+              <path
+                d="M464 688a48 48 0 1096 0 48 48 0 10-96 0zm24-112h48c4.4 0 8-3.6 8-8V296c0-4.4-3.6-8-8-8h-48c-4.4 0-8 3.6-8 8v272c0 4.4 3.6 8 8 8z"
+              />
+            </svg>
+          </span>
+          <div
+            class="ant-alert-content"
+          >
+            <div
+              class="ant-alert-message"
+            >
+              Important - Create the report before adding a code clause
+            </div>
+            <div
+              class="ant-alert-description"
+            >
+              If an HSRC clause requires a report, you must create the report first.
+        Reports created here can then be selected when adding the clause in the Health, Safety and Reclamation Code table.
+            </div>
+          </div>
+        </div>
+        <br />
         <div
           class="ant-row ant-row-end"
         >

--- a/services/core-web/src/tests/components/Forms/reports/__snapshots__/AddReportDefinitionForm.spec.tsx.snap
+++ b/services/core-web/src/tests/components/Forms/reports/__snapshots__/AddReportDefinitionForm.spec.tsx.snap
@@ -10,6 +10,13 @@ exports[`AddReportDefinitionForm renders properly 1`] = `
   >
     Report Details
   </h3>
+  <span
+    class="ant-typography"
+  >
+    <i>
+      The information entered here is displayed to mine proponents in MineSpace when they select and submit this report.
+    </i>
+  </span>
   <div
     class="ant-form-item ant-form-item-with-help"
   >
@@ -40,14 +47,23 @@ exports[`AddReportDefinitionForm renders properly 1`] = `
           <div
             class="ant-form-item-control-input-content"
           >
-            <input
-              aria-label="report_name"
+            <textarea
               class="ant-input"
-              data-testid="report_name"
               name="report_name"
-              type="text"
-              value=""
+              style="height: 0px; resize: none; min-height: -12px;"
             />
+            <div
+              class="ant-row ant-row-space-between form-item-help report_name-form-help"
+            >
+              <span>
+                Maximum 200 characters
+              </span>
+              <span
+                class="flex-end"
+              >
+                200 / 200
+              </span>
+            </div>
           </div>
         </div>
         <div
@@ -84,6 +100,16 @@ exports[`AddReportDefinitionForm renders properly 1`] = `
             style="width: 100%;"
           >
             Description
+            <br />
+            <span
+              class="label-subtitle"
+            >
+              <p>
+                <i>
+                  A short, plain-language summary of what the report is and when it is required. This text is shown to mines when they choose a report to submit in MineSpace.
+                </i>
+              </p>
+            </span>
           </div>
         </label>
       </div>
@@ -99,9 +125,20 @@ exports[`AddReportDefinitionForm renders properly 1`] = `
             <textarea
               class="ant-input"
               name="description"
-              placeholder="Describe the report's definition / purpose for the mine proponent"
               style="height: 0px; resize: none; min-height: -12px;"
             />
+            <div
+              class="ant-row ant-row-space-between form-item-help description-form-help"
+            >
+              <span>
+                Maximum 3000 characters
+              </span>
+              <span
+                class="flex-end"
+              >
+                3000 / 3000
+              </span>
+            </div>
           </div>
         </div>
         <div
@@ -352,13 +389,6 @@ exports[`AddReportDefinitionForm renders properly 1`] = `
     </div>
   </div>
   <div
-    class="ant-typography margin-small--bottom"
-  >
-    <strong>
-      Report Type
-    </strong>
-  </div>
-  <div
     class="ant-form-item ant-form-item-with-help"
   >
     <div
@@ -375,7 +405,17 @@ exports[`AddReportDefinitionForm renders properly 1`] = `
           <div
             style="width: 100%;"
           >
-            What is the type of the report?
+            Report Type
+            <br />
+            <span
+              class="label-subtitle"
+            >
+              <p>
+                <i>
+                  This determines where the report appears in MineSpace and how mines are directed to submit it.
+                </i>
+              </p>
+            </span>
           </div>
         </label>
       </div>
@@ -478,7 +518,17 @@ exports[`AddReportDefinitionForm renders properly 1`] = `
           <div
             style="width: 100%;"
           >
-            Is this a common report
+            Available as a common report?
+            <br />
+            <span
+              class="label-subtitle"
+            >
+              <p>
+                <i>
+                  Common reports appear as quick-select options for mines when starting a new report submission in MineSpace.
+                </i>
+              </p>
+            </span>
           </div>
         </label>
       </div>


### PR DESCRIPTION
## Objective 
[MDS-6897](https://bcmines.atlassian.net/browse/MDS-6897)

_Why are you making this change? Provide a short explanation and/or screenshots_

These changes are intended to provide better clarity to users when adding or editing Health, Safety and Reclamation Codes and their associated reports.

Instructional text and warning alerts have been added to guide users through the two-step process of creating a report before linking it to an HSRC clause. Several field labels were also updated to use plain-language terminology that better reflects how the data is used in context, and subtitle hints were added beneath key fields to describe what information is expected.

See the highlighted changes below, based on [this Miro board design.](https://miro.com/app/board/uXjVHey1k7o=/)

_Permit Condition Management → HSRC -> Manage Compliance Codes → Add Code:_
<img width="468" height="899" alt="image" src="https://github.com/user-attachments/assets/d27568fc-33d4-4728-a164-4b94b0eb3d0c" />

_Permit Condition Management → HSRC -> Manage Compliance Reports:_
<img width="1688" height="609" alt="image" src="https://github.com/user-attachments/assets/686b3a32-ceae-416b-8aee-fa9f156862c2" />

_Permit Condition Management → HSRC -> Manage Compliance Reports → Add Report:_
<img width="625" height="811" alt="image" src="https://github.com/user-attachments/assets/5d71265d-078c-4567-bd1c-ef2fa2e1df2e" />
