### PR TITLE
[MDS-6845] Hide Additional Mine Links / Banner for MineSpace Users

### DIFF
--- a/services/common/src/components/permits/ViewPermit.tsx
+++ b/services/common/src/components/permits/ViewPermit.tsx
@@ -303,8 +303,9 @@ const ViewPermit: FC = () => {
     <ActionMenuButton actions={headerActions} />
   ) : null;
 
-  // filter out the mine already shown in the primary CoreTag (the one from the URL context)
-  const additionalMines = permit?.mine?.filter((m) => m.mine_guid !== id) ?? [];
+  // Core only: filter out the mine already shown in the primary CoreTag (the one from the URL context)
+  // MineSpace users should not see additional mine associations
+  const additionalMines = isCore ? (permit?.mine?.filter((m) => m.mine_guid !== id) ?? []) : [];
 
   return (
     <div className="fixed-tabs-container permit-tabs-container">

--- a/services/common/src/components/permits/ViewPermitOverview.tsx
+++ b/services/common/src/components/permits/ViewPermitOverview.tsx
@@ -29,6 +29,7 @@ import {
   getPermitStatusOptions,
 } from "@mds/common/redux/selectors/staticContentSelectors";
 import { getPermitAmendmentTypeOptions } from "@mds/common/redux/reducers/staticContentReducer";
+import { getIsCore } from "@mds/common/redux/reducers/authenticationReducer";
 import {
   renderDocumentLinkColumn,
   uploadedByColumn,
@@ -55,6 +56,7 @@ const ViewPermitOverview: FC<ViewPermitOverviewProps> = ({ latestAmendment }) =>
   const { id, permitGuid } = useParams<{ id: string; permitGuid: string }>();
   const permit: IPermit = useSelector(getPermitByGuid(permitGuid));
   const mine: IMine = useSelector(getMineById(id));
+  const isCore = useSelector(getIsCore);
 
   const documentColumns: ColumnsType<IPermitAmendmentDocument> = [
     renderDocumentLinkColumn("document_name", "File Name", true),
@@ -77,7 +79,7 @@ const ViewPermitOverview: FC<ViewPermitOverviewProps> = ({ latestAmendment }) =>
       {permit && mine ? (
         <Row>
           <Col span={12} className="view-permits-detail-section">
-            {permit.mine?.length > 1 && (
+            {isCore && permit.mine?.length > 1 && (
               <Alert
                 className="margin-medium--bottom permit-multi-mine-alert"
                 message="This permit is associated with multiple mines, please review the associated mine list for more details"


### PR DESCRIPTION
## Objective 

[MDS-6845](https://bcmines.atlassian.net/browse/MDS-6845)

_Why are you making this change? Provide a short explanation and/or screenshots_
 
With the recent upgrade to Global Search in Core, users can search directly for permit numbers.
Some permits are associated with multiple mines, but search results currently present the permit as if it is associated with a single mine, which can mislead users and result in incorrect assumptions.

**Changes Made This PR:**
- Gated the "Additional Mine" list and Alert/Banner behind the existing `isCore` flag, so that MineSpace users do not see the links to other mines (only see the details for the mine they are viewing)
