### PR TITLE
[MDS-6853] Fix Global Search Results Showing Mine GUID Instead of Mine Name

### DIFF
--- a/services/core-api/app/api/search/search/search_filters.py
+++ b/services/core-api/app/api/search/search/search_filters.py
@@ -36,8 +36,8 @@ def build_mine_guid_filter(mine_guid):
             "should": [
                 {"term": {"mine_guid": mine_guid}},
                 {"term": {"mine_guid.keyword": mine_guid}},
-                {"term": {"mine_guids": mine_guid}},
-                {"term": {"mine_guids.keyword": mine_guid}},
+                {"term": {"mine_guids.mine_guid": mine_guid}},
+                {"term": {"mine_guids.mine_guid.keyword": mine_guid}},
                 {"term": {"mine.mine_guid": mine_guid}},
                 {"term": {"mine.mine_guid.keyword": mine_guid}},
             ],

--- a/services/core-api/app/api/search/search/search_transformers.py
+++ b/services/core-api/app/api/search/search/search_transformers.py
@@ -83,11 +83,11 @@ def prepare_permit_source(source):
             party_name = first_permittee.get('party_name', '')
             current_permittee = f"{first_name} {party_name}".strip() if first_name else party_name
 
-    mine_guids = source.get('mine_guids', [])
+    mine_details = source.get('mine_guids', [])
     mines = []
-    if mine_guids:
-        for guid in (mine_guids if isinstance(mine_guids, list) else [mine_guids]):
-            mines.append({'mine_guid': guid, 'mine_name': '', 'mine_no': ''})
+    if mine_details:
+        for mine_xref in (mine_details if isinstance(mine_details, list) else [mine_details]):
+            mines.append({'mine_guid':mine_xref.get('mine_guid'), 'mine_name': mine_xref.get('mine', {}).get('mine_name', ''), 'mine_no': mine_xref.get('mine', {}).get('mine_no', '')}) 
 
     prepared = dict(source)
     prepared['current_permittee'] = current_permittee

--- a/services/core-api/app/api/search/search/simple_search_service.py
+++ b/services/core-api/app/api/search/search/simple_search_service.py
@@ -282,7 +282,7 @@ class SimpleSearchService:
             return source.get('mine_guid')
         elif doc_type == 'permit':
             mine_guids = source.get('mine_guids', [])
-            return mine_guids[0] if mine_guids and isinstance(mine_guids, list) else None
+            return mine_guids[0].get('mine_guid') if mine_guids and isinstance(mine_guids, list) else None
         elif doc_type in ['notice_of_departure', 'explosives_permit', 'now_application']:
             mine_info = source.get('mine')
             return mine_info.get('mine_guid') if isinstance(mine_info, dict) else None

--- a/services/core-api/tests/search/test_search_transformers.py
+++ b/services/core-api/tests/search/test_search_transformers.py
@@ -151,16 +151,52 @@ class TestPreparePermitSources:
                 'first_name': 'John',
                 'party_name': 'Doe'
             }],
-            'mine_guids': ['mine-guid-1', 'mine-guid-2']
+            'mine_guids': [
+                {
+                    'mine_guid': 'mine-guid-1',
+                    'permit_id': 1,
+                    'mine': {'mine_guid': 'mine-guid-1', 'mine_name': 'Test Mine One', 'mine_no': 'M-001'}
+                },
+                {
+                    'mine_guid': 'mine-guid-2',
+                    'permit_id': 1,
+                    'mine': {'mine_guid': 'mine-guid-2', 'mine_name': 'Test Mine Two', 'mine_no': 'M-002'}
+                }
+            ]
         }
-        
+
         result = prepare_permit_source(source)
-        
+
         assert result['permit_guid'] == 'permit-123'
         assert result['permit_no'] == 'P-001'
         assert result['current_permittee'] == 'John Doe'
         assert len(result['mine']) == 2
         assert result['mine'][0]['mine_guid'] == 'mine-guid-1'
