### PR TITLE
[MDS-6914] Exclude Deleted Contacts from Ministry Distribution Lists

### DIFF
--- a/services/core-api/app/api/ministry_contacts/models/distribution_list.py
+++ b/services/core-api/app/api/ministry_contacts/models/distribution_list.py
@@ -55,4 +55,4 @@ class DistributionList(SoftDeleteMixin, AuditMixin, Base):
         return cls.query.filter_by(distribution_list_guid=guid, deleted_ind=False).first()
 
     def get_emails(self):
-        return [user.ministry_contact.email for user in self.users if user.ministry_contact and user.ministry_contact.email]
+        return [user.ministry_contact.email for user in self.users if not user.deleted_ind and user.ministry_contact and user.ministry_contact.email]

--- a/services/core-api/app/api/ministry_contacts/resources/ministry_contact.py
+++ b/services/core-api/app/api/ministry_contacts/resources/ministry_contact.py
@@ -78,6 +78,9 @@ class MinistryContactResource(Resource, UserMixin):
         contact.deleted_ind = True
         current_app.logger.info(f'Deleting {contact}')
 
+        for dlu in DistributionListUser.find_by_contact_guid(contact_guid):
+            dlu.deleted_ind = True
+
         contact.save()
 
         return None, 204

--- a/services/core-api/tests/ministry_contacts/models/test_distribution_list.py
+++ b/services/core-api/tests/ministry_contacts/models/test_distribution_list.py
@@ -1,5 +1,7 @@
 import pytest
 from app.api.ministry_contacts.models.distribution_list import DistributionList
+from app.api.ministry_contacts.models.distribution_list_user import DistributionListUser
+from tests.factories import MinistryContactFactory
 
 def test_distribution_list_find_by_name(db_session):
     # The DB is seeded with distribution lists, e.g. "Core Default" or "Major Projects"
@@ -13,6 +15,28 @@ def test_distribution_list_get_emails(db_session):
     assert dl is not None
     emails = dl.get_emails()
     assert isinstance(emails, list)
+
+def test_distribution_list_get_emails_excludes_soft_deleted_users(db_session):
+    dl = DistributionList.create('DL Soft Delete Test')
+    db_session.add(dl)
+
+    contact = MinistryContactFactory()
+    db_session.add(contact)
+    db_session.flush()
+
+    dlu = DistributionListUser.create(dl.distribution_list_guid, contact.contact_guid)
+    db_session.add(dlu)
+    db_session.commit()
+
+    dl = DistributionList.find_by_name('DL Soft Delete Test')
+    assert contact.email in dl.get_emails()
+
+    dlu.deleted_ind = True
+    db_session.commit()
+    db_session.expire(dl)
+
+    assert contact.email not in dl.get_emails()
+
 
 def test_distribution_list_create(db_session):
     dl = DistributionList.create('Test List')

--- a/services/core-api/tests/ministry_contacts/resources/test_ministry_contact.py
+++ b/services/core-api/tests/ministry_contacts/resources/test_ministry_contact.py
@@ -5,6 +5,7 @@ from flask_restx import marshal
 from tests.factories import MinistryContactFactory
 from app.api.ministry_contacts.response_models import MINISTRY_CONTACT_MODEL
 from app.api.ministry_contacts.models.distribution_list import DistributionList
+from app.api.ministry_contacts.models.distribution_list_user import DistributionListUser
 
 
 #GET
@@ -114,6 +115,25 @@ def test_put_ministry_contact_success(test_client, db_session, auth_headers):
 
 
 #DELETE
+def test_delete_ministry_contact_cascades_to_distribution_list_users(test_client, db_session, auth_headers):
+    dl = DistributionList.create('DL Cascade Delete Test')
+    db_session.add(dl)
+
+    contact = MinistryContactFactory()
+    db_session.flush()
+
+    dlu = DistributionListUser.create(dl.distribution_list_guid, contact.contact_guid)
+    db_session.add(dlu)
+    db_session.commit()
+
+    delete_resp = test_client.delete(
+        f'/ministry-contacts/{contact.contact_guid}', headers=auth_headers['full_auth_header'])
+    assert delete_resp.status_code == 204
+
+    db_session.expire(dlu)
+    assert dlu.deleted_ind is True
+
+
 def test_soft_delete_ministry_contact_by_guid(test_client, db_session, auth_headers):
     contact = MinistryContactFactory()
 


### PR DESCRIPTION
## Objective 

[MDS-6914](https://bcmines.atlassian.net/browse/MDS-6914)

_Why are you making this change? Provide a short explanation and/or screenshots_

During testing it was noticed that for the following scenarios, a user would still receive a system email despite not being part of that Notification Group (Distribution List):
- The entire MCM contact is deleted
- The MCM contact _used_ to be part of a Notification Group (eg 'incidents'), but was later removed

This PR adds logic to check for the deleted status of the MCM contact, resolving the issue. 
Unit tests for this scenario were also added.

**Changes Made:**
- `distribution_list.py`: `get_emails()` now skips soft-deleted `DistributionListUser` rows (`not user.deleted_ind`)
- `ministry_contact.py`:  deleting a contact now cascades to soft-delete all associated `DistributionListUser` rows
- `test_distribution_list.py`:  test - removed DL user is excluded from `get_emails()`
- `test_ministry_contact.py`:  test - deleting a contact soft-deletes its DL memberships