### PR TITLE
[MDS-6946] Adjusted major mine contact that is not general contact to not show in minespace

### DIFF
--- a/services/core-api/app/api/ministry_contacts/models/ministry_contact.py
+++ b/services/core-api/app/api/ministry_contacts/models/ministry_contact.py
@@ -109,7 +109,7 @@ class MinistryContact(SoftDeleteMixin, AuditMixin, Base):
     @classmethod
     def find_major_mine_office(cls):
         return cls.query.filter_by(
-            is_major_mine=True, mine_region_code=None).filter_by(deleted_ind=False)
+            is_major_mine=True, mine_region_code=None, is_general_contact=True).filter_by(deleted_ind=False)
 
     @classmethod
     def get_all(cls, is_major_mine=None):

--- a/services/core-api/tests/ministry_contacts/models/test_ministry_contact_model.py
+++ b/services/core-api/tests/ministry_contacts/models/test_ministry_contact_model.py
@@ -54,6 +54,18 @@ def test_find_ministry_contacts_by_mine_region_regional_mine_includes_general_co
     assert contact.contact_guid in [c.contact_guid for c in results]
 
 
+def test_find_ministry_contacts_by_mine_region_excludes_non_general_no_region_major_mine_contact(db_session):
+    contact = MinistryContactFactory(is_major_mine=True, is_general_contact=False, mine_region_code=None)
+    results = MinistryContact.find_ministry_contacts_by_mine_region('NE', True)
+    assert contact.contact_guid not in [c.contact_guid for c in results]
+
+
+def test_find_ministry_contacts_by_mine_region_includes_general_no_region_major_mine_contact(db_session):
+    contact = MinistryContactFactory(is_major_mine=True, is_general_contact=True, mine_region_code=None)
+    results = MinistryContact.find_ministry_contacts_by_mine_region('NE', True)
+    assert contact.contact_guid in [c.contact_guid for c in results]
+
+
 # def test_find_all(db_session):
 #     batch_size = 3
 #     contacts = MinistryContactFactory.create_batch(size=batch_size)


### PR DESCRIPTION


## Objective 

[MDS-6946](https://bcmines.atlassian.net/browse/MDS-6946)

- There was an issue where a Minespace MCM contact that was created as a major mine contact, but not a general contact, when there is no mine region selected for it, the contact would appear in the contact section for all Minespace major mines. The expected behaviour is when a Minespace MCM contact is not a general contact it shouldn't show up in Minespace at all.
- The fix was to add `is_general_contact=True` check in the filter of the `find_majoy_mine_office` function. From what I can tell this logic is only really called within Minespace.
