### PR TITLE
[MDS-6845] Update Permit Search Banner

### DIFF
--- a/services/common/src/components/permits/ViewPermitOverview.tsx
+++ b/services/common/src/components/permits/ViewPermitOverview.tsx
@@ -64,14 +64,6 @@ const ViewPermitOverview: FC<ViewPermitOverviewProps> = ({ latestAmendment }) =>
 
   return (
     <div className="view-permits-content">
-      {permit?.mine?.length > 1 && (
-        <Alert
-          className="margin-large--bottom"
-          message="This permit is associated with multiple mines, please review the associated mine list for more details"
-          type="warning"
-          showIcon
-        />
-      )}
       <Row justify="space-between" align="middle">
         <Col>
           <Title className="margin-none padding-lg--top padding-lg--bottom" level={2}>
@@ -85,6 +77,14 @@ const ViewPermitOverview: FC<ViewPermitOverviewProps> = ({ latestAmendment }) =>
       {permit && mine ? (
         <Row>
           <Col span={12} className="view-permits-detail-section">
+            {permit.mine?.length > 1 && (
+              <Alert
+                className="margin-medium--bottom permit-multi-mine-alert"
+                message="This permit is associated with multiple mines, please review the associated mine list for more details"
+                type="warning"
+                showIcon
+              />
+            )}
             <Title level={4}>Permit Details</Title>
             <Row>
               <Col span={12}>

--- a/services/core-web/src/styles/components/ViewPermit.scss
+++ b/services/core-web/src/styles/components/ViewPermit.scss
@@ -37,6 +37,12 @@
   }
 }
 
+.permit-multi-mine-alert {
+  .ant-alert-message {
+    font-size: 0.9em;
+  }
+}
+
 .view-permits-detail-section {
   padding: 24px 20px;
 


### PR DESCRIPTION
## Objective 

[MDS-6845](https://bcmines.atlassian.net/browse/MDS-6845)

_Why are you making this change? Provide a short explanation and/or screenshots_
 
With the recent upgrade to Global Search in Core, users can search directly for permit numbers.
Some permits are associated with multiple mines, but search results currently present the permit as if it is associated with a single mine, which can mislead users and result in incorrect assumptions.

**Changes Made This PR:**
- Updated layout of banner & CSS to work better with existing elements