+        assert result['mine'][0]['mine_name'] == 'Test Mine One'
+        assert result['mine'][0]['mine_no'] == 'M-001'
+        assert result['mine'][1]['mine_guid'] == 'mine-guid-2'
+        assert result['mine'][1]['mine_name'] == 'Test Mine Two'
+        assert result['mine'][1]['mine_no'] == 'M-002'
+
+    def test_prepare_permit_source_mine_with_missing_name(self):
+        source = {
+            'permit_guid': 'permit-789',
+            'permit_no': 'P-003',
+            'mine_guids': [
+                {
+                    'mine_guid': 'mine-guid-3',
+                    'permit_id': 2,
+                    'mine': {}
+                }
+            ]
+        }
+
+        result = prepare_permit_source(source)
+
+        assert len(result['mine']) == 1
+        assert result['mine'][0]['mine_guid'] == 'mine-guid-3'
+        assert result['mine'][0]['mine_name'] == ''
+        assert result['mine'][0]['mine_no'] == ''
 
     def test_prepare_permit_source_organization_permittee(self):
         source = {

--- a/services/core-api/tests/search/test_simple_search_service.py
+++ b/services/core-api/tests/search/test_simple_search_service.py
@@ -127,10 +127,16 @@ class TestSimpleSearchService:
     
     def test_extract_mine_guid_from_permit(self, service):
         """Test extracting mine_guid from permit document."""
-        source = {'mine_guids': ['def-456', 'ghi-789'], 'permit_no': 'P-001'}
-        
+        source = {
+            'mine_guids': [
+                {'mine_guid': 'def-456', 'permit_id': 1, 'mine': {'mine_guid': 'def-456', 'mine_name': 'Test Mine', 'mine_no': 'M-001'}},
+                {'mine_guid': 'ghi-789', 'permit_id': 1, 'mine': {'mine_guid': 'ghi-789', 'mine_name': 'Other Mine', 'mine_no': 'M-002'}},
+            ],
+            'permit_no': 'P-001'
+        }
+
         guid = service._extract_mine_guid('permit', source)
-        
+
         assert guid == 'def-456'  # First GUID
     
     def test_extract_mine_guid_from_nod(self, service):

--- a/services/core-web/src/components/search/PermitResultsTable.js
+++ b/services/core-web/src/components/search/PermitResultsTable.js
@@ -6,8 +6,7 @@ import { Link } from "react-router-dom";
 import * as router from "@/constants/routes";
 import CoreTable from "@mds/common/components/common/CoreTable";
 import {
-  renderHighlightedTextColumn,
-  renderTextColumn,
+  renderHighlightedTextColumn
 } from "@mds/common/components/common/CoreTableCommonColumns";
 import { useFeatureFlag } from "@mds/common/providers/featureFlags/useFeatureFlag";
 import { Feature } from "@mds/common/utils/featureFlag";
@@ -50,7 +49,6 @@ export const PermitResultsTable = (props) => {
       },
     },
     renderHighlightedTextColumn("current_permittee", "Permittee", props.highlightRegex),
