### PR TITLE
[MDS-6845] Added Banner to Permit Overview Page for Multi-Mine Associated Permits

### DIFF
--- a/services/common/src/components/common/CommonPageHeader.tsx
+++ b/services/common/src/components/common/CommonPageHeader.tsx
@@ -90,6 +90,7 @@ const CommonPageHeader: FC<CommonPageHeaderProps> = ({
                     additionalMines?.length > 0 ? (
                       <Popover
                         title="Associated Mines"
+                        trigger={["hover", "click"]}
                         overlayStyle={{ maxWidth: 360 }}
                         overlayInnerStyle={{
                           border: "1px solid #d9d9d9",

--- a/services/common/src/components/permits/ViewPermitOverview.tsx
+++ b/services/common/src/components/permits/ViewPermitOverview.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from "react";
-import { Col, Divider, Row, Skeleton, Table, Typography } from "antd";
+import { Alert, Col, Divider, Row, Skeleton, Table, Typography } from "antd";
 import {
   IExemptionFeeStatusOption,
   IMine,
@@ -64,6 +64,14 @@ const ViewPermitOverview: FC<ViewPermitOverviewProps> = ({ latestAmendment }) =>
 
   return (
     <div className="view-permits-content">
+      {permit?.mine?.length > 1 && (
+        <Alert
+          className="margin-large--bottom"
+          message="This permit is associated with multiple mines, please review the associated mine list for more details"
+          type="warning"
+          showIcon
+        />
+      )}
       <Row justify="space-between" align="middle">
         <Col>
           <Title className="margin-none padding-lg--top padding-lg--bottom" level={2}>

--- a/services/core-web/src/components/search/GlobalSearch/components/SearchResultItem.tsx
+++ b/services/core-web/src/components/search/GlobalSearch/components/SearchResultItem.tsx
@@ -67,6 +67,7 @@ export const SearchResultItem: React.FC<SearchResultItemProps> = ({
             </Text>
             {item.result.mines && item.result.mines.length > 1 && (
               <Popover
+                trigger={["hover", "click"]}
                 content={
                   <>
                     {item.result.mines.map((mine, index) => (

--- a/services/core-web/src/styles/components/Tag.scss
+++ b/services/core-web/src/styles/components/Tag.scss
@@ -19,13 +19,19 @@
 .tag-more-btn {
   background: none;
   border: none;
-  padding: 0;
+  padding: 2px 4px;
   cursor: pointer;
   color: inherit;
   font: inherit;
   font-size: 0.85em;
   white-space: nowrap;
   text-decoration: underline;
+
+  &:focus-visible {
+    outline: 2px solid $primary-btn-color;
+    outline-offset: 2px;
+    border-radius: 2px;
+  }
 }
 
 .tag-more-popover {


### PR DESCRIPTION
## Objective 

[MDS-6845](https://bcmines.atlassian.net/browse/MDS-6845)

_Why are you making this change? Provide a short explanation and/or screenshots_
 
With the recent upgrade to Global Search in Core, users can search directly for permit numbers.
Some permits are associated with multiple mines, but search results currently present the permit as if it is associated with a single mine, which can mislead users and result in incorrect assumptions.

**Changes Made This PR:**
- Added an alert/banner to the Permit Overview Page, to clearly indicate to users when they are viewing a permit that is associated with multiple mines
- Updated some UI elements to be WCAG 2.1 / BC Gov Accessibility Standards Compliant
