### PR TITLE
[MDS-6914] Fix General Contacts Bug in MineSpace

### DIFF
--- a/services/core-api/app/api/ministry_contacts/models/ministry_contact.py
+++ b/services/core-api/app/api/ministry_contacts/models/ministry_contact.py
@@ -95,7 +95,8 @@ class MinistryContact(SoftDeleteMixin, AuditMixin, Base):
         if is_major_mine == True:
             return cls.query.filter_by(
                 mine_region_code=mine_region_code,
-                is_major_mine=is_major_mine).filter_by(deleted_ind=False).union(mmo_contact).all()
+                is_major_mine=is_major_mine,
+                is_general_contact=True).filter_by(deleted_ind=False).union(mmo_contact).all()
         elif is_major_mine == False:
             return cls.query.filter_by(
                 mine_region_code=mine_region_code, is_major_mine=is_major_mine).filter_by(

--- a/services/core-api/tests/ministry_contacts/models/test_ministry_contact_model.py
+++ b/services/core-api/tests/ministry_contacts/models/test_ministry_contact_model.py
@@ -30,6 +30,30 @@ def test_find_ministry_contacts_by_mine_region(db_session):
             c.mine_region == contact.mine_region for c in ministry_contact)
 
 
+def test_find_ministry_contacts_by_mine_region_excludes_non_general_major_mine_contact(db_session):
+    contact = MinistryContactFactory(is_major_mine=True, is_general_contact=False)
+    results = MinistryContact.find_ministry_contacts_by_mine_region(contact.mine_region_code, True)
+    assert contact.contact_guid not in [c.contact_guid for c in results]
+
+
+def test_find_ministry_contacts_by_mine_region_includes_general_major_mine_contact(db_session):
+    contact = MinistryContactFactory(is_major_mine=True, is_general_contact=True)
+    results = MinistryContact.find_ministry_contacts_by_mine_region(contact.mine_region_code, True)
+    assert contact.contact_guid in [c.contact_guid for c in results]
+
+
+def test_find_ministry_contacts_by_mine_region_includes_non_general_regional_contact(db_session):
+    contact = MinistryContactFactory(is_major_mine=False, is_general_contact=False)
+    results = MinistryContact.find_ministry_contacts_by_mine_region(contact.mine_region_code, False)
+    assert contact.contact_guid in [c.contact_guid for c in results]
+
+
+def test_find_ministry_contacts_by_mine_region_regional_mine_includes_general_contact_via_union(db_session):
+    contact = MinistryContactFactory(is_major_mine=True, is_general_contact=True)
+    results = MinistryContact.find_ministry_contacts_by_mine_region(contact.mine_region_code, False)
+    assert contact.contact_guid in [c.contact_guid for c in results]
+
+
 # def test_find_all(db_session):
 #     batch_size = 3
 #     contacts = MinistryContactFactory.create_batch(size=batch_size)


### PR DESCRIPTION
## Objective 

[MDS-6914](https://bcmines.atlassian.net/browse/MDS-6914)
[MDS-6946](https://bcmines.atlassian.net/browse/MDS-6946)

_Why are you making this change? Provide a short explanation and/or screenshots_

It was noticed that after merging MDS-6914, when a new contact is added in the MCM contacts page they get added to the 'MineSpace General Contacts' list, even if they are not selected as a general contact.

This PR resolves that issue by making it so major mine contacts now require `is_general_contact=True` to appear in MineSpace (regional mine contact behaviour was left unchanged, as that's appears to be working as intended)