-    renderTextColumn("current_permittee", "Permittee"),
     {
       title: "Mine(s)",
       key: "mine_guid",

--- a/services/core-web/src/tests/components/search/__snapshots__/PermitResultsTable.spec.tsx.snap
+++ b/services/core-web/src/tests/components/search/__snapshots__/PermitResultsTable.spec.tsx.snap
@@ -24,12 +24,6 @@ exports[`PermitResultsTable renders properly 1`] = `
           "title": "Permittee",
         },
         Object {
-          "dataIndex": "current_permittee",
-          "key": "current_permittee",
-          "render": [Function],
-          "title": "Permittee",
-        },
-        Object {
           "key": "mine_guid",
           "render": [Function],
           "title": "Mine(s)",

--- a/services/core-web/src/tests/components/search/__snapshots__/SearchResultsV2.spec.tsx.snap
+++ b/services/core-web/src/tests/components/search/__snapshots__/SearchResultsV2.spec.tsx.snap
@@ -3741,11 +3741,6 @@ exports[`SearchResultsV2 Integration Tests Snapshots matches snapshot with searc
                                         <th
                                           class="ant-table-cell"
                                         >
-                                          Permittee
-                                        </th>
-                                        <th
-                                          class="ant-table-cell"
-                                        >
                                           Mine(s)
                                         </th>
                                       </tr>
@@ -3773,16 +3768,6 @@ exports[`SearchResultsV2 Integration Tests Snapshots matches snapshot with searc
                                               Current Permittee
                                             </span>
                                           </span>
-                                        </td>
-                                        <td
-                                          class="ant-table-cell"
-                                        >
-                                          <div
-                                            class="current_permittee-column"
-                                            title="Permittee"
-                                          >
-                                            Current Permittee
-                                          </div>
                                         </td>
                                         <td
                                           class="ant-table-cell"

--- a/services/pgsync/schema.json
+++ b/services/pgsync/schema.json
@@ -260,10 +260,33 @@
                         "mine_guid",
                         "permit_id"
                     ],
+                    "children": [
+                        {
+                            "table": "mine",
+                            "columns": [
+                                "mine_guid",
+                                "mine_name",
+                                "mine_no"
+                            ],
+                            "label": "mine",
+                            "relationship": {
+                                "type": "one_to_one",
+                                "variant": "object",
+                                "foreign_key": {
+                                    "child": [
+                                        "mine_guid"
+                                    ],
+                                    "parent": [
+                                        "mine_guid"
+                                    ]
+                                }
+                            }
+                        }
+                    ],
                     "label": "mine_guids",
                     "relationship": {
                         "type": "one_to_many",
-                        "variant": "scalar",
+                        "variant": "object",
                         "foreign_key": {
                             "child": [
                                 "permit_id"


### PR DESCRIPTION
## Objective 

[MDS-6853](https://bcmines.atlassian.net/browse/MDS-6853)

_Why are you making this change? Provide a short explanation and/or screenshots_

When performing a global search for a specific permit (eg 'C-85'), the results show the "mine name" as the mine GUID, making it hard to correctly identify the mine.  

Additionally, there are 2 "permittee" columns in the resulting data table when there should only be one. 

These changes remove the additional "permittee" column, and updates the ElasticSearch/PGSync schema to return the mine name, along with mine GUID. 

**Changes Made:**

`PermitResultsTable.js`:
- Removed duplicate `renderTextColumn("current_permittee", "Permittee")` column definition and import

`pgsync/schema.json`:
-  Updated the `mine_permits` index `mine_permit_xref` child from `variant: "scalar"` to `variant: "object"`, and added a nested mine child that joins through to the mine table via `mine_guid`, pulling `mine_name` and `mine_no` into the indexed document

`search_transformers.py`:
- Updated `prepare_permit_source` to read `mine_name` and `mine_no` from the nested mine object within each xref entry, instead of hardcoding empty strings

`search_filters.py`:
- Updated `build_mine_guid_filter` to use field paths `mine_guids.mine_guid` and `mine_guids.mine_guid.keyword`, which is now required because `mine_guids` has been changed to a list of objects rather than a flat list of strings

`simple_search_service.py`:
- Updated `_extract_mine_guid` to call `.get('mine_guid')` on the first xref object, since `mine_guids[0]` is now a dict rather than a plain string

`test_search_transformers.py` & `test_simple_search_service.py`:
- Updated unit tests to use the new xref object format, and added assertions for `mine_name` and `mine_no`
- Added new test (`test_prepare_permit_source_mine_with_missing_name`) to cover the edge case where the nested mine object is empty
- Updated `test_extract_mine_guid_from_permit` input fixture to use the new xref object format
- Updated all relevant snaps