### PR TITLE
[MDS-6906] Fix for file version not collapsing

### DIFF
--- a/services/common/src/components/documents/DocumentTable.tsx
+++ b/services/common/src/components/documents/DocumentTable.tsx
@@ -353,7 +353,7 @@ export const DocumentTable: FC<DocumentTableProps> = ({
     : {};
 
   const coreTableProps = {
-    rowKey: "document_manager_guid",
+    rowKey: (record: any) => record.mine_document_version_guid ?? record.document_manager_guid,
     condition: isLoaded,
     dataSource: documents,
     columns: columns,

--- a/services/common/src/components/documents/DocumentTable.tsx
+++ b/services/common/src/components/documents/DocumentTable.tsx
@@ -108,7 +108,14 @@ export const DocumentTable: FC<DocumentTableProps> = ({
       latestByDocManager.set(doc.document_manager_guid, doc);
     });
 
-    return selectedRows.map((row) => latestByDocManager.get(row.document_manager_guid) ?? row)
+    const seen = new Set<string>();
+    return selectedRows
+      .map((row) => latestByDocManager.get(row.document_manager_guid) ?? row)
+      .filter((row) => {
+        if (seen.has(row.document_manager_guid)) return false;
+        seen.add(row.document_manager_guid);
+        return true;
+      });
   };
 
   const openArchiveModal = (docs: MineDocument[]) => {


### PR DESCRIPTION
## Objective 

[MDS-6906](https://bcmines.atlassian.net/browse/MDS-6906)

- Parent and child records were using the same `document_manager_guid `as their row key. This causes issues with expand collpasing. The fix was to make it so child records use their `mine_document_version_guid ` as the row key instead.
