### PR TITLE
[MDS-6845] [Core] Permit-Search-Indicate-Multiple-Mine-Relationships (PR #2)

### DIFF
--- a/services/common/src/components/common/CommonPageHeader.spec.tsx
+++ b/services/common/src/components/common/CommonPageHeader.spec.tsx
@@ -10,34 +10,56 @@ const initialState = {
   [MINES]: MOCK.MINES,
 };
 
+const defaultProps = {
+  entityType: "Llama",
+  entityLabel: "George",
+  mineGuid: MOCK.MINES.mineIds[0],
+  current_permittee: "Permit Holder",
+  breadCrumbs: [
+    { route: "https://example.com", text: "All Llamas" },
+    { route: "https://example.com/specific", text: "Specific Llamas" },
+  ],
+  tabProps: {
+    items: [{ key: "overview", label: "Overview", children: <div>Overview Content</div> }],
+    defaultActiveKey: "overview",
+  },
+};
+
 describe("CommonPageHeader", () => {
   it("renders properly", () => {
     const { container } = render(
       <ReduxWrapper initialState={initialState}>
         <BrowserRouter>
-          <CommonPageHeader
-            entityType="Llama"
-            entityLabel="George"
-            mineGuid={MOCK.MINES.mineIds[0]}
-            current_permittee="Permit Holder"
-            breadCrumbs={[
-              { route: "https://example.com", text: "All Llamas" },
-              { route: "https://example.com/specific", text: "Specific Llamas" },
-            ]}
-            tabProps={{
-              items: [
-                {
-                  key: "overview",
-                  label: "Overview",
-                  children: <div>Overview Content</div>,
-                },
-              ],
-              defaultActiveKey: "overview",
-            }}
-          />
+          <CommonPageHeader {...defaultProps} />
         </BrowserRouter>
       </ReduxWrapper>
     );
     expect(container).toMatchSnapshot();
+  });
+
+  it("shows the additional mines button when additionalMines are provided", () => {
+    const additionalMines = [
+      { mine_guid: "abc-123", mine_name: "Mine Two" },
+      { mine_guid: "def-456", mine_name: "Mine Three" },
+    ];
+    const { getByRole } = render(
+      <ReduxWrapper initialState={initialState}>
+        <BrowserRouter>
+          <CommonPageHeader {...defaultProps} additionalMines={additionalMines} />
+        </BrowserRouter>
+      </ReduxWrapper>
+    );
+    expect(getByRole("button", { name: /show 2 more associated mines/i })).toBeInTheDocument();
+  });
+
+  it("does not show the additional mines button when no additionalMines are provided", () => {
+    const { queryByRole } = render(
+      <ReduxWrapper initialState={initialState}>
+        <BrowserRouter>
+          <CommonPageHeader {...defaultProps} />
+        </BrowserRouter>
+      </ReduxWrapper>
+    );
+    expect(queryByRole("button", { name: /more associated mines/i })).not.toBeInTheDocument();
   });
 });

--- a/services/common/src/components/common/CommonPageHeader.tsx
+++ b/services/common/src/components/common/CommonPageHeader.tsx
@@ -1,6 +1,6 @@
 import React, { FC, ReactNode, useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { Col, Row, Tabs, TabsProps, Typography } from "antd";
+import { Col, Popover, Row, Tabs, TabsProps, Typography } from "antd";
 import { Link } from "react-router-dom";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import CoreTag from "./CoreTag";
@@ -26,6 +26,7 @@ interface CommonPageHeaderProps {
   tabProps?: TabsProps;
   pageContent?: ReactNode;
   extraElement?: ReactNode;
+  additionalMines?: { mine_guid: string; mine_name: string }[];
 }
 
 const { Title, Text } = Typography;
@@ -39,6 +40,7 @@ const CommonPageHeader: FC<CommonPageHeaderProps> = ({
   tabProps,
   pageContent,
   extraElement,
+  additionalMines,
 }) => {
   const mine = useSelector(getMineById(mineGuid));
   const dispatch = useDispatch();
@@ -84,6 +86,58 @@ const CommonPageHeader: FC<CommonPageHeaderProps> = ({
                   icon={<FontAwesomeIcon icon={faLocationDot} />}
                   text={mine?.mine_name}
                   link={GLOBAL_ROUTES?.MINE_DASHBOARD.dynamicRoute(mineGuid)}
+                  suffix={
+                    additionalMines?.length > 0 ? (
+                      <Popover
+                        title="Associated Mines"
+                        overlayStyle={{ maxWidth: 360 }}
+                        overlayInnerStyle={{
+                          border: "1px solid #d9d9d9",
+                          borderRadius: 8,
+                          boxShadow: "0 6px 16px rgba(0,0,0,0.15)",
+                        }}
+                        content={
+                          <div>
+                            <Typography.Text
+                              type="secondary"
+                              style={{ fontSize: "0.85em", display: "block", marginBottom: 12, fontStyle: "italic" }}
+                            >
+                              This permit applies to multiple mine sites due to historical amendments or operational grouping.
+                            </Typography.Text>
+                            <div style={{ display: "flex", flexDirection: "column", gap: 8, alignItems: "flex-start" }}>
+                              {additionalMines.map((m) => (
+                                <div key={m.mine_guid} style={{ display: "inline-block" }}>
+                                  <CoreTag
+                                    icon={<FontAwesomeIcon icon={faLocationDot} />}
+                                    text={m.mine_name}
+                                    link={GLOBAL_ROUTES?.MINE_DASHBOARD.dynamicRoute(m.mine_guid)}
+                                  />
+                                </div>
+                              ))}
+                            </div>
+                          </div>
+                        }
+                      >
+                        <button
+                          type="button"
+                          aria-label={`Show ${additionalMines.length} more associated mines`}
+                          style={{
+                            background: "none",
+                            border: "none",
+                            padding: 0,
+                            cursor: "pointer",
+                            color: "inherit",
+                            font: "inherit",
+                            fontSize: "0.85em",
+                            whiteSpace: "nowrap",
+                            textDecoration: "underline",
+                          }}
+                        >
+                          + {additionalMines.length} More
+                        </button>
+                      </Popover>
+                    ) : undefined
+                  }
                 />
               </Col>
               {current_permittee && (

--- a/services/common/src/components/common/CommonPageHeader.tsx
+++ b/services/common/src/components/common/CommonPageHeader.tsx
@@ -98,15 +98,12 @@ const CommonPageHeader: FC<CommonPageHeaderProps> = ({
                         }}
                         content={
                           <div>
-                            <Typography.Text
-                              type="secondary"
-                              style={{ fontSize: "0.85em", display: "block", marginBottom: 12, fontStyle: "italic" }}
-                            >
+                            <Typography.Text type="secondary" className="tag-more-popover__description">
                               This permit applies to multiple mine sites due to historical amendments or operational grouping.
                             </Typography.Text>
-                            <div style={{ display: "flex", flexDirection: "column", gap: 8, alignItems: "flex-start" }}>
+                            <div className="tag-more-popover__mines">
                               {additionalMines.map((m) => (
-                                <div key={m.mine_guid} style={{ display: "inline-block" }}>
+                                <div key={m.mine_guid} className="tag-more-popover__mine">
                                   <CoreTag
                                     icon={<FontAwesomeIcon icon={faLocationDot} />}
                                     text={m.mine_name}
@@ -121,17 +118,7 @@ const CommonPageHeader: FC<CommonPageHeaderProps> = ({
                         <button
                           type="button"
                           aria-label={`Show ${additionalMines.length} more associated mines`}
-                          style={{
-                            background: "none",
-                            border: "none",
-                            padding: 0,
-                            cursor: "pointer",
-                            color: "inherit",
-                            font: "inherit",
-                            fontSize: "0.85em",
-                            whiteSpace: "nowrap",
-                            textDecoration: "underline",
-                          }}
+                          className="tag-more-btn"
                         >
                           + {additionalMines.length} More
                         </button>

--- a/services/common/src/components/common/CoreTag.tsx
+++ b/services/common/src/components/common/CoreTag.tsx
@@ -24,7 +24,7 @@ const CoreTag: FC<TagProps> = ({ text, icon, link, suffix }) => {
     <Row justify="space-between" align="middle" className="tag">
       {icon}
       <Typography.Text className="margin-medium--left">{getText()}</Typography.Text>
-      {suffix && <span style={{ marginLeft: 8 }}>{suffix}</span>}
+      {suffix && <span className="margin-small--left">{suffix}</span>}
     </Row>
   );
 };

--- a/services/common/src/components/common/CoreTag.tsx
+++ b/services/common/src/components/common/CoreTag.tsx
@@ -6,9 +6,10 @@ interface TagProps {
   text: string;
   icon: ReactNode;
   link?: string;
+  suffix?: ReactNode;
 }
 
-const CoreTag: FC<TagProps> = ({ text, icon, link }) => {
+const CoreTag: FC<TagProps> = ({ text, icon, link, suffix }) => {
   const getText = () => {
     return link ? (
       <Link style={{ textDecoration: "none", color: "inherit" }} to={link}>
@@ -23,6 +24,7 @@ const CoreTag: FC<TagProps> = ({ text, icon, link }) => {
     <Row justify="space-between" align="middle" className="tag">
       {icon}
       <Typography.Text className="margin-medium--left">{getText()}</Typography.Text>
+      {suffix && <span style={{ marginLeft: 8 }}>{suffix}</span>}
     </Row>
   );
 };

--- a/services/common/src/components/permits/ViewPermit.tsx
+++ b/services/common/src/components/permits/ViewPermit.tsx
@@ -303,6 +303,9 @@ const ViewPermit: FC = () => {
     <ActionMenuButton actions={headerActions} />
   ) : null;
 
+  // filter out the mine already shown in the primary CoreTag (the one from the URL context)
+  const additionalMines = permit?.mine?.filter((m) => m.mine_guid !== id) ?? [];
+
   return (
     <div className="fixed-tabs-container permit-tabs-container">
       <CommonPageHeader
@@ -312,6 +315,7 @@ const ViewPermit: FC = () => {
         current_permittee={permit?.current_permittee ?? ""}
         breadCrumbs={[{ route: GLOBAL_ROUTES.MINE_PERMITS.dynamicRoute(id), text: "All Permits" }]}
         extraElement={headerActionComponent}
+        additionalMines={additionalMines}
         tabProps={{
           items: tabItems,
           defaultActiveKey: activeTab,

--- a/services/common/src/interfaces/permits/permit.interface.ts
+++ b/services/common/src/interfaces/permits/permit.interface.ts
@@ -24,6 +24,7 @@ export interface IPermit {
   site_properties: IMineType;
   permit_prefix: string;
   mine_guid?: string;
+  mine?: { mine_guid: string; mine_name: string; mine_no?: string }[];
   status_changed_timestamp?: string;
   update_user: string;
   update_timestamp: string;

--- a/services/core-api/app/api/mines/response_models.py
+++ b/services/core-api/app/api/mines/response_models.py
@@ -364,6 +364,7 @@ PERMIT_MODEL = api.model(
         'exemption_fee_status_note': fields.String,
         'site_properties': fields.List(fields.Nested(MINE_TYPE_MODEL)),
         'permit_prefix': fields.String,
+        'mine': fields.List(fields.Nested(BASIC_MINE_LIST), attribute='_all_mines'),
         'status_changed_timestamp': fields.DateTime,
         'update_user': fields.String,
         'update_timestamp': fields.String,

--- a/services/core-web/src/components/search/GlobalSearch/components/SearchResultItem.tsx
+++ b/services/core-web/src/components/search/GlobalSearch/components/SearchResultItem.tsx
@@ -69,12 +69,16 @@ export const SearchResultItem: React.FC<SearchResultItemProps> = ({
               <Popover
                 content={
                   <>
-                    {item.result.mines.map((mine) => (
-                      <Link
-                        key={"mine-link-" + mine.mine_guid}
-                        to={router.MINE_GENERAL.dynamicRoute(mine.mine_guid)}>
-                        {mine.mine_name}
-                      </Link>
+                    {item.result.mines.map((mine, index) => (
+                      <React.Fragment key={"mine-link-" + mine.mine_guid}>
+                        {index > 0 && ", "}
+                        <Link
+                          to={router.MINE_GENERAL.dynamicRoute(mine.mine_guid)}
+                          onClick={(e) => e.stopPropagation()}
+                        >
+                          {mine.mine_name}
+                        </Link>
+                      </React.Fragment>
                     ))}
                   </>
                 }
@@ -82,9 +86,9 @@ export const SearchResultItem: React.FC<SearchResultItemProps> = ({
                 <button
                   type="button"
                   onClick={(e) => e.stopPropagation()}
-                  style={{ background: 'none', border: 'none', padding: 0, cursor: 'pointer', color: 'inherit', font: 'inherit' }} // Strip all styling, keep as inline text
+                  style={{ background: 'none', border: 'none', padding: 0, cursor: 'pointer', color: '#1890ff', font: 'inherit', textDecoration: 'underline' }} // Strip all styling, keep as inline text
                 >
-                  Associated with {item.result.mines.length} Mines
+                  • Associated with {item.result.mines.length} Mines
                 </button>
               </Popover>
             )}

--- a/services/core-web/src/styles/components/Tag.scss
+++ b/services/core-web/src/styles/components/Tag.scss
@@ -15,3 +15,35 @@
     color: $primary-btn-color;
   }
 }
+
+.tag-more-btn {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  color: inherit;
+  font: inherit;
+  font-size: 0.85em;
+  white-space: nowrap;
+  text-decoration: underline;
+}
+
+.tag-more-popover {
+  &__description {
+    display: block;
+    font-size: 0.85em;
+    font-style: italic;
+    margin-bottom: 12px;
+  }
+
+  &__mines {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    align-items: flex-start;
+  }
+
+  &__mine {
+    display: inline-block;
+  }
+}

--- a/services/core-web/src/tests/components/common/CoreTag.spec.tsx
+++ b/services/core-web/src/tests/components/common/CoreTag.spec.tsx
@@ -8,4 +8,11 @@ describe("CoreTag", () => {
     const { container } = render(<CoreTag icon={<CompanyIcon />} text="test" />);
     expect(container.firstChild).toMatchSnapshot();
   });
+
+  it("renders a suffix when provided", () => {
+    const { getByText } = render(
+      <CoreTag icon={<CompanyIcon />} text="test" suffix={<span>extra content</span>} />
+    );
+    expect(getByText("extra content")).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Objective 

[MDS-6845](https://bcmines.atlassian.net/browse/MDS-6845)

_Why are you making this change? Provide a short explanation and/or screenshots_
 
With the recent upgrade to Global Search in Core, users can search directly for permit numbers.
Some permits are associated with multiple mines, but search results currently present the permit as if it is associated with a single mine, which can mislead users and result in incorrect assumptions.

The changes in this PR have been made so that:
1. [COMPLETE in PR 1] If a permit is associated to one mine, display the global search results normally (no changes)
2. [COMPLETE in PR 1] If a permit is associated to multiple mines, results explicitly indicate multiple associations, and these associations can be navigated to
3. [COMPLETE in this PR] On the permit details page, show a dedicated “associated mines” section

**Changes Made This PR:**
- Updated Permit Interface, added: `mine?: { mine_guid, mine_name, mine_no? }[]`
- Updated CommonPageHeader, added `additionalMines` prop; now renders `+ N More` Popover inside the mine tag when more than one mine is associated to the displayed permit
- Updated CommonPageHeader unit tests, to cover the above changes
- Updated parent `ViewMine` page to derive the additional mines by filtering `permit.mine` to exclude the current mine from the URL (avoided duplicate link)
- Updated mines API to include `mine` field in the `PERMIT_MODEL`, using the existing `_all_mines` relationship in the `BASIC_MINE_LIST` model 
