### PR TITLE
[MDS-6940] Fix for now document search results persisting across applications

### DIFF
--- a/services/common/src/redux/slices/nowApplicationSearchSlice.spec.ts
+++ b/services/common/src/redux/slices/nowApplicationSearchSlice.spec.ts
@@ -323,4 +323,3 @@ describe('async actions', () => {
         expect(selectNowSearchLoading(store.getState())).toBe(false);
     });
 });
-});

--- a/services/common/src/redux/slices/nowApplicationSearchSlice.spec.ts
+++ b/services/common/src/redux/slices/nowApplicationSearchSlice.spec.ts
@@ -9,6 +9,7 @@ import {
     indexNowApplicationDocuments,
     cancelNowIndexing,
     fetchNowIndexingStatus,
+    clearNowSearch,
     selectNowSearchQuery,
     selectNowSearchFilters,
     selectNowSearchResults,
@@ -147,147 +148,179 @@ describe('nowApplicationSearchSlice', () => {
             };
 
             store.dispatch(updateNowSearchResults(mockResults as any));
-
             const promptData = { answers: ['test answer'] };
             store.dispatch(updateNowPromptResults(promptData as any));
 
             expect(selectNowSearchResults(store.getState())?.prompt).toEqual(promptData);
         });
+
+        it('should clear search state when navigating to a different application', () => {
+            const store = getStore();
+
+            store.dispatch(setNowQuery('max annual tonnage'));
+            store.dispatch(setNowFilters([{ category: 'Type', value: 'PDF' }]));
+            store.dispatch(updateNowSearchResults({ documents: [{ content: 'result', id: '1' }] } as any));
+
+            // Navigate to a different application
+            store.dispatch(clearNowSearch('different-guid'));
+
+            expect(selectNowSearchQuery(store.getState())).toBe('');
+            expect(selectNowSearchFilters(store.getState())).toEqual([]);
+            expect(selectNowSearchResults(store.getState())).toBeNull();
+            expect(selectNowAllFacets(store.getState())).toEqual({});
+        });
+
+        it('should preserve search state when returning to the same application', () => {
+            const store = getStore();
+            const guid = 'app-guid-123';
+
+            // Simulate a completed search on this application
+            store.dispatch(clearNowSearch(guid)); // sets the stored guid
+            store.dispatch(setNowQuery('max annual tonnage'));
+            store.dispatch(updateNowSearchResults({ documents: [{ content: 'result', id: '1' }] } as any));
+
+            // Navigate away and back to the same application
+            store.dispatch(clearNowSearch(guid));
+
+            expect(selectNowSearchQuery(store.getState())).toBe('max annual tonnage');
+            expect(selectNowSearchResults(store.getState())).not.toBeNull();
+        });
+    });
+});
+
+describe('async actions', () => {
+    it('should handle indexNowApplicationDocuments', async () => {
+        const store = getStore();
+        const mockPost = jest.fn().mockResolvedValue({ data: {} });
+        (CustomAxios as jest.Mock).mockReturnValue({ post: mockPost });
+
+        const promise = store.dispatch(indexNowApplicationDocuments('test-guid'));
+
+        // wait a tick for pending
+        expect(selectNowIndexing(store.getState())).toBe(true);
+
+        await promise;
+        expect(mockPost).toHaveBeenCalled();
+        expect(selectNowIndexing(store.getState())).toBe(false);
     });
 
-    describe('async actions', () => {
-        it('should handle indexNowApplicationDocuments', async () => {
-            const store = getStore();
-            const mockPost = jest.fn().mockResolvedValue({ data: {} });
-            (CustomAxios as jest.Mock).mockReturnValue({ post: mockPost });
+    it('should handle cancelNowIndexing', async () => {
+        const store = getStore();
+        const mockDelete = jest.fn().mockResolvedValue({ data: {} });
+        const mockGet = jest.fn().mockResolvedValue({ data: { status: 'cancelled' } });
+        (CustomAxios as jest.Mock).mockReturnValue({ delete: mockDelete, get: mockGet });
 
-            const promise = store.dispatch(indexNowApplicationDocuments('test-guid'));
-            
-            // wait a tick for pending
-            expect(selectNowIndexing(store.getState())).toBe(true);
-            
-            await promise;
-            expect(mockPost).toHaveBeenCalled();
-            expect(selectNowIndexing(store.getState())).toBe(false);
+        const promise = store.dispatch(cancelNowIndexing('test-guid'));
+
+        expect(selectNowCancelling(store.getState())).toBe(true);
+
+        await promise;
+        expect(mockDelete).toHaveBeenCalled();
+        expect(selectNowCancelling(store.getState())).toBe(false);
+    });
+
+    it('should handle fetchNowIndexingStatus', async () => {
+        const store = getStore();
+        const mockStatus = { status: 'success', items_processed: 5 };
+        const mockGet = jest.fn().mockResolvedValue({ data: mockStatus });
+        (CustomAxios as jest.Mock).mockReturnValue({ get: mockGet });
+
+        const promise = store.dispatch(fetchNowIndexingStatus('test-guid'));
+
+        expect(selectNowIndexerStatusLoading(store.getState())).toBe(true);
+
+        await promise;
+        expect(mockGet).toHaveBeenCalled();
+        expect(selectNowIndexerStatusLoading(store.getState())).toBe(false);
+        expect(selectNowIndexerStatus(store.getState())).toEqual(mockStatus);
+    });
+
+    it('should handle searchNowApplicationDocuments with SSE success', async () => {
+        const store = getStore();
+        let onMessageHandler: any;
+        let onDisconnectHandler: any;
+
+        const mockClose = jest.fn();
+
+        (createEventSource as jest.Mock).mockImplementation((options) => {
+            onMessageHandler = options.onMessage;
+            onDisconnectHandler = options.onDisconnect;
+            return { close: mockClose };
         });
 
-        it('should handle cancelNowIndexing', async () => {
-            const store = getStore();
-            const mockDelete = jest.fn().mockResolvedValue({ data: {} });
-            const mockGet = jest.fn().mockResolvedValue({ data: { status: 'cancelled' } });
-            (CustomAxios as jest.Mock).mockReturnValue({ delete: mockDelete, get: mockGet });
+        const promise = store.dispatch(searchNowApplicationDocuments({
+            nowApplicationGuid: 'test-guid',
+            query: 'test',
+            filters: [{ category: 'Type', value: 'PDF' }]
+        }));
 
-            const promise = store.dispatch(cancelNowIndexing('test-guid'));
-            
-            expect(selectNowCancelling(store.getState())).toBe(true);
-            
-            await promise;
-            expect(mockDelete).toHaveBeenCalled();
-            expect(selectNowCancelling(store.getState())).toBe(false);
+        // trigger SSE events
+        if (onMessageHandler) {
+            onMessageHandler({ event: SearchEventType.AI_START, data: '{}' });
+            expect(selectNowAiLoading(store.getState())).toBe(true);
+
+            onMessageHandler({ event: SearchEventType.DOCUMENTS, data: JSON.stringify({ documents: [] }) });
+            expect(selectNowDocumentLoading(store.getState())).toBe(false);
+
+            onMessageHandler({ event: SearchEventType.PROMPT, data: JSON.stringify({ answers: ['answer'] }) });
+
+            onMessageHandler({ event: SearchEventType.AI_COMPLETE, data: '{}' });
+            expect(selectNowAiLoading(store.getState())).toBe(false);
+        }
+
+        if (onDisconnectHandler) {
+            onDisconnectHandler();
+        }
+
+        await promise;
+        expect(createEventSource).toHaveBeenCalled();
+    });
+
+    it('should handle searchNowApplicationDocuments with SSE error event', async () => {
+        const store = getStore();
+        let onMessageHandler: any;
+
+        (createEventSource as jest.Mock).mockImplementation((options) => {
+            onMessageHandler = options.onMessage;
+            return { close: jest.fn() };
         });
 
-        it('should handle fetchNowIndexingStatus', async () => {
-            const store = getStore();
-            const mockStatus = { status: 'success', items_processed: 5 };
-            const mockGet = jest.fn().mockResolvedValue({ data: mockStatus });
-            (CustomAxios as jest.Mock).mockReturnValue({ get: mockGet });
+        const promise = store.dispatch(searchNowApplicationDocuments({
+            nowApplicationGuid: 'test-guid',
+            query: 'test',
+            filters: []
+        }));
 
-            const promise = store.dispatch(fetchNowIndexingStatus('test-guid'));
-            
-            expect(selectNowIndexerStatusLoading(store.getState())).toBe(true);
-            
-            await promise;
-            expect(mockGet).toHaveBeenCalled();
-            expect(selectNowIndexerStatusLoading(store.getState())).toBe(false);
-            expect(selectNowIndexerStatus(store.getState())).toEqual(mockStatus);
+        if (onMessageHandler) {
+            onMessageHandler({ event: SearchEventType.ERROR, data: JSON.stringify({ message: 'test error' }) });
+        }
+
+        await promise;
+
+        expect(selectNowAiLoading(store.getState())).toBe(false);
+        expect(selectNowDocumentLoading(store.getState())).toBe(false);
+        const results = selectNowSearchResults(store.getState());
+        expect(results?.prompt?.answers?.[0]).toEqual('test error');
+    });
+
+    it('should handle searchNowApplicationDocuments eventSource setup failure', async () => {
+        const store = getStore();
+
+        (createEventSource as jest.Mock).mockImplementation(() => {
+            throw new Error("setup error");
         });
 
-        it('should handle searchNowApplicationDocuments with SSE success', async () => {
-            const store = getStore();
-            let onMessageHandler: any;
-            let onDisconnectHandler: any;
-
-            const mockClose = jest.fn();
-
-            (createEventSource as jest.Mock).mockImplementation((options) => {
-                onMessageHandler = options.onMessage;
-                onDisconnectHandler = options.onDisconnect;
-                return { close: mockClose };
-            });
-
-            const promise = store.dispatch(searchNowApplicationDocuments({
-                nowApplicationGuid: 'test-guid',
-                query: 'test',
-                filters: [{ category: 'Type', value: 'PDF' }]
-            }));
-
-            // trigger SSE events
-            if (onMessageHandler) {
-                onMessageHandler({ event: SearchEventType.AI_START, data: '{}' });
-                expect(selectNowAiLoading(store.getState())).toBe(true);
-
-                onMessageHandler({ event: SearchEventType.DOCUMENTS, data: JSON.stringify({ documents: [] }) });
-                expect(selectNowDocumentLoading(store.getState())).toBe(false);
-                
-                onMessageHandler({ event: SearchEventType.PROMPT, data: JSON.stringify({ answers: ['answer'] }) });
-                
-                onMessageHandler({ event: SearchEventType.AI_COMPLETE, data: '{}' });
-                expect(selectNowAiLoading(store.getState())).toBe(false);
-            }
-
-            if (onDisconnectHandler) {
-                onDisconnectHandler();
-            }
-
-            await promise;
-            expect(createEventSource).toHaveBeenCalled();
-        });
-
-        it('should handle searchNowApplicationDocuments with SSE error event', async () => {
-            const store = getStore();
-            let onMessageHandler: any;
-
-            (createEventSource as jest.Mock).mockImplementation((options) => {
-                onMessageHandler = options.onMessage;
-                return { close: jest.fn() };
-            });
-
-            const promise = store.dispatch(searchNowApplicationDocuments({
+        try {
+            await store.dispatch(searchNowApplicationDocuments({
                 nowApplicationGuid: 'test-guid',
                 query: 'test',
                 filters: []
-            }));
+            })).unwrap();
+        } catch (e) {
+            // expected
+        }
 
-            if (onMessageHandler) {
-                onMessageHandler({ event: SearchEventType.ERROR, data: JSON.stringify({ message: 'test error' }) });
-            }
-
-            await promise;
-            
-            expect(selectNowAiLoading(store.getState())).toBe(false);
-            expect(selectNowDocumentLoading(store.getState())).toBe(false);
-            const results = selectNowSearchResults(store.getState());
-            expect(results?.prompt?.answers?.[0]).toEqual('test error');
-        });
-
-        it('should handle searchNowApplicationDocuments eventSource setup failure', async () => {
-            const store = getStore();
-
-            (createEventSource as jest.Mock).mockImplementation(() => {
-                throw new Error("setup error");
-            });
-
-            try {
-                await store.dispatch(searchNowApplicationDocuments({
-                    nowApplicationGuid: 'test-guid',
-                    query: 'test',
-                    filters: []
-                })).unwrap();
-            } catch (e) {
-                // expected
-            }
-
-            expect(selectNowSearchLoading(store.getState())).toBe(false);
-        });
+        expect(selectNowSearchLoading(store.getState())).toBe(false);
     });
+});
 });

--- a/services/common/src/redux/slices/nowApplicationSearchSlice.ts
+++ b/services/common/src/redux/slices/nowApplicationSearchSlice.ts
@@ -107,6 +107,16 @@ const nowApplicationSearchSlice = createAppSlice({
     setNowDocumentLoading: create.reducer((state, action: { payload: boolean }) => {
       state.documentLoading = action.payload;
     }),
+    clearNowSearch: create.reducer((state, action: { payload: string }) => {
+      if (state.nowApplicationGuid === action.payload) {
+        return;
+      }
+      state.results = null;
+      state.query = "";
+      state.filters = [];
+      state.allFacets = {};
+      state.nowApplicationGuid = action.payload;
+    }),
 
     /**
      * Triggers document indexing for a NoW application via the core-api proxy.
@@ -360,6 +370,7 @@ export const {
   updateNowPromptResults,
   setNowAiLoading,
   setNowDocumentLoading,
+  clearNowSearch,
 } = nowApplicationSearchSlice.actions;
 
 export const {

--- a/services/core-web/src/components/mine/Permit/Search/__snapshots__/PermitConditionSearch.integration.spec.tsx.snap
+++ b/services/core-web/src/components/mine/Permit/Search/__snapshots__/PermitConditionSearch.integration.spec.tsx.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`PermitConditionSearch Integration Tests clears filters properly 1`] = `<div />`;
+
 exports[`PermitConditionSearch Integration Tests shows and applies filters 1`] = `
 <div>
   <form

--- a/services/core-web/src/components/mine/Permit/Search/__snapshots__/PermitConditionSearch.integration.spec.tsx.snap
+++ b/services/core-web/src/components/mine/Permit/Search/__snapshots__/PermitConditionSearch.integration.spec.tsx.snap
@@ -1,7 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`PermitConditionSearch Integration Tests clears filters properly 1`] = `<div />`;
-
 exports[`PermitConditionSearch Integration Tests shows and applies filters 1`] = `
 <div>
   <form

--- a/services/core-web/src/components/noticeOfWork/applications/search/NowApplicationDocumentSearch.spec.tsx
+++ b/services/core-web/src/components/noticeOfWork/applications/search/NowApplicationDocumentSearch.spec.tsx
@@ -41,7 +41,7 @@ const createMockStore = (preloadedState = {}) => {
                 query: '',
                 filters: [],
                 allFacets: {},
-                nowApplicationGuid: null,
+                nowApplicationGuid: "test-guid",
                 ...preloadedState,
             },
         },
@@ -104,7 +104,7 @@ describe('NowApplicationDocumentSearch', () => {
 
         const indexBtn = await screen.findByText('Index Documents');
         expect(indexBtn).toBeInTheDocument();
-        
+
         fireEvent.click(indexBtn);
     });
 
@@ -144,7 +144,7 @@ describe('NowApplicationDocumentSearch', () => {
 
         const expandBtn = screen.getByTitle('Expand');
         fireEvent.click(expandBtn);
-        
+
         expect(screen.getByTitle('Compress')).toBeInTheDocument();
     });
 });

--- a/services/core-web/src/components/noticeOfWork/applications/search/NowApplicationDocumentSearch.tsx
+++ b/services/core-web/src/components/noticeOfWork/applications/search/NowApplicationDocumentSearch.tsx
@@ -23,6 +23,7 @@ import {
 import { useAppDispatch, useAppSelector } from "@mds/common/redux/rootState";
 import {
   cancelNowIndexing,
+  clearNowSearch,
   fetchNowIndexingStatus,
   indexNowApplicationDocuments,
   NowIndexerStatus,
@@ -136,6 +137,10 @@ const NowApplicationDocumentSearch: React.FC<NowApplicationDocumentSearchProps> 
   const refreshStatus = () => dispatch(fetchNowIndexingStatus(nowApplicationGuid));
   const isRunning = indexerStatus?.status === "running";
   const isIndexed = indexerStatus?.status && indexerStatus?.status !== "never_run";
+
+  useEffect(() => {
+    dispatch(clearNowSearch(nowApplicationGuid));
+  }, [nowApplicationGuid]);
 
   // Fetch status on mount and whenever indexing is triggered.
   useEffect(() => {
@@ -288,9 +293,8 @@ const NowApplicationDocumentSearch: React.FC<NowApplicationDocumentSearchProps> 
                   <Card
                     title="AI-Generated Response"
                     loading={false}
-                    className={`permit-search__ai-response ${
-                      isAIResponseExpanded ? "permit-search__ai-response--expanded" : ""
-                    }`}
+                    className={`permit-search__ai-response ${isAIResponseExpanded ? "permit-search__ai-response--expanded" : ""
+                      }`}
                   >
                     <FontAwesomeIcon
                       icon={isAIResponseExpanded ? faCompress : faExpand}


### PR DESCRIPTION
## Objective 

[MDS-6940](https://bcmines.atlassian.net/browse/MDS-6940)

- Added a clearing of cached search results when user moves to different NoW application's document search page.
- If user just goes back to the same NoW application's document search page as the last one then the search results will persist.
