### PR TITLE
[MDS-6895] fix for crr reports showing up as prr in view mode

### DIFF
--- a/services/core-web/src/components/admin/complianceCodes/ComplianceReportManagement.spec.tsx
+++ b/services/core-web/src/components/admin/complianceCodes/ComplianceReportManagement.spec.tsx
@@ -1,11 +1,12 @@
 import React from "react";
-import { render, waitFor } from "@testing-library/react";
+import { render, waitFor, fireEvent } from "@testing-library/react";
 import { ReduxWrapper } from "@/tests/utils/ReduxWrapper";
 import {
     complianceReportReducerType,
 } from "@mds/common/redux/slices/complianceReportsSlice";
 import ComplianceManagement from "./ComplianceManagement";
 import queryString from "query-string";
+import * as modalActions from "@mds/common/redux/actions/modalActions";
 
 const reportParams = {
     page: 1,
@@ -48,6 +49,11 @@ function mockFunction() {
 
 jest.mock("react-router-dom", () => mockFunction());
 
+jest.mock("@mds/common/redux/actions/modalActions", () => ({
+    openModal: jest.fn().mockReturnValue({ type: "OPEN_MODAL", payload: { props: {}, content: null } }),
+    closeModal: jest.fn().mockReturnValue({ type: "CLOSE_MODAL" }),
+}));
+
 describe("ComplianceReportManagement", () => {
     it("renders properly", async () => {
         const { container } = render(
@@ -62,5 +68,108 @@ describe("ComplianceReportManagement", () => {
         })
 
         expect(container).toMatchSnapshot();
+    });
+
+    describe("View modal report_type derivation", () => {
+        const routerMock = jest.requireMock("react-router-dom");
+        const loadedParams = { page: 1, per_page: 50, show_expired: true };
+
+        const makeRecord = (overrides: object) => ({
+            mine_report_definition_guid: "test-guid",
+            report_name: "Test Report",
+            description: "",
+            due_date_period_months: 12,
+            mine_report_due_date_type: "FIS",
+            default_due_date: null,
+            categories: [],
+            compliance_articles: [{
+                compliance_article_id: 1,
+                article_act_code: "HSRCM",
+                section: "1",
+                sub_section: null,
+                paragraph: null,
+                sub_paragraph: null,
+                description: "",
+                long_description: "",
+                effective_date: "2020-01-01",
+                expiry_date: "9999-12-31",
+                help_reference_link: "",
+                cim_or_cpo: null,
+                reports: [],
+            }],
+            active_ind: true,
+            is_common: false,
+            is_prr_only: false,
+            ...overrides,
+        });
+
+        const makeState = (records) => ({
+            [complianceReportReducerType]: {
+                reportPageData: {
+                    records,
+                    current_page: 1,
+                    items_per_page: 50,
+                    total: records.length,
+                    total_pages: 1,
+                },
+                params: loadedParams,
+            },
+        });
+
+        beforeEach(() => {
+            jest.clearAllMocks();
+            // Use empty search so queryParams === loadedParams, making isLoaded true
+            routerMock.useLocation.mockImplementation(() => ({ search: "" }));
+        });
+
+        it("opens modal with report_type CRR and boolean is_prr_only=false for a CRR record", async () => {
+            const crrRecord = makeRecord({ mine_report_definition_guid: "crr-guid", is_prr_only: false });
+            const { getAllByText, findByTestId } = render(
+                <ReduxWrapper initialState={makeState([crrRecord])}>
+                    <ComplianceManagement />
+                </ReduxWrapper>
+            );
+
+            const actionsButton = getAllByText("Actions")[0];
+            fireEvent.mouseEnter(actionsButton);
+            const viewButton = await findByTestId("action-button-view");
+            fireEvent.click(viewButton);
+
+            expect(modalActions.openModal).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    props: expect.objectContaining({
+                        initialValues: expect.objectContaining({
+                            report_type: "CRR",
+                            is_prr_only: false,
+                        }),
+                    }),
+                })
+            );
+        });
+
+        it("opens modal with report_type PRR and boolean is_prr_only=true for a PRR record", async () => {
+            const prrRecord = makeRecord({ mine_report_definition_guid: "prr-guid", is_prr_only: true });
+            const { getAllByText, findByTestId } = render(
+                <ReduxWrapper initialState={makeState([prrRecord])}>
+                    <ComplianceManagement />
+                </ReduxWrapper>
+            );
+
+            const actionsButton = getAllByText("Actions")[0];
+            fireEvent.mouseEnter(actionsButton);
+            const viewButton = await findByTestId("action-button-view");
+            fireEvent.click(viewButton);
+
+            expect(modalActions.openModal).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    props: expect.objectContaining({
+                        initialValues: expect.objectContaining({
+                            report_type: "PRR",
+                            is_prr_only: true,
+                        }),
+                    }),
+                })
+            );
+        });
     });
 })

--- a/services/core-web/src/components/admin/complianceCodes/ComplianceReportManagement.tsx
+++ b/services/core-web/src/components/admin/complianceCodes/ComplianceReportManagement.tsx
@@ -75,9 +75,9 @@ const ComplianceReportManagement: FC = () => {
 
     const sortParams = order
       ? {
-          sort_dir: order.replace("end", ""),
-          sort_field,
-        }
+        sort_dir: order.replace("end", ""),
+        sort_field,
+      }
       : {};
 
     const newParams = {
@@ -187,7 +187,8 @@ const ComplianceReportManagement: FC = () => {
       ...sectionFilter,
     },
     {
-      ...renderTextColumn("is_prr_only", "Report Type"),
+      ...renderTextColumn("report_type_label", "Report Type"),
+      key: "is_prr_only",
       filters: [
         { value: false, text: "Code Required Report" },
         { value: true, text: "Permit Required Report" },
@@ -219,10 +220,10 @@ const ComplianceReportManagement: FC = () => {
   const transformData = (reports: IMineReportDefinition[]) => {
     return reports.map((r) => {
       const formattedComplianceArticle = formatCode(r.compliance_articles[0]);
-      const is_prr_only = r.is_prr_only ? "Permit Required Report" : "Code Required Report";
+      const report_type_label = r.is_prr_only ? "Permit Required Report" : "Code Required Report";
       return {
         ...r,
-        is_prr_only,
+        report_type_label,
         ...formattedComplianceArticle,
       };
     });

--- a/services/core-web/src/components/admin/complianceCodes/__snapshots__/ComplianceReportManagement.spec.tsx.snap
+++ b/services/core-web/src/components/admin/complianceCodes/__snapshots__/ComplianceReportManagement.spec.tsx.snap
@@ -547,7 +547,7 @@ exports[`ComplianceReportManagement renders properly 1`] = `
                             class="ant-table-cell"
                           >
                             <div
-                              class="is_prr_only-column"
+                              class="report_type_label-column"
                               title="Report Type"
                             >
                               Code Required Report
@@ -627,7 +627,7 @@ exports[`ComplianceReportManagement renders properly 1`] = `
                             class="ant-table-cell"
                           >
                             <div
-                              class="is_prr_only-column"
+                              class="report_type_label-column"
                               title="Report Type"
                             >
                               Code Required Report
@@ -707,7 +707,7 @@ exports[`ComplianceReportManagement renders properly 1`] = `
                             class="ant-table-cell"
                           >
                             <div
-                              class="is_prr_only-column"
+                              class="report_type_label-column"
                               title="Report Type"
                             >
                               Code Required Report
@@ -787,7 +787,7 @@ exports[`ComplianceReportManagement renders properly 1`] = `
                             class="ant-table-cell"
                           >
                             <div
-                              class="is_prr_only-column"
+                              class="report_type_label-column"
                               title="Report Type"
                             >
                               Code Required Report
@@ -867,7 +867,7 @@ exports[`ComplianceReportManagement renders properly 1`] = `
                             class="ant-table-cell"
                           >
                             <div
-                              class="is_prr_only-column"
+                              class="report_type_label-column"
                               title="Report Type"
                             >
                               Code Required Report
@@ -947,7 +947,7 @@ exports[`ComplianceReportManagement renders properly 1`] = `
                             class="ant-table-cell"
                           >
                             <div
-                              class="is_prr_only-column"
+                              class="report_type_label-column"
                               title="Report Type"
                             >
                               Code Required Report
@@ -1027,7 +1027,7 @@ exports[`ComplianceReportManagement renders properly 1`] = `
                             class="ant-table-cell"
                           >
                             <div
-                              class="is_prr_only-column"
+                              class="report_type_label-column"
                               title="Report Type"
                             >
                               Code Required Report
@@ -1107,7 +1107,7 @@ exports[`ComplianceReportManagement renders properly 1`] = `
                             class="ant-table-cell"
                           >
                             <div
-                              class="is_prr_only-column"
+                              class="report_type_label-column"
                               title="Report Type"
                             >
                               Code Required Report
@@ -1187,7 +1187,7 @@ exports[`ComplianceReportManagement renders properly 1`] = `
                             class="ant-table-cell"
                           >
                             <div
-                              class="is_prr_only-column"
+                              class="report_type_label-column"
                               title="Report Type"
                             >
                               Code Required Report
@@ -1267,7 +1267,7 @@ exports[`ComplianceReportManagement renders properly 1`] = `
                             class="ant-table-cell"
                           >
                             <div
-                              class="is_prr_only-column"
+                              class="report_type_label-column"
                               title="Report Type"
                             >
                               Code Required Report


### PR DESCRIPTION
## Objective 

[MDS-6895](https://bcmines.atlassian.net/browse/MDS-6895)

- The cause of the bug was due to the `transformData` function in `ComplianceReportManagement.tsx` file. `is_prr_only` is suppose to be a boolean but in `transformData` it changes the property to a string and because of this the radio button selection tied to `is_prr_only` results to true all the time leading to the prr radio button being selected even though the report is a crr. The fix was to rename the text column and make it so `is_prr_only` isn't changed to a string.
