### PR TITLE
[CHORE] Chore further permit headers

### DIFF
--- a/services/permits/app/pipelines/document_search/document_search_pipeline.py
+++ b/services/permits/app/pipelines/document_search/document_search_pipeline.py
@@ -51,6 +51,7 @@ def create_now_document_search_store() -> AzureSearchDocumentStore:
             highlight_pre_tag="**",
             highlight_post_tag="**",
         ),
+        headers={"Authorization": f"Bearer {config.search.api_key.resolve_value()}"},
     )
 
 
@@ -64,6 +65,7 @@ def create_now_document_search_client() -> SearchClient:
         endpoint=config.search.endpoint.resolve_value(),
         index_name=config.search.index_name.resolve_value(),
         credential=AzureKeyCredential(config.search.api_key.resolve_value()),
+        headers={"Authorization": f"Bearer {config.search.api_key.resolve_value()}"},
     )
 
 

--- a/services/permits/app/pipelines/document_search/document_search_pipeline.py
+++ b/services/permits/app/pipelines/document_search/document_search_pipeline.py
@@ -85,6 +85,7 @@ def create_document_search_retrieval_pipeline() -> AsyncPipeline:
         azure_endpoint=config.openai.endpoint.resolve_value(),
         azure_deployment=config.openai.embedding_model,
         api_key=config.openai.api_key,
+        default_headers={"Authorization": f"Bearer {config.openai.api_key.resolve_value()}"},
     )
 
     retriever = AzureAISearchHybridRetriever(
@@ -105,6 +106,7 @@ def create_document_search_retrieval_pipeline() -> AsyncPipeline:
         api_key=config.openai.api_key,
         api_version=config.openai.api_version,
         generation_kwargs={"temperature": 0, "max_tokens": 8192, "n": 1},
+        default_headers={"Authorization": f"Bearer {config.openai.api_key.resolve_value()}"},
     )
 
     pipeline.add_component("text_embedder", text_embedder)

--- a/services/permits/app/pipelines/document_search/indexing.py
+++ b/services/permits/app/pipelines/document_search/indexing.py
@@ -50,6 +50,7 @@ openai_client = AzureOpenAI(
     azure_endpoint=config.openai.endpoint.resolve_value(),
     api_key=config.openai.api_key.resolve_value(),
     api_version=config.openai.api_version,
+    default_headers={"Authorization": f"Bearer {config.openai.api_key.resolve_value()}"},
 )
 
 # Re-export for convenience so callers only need to import from this module.

--- a/services/permits/app/pipelines/permit_condition_extraction/permit_condition_pipeline.py
+++ b/services/permits/app/pipelines/permit_condition_extraction/permit_condition_pipeline.py
@@ -95,6 +95,7 @@ def permit_condition_pipeline():
         api_key=config.openai.api_key,
         timeout=600,
         generation_kwargs={"temperature": temperature, "max_tokens": max_tokens},
+        default_headers={"Authorization": f"Bearer {config.openai.api_key.resolve_value()}"},
     )
 
     logger.info(

--- a/services/permits/app/pipelines/permit_condition_search/permit_condition_search_pipeline.py
+++ b/services/permits/app/pipelines/permit_condition_search/permit_condition_search_pipeline.py
@@ -140,6 +140,7 @@ def create_permit_condition_search_retrieval_pipeline():
         azure_endpoint=config.openai.endpoint.resolve_value(),
         azure_deployment=config.openai.embedding_model,
         api_key=config.openai.api_key,
+        default_headers={"Authorization": f"Bearer {config.openai.api_key.resolve_value()}"},
     )
 
     retriever = AzureAISearchHybridRetriever(
@@ -172,6 +173,7 @@ def create_permit_condition_search_retrieval_pipeline():
         api_key=config.openai.api_key,
         api_version=config.openai.api_version,
         generation_kwargs={"temperature": 0, "max_tokens": 16384, "n": 1},
+        default_headers={"Authorization": f"Bearer {config.openai.api_key.resolve_value()}"},
     )
 
     retrieval_pipeline.add_component("text_embedder", text_embedder)

--- a/services/permits/app/pipelines/permit_condition_search/permit_condition_search_pipeline.py
+++ b/services/permits/app/pipelines/permit_condition_search/permit_condition_search_pipeline.py
@@ -60,6 +60,7 @@ def create_azure_search_document_store():
             highlight_pre_tag="**",
             highlight_post_tag="**",
         ),
+        headers={"Authorization": f"Bearer {config.search.api_key.resolve_value()}"},
     )
 
 


### PR DESCRIPTION
The previous PR added the api key as a header to the indexing requests, but it's failing with the same error on the status checks now.  Added the header there, and in the search query.
