### PR TITLE
[CHORE] Add default headers with Bearer token authorization to pipelines

### DIFF
--- a/services/permits/app/pipelines/document_search/document_search_pipeline.py
+++ b/services/permits/app/pipelines/document_search/document_search_pipeline.py
@@ -85,6 +85,7 @@ def create_document_search_retrieval_pipeline() -> AsyncPipeline:
         azure_endpoint=config.openai.endpoint.resolve_value(),
         azure_deployment=config.openai.embedding_model,
         api_key=config.openai.api_key,
+        default_headers={"Authorization": f"Bearer {config.openai.api_key.resolve_value()}"},
     )
 
     retriever = AzureAISearchHybridRetriever(
@@ -105,6 +106,7 @@ def create_document_search_retrieval_pipeline() -> AsyncPipeline:
         api_key=config.openai.api_key,
         api_version=config.openai.api_version,
         generation_kwargs={"temperature": 0, "max_tokens": 8192, "n": 1},
+        default_headers={"Authorization": f"Bearer {config.openai.api_key.resolve_value()}"},
     )
 
     pipeline.add_component("text_embedder", text_embedder)

--- a/services/permits/app/pipelines/document_search/indexing.py
+++ b/services/permits/app/pipelines/document_search/indexing.py
@@ -50,6 +50,7 @@ openai_client = AzureOpenAI(
     azure_endpoint=config.openai.endpoint.resolve_value(),
     api_key=config.openai.api_key.resolve_value(),
     api_version=config.openai.api_version,
+    default_headers={"Authorization": f"Bearer {config.openai.api_key.resolve_value()}"},
 )
 
 # Re-export for convenience so callers only need to import from this module.

--- a/services/permits/app/pipelines/permit_condition_extraction/permit_condition_pipeline.py
+++ b/services/permits/app/pipelines/permit_condition_extraction/permit_condition_pipeline.py
@@ -95,6 +95,7 @@ def permit_condition_pipeline():
         api_key=config.openai.api_key,
         timeout=600,
         generation_kwargs={"temperature": temperature, "max_tokens": max_tokens},
+        default_headers={"Authorization": f"Bearer {config.openai.api_key.resolve_value()}"},
     )
 
     logger.info(

--- a/services/permits/app/pipelines/permit_condition_search/permit_condition_search_pipeline.py
+++ b/services/permits/app/pipelines/permit_condition_search/permit_condition_search_pipeline.py
@@ -140,6 +140,7 @@ def create_permit_condition_search_retrieval_pipeline():
         azure_endpoint=config.openai.endpoint.resolve_value(),
         azure_deployment=config.openai.embedding_model,
         api_key=config.openai.api_key,
+        default_headers={"Authorization": f"Bearer {config.openai.api_key.resolve_value()}"},
     )
 
     retriever = AzureAISearchHybridRetriever(
@@ -172,6 +173,7 @@ def create_permit_condition_search_retrieval_pipeline():
         api_key=config.openai.api_key,
         api_version=config.openai.api_version,
         generation_kwargs={"temperature": 0, "max_tokens": 16384, "n": 1},
+        default_headers={"Authorization": f"Bearer {config.openai.api_key.resolve_value()}"},
     )
 
     retrieval_pipeline.add_component("text_embedder", text_embedder)


### PR DESCRIPTION
## Objective 

This PR aims to resolve 401 Unauthorized errors encountered in live test environment during document search indexing and permit extraction.

  Problem
  The Azure OpenAI proxy (APIM) used in our environments has a strict requirement: it requires the API key to be provided in both the standard api-key header and as a Bearer token in the Authorization header.

  The openai Python SDK (specifically version 1.35.1 used in our OpenShift pods) follows standard Azure OpenAI behavior:
   * When configured with an api_key, it sends only the api-key header.
   * It only sends the Authorization: Bearer header if it is specifically configured for Azure AD / Entra ID authentication.

  The proxy seems to require both headers even when using a standard API key, the SDK's default behavior resulted in "Access denied" errors from the proxy. This issue seems to have been previously masked due to cache errors.  Attempting a permit extraction with an existing document succeeds in the test environment since that document is cached, but a new document will fail to extract currently, so it seems to affect the other AI resources as well.

This PR explicitly injects the api key as a default header bearer token in order to ensure it's pressence.

   1 default_headers={"Authorization": f"Bearer {api_key}"}

Verified this fix by running a diagnostic script directly inside the permits-celery pod in the 4c2ba9-test project:
   * Test 1 (SDK behavior): Request with only api-key header -> 401 Unauthorized
   * Test 2 (With Fix): Request with api-key + Authorization: Bearer header -> 200 OK

_Why are you making this change? Provide a short explanation and/or screenshots_
