### PR TITLE
[MDS-6845] [Core] Permit-Search-Indicate-Multiple-Mine-Relationships

### DIFF
--- a/services/common/src/interfaces/search/searchResult.interface.ts
+++ b/services/common/src/interfaces/search/searchResult.interface.ts
@@ -16,6 +16,10 @@ export interface ISimpleSearchResult {
   description?: string;
   highlight?: string;
   mine_guid?: string;
+  mines?: {
+    mine_guid: string;
+    mine_name: string;
+  }[];
 }
 
 export interface IExplosivesPermitSearchResult {

--- a/services/core-api/app/api/search/response_models.py
+++ b/services/core-api/app/api/search/response_models.py
@@ -16,6 +16,12 @@ SEARCH_RESULT_MODEL = api.model('SearchResult', {
     'type': fields.String,
 })
 
+MINE_MODEL = api.model('Mine_simple ', {
+    'mine_name': fields.String,
+    'mine_guid': fields.String,
+    'mine_no': fields.String,
+})
+
 SIMPLE_SEARCH_MODEL = api.model('SimpleSearchResult', {
     'id': fields.String,
     'value': fields.String,
@@ -25,11 +31,6 @@ SIMPLE_SEARCH_MODEL = api.model('SimpleSearchResult', {
     'mines': fields.List(fields.Nested(MINE_MODEL))
 })
 
-MINE_MODEL = api.model('Mine_simple ', {
-    'mine_name': fields.String,
-    'mine_guid': fields.String,
-    'mine_no': fields.String,
-})
 PERMIT_SEARCH_MODEL = api.model(
     'Permit', {
         'permit_guid': fields.String,

--- a/services/core-api/app/api/search/response_models.py
+++ b/services/core-api/app/api/search/response_models.py
@@ -22,6 +22,7 @@ SIMPLE_SEARCH_MODEL = api.model('SimpleSearchResult', {
     'description': fields.String,
     'highlight': fields.String,
     'mine_guid': fields.String,
+    'mines': fields.List(fields.Nested(MINE_MODEL))
 })
 
 MINE_MODEL = api.model('Mine_simple ', {

--- a/services/core-api/app/api/search/search/simple_search_service.py
+++ b/services/core-api/app/api/search/search/simple_search_service.py
@@ -247,6 +247,7 @@ class SimpleSearchService:
                     break
         
         mine_guid = self._extract_mine_guid(doc_type, source)
+        mines = self._extract_mines(doc_type, source)
         
         return SearchResult(
             score,
@@ -256,7 +257,8 @@ class SimpleSearchService:
                 'value': value,
                 'description': description,
                 'highlight': highlight_text,
-                'mine_guid': mine_guid
+                'mine_guid': mine_guid,
+                'mines': mines
             }
         )
     
@@ -287,6 +289,14 @@ class SimpleSearchService:
             mine_info = source.get('mine')
             return mine_info.get('mine_guid') if isinstance(mine_info, dict) else None
         return None
+    
+    def _extract_mines(self, doc_type, source):
+        """Extract mines (details) from source based on document type."""
+        if doc_type == 'permit':
+            mine_guids = source.get('mine_guids', [])
+            return [{"mine_guid": mine.get("mine_guid"), "mine_name": mine.get("mine_name", "")} for mine in mine_guids] if mine_guids else None
+        else:
+            return None
     
     def _process_mine_result(self, source):
         """Process mine search result."""

--- a/services/core-api/tests/factories.py
+++ b/services/core-api/tests/factories.py
@@ -1716,7 +1716,7 @@ class NoticeOfDepartureFactory(BaseFactory):
         permit = factory.SubFactory('tests.factories.PermitFactory')
 
     nod_guid = GUID
-    nod_no = factory.LazyAttribute(lambda a: f'NOD-X-45564456-{randrange(1,1000)}')
+    nod_no = factory.Sequence(lambda n: f'NOD-X-45564456-{n}')
     mine_guid = factory.SelfAttribute('mine.mine_guid')
     permit_guid = factory.SelfAttribute('permit.permit_guid')
     nod_title = factory.Faker('text', max_nb_chars=50)

--- a/services/core-api/tests/search/test_simple_search_service.py
+++ b/services/core-api/tests/search/test_simple_search_service.py
@@ -139,6 +139,25 @@ class TestSimpleSearchService:
 
         assert guid == 'def-456'  # First GUID
     
+    def test_extract_mines_from_permit(self, service):
+        """Test extracting mines from permit document."""
+
+        source = {
+            'mine_guids': [
+                {'mine_guid': 'def-456', 'mine_name': 'Test Mine', 'mine_no': 'M-001'},
+                {'mine_guid': 'ghi-789', 'mine_name': 'Other Mine', 'mine_no': 'M-002'},
+            ],
+            'permit_no': 'P-001'
+        }
+
+        mines = service._extract_mines('permit', source)
+        
+        assert len(mines) == 2
+        assert all("mine_no" not in mine for mine in mines)
+        assert mines[0]['mine_guid'] == 'def-456' # First GUID
+        assert mines[0]['mine_name'] == 'Test Mine' # First Mine
+
+    
     def test_extract_mine_guid_from_nod(self, service):
         """Test extracting mine_guid from NOD document."""
         source = {'mine': {'mine_guid': 'jkl-012'}, 'nod_no': 'NOD-001'}

--- a/services/core-web/src/components/search/GlobalSearch/GlobalSearch.tsx
+++ b/services/core-web/src/components/search/GlobalSearch/GlobalSearch.tsx
@@ -241,7 +241,7 @@ const GlobalSearch: React.FC<GlobalSearchProps> = ({
       saveRecentSearch(searchTerm);
     }
     handleClose();
-    
+
     // Map filter keys to search results page tab keys
     const filterToTabMap: Record<string, string> = {
       mine: "mine",
@@ -253,10 +253,10 @@ const GlobalSearch: React.FC<GlobalSearchProps> = ({
       nod: "notice_of_departure",
       document: "document",
     };
-    
+
     // Get tab from first active filter if any
     const tab = activeFilters.length > 0 ? filterToTabMap[activeFilters[0]] : null;
-    
+
     history.push(router.SEARCH_RESULTS.dynamicRoute({ q: searchTerm || "*", t: tab }));
   };
 

--- a/services/core-web/src/components/search/GlobalSearch/components/SearchResultItem.tsx
+++ b/services/core-web/src/components/search/GlobalSearch/components/SearchResultItem.tsx
@@ -1,8 +1,10 @@
 import React, { useState } from "react";
-import { List, Avatar, Typography } from "antd";
+import { Link } from "react-router-dom";
+import { List, Avatar, Typography, Popover } from "antd";
 import { EnterOutlined } from "@ant-design/icons";
 import classNames from "classnames";
 import { ISearchResult, ISimpleSearchResult } from "@mds/common/interfaces";
+import * as router from "@/constants/routes";
 import { SEARCH_TYPE_CONFIG, RESULT_TYPE_MAP } from "../utils/searchConfig";
 import { highlightMatch } from "../utils/searchHelpers";
 
@@ -52,16 +54,37 @@ export const SearchResultItem: React.FC<SearchResultItemProps> = ({
         }
         title={<Text strong={isSelected} className="search-result-item__title">{highlightMatch(item.result.value, searchTerm)}</Text>}
         description={
-          <Text type="secondary" ellipsis>
-            {config.label}
-            {item.result.description && <span style={{ marginLeft: 8 }}>• {item.result.description}</span>}
-            {item.result.highlight && (
-              <span
-                className="search-result-item__highlight"
-                dangerouslySetInnerHTML={{ __html: `• ${item.result.highlight}` }}
-              />
+          <>
+            <Text type="secondary" ellipsis>
+              {config.label}
+              {item.result.description && <span style={{ marginLeft: 8 }}>• {item.result.description}</span>}
+              {item.result.highlight && (
+                <span
+                  className="search-result-item__highlight"
+                  dangerouslySetInnerHTML={{ __html: `• ${item.result.highlight}` }}
+                />
+              )}
+            </Text>
+            {item.result.mines && item.result.mines.length > 1 && (
+              <Popover
+                content={
+                  <>
+                    {item.result.mines.map((mine) => (
+                      <Link
+                        key={"mine-link-" + mine.mine_guid}
+                        to={router.MINE_GENERAL.dynamicRoute(mine.mine_guid)}>
+                        {mine.mine_name}
+                      </Link>
+                    ))}
+                  </>
+                }
+              >
+                <span onClick={(e) => e.stopPropagation()}>
+                  Associated with {item.result.mines.length} Mines
+                </span>
+              </Popover>
             )}
-          </Text>
+          </>
         }
       />
       <EnterOutlined className="search-result-item__enter-icon" style={{ visibility: isSelected ? 'visible' : 'hidden' }} />

--- a/services/core-web/src/components/search/GlobalSearch/components/SearchResultItem.tsx
+++ b/services/core-web/src/components/search/GlobalSearch/components/SearchResultItem.tsx
@@ -79,9 +79,13 @@ export const SearchResultItem: React.FC<SearchResultItemProps> = ({
                   </>
                 }
               >
-                <span onClick={(e) => e.stopPropagation()}>
+                <button
+                  type="button"
+                  onClick={(e) => e.stopPropagation()}
+                  style={{ background: 'none', border: 'none', padding: 0, cursor: 'pointer', color: 'inherit', font: 'inherit' }} // Strip all styling, keep as inline text
+                >
                   Associated with {item.result.mines.length} Mines
-                </span>
+                </button>
               </Popover>
             )}
           </>

--- a/services/core-web/src/components/search/PermitResultsTable.js
+++ b/services/core-web/src/components/search/PermitResultsTable.js
@@ -56,13 +56,13 @@ export const PermitResultsTable = (props) => {
         if (!record.mine || record.mine.length === 0) {
           return "-";
         }
-        return record.mine.map((mine) => (
-          <Link
-            to={router.MINE_PERMITS.dynamicRoute(mine.mine_guid)}
-            key={"mine-link-" + mine.mine_guid}
-          >
-            <Highlight search={props.highlightRegex}>{mine.mine_name || mine.mine_guid}</Highlight>
-          </Link>
+        return record.mine.map((mine, index) => (
+          <React.Fragment key={"mine-link-" + mine.mine_guid}>
+            {index > 0 && ", "}
+            <Link to={router.MINE_PERMITS.dynamicRoute(mine.mine_guid)}>
+              <Highlight search={props.highlightRegex}>{mine.mine_name || mine.mine_guid}</Highlight>
+            </Link>
+          </React.Fragment>
         ));
       },
     },

--- a/services/core-web/src/tests/components/search/PermitResultsTable.spec.tsx
+++ b/services/core-web/src/tests/components/search/PermitResultsTable.spec.tsx
@@ -1,7 +1,17 @@
 import React from "react";
 import { shallow } from "enzyme";
 import { PermitResultsTable } from "@/components/search/PermitResultsTable";
+import CoreTable from "@mds/common/components/common/CoreTable";
 import * as MOCK from "@mds/common/tests/mocks/dataMocks";
+
+const multiMinePermitMock = {
+  permit_guid: "...",
+  permit_no: "CX-123",
+  mine: [
+    { mine_guid: "abc", mine_name: "Mine One", mine_no: "M-001" },
+    { mine_guid: "def", mine_name: "Mine Two", mine_no: "M-002" },
+  ]
+}
 
 const reducerProps = {
   header: MOCK.SEARCH_OPTIONS[2].description,
@@ -14,4 +24,17 @@ describe("PermitResultsTable", () => {
     const component = shallow(<PermitResultsTable {...reducerProps} />);
     expect(component).toMatchSnapshot();
   });
+
+  it("renders comma-separated mine links for multi-mine permits", () => {
+    const component = shallow(<PermitResultsTable
+      header="Permits"
+      highlightRegex={RegExp(".*")}
+      searchResults={[multiMinePermitMock]}
+    />);
+    const columns = component.find(CoreTable).prop('columns');
+    const mineColumn = columns[2]; // the Mine(s) column from the PermitResultsTable
+    const rendered = shallow(<div>{mineColumn.render(multiMinePermitMock)}</div>); // Render the mine column with 2 associated mines
+    expect(rendered.find('Link').length).toBe(2); // There should be 2 links (1 for each associated mine) in the rendered mine column
+  });
+
 });

--- a/services/core-web/src/tests/components/search/SearchResultItem.spec.tsx
+++ b/services/core-web/src/tests/components/search/SearchResultItem.spec.tsx
@@ -1,0 +1,90 @@
+import React from "react";
+import { shallow } from "enzyme";
+import { List, Popover } from "antd";
+import { SearchResultItem } from "@/components/search/GlobalSearch/components/SearchResultItem";
+
+const mockOnClick = jest.fn();
+const mockOnMouseEnter = jest.fn();
+
+const defaultProps = {
+  index: 0,
+  selectedIndex: -1,
+  searchTerm: "test",
+  onClick: mockOnClick,
+  onMouseEnter: mockOnMouseEnter,
+};
+
+const mineResult = {
+  type: "mine",
+  score: 1.0,
+  result: {
+    id: "mine-guid-1",
+    value: "Test Mine",
+    description: "Mine #: M-001",
+    highlight: null,
+    mine_guid: "mine-guid-1",
+    mines: null,
+  },
+};
+
+const singleMinePermit = {
+  type: "permit",
+  score: 1.0,
+  result: {
+    id: "permit-guid-1",
+    value: "CX-123",
+    description: "Jane Smith | Status: APP",
+    highlight: null,
+    mine_guid: "mine-guid-1",
+    mines: [{ mine_guid: "mine-guid-1", mine_name: "Mine One" }],
+  },
+};
+
+const multiMinePermit = {
+  type: "permit",
+  score: 1.0,
+  result: {
+    id: "permit-guid-2",
+    value: "CX-456",
+    description: "John Doe | Status: APP",
+    highlight: null,
+    mine_guid: "mine-guid-1",
+    mines: [
+      { mine_guid: "mine-guid-1", mine_name: "Mine One" },
+      { mine_guid: "mine-guid-2", mine_name: "Mine Two" },
+    ],
+  },
+};
+
+describe("SearchResultItem", () => {
+  it("renders properly for a non-permit result", () => {
+    const component = shallow(<SearchResultItem item={mineResult as any} {...defaultProps} />);
+    expect(component).toMatchSnapshot();
+  });
+
+  it("does not show multi-mine indicator for a single-mine permit", () => {
+    const component = shallow(<SearchResultItem item={singleMinePermit as any} {...defaultProps} />);
+    expect(component.find("button").length).toBe(0);
+  });
+
+  it("shows multi-mine indicator for a permit with multiple mines", () => {
+    const component = shallow(<SearchResultItem item={multiMinePermit as any} {...defaultProps} />);
+    const description = shallow(<div>{component.find(List.Item.Meta).prop("description")}</div>);
+    expect(description.find("button").length).toBe(1);
+    expect(description.find("button").text()).toContain("Associated with 2 Mines");
+  });
+
+  it("renders a popover for multi-mine permits", () => {
+    const component = shallow(<SearchResultItem item={multiMinePermit as any} {...defaultProps} />);
+    const description = shallow(<div>{component.find(List.Item.Meta).prop("description")}</div>);
+    expect(description.find(Popover).length).toBe(1);
+  });
+
+  it("calls stopPropagation when the mine indicator button is clicked", () => {
+    const component = shallow(<SearchResultItem item={multiMinePermit as any} {...defaultProps} />);
+    const description = shallow(<div>{component.find(List.Item.Meta).prop("description")}</div>);
+    const mockEvent = { stopPropagation: jest.fn() };
+    description.find("button").simulate("click", mockEvent);
+    expect(mockEvent.stopPropagation).toHaveBeenCalled();
+  });
+});

--- a/services/core-web/src/tests/components/search/__snapshots__/SearchResultItem.spec.tsx.snap
+++ b/services/core-web/src/tests/components/search/__snapshots__/SearchResultItem.spec.tsx.snap
@@ -1,0 +1,64 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SearchResultItem renders properly for a non-permit result 1`] = `
+<ForwardRef(InternalItem)
+  className="search-result-item"
+  onClick={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+>
+  <Meta
+    avatar={
+      <Avatar
+        icon={<ForwardRef(EnvironmentOutlined) />}
+        style={
+          Object {
+            "backgroundColor": "#2e7d3220",
+            "color": "#2e7d32",
+          }
+        }
+      />
+    }
+    description={
+      <React.Fragment>
+        <ForwardRef(Text)
+          ellipsis={true}
+          type="secondary"
+        >
+          Mine
+          <span
+            style={
+              Object {
+                "marginLeft": 8,
+              }
+            }
+          >
+            • 
+            Mine #: M-001
+          </span>
+        </ForwardRef(Text)>
+      </React.Fragment>
+    }
+    title={
+      <ForwardRef(Text)
+        className="search-result-item__title"
+        strong={false}
+      >
+        
+        <mark>
+          Test
+        </mark>
+         Mine
+      </ForwardRef(Text)>
+    }
+  />
+  <ForwardRef(EnterOutlined)
+    className="search-result-item__enter-icon"
+    style={
+      Object {
+        "visibility": "hidden",
+      }
+    }
+  />
+</ForwardRef(InternalItem)>
+`;


### PR DESCRIPTION
## Objective 

[MDS-6845](https://bcmines.atlassian.net/browse/MDS-6845)

_Why are you making this change? Provide a short explanation and/or screenshots_

With the recent upgrade to Global Search in Core, users can search directly for permit numbers.
Some permits are associated with multiple mines, but search results currently present the permit as if it is associated with a single mine, which can mislead users and result in incorrect assumptions.

The changes in this PR have been made so that:
1. [COMPLETE] If a permit is associated to one mine, display the global search results normally (no changes)
2. [COMPLETE] If a permit is associated to multiple mines, results explicitly indicate multiple associations, and these associations can be navigated to
3. [NOT STARTED] On the permit details page, show a dedicated “associated mines” section

I a requesting review and deployment into the Dev/Test env now, because I cannot easily test these changes locally (since the Permit Service doesn't deploy well locally). 

The changes for task 3 (Permit Details Page) will follow once I verify these are working as expected. 