### PR TITLE
[CHORE] - Clean up old celery tasks on re-indexing

### DIFF
--- a/services/permits/app/pipelines/document_search/document_search_pipeline.py
+++ b/services/permits/app/pipelines/document_search/document_search_pipeline.py
@@ -51,6 +51,7 @@ def create_now_document_search_store() -> AzureSearchDocumentStore:
             highlight_pre_tag="**",
             highlight_post_tag="**",
         ),
+        headers={"Authorization": f"Bearer {config.search.api_key.resolve_value()}"},
     )
 
 
@@ -64,6 +65,7 @@ def create_now_document_search_client() -> SearchClient:
         endpoint=config.search.endpoint.resolve_value(),
         index_name=config.search.index_name.resolve_value(),
         credential=AzureKeyCredential(config.search.api_key.resolve_value()),
+        headers={"Authorization": f"Bearer {config.search.api_key.resolve_value()}"},
     )
 
 

--- a/services/permits/app/pipelines/document_search/document_search_pipeline.py
+++ b/services/permits/app/pipelines/document_search/document_search_pipeline.py
@@ -85,6 +85,7 @@ def create_document_search_retrieval_pipeline() -> AsyncPipeline:
         azure_endpoint=config.openai.endpoint.resolve_value(),
         azure_deployment=config.openai.embedding_model,
         api_key=config.openai.api_key,
+        default_headers={"Authorization": f"Bearer {config.openai.api_key.resolve_value()}"},
     )
 
     retriever = AzureAISearchHybridRetriever(
@@ -105,6 +106,7 @@ def create_document_search_retrieval_pipeline() -> AsyncPipeline:
         api_key=config.openai.api_key,
         api_version=config.openai.api_version,
         generation_kwargs={"temperature": 0, "max_tokens": 8192, "n": 1},
+        default_headers={"Authorization": f"Bearer {config.openai.api_key.resolve_value()}"},
     )
 
     pipeline.add_component("text_embedder", text_embedder)

--- a/services/permits/app/pipelines/document_search/indexing.py
+++ b/services/permits/app/pipelines/document_search/indexing.py
@@ -50,6 +50,7 @@ openai_client = AzureOpenAI(
     azure_endpoint=config.openai.endpoint.resolve_value(),
     api_key=config.openai.api_key.resolve_value(),
     api_version=config.openai.api_version,
+    default_headers={"Authorization": f"Bearer {config.openai.api_key.resolve_value()}"},
 )
 
 # Re-export for convenience so callers only need to import from this module.

--- a/services/permits/app/pipelines/document_search/resources/document_search_resource.py
+++ b/services/permits/app/pipelines/document_search/resources/document_search_resource.py
@@ -149,10 +149,17 @@ async def index_now_application_documents(
     # Enqueue the Celery task; register its ID per-document and in the application set.
     from app.tasks.tasks import run_now_document_indexing
     task = run_now_document_indexing.delay(now_application_guid, tmp_paths, doc_metadata_list)
+
+    task_set_key = _task_set_key(now_application_guid)
+
     if doc_guid:
         _redis.setex(_task_key(now_application_guid, doc_guid), _TASK_KEY_TTL, task.id)
-    _redis.sadd(_task_set_key(now_application_guid), task.id)
-    _redis.expire(_task_set_key(now_application_guid), _TASK_KEY_TTL)
+    else:
+        # If we are indexing the whole application (not just a single doc), clear stale state
+        _redis.delete(task_set_key)
+
+    _redis.sadd(task_set_key, task.id)
+    _redis.expire(task_set_key, _TASK_KEY_TTL)
 
     logger.info(
         "Enqueued indexing task %s for document %s in NoW application %s",
@@ -413,6 +420,7 @@ async def get_indexing_status(now_application_guid: str):
                 "percent": overall_percent,
             }
 
+        # Only return 'failed' if all active tasks are finished and at least one failed.
         if any(s == "FAILURE" for s in states):
             failed_result = next(r for r in task_results if r.state == "FAILURE")
             return {

--- a/services/permits/app/pipelines/permit_condition_extraction/permit_condition_pipeline.py
+++ b/services/permits/app/pipelines/permit_condition_extraction/permit_condition_pipeline.py
@@ -95,6 +95,7 @@ def permit_condition_pipeline():
         api_key=config.openai.api_key,
         timeout=600,
         generation_kwargs={"temperature": temperature, "max_tokens": max_tokens},
+        default_headers={"Authorization": f"Bearer {config.openai.api_key.resolve_value()}"},
     )
 
     logger.info(

--- a/services/permits/app/pipelines/permit_condition_search/permit_condition_search_pipeline.py
+++ b/services/permits/app/pipelines/permit_condition_search/permit_condition_search_pipeline.py
@@ -140,6 +140,7 @@ def create_permit_condition_search_retrieval_pipeline():
         azure_endpoint=config.openai.endpoint.resolve_value(),
         azure_deployment=config.openai.embedding_model,
         api_key=config.openai.api_key,
+        default_headers={"Authorization": f"Bearer {config.openai.api_key.resolve_value()}"},
     )
 
     retriever = AzureAISearchHybridRetriever(
@@ -172,6 +173,7 @@ def create_permit_condition_search_retrieval_pipeline():
         api_key=config.openai.api_key,
         api_version=config.openai.api_version,
         generation_kwargs={"temperature": 0, "max_tokens": 16384, "n": 1},
+        default_headers={"Authorization": f"Bearer {config.openai.api_key.resolve_value()}"},
     )
 
     retrieval_pipeline.add_component("text_embedder", text_embedder)

--- a/services/permits/app/pipelines/permit_condition_search/permit_condition_search_pipeline.py
+++ b/services/permits/app/pipelines/permit_condition_search/permit_condition_search_pipeline.py
@@ -60,6 +60,7 @@ def create_azure_search_document_store():
             highlight_pre_tag="**",
             highlight_post_tag="**",
         ),
+        headers={"Authorization": f"Bearer {config.search.api_key.resolve_value()}"},
     )
 
 


### PR DESCRIPTION
## Objective 

If there were any failed celery tasks marked as failed for the same application guid, they were causing a failed status for the now document indexing even after success.  Added a cleaup function when a new one is triggered to fix this.

_Why are you making this change? Provide a short explanation and/or screenshots_
