### PR TITLE
[MDS-6893] - Fix document versioning shift and metadata alignment

### DIFF
--- a/services/core-api/sync_versions.py
+++ b/services/core-api/sync_versions.py
@@ -1,0 +1,48 @@
+from app.extensions import db
+from sqlalchemy import text
+
+def sync_versions():
+    print("Syncing fixes from docman to Core API (mine_document and mine_document_version)...")
+    
+    try:
+        sync_doc_sql = """
+            UPDATE mine_document SET upload_date = d.upload_started_date, document_name = d.file_display_name
+            FROM docman.document d
+            WHERE mine_document.document_manager_guid = d.document_guid;
+        """
+        db.session.execute(text(sync_doc_sql))
+        
+        sync_ver_sql = """
+            UPDATE mine_document_version SET document_name = dv.file_display_name, upload_date = dv.created_date
+            FROM docman.document_version dv 
+            WHERE mine_document_version.document_manager_version_guid = dv.id;
+        """
+        db.session.execute(text(sync_ver_sql))
+        
+        # Ensure strictly increasing upload dates in mine_document_version for UI sorting
+        sort_sql = """
+            WITH sorted_versions AS (
+                SELECT 
+                    mine_document_version_guid,
+                    ROW_NUMBER() OVER (PARTITION BY mine_document_guid ORDER BY upload_date ASC, mine_document_version_guid ASC) as rn
+                FROM mine_document_version
+            )
+            UPDATE mine_document_version
+            SET upload_date = upload_date + (rn * interval '1 microsecond')
+            FROM sorted_versions
+            WHERE mine_document_version.mine_document_version_guid = sorted_versions.mine_document_version_guid;
+        """
+        db.session.execute(text(sort_sql))
+        
+        db.session.commit()
+        print("Core API sync successful. All data aligned!")
+        
+    except Exception as e:
+        print(f"CRITICAL ERROR: Failed to commit to database: {e}")
+        db.session.rollback()
+
+if __name__ == "__main__":
+    from app import create_app
+    app = create_app()
+    with app.app_context():
+        sync_versions()

--- a/services/document-manager/backend/app/__init__.py
+++ b/services/document-manager/backend/app/__init__.py
@@ -36,7 +36,7 @@ def create_app(test_config=None):
     def log_response_info(response):
         # Get request information
         method = request.method
-        path = request.path
+        path = request.full_path
         ip_address = request.remote_addr
         http_version = request.environ.get('SERVER_PROTOCOL', 'HTTP/1.1')
 
@@ -70,6 +70,11 @@ def create_app(test_config=None):
             'message': str(error),
         }, getattr(error, 'code', 500)
 
+    @app.cli.command("fix-versions")
+    def fix_versions_command():
+        from fix_versions import fix_all_versions
+        fix_all_versions()
+
     return app
 
 
@@ -93,7 +98,7 @@ def register_extensions(app, test_config=None):
             jwt_cypress.init_app(app)
         except Exception as e:
             with app.app_context():
-                current_app.logger.error('Failed to initialize cypress auth. Make sure keycloak is running', e)
+                current_app.logger.error(f'Failed to initialize cypress auth. Make sure keycloak is running: {e}')
 
     migrate.init_app(app, db)
     CORS(app)

--- a/services/document-manager/backend/app/docman/resources/document.py
+++ b/services/document-manager/backend/app/docman/resources/document.py
@@ -135,17 +135,18 @@ class DocumentListResource(Resource):
         else:
             as_attachment = '.pdf' not in document.file_display_name.lower()
 
+        display_name = document_version.file_display_name if document_version else document.file_display_name
         if document.object_store_path:
             return ObjectStoreStorageService().download_file(
                 path=document.object_store_path,
-                display_name=quote(document.file_display_name),
+                display_name=quote(display_name),
                 as_attachment=as_attachment,
                 version_id=version_id
             )
         else:
             return send_file(
                 path_or_file=document.full_storage_path,
-                download_name=document.file_display_name,
+                download_name=display_name,
                 as_attachment=as_attachment)
         cache.delete(DOWNLOAD_TOKEN(token_guid))
 

--- a/services/document-manager/backend/app/docman/utils/document_upload_helper.py
+++ b/services/document-manager/backend/app/docman/utils/document_upload_helper.py
@@ -243,7 +243,8 @@ class DocumentUploadHelper:
             oss.copy_file(source_key=key, key=new_key)
 
             if version_guid is not None and versions is None:
-                versions = oss.list_versions(new_key)['Versions']
+                all_versions = oss.list_versions(new_key).get('Versions', [])
+                versions = [v for v in all_versions if v['Key'] == new_key]
 
         except Exception as e:
             handle_status_and_update_doc(e, doc_guid)
@@ -264,14 +265,12 @@ class DocumentUploadHelper:
                 db.session.add(doc)
 
             # update the record of the previous version
-            if versions is not None and len(versions) >= 1:
+            if versions is not None and len(versions) >= 2:
                 # Sort the versions
                 versions.sort(key=lambda v: v["LastModified"], reverse=True)
 
-                # create a version record for the previous version
-                previous_version_data = versions[0]
-
-                # get the versionId of the previous version
+                # get the versionId of the previous version (the second newest)
+                previous_version_data = versions[1]
                 previous_version_id = previous_version_data["VersionId"]
 
                 # find the corresponding DocumentVersion record

--- a/services/document-manager/backend/fix_versions.py
+++ b/services/document-manager/backend/fix_versions.py
@@ -1,0 +1,73 @@
+from app.services.object_store_storage_service import ObjectStoreStorageService
+from app.docman.models.document_version import DocumentVersion
+from app.docman.models.document import Document
+from app.extensions import db
+from app.utils.include.user_info import User
+
+def fix_all_versions():
+    oss = ObjectStoreStorageService()
+    
+    # We set test_mode to True so that User().get_user_username() uses DUMMY_AUTH_CLAIMS
+    # instead of trying to read the JWT auth headers, thereby avoiding the out-of-context error.
+    User._test_mode = True
+    
+    with db.session.no_autoflush:
+        documents = db.session.query(Document).join(DocumentVersion).distinct().all()
+        print(f"Found {len(documents)} documents with versions to check.")
+
+        for doc in documents:
+            try:
+                s3_versions_resp = oss.list_versions(doc.object_store_path)
+                # Filter for exact key match and sort by LastModified ascending
+                s3_versions = [v for v in s3_versions_resp.get('Versions', []) if v['Key'] == doc.object_store_path]
+                s3_versions.sort(key=lambda x: x['LastModified'])
+            except Exception as e:
+                print(f"  ERROR fetching S3 versions for {doc.document_guid}: {e}")
+                continue
+            
+            # Get DB versions sorted by created_date ascending
+            db_versions = db.session.query(DocumentVersion).filter_by(document_guid=doc.document_guid).order_by(DocumentVersion.created_date).all()
+            
+            if len(s3_versions) != len(db_versions) + 1:
+                print(f"  WARNING: Version count mismatch for {doc.document_guid}. S3:{len(s3_versions)}, DB:{len(db_versions)}+1. Skipping.")
+                continue
+
+            # The db_versions represent the historical snapshots (S1, S2, ..., Sn-1)
+            # The current Document record represents the latest version (Sn)
+            
+            for i, db_v in enumerate(db_versions):
+                s3_v = s3_versions[i]
+                s3_date = s3_v['LastModified'].replace(tzinfo=None)
+                s3_id = s3_v['VersionId']
+
+                # We only update if there's a change needed
+                if db_v.object_store_version_id != s3_id:
+                    print(f"[{doc.document_guid}] FIXING V{i+1}: Name: {db_v.file_display_name} | Old ID: {db_v.object_store_version_id} -> New ID: {s3_id}")
+                    db_v.object_store_version_id = s3_id
+                    # Also update dates to match S3 truth
+                    db_v.upload_completed_date = s3_date
+                    db.session.add(db_v)
+
+            # Check the current Document record against the latest S3 version
+            latest_s3_version = s3_versions[-1]
+            latest_s3_date = latest_s3_version['LastModified'].replace(tzinfo=None)
+            
+            # Since Document doesn't store object_store_version_id, we just check metadata/dates if needed
+            if doc.upload_completed_date != latest_s3_date:
+                print(f"[{doc.document_guid}] UPDATING Current Doc Date: {doc.upload_completed_date} -> {latest_s3_date}")
+                doc.upload_completed_date = latest_s3_date
+                db.session.add(doc)
+
+        try:
+            print("Summary of changes prepared. Committing...")
+            db.session.commit()
+            print("Commit successful.")
+        except Exception as e:
+            print(f"CRITICAL ERROR: Failed to commit to database: {e}")
+            db.session.rollback()
+
+if __name__ == "__main__":
+    from app import create_app
+    app = create_app()
+    with app.app_context():
+        fix_all_versions()


### PR DESCRIPTION
## Objective 

[MDS-6893](https://bcmines.atlassian.net/browse/MDS-6893)

  Problem
  An error in the document upload process caused new document versions to be incorrectly mapped to S3 version IDs. Specifically, DocumentVersion records (which represent historical snapshots) were being assigned the VersionId
  of the newest upload instead of the previous one, leading to a "shift" where downloading Version 1 would provide Version 2, and so on.

  Additionally, metadata (filenames and upload dates) between the Document Manager and Core API had become de-synchronized due to these incorrect mappings.

  Changes

  1. Permanent Fixes (Document Manager)
   - document_upload_helper.py: 
       - Corrected the version indexing logic in complete_upload. It now correctly identifies the second-newest S3 version (versions[1]) to associate with the DocumentVersion record created during a replacement.
       - Added robust filtering for S3 list_versions to ensure auxiliary files (e.g., .info files) do not interfere with version counts.
   - document.py (Resource): Updated the download logic to ensure the correct display_name is used for historical versions.
   - __init__.py: Added a new Flask CLI command fix-versions to trigger the repair script.
   - Logging Improvements: Standardized error logging and updated request path logging to include query parameters for better debugging.

  2. Data Repair & Synchronization
   - fix_versions.py: A maintenance script that:
       - Lists all versions for affected documents directly from S3.
       - Sorts both DB records and S3 versions chronologically.
       - Re-aligns object_store_version_id and upload_completed_date based on the S3 "source of truth."
   - sync_versions.py (Core API): A synchronization script that:
       - Pulls corrected filenames and timestamps from the Document Manager into the Core API (mine_document and mine_document_version).

  Maintenance Note
  The scripts services/document-manager/backend/fix_versions.py and services/core-api/sync_versions.py are intended for a one-time execution in each environment and can be removed in a subsequent cleanup PR once deployments are complete.

_Why are you making this change? Provide a short explanation and/or screenshots_
