### PR TITLE
[CHORE] Update NRIS ETL Logging

### DIFF
--- a/services/nris-api/backend/Dockerfile.ci
+++ b/services/nris-api/backend/Dockerfile.ci
@@ -45,6 +45,8 @@ RUN chmod 775 /app/
 
 USER 1001
 
+ENV PYTHONUNBUFFERED=1
+
 # Run the server
 EXPOSE 5500
 CMD ["./app.sh"]

--- a/services/nris-api/backend/app/config.py
+++ b/services/nris-api/backend/app/config.py
@@ -16,7 +16,7 @@ class Config(object):
         'version': 1,
         'formatters': {
             'default': {
-                'format': '%(asctime)s %(levelname)s [%(name)s] [%(filename)s:%(lineno)d]',
+                'format': '%(asctime)s %(levelname)s [%(name)s] [%(filename)s:%(lineno)d] %(message)s',
             }
         },
         'handlers': {


### PR DESCRIPTION
 This PR was made to include the message object in the NRIS logs (I noticed it was missing in the previous PR), and update the Python log buffer size to release logs more quickly (so buffered logs don't get lost if the NRIS container/pod crashes. 

## Objective 

RELATES TO: [MDS-6760](https://bcmines.atlassian.net/browse/MDS-6760)

_Why are you making this change? Provide a short explanation and/or screenshots_

1. In NRIS `config.py`, the output log was missing `%(message)s` in the log format string, so the actual log message would never be included in the output.
2. In `Dockerfile.ci`, I added `PYTHONUNBUFFERED=1` so Python flushes stdout immediately in the container rather than buffering until the buffer fills or the process exits.