### PR TITLE
[MDS-6946] Adjustment to make general contact option determine if it shows in minespace

### DIFF
--- a/services/core-api/app/api/ministry_contacts/models/ministry_contact.py
+++ b/services/core-api/app/api/ministry_contacts/models/ministry_contact.py
@@ -104,7 +104,7 @@ class MinistryContact(SoftDeleteMixin, AuditMixin, Base):
 
     @classmethod
     def find_ministry_general_contacts(cls):
-        return cls.query.filter_by(is_general_contact=True).filter_by(deleted_ind=False)
+        return cls.query.filter_by(is_general_contact=True, mine_region_code=None).filter_by(deleted_ind=False)
 
     @classmethod
     def find_major_mine_office(cls):

--- a/services/core-api/app/api/ministry_contacts/resources/ministry_contact_list.py
+++ b/services/core-api/app/api/ministry_contacts/resources/ministry_contact_list.py
@@ -91,9 +91,6 @@ class MinistryContactListResource(Resource, UserMixin):
         elif unique_global and contact_type in unique_global:
             raise BadRequest(f'Error: Restricted to one {contact_desc[0].description} contact.')
 
-        elif is_major_mine == False and is_general_contact == True:
-            raise BadRequest(f'Error: General contacts must be a major mine contact.')
-
         contact = MinistryContact.create(
             emli_contact_type_code=contact_type,
             mine_region_code=data.get('mine_region_code'),

--- a/services/core-api/app/api/ministry_contacts/resources/ministry_contact_list.py
+++ b/services/core-api/app/api/ministry_contacts/resources/ministry_contact_list.py
@@ -68,8 +68,6 @@ class MinistryContactListResource(Resource, UserMixin):
         data = self.parser.parse_args()
 
         contact_type = data.get('emli_contact_type_code', None)
-        is_major_mine = data.get('is_major_mine', None)
-        is_general_contact = data.get('is_general_contact', None)
         contact_desc = MinistryContactType.find_contact_type(contact_type)
 
         mmo_contact = MinistryContact.find_ministry_contact('MMO')

--- a/services/core-api/tests/ministry_contacts/models/test_ministry_contact_model.py
+++ b/services/core-api/tests/ministry_contacts/models/test_ministry_contact_model.py
@@ -50,19 +50,19 @@ def test_find_ministry_contacts_by_mine_region_includes_non_general_regional_con
 
 def test_find_ministry_contacts_by_mine_region_regional_mine_includes_general_contact_via_union(db_session):
     contact = MinistryContactFactory(is_major_mine=True, is_general_contact=True, mine_region_code=None)
-    results = MinistryContact.find_ministry_contacts_by_mine_region('NE', False)
+    results = MinistryContact.find_ministry_contacts_by_mine_region(contact.mine_region_code, False)
     assert contact.contact_guid in [c.contact_guid for c in results]
 
 
 def test_find_ministry_contacts_by_mine_region_excludes_non_general_no_region_major_mine_contact(db_session):
     contact = MinistryContactFactory(is_major_mine=True, is_general_contact=False, mine_region_code=None)
-    results = MinistryContact.find_ministry_contacts_by_mine_region('NE', True)
+    results = MinistryContact.find_ministry_contacts_by_mine_region(contact.mine_region_code, True)
     assert contact.contact_guid not in [c.contact_guid for c in results]
 
 
 def test_find_ministry_contacts_by_mine_region_includes_general_no_region_major_mine_contact(db_session):
     contact = MinistryContactFactory(is_major_mine=True, is_general_contact=True, mine_region_code=None)
-    results = MinistryContact.find_ministry_contacts_by_mine_region('NE', True)
+    results = MinistryContact.find_ministry_contacts_by_mine_region(contact.mine_region_code, True)
     assert contact.contact_guid in [c.contact_guid for c in results]
 
 

--- a/services/core-api/tests/ministry_contacts/models/test_ministry_contact_model.py
+++ b/services/core-api/tests/ministry_contacts/models/test_ministry_contact_model.py
@@ -49,8 +49,8 @@ def test_find_ministry_contacts_by_mine_region_includes_non_general_regional_con
 
 
 def test_find_ministry_contacts_by_mine_region_regional_mine_includes_general_contact_via_union(db_session):
-    contact = MinistryContactFactory(is_major_mine=True, is_general_contact=True)
-    results = MinistryContact.find_ministry_contacts_by_mine_region(contact.mine_region_code, False)
+    contact = MinistryContactFactory(is_major_mine=True, is_general_contact=True, mine_region_code=None)
+    results = MinistryContact.find_ministry_contacts_by_mine_region('NE', False)
     assert contact.contact_guid in [c.contact_guid for c in results]
 
 

--- a/services/core-web/src/components/Forms/MinistryContacts/MinistryContactForm.tsx
+++ b/services/core-web/src/components/Forms/MinistryContacts/MinistryContactForm.tsx
@@ -104,7 +104,7 @@ export const MinistryContactForm: FC<MinistryContactFormProps> = (props) => {
               disabled={props.isEdit}
             />
           </Col>
-          {formValues.is_major_mine && (
+          {formValues.is_major_mine !== undefined && (
             <Col span={12}>
               <Field
                 id="is_general_contact"

--- a/services/core-web/src/tests/components/Forms/MinistryContacts/__snapshots__/MinistryContactForm.spec.tsx.snap
+++ b/services/core-web/src/tests/components/Forms/MinistryContacts/__snapshots__/MinistryContactForm.spec.tsx.snap
@@ -109,6 +109,128 @@ exports[`MinistryContactForm renders properly for creating contact 1`] = `
             </div>
           </div>
         </div>
+        <div
+          class="ant-col ant-col-12"
+          style="padding-left: 8px; padding-right: 8px;"
+        >
+          <div
+            class="ant-form-item ant-form-item-with-help"
+          >
+            <div
+              class="ant-row ant-form-item-row"
+            >
+              <div
+                class="ant-col ant-form-item-label"
+              >
+                <label
+                  class="ant-form-item-required"
+                  for="MINISTRY_CONTACT_FORM_is_general_contact"
+                  title=""
+                >
+                  <div
+                    style="width: 100%;"
+                  >
+                    Is this a general contact?
+                     
+                    <span
+                      aria-label="info-circle"
+                      class="anticon anticon-info-circle info-tooltip icon-sm"
+                      role="img"
+                      style="color: rgb(94, 70, 161);"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class=""
+                        data-icon="info-circle"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                        />
+                        <path
+                          d="M464 336a48 48 0 1096 0 48 48 0 10-96 0zm72 112h-48c-4.4 0-8 3.6-8 8v272c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V456c0-4.4-3.6-8-8-8z"
+                        />
+                      </svg>
+                    </span>
+                  </div>
+                </label>
+              </div>
+              <div
+                class="ant-col ant-form-item-control"
+              >
+                <div
+                  class="ant-form-item-control-input"
+                >
+                  <div
+                    class="ant-form-item-control-input-content"
+                  >
+                    <div
+                      class="ant-radio-group ant-radio-group-solid"
+                    >
+                      <label
+                        class="ant-radio-wrapper ant-radio-wrapper-in-form-item"
+                      >
+                        <span
+                          class="ant-radio"
+                        >
+                          <input
+                            class="ant-radio-input"
+                            name="is_general_contact"
+                            type="radio"
+                            value="true"
+                          />
+                          <span
+                            class="ant-radio-inner"
+                          />
+                        </span>
+                        <span>
+                          Yes
+                        </span>
+                      </label>
+                      <label
+                        class="ant-radio-wrapper ant-radio-wrapper-in-form-item"
+                      >
+                        <span
+                          class="ant-radio"
+                        >
+                          <input
+                            class="ant-radio-input"
+                            name="is_general_contact"
+                            type="radio"
+                            value="false"
+                          />
+                          <span
+                            class="ant-radio-inner"
+                          />
+                        </span>
+                        <span>
+                          No
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  style="display: flex; flex-wrap: nowrap;"
+                >
+                  <div
+                    class="ant-form-item-explain ant-form-item-explain-connected"
+                    id="MINISTRY_CONTACT_FORM_is_general_contact_help"
+                    role="alert"
+                  >
+                    <div
+                      class=""
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
       <div
         class="ant-row"
@@ -972,6 +1094,128 @@ exports[`MinistryContactForm renders properly for editing contact 1`] = `
                   <div
                     class="ant-form-item-explain ant-form-item-explain-connected"
                     id="MINISTRY_CONTACT_FORM_is_major_mine_help"
+                    role="alert"
+                  >
+                    <div
+                      class=""
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="ant-col ant-col-12"
+          style="padding-left: 8px; padding-right: 8px;"
+        >
+          <div
+            class="ant-form-item ant-form-item-with-help"
+          >
+            <div
+              class="ant-row ant-form-item-row"
+            >
+              <div
+                class="ant-col ant-form-item-label"
+              >
+                <label
+                  class="ant-form-item-required"
+                  for="MINISTRY_CONTACT_FORM_is_general_contact"
+                  title=""
+                >
+                  <div
+                    style="width: 100%;"
+                  >
+                    Is this a general contact?
+                     
+                    <span
+                      aria-label="info-circle"
+                      class="anticon anticon-info-circle info-tooltip icon-sm"
+                      role="img"
+                      style="color: rgb(94, 70, 161);"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class=""
+                        data-icon="info-circle"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                        />
+                        <path
+                          d="M464 336a48 48 0 1096 0 48 48 0 10-96 0zm72 112h-48c-4.4 0-8 3.6-8 8v272c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V456c0-4.4-3.6-8-8-8z"
+                        />
+                      </svg>
+                    </span>
+                  </div>
+                </label>
+              </div>
+              <div
+                class="ant-col ant-form-item-control"
+              >
+                <div
+                  class="ant-form-item-control-input"
+                >
+                  <div
+                    class="ant-form-item-control-input-content"
+                  >
+                    <div
+                      class="ant-radio-group ant-radio-group-solid"
+                    >
+                      <label
+                        class="ant-radio-wrapper ant-radio-wrapper-in-form-item"
+                      >
+                        <span
+                          class="ant-radio"
+                        >
+                          <input
+                            class="ant-radio-input"
+                            name="is_general_contact"
+                            type="radio"
+                            value="true"
+                          />
+                          <span
+                            class="ant-radio-inner"
+                          />
+                        </span>
+                        <span>
+                          Yes
+                        </span>
+                      </label>
+                      <label
+                        class="ant-radio-wrapper ant-radio-wrapper-in-form-item"
+                      >
+                        <span
+                          class="ant-radio"
+                        >
+                          <input
+                            class="ant-radio-input"
+                            name="is_general_contact"
+                            type="radio"
+                            value="false"
+                          />
+                          <span
+                            class="ant-radio-inner"
+                          />
+                        </span>
+                        <span>
+                          No
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  style="display: flex; flex-wrap: nowrap;"
+                >
+                  <div
+                    class="ant-form-item-explain ant-form-item-explain-connected"
+                    id="MINISTRY_CONTACT_FORM_is_general_contact_help"
                     role="alert"
                   >
                     <div

--- a/services/minespace-web/src/components/dashboard/mine/overview/Overview.js
+++ b/services/minespace-web/src/components/dashboard/mine/overview/Overview.js
@@ -147,7 +147,8 @@ export const Overview = (props) => {
               <Col span={24} key="regional">
                 <Card title="Regional Ministry Contacts">
                   {props.MinistryContactInfo.filter(
-                    ({ is_general_contact }) => !is_general_contact
+                    ({ is_major_mine, is_general_contact, mine_region_code }) =>
+                      !is_major_mine && is_general_contact && mine_region_code === mine.mine_region
                   ).map((contact) => (
                     <MinistryContactItem contact={contact} key={contact.id} />
                   ))}
@@ -156,7 +157,10 @@ export const Overview = (props) => {
               <Col span={24} key="general">
                 <Card title="General Ministry Contacts">
                   {props.MinistryContactInfo.filter(
-                    ({ is_general_contact }) => is_general_contact
+                    ({ is_major_mine, is_general_contact, mine_region_code }) =>
+                      is_major_mine &&
+                      is_general_contact &&
+                      (!mine_region_code || mine_region_code === mine.mine_region)
                   ).map((contact) => (
                     <MinistryContactItem contact={contact} key={contact.id} />
                   ))}


### PR DESCRIPTION


## Objective 

[MDS-6946](https://bcmines.atlassian.net/browse/MDS-6946)

- Adjusted the MCM contact creation modal to have general contact option be available even if user selects no to the major mine contact option.
- The general contact option is now the main indicator to determine if a contact shows up in minespace's frontend or not.
- Fixed a bug that occurs when a contact is major contact, a general contact, and region is selected, the contact will show up for all regional mines under the "General Ministry Contacts" section. It now should only show up for the regional mine that belongs in the selected region.
