### PR TITLE
[MDS-6845] [Core] Permit-Search-Indicate-Multiple-Mine-Relationships (PR #3)

### DIFF
--- a/services/core-web/src/components/search/GlobalSearch/components/SearchResultItem.tsx
+++ b/services/core-web/src/components/search/GlobalSearch/components/SearchResultItem.tsx
@@ -86,7 +86,16 @@ export const SearchResultItem: React.FC<SearchResultItemProps> = ({
                 <button
                   type="button"
                   onClick={(e) => e.stopPropagation()}
-                  style={{ background: 'none', border: 'none', padding: 0, cursor: 'pointer', color: '#1890ff', font: 'inherit', textDecoration: 'underline' }} // Strip all styling, keep as inline text
+                  style={{
+                    background: 'none',
+                    border: 'none',
+                    padding: 0,
+                    cursor: 'pointer',
+                    color: '#1890ff',
+                    font: 'inherit',
+                    textDecoration: 'underline',
+                    marginLeft: 8
+                  }} // Strip all styling, keep as inline text
                 >
                   • Associated with {item.result.mines.length} Mines
                 </button>


### PR DESCRIPTION
## Objective 

[MDS-6845](https://bcmines.atlassian.net/browse/MDS-6845)

_Why are you making this change? Provide a short explanation and/or screenshots_
 
With the recent upgrade to Global Search in Core, users can search directly for permit numbers.
Some permits are associated with multiple mines, but search results currently present the permit as if it is associated with a single mine, which can mislead users and result in incorrect assumptions.

The changes in this PR have been made so that:
1. [COMPLETE in PR 1] If a permit is associated to one mine, display the global search results normally (no changes)
2. [COMPLETE in PR 1] If a permit is associated to multiple mines, results explicitly indicate multiple associations, and these associations can be navigated to
3. [COMPLETE in PR 2] On the permit details page, show a dedicated “associated mines” section

**Changes Made This PR:**
- Added spacing between the new "Associated With _N_ Mines" text, to keep it consistent with the other items rendered in the list
