### PR TITLE
[MDS-6852] fixing mine guid being null when selecting a NoD in global search

### DIFF
--- a/services/pgsync/schema.json
+++ b/services/pgsync/schema.json
@@ -375,6 +375,7 @@
                 {
                     "table": "mine",
                     "columns": [
+                        "mine_guid",
                         "mine_name",
                         "mine_no"
                     ],


### PR DESCRIPTION
## Objective 

[MDS-6852](https://bcmines.atlassian.net/browse/MDS-6852)

- Found an issue in pgsync `schema.json` file where `notices_of_departure` index is defined the mine child object only had `["mine_name", "mine_no"]` so when the function `_extract_mine_guid` in the `simple_search_service.py` file runs for `notice_of_departure` the `mine_guid` would always return None.

- The fix was adding `mine_guid` to the mine column under `notices_of_departure` in `schema.json` and have pgysnc re-index.
