### PR TITLE
[MDS-6953] - MCM contact management validation

### DIFF
--- a/services/common/src/constants/enums.ts
+++ b/services/common/src/constants/enums.ts
@@ -342,4 +342,7 @@ export enum MinistryContactTypeCodes {
   CHP = "CHP",
   CHI = "CHI",
   RDC = "RDC",
+  GEN = "GEN",
 }
+
+export const officeContactTypeCodes = [MinistryContactTypeCodes.ROE, MinistryContactTypeCodes.MMO];

--- a/services/common/src/constants/enums.ts
+++ b/services/common/src/constants/enums.ts
@@ -335,3 +335,11 @@ export enum NOW_APPLICATION_NATION_EVENT_PARTY_OPTIONS {
   permitting_inspector = "Permitting Inspector",
   proponent = "Proponent",
 }
+
+export enum MinistryContactTypeCodes {
+  ROE = "ROE",
+  MMO = "MMO",
+  CHP = "CHP",
+  CHI = "CHI",
+  RDC = "RDC",
+}

--- a/services/common/src/redux/selectors/staticContentSelectors.ts
+++ b/services/common/src/redux/selectors/staticContentSelectors.ts
@@ -920,7 +920,7 @@ export const getDropdownMinistryContactTypes = createSelectorWrapper(
 );
 
 export const getMinistryContactTypesHash = createSelector(
-  [getDropdownMinistryContactTypes],
+  [(state) => getDropdownMinistryContactTypes(state, false)],
   createLabelHash
 );
 

--- a/services/core-api/app/api/ministry_contacts/models/ministry_contact_type.py
+++ b/services/core-api/app/api/ministry_contacts/models/ministry_contact_type.py
@@ -15,7 +15,7 @@ class MinistryContactType(AuditMixin, Base):
 
     @classmethod
     def get_all(cls):
-        return cls.query.filter_by(active_ind=True).all()
+        return cls.query.all()
 
     @classmethod
     def get_active(cls):

--- a/services/core-api/app/api/ministry_contacts/resources/ministry_contact.py
+++ b/services/core-api/app/api/ministry_contacts/resources/ministry_contact.py
@@ -15,11 +15,11 @@ class MinistryContactResource(Resource, UserMixin):
     parser = reqparse.RequestParser()
     parser.add_argument('first_name', type=str, trim=True, help='MCM First name', location='json')
     parser.add_argument('last_name', type=str, trim=True, help='MCM Last name.', location='json')
-    parser.add_argument('email', type=str, help='MCM email.', required=True, location='json')
+    parser.add_argument('email', type=str, help='MCM email.', required=False, location='json')
     parser.add_argument(
         'is_general_contact', type=bool, help='is is_general_contact? true/false', location='json')
     parser.add_argument(
-        'phone_number', type=str, help='MCM phone number', required=True, location='json')
+        'phone_number', type=str, help='MCM phone number', required=False, location='json')
     parser.add_argument(
         'fax_number', type=str, help='MCM Regional Office fax number', location='json')
     parser.add_argument(
@@ -33,6 +33,8 @@ class MinistryContactResource(Resource, UserMixin):
         help='MCM Regional Office mailing address line 2',
         location='json')
     parser.add_argument(
+        'mine_region_code', type=str, trim=True, help='Mine region code', location='json')
+    parser.add_argument(
         'distribution_list_guids', type=list, location='json', default=[])
 
     @api.doc(description='Update an existing MCM contact.')
@@ -45,8 +47,18 @@ class MinistryContactResource(Resource, UserMixin):
 
         data = self.parser.parse_args()
 
+        if not data.get('email') and not data.get('phone_number'):
+            raise BadRequest('Either email or phone number is required.')
+
         distribution_list_guids = data.pop('distribution_list_guids', [])
         
+        new_region_code = data.get('mine_region_code')
+        if new_region_code and new_region_code != contact.mine_region_code:
+            if contact.emli_contact_type_code == 'ROE':
+                existing_roe = MinistryContact.find_ministry_contact('ROE', new_region_code)
+                if existing_roe and existing_roe.contact_guid != contact.contact_guid:
+                    raise BadRequest('Error: Restricted to one Regional Office contact by mine region.')
+
         for key, value in data.items():
             setattr(contact, key, value)
 

--- a/services/core-api/app/api/ministry_contacts/resources/ministry_contact.py
+++ b/services/core-api/app/api/ministry_contacts/resources/ministry_contact.py
@@ -47,12 +47,12 @@ class MinistryContactResource(Resource, UserMixin):
 
         data = self.parser.parse_args()
 
-        if contact.emli_contact_type_code == 'RDC':
-            if not data.get('email'):
-                raise BadRequest('Email is required.')
-        else:
-            if not data.get('email') or not data.get('phone_number'):
-                raise BadRequest('Both email and phone number are required.')
+        if not data.get('email'):
+            raise BadRequest('Email is required.')
+
+        if contact.emli_contact_type_code != 'RDC' and not data.get('is_general_contact'):
+            if not data.get('phone_number'):
+                raise BadRequest('Phone number is required.')
 
         distribution_list_guids = data.pop('distribution_list_guids', [])
         

--- a/services/core-api/app/api/ministry_contacts/resources/ministry_contact.py
+++ b/services/core-api/app/api/ministry_contacts/resources/ministry_contact.py
@@ -15,7 +15,7 @@ class MinistryContactResource(Resource, UserMixin):
     parser = reqparse.RequestParser()
     parser.add_argument('first_name', type=str, trim=True, help='MCM First name', location='json')
     parser.add_argument('last_name', type=str, trim=True, help='MCM Last name.', location='json')
-    parser.add_argument('email', type=str, help='MCM email.', required=False, location='json')
+    parser.add_argument('email', type=str, help='MCM email.', required=True, location='json')
     parser.add_argument(
         'is_general_contact', type=bool, help='is is_general_contact? true/false', location='json')
     parser.add_argument(
@@ -47,8 +47,8 @@ class MinistryContactResource(Resource, UserMixin):
 
         data = self.parser.parse_args()
 
-        if not data.get('email') and not data.get('phone_number'):
-            raise BadRequest('Either email or phone number is required.')
+        if contact.emli_contact_type_code != 'RDC' and not data.get('phone_number'):
+            raise BadRequest('Phone number is required.')
 
         distribution_list_guids = data.pop('distribution_list_guids', [])
         
@@ -60,6 +60,8 @@ class MinistryContactResource(Resource, UserMixin):
                     raise BadRequest('Error: Restricted to one Regional Office contact by mine region.')
 
         for key, value in data.items():
+            if key == 'mine_region_code' and 'mine_region_code' not in (request.json or {}):
+                continue
             setattr(contact, key, value)
 
         # Soft delete existing records

--- a/services/core-api/app/api/ministry_contacts/resources/ministry_contact.py
+++ b/services/core-api/app/api/ministry_contacts/resources/ministry_contact.py
@@ -47,8 +47,12 @@ class MinistryContactResource(Resource, UserMixin):
 
         data = self.parser.parse_args()
 
-        if contact.emli_contact_type_code != 'RDC' and not data.get('phone_number'):
-            raise BadRequest('Phone number is required.')
+        if contact.emli_contact_type_code == 'RDC':
+            if not data.get('email'):
+                raise BadRequest('Email is required.')
+        else:
+            if not data.get('email') or not data.get('phone_number'):
+                raise BadRequest('Both email and phone number are required.')
 
         distribution_list_guids = data.pop('distribution_list_guids', [])
         

--- a/services/core-api/app/api/ministry_contacts/resources/ministry_contact_list.py
+++ b/services/core-api/app/api/ministry_contacts/resources/ministry_contact_list.py
@@ -68,8 +68,13 @@ class MinistryContactListResource(Resource, UserMixin):
         data = self.parser.parse_args()
 
         contact_type = data.get('emli_contact_type_code', None)
-        if contact_type != 'RDC' and not data.get('phone_number'):
-            raise BadRequest('Phone number is required.')
+
+        if contact_type == 'RDC':
+            if not data.get('email'):
+                raise BadRequest('Email is required.')
+        else:
+            if not data.get('email') or not data.get('phone_number'):
+                raise BadRequest('Both email and phone number are required.')
 
         contact_desc = MinistryContactType.find_contact_type(contact_type)
 

--- a/services/core-api/app/api/ministry_contacts/resources/ministry_contact_list.py
+++ b/services/core-api/app/api/ministry_contacts/resources/ministry_contact_list.py
@@ -23,9 +23,9 @@ class MinistryContactListResource(Resource, UserMixin):
         'mine_region_code', type=str, trim=True, help='MCM mine region code', location='json')
     parser.add_argument('first_name', type=str, trim=True, help='MCM First name', location='json')
     parser.add_argument('last_name', type=str, trim=True, help='MCM Last name.', location='json')
-    parser.add_argument('email', type=str, help='MCM email.', required=True, location='json')
+    parser.add_argument('email', type=str, help='MCM email.', required=False, location='json')
     parser.add_argument(
-        'phone_number', type=str, help='MCM phone number', required=True, location='json')
+        'phone_number', type=str, help='MCM phone number', required=False, location='json')
     parser.add_argument(
         'fax_number', type=str, help='MCM Regional Office fax number', location='json')
     parser.add_argument(
@@ -66,6 +66,9 @@ class MinistryContactListResource(Resource, UserMixin):
     @requires_role_edit_ministry_contacts
     def post(self):
         data = self.parser.parse_args()
+
+        if not data.get('email') and not data.get('phone_number'):
+            raise BadRequest('Either email or phone number is required.')
 
         contact_type = data.get('emli_contact_type_code', None)
         contact_desc = MinistryContactType.find_contact_type(contact_type)

--- a/services/core-api/app/api/ministry_contacts/resources/ministry_contact_list.py
+++ b/services/core-api/app/api/ministry_contacts/resources/ministry_contact_list.py
@@ -23,7 +23,7 @@ class MinistryContactListResource(Resource, UserMixin):
         'mine_region_code', type=str, trim=True, help='MCM mine region code', location='json')
     parser.add_argument('first_name', type=str, trim=True, help='MCM First name', location='json')
     parser.add_argument('last_name', type=str, trim=True, help='MCM Last name.', location='json')
-    parser.add_argument('email', type=str, help='MCM email.', required=False, location='json')
+    parser.add_argument('email', type=str, help='MCM email.', required=True, location='json')
     parser.add_argument(
         'phone_number', type=str, help='MCM phone number', required=False, location='json')
     parser.add_argument(
@@ -67,10 +67,10 @@ class MinistryContactListResource(Resource, UserMixin):
     def post(self):
         data = self.parser.parse_args()
 
-        if not data.get('email') and not data.get('phone_number'):
-            raise BadRequest('Either email or phone number is required.')
-
         contact_type = data.get('emli_contact_type_code', None)
+        if contact_type != 'RDC' and not data.get('phone_number'):
+            raise BadRequest('Phone number is required.')
+
         contact_desc = MinistryContactType.find_contact_type(contact_type)
 
         mmo_contact = MinistryContact.find_ministry_contact('MMO')

--- a/services/core-api/app/api/ministry_contacts/resources/ministry_contact_list.py
+++ b/services/core-api/app/api/ministry_contacts/resources/ministry_contact_list.py
@@ -69,12 +69,12 @@ class MinistryContactListResource(Resource, UserMixin):
 
         contact_type = data.get('emli_contact_type_code', None)
 
-        if contact_type == 'RDC':
-            if not data.get('email'):
-                raise BadRequest('Email is required.')
-        else:
-            if not data.get('email') or not data.get('phone_number'):
-                raise BadRequest('Both email and phone number are required.')
+        if not data.get('email'):
+            raise BadRequest('Email is required.')
+
+        if contact_type != 'RDC' and not data.get('is_general_contact'):
+            if not data.get('phone_number'):
+                raise BadRequest('Phone number is required.')
 
         contact_desc = MinistryContactType.find_contact_type(contact_type)
 

--- a/services/core-api/tests/ministry_contacts/resources/test_ministry_contact.py
+++ b/services/core-api/tests/ministry_contacts/resources/test_ministry_contact.py
@@ -151,8 +151,9 @@ def test_soft_delete_ministry_contact_by_guid(test_client, db_session, auth_head
     assert 'not found' in get_data['message']
 
 
-def test_put_ministry_contact_only_email(test_client, db_session, auth_headers):
-    contact = MinistryContactFactory()
+def test_put_rdc_contact_only_email(test_client, db_session, auth_headers):
+    # RDC only requires email, phone is optional
+    contact = MinistryContactFactory(emli_contact_type_code='RDC')
     data = marshal(contact, MINISTRY_CONTACT_MODEL)
     data['phone_number'] = None
     data['email'] = 'onlyemail@example.com'
@@ -165,24 +166,10 @@ def test_put_ministry_contact_only_email(test_client, db_session, auth_headers):
     assert put_resp.status_code == 200
 
 
-def test_put_ministry_contact_only_phone(test_client, db_session, auth_headers):
-    contact = MinistryContactFactory()
+def test_put_rdc_contact_missing_email(test_client, db_session, auth_headers):
+    # RDC requires email
+    contact = MinistryContactFactory(emli_contact_type_code='RDC')
     data = marshal(contact, MINISTRY_CONTACT_MODEL)
-    data['phone_number'] = '111-222-3333'
-    data['email'] = None
-
-    put_resp = test_client.put(
-        f'/ministry-contacts/{contact.contact_guid}',
-        json=data,
-        headers=auth_headers['full_auth_header'])
-
-    assert put_resp.status_code == 200
-
-
-def test_put_ministry_contact_missing_both(test_client, db_session, auth_headers):
-    contact = MinistryContactFactory()
-    data = marshal(contact, MINISTRY_CONTACT_MODEL)
-    data['phone_number'] = None
     data['email'] = None
 
     put_resp = test_client.put(
@@ -191,5 +178,20 @@ def test_put_ministry_contact_missing_both(test_client, db_session, auth_headers
         headers=auth_headers['full_auth_header'])
 
     assert put_resp.status_code == 400
+
+
+def test_put_non_rdc_contact_missing_phone(test_client, db_session, auth_headers):
+    # Non-RDC requires phone number
+    contact = MinistryContactFactory(emli_contact_type_code='ROE')
+    data = marshal(contact, MINISTRY_CONTACT_MODEL)
+    data['phone_number'] = None
+    data['email'] = 'test@example.com'
+
+    put_resp = test_client.put(
+        f'/ministry-contacts/{contact.contact_guid}',
+        json=data,
+        headers=auth_headers['full_auth_header'])
+
+    assert put_resp.status_code == 400
     put_data = json.loads(put_resp.data.decode())
-    assert 'Either email or phone number is required' in put_data['message']
+    assert 'Phone number is required.' in put_data['message']

--- a/services/core-api/tests/ministry_contacts/resources/test_ministry_contact.py
+++ b/services/core-api/tests/ministry_contacts/resources/test_ministry_contact.py
@@ -149,3 +149,47 @@ def test_soft_delete_ministry_contact_by_guid(test_client, db_session, auth_head
 
     assert get_resp.status_code == 404
     assert 'not found' in get_data['message']
+
+
+def test_put_ministry_contact_only_email(test_client, db_session, auth_headers):
+    contact = MinistryContactFactory()
+    data = marshal(contact, MINISTRY_CONTACT_MODEL)
+    data['phone_number'] = None
+    data['email'] = 'onlyemail@example.com'
+
+    put_resp = test_client.put(
+        f'/ministry-contacts/{contact.contact_guid}',
+        json=data,
+        headers=auth_headers['full_auth_header'])
+
+    assert put_resp.status_code == 200
+
+
+def test_put_ministry_contact_only_phone(test_client, db_session, auth_headers):
+    contact = MinistryContactFactory()
+    data = marshal(contact, MINISTRY_CONTACT_MODEL)
+    data['phone_number'] = '111-222-3333'
+    data['email'] = None
+
+    put_resp = test_client.put(
+        f'/ministry-contacts/{contact.contact_guid}',
+        json=data,
+        headers=auth_headers['full_auth_header'])
+
+    assert put_resp.status_code == 200
+
+
+def test_put_ministry_contact_missing_both(test_client, db_session, auth_headers):
+    contact = MinistryContactFactory()
+    data = marshal(contact, MINISTRY_CONTACT_MODEL)
+    data['phone_number'] = None
+    data['email'] = None
+
+    put_resp = test_client.put(
+        f'/ministry-contacts/{contact.contact_guid}',
+        json=data,
+        headers=auth_headers['full_auth_header'])
+
+    assert put_resp.status_code == 400
+    put_data = json.loads(put_resp.data.decode())
+    assert 'Either email or phone number is required' in put_data['message']

--- a/services/core-api/tests/ministry_contacts/resources/test_ministry_contact.py
+++ b/services/core-api/tests/ministry_contacts/resources/test_ministry_contact.py
@@ -152,7 +152,7 @@ def test_soft_delete_ministry_contact_by_guid(test_client, db_session, auth_head
 
 
 def test_put_rdc_contact_only_email(test_client, db_session, auth_headers):
-    # RDC only requires email, phone is optional
+    # RDC only requires email or phone (either or)
     contact = MinistryContactFactory(emli_contact_type_code='RDC')
     data = marshal(contact, MINISTRY_CONTACT_MODEL)
     data['phone_number'] = None
@@ -166,10 +166,11 @@ def test_put_rdc_contact_only_email(test_client, db_session, auth_headers):
     assert put_resp.status_code == 200
 
 
-def test_put_rdc_contact_missing_email(test_client, db_session, auth_headers):
-    # RDC requires email
+def test_put_rdc_contact_only_phone(test_client, db_session, auth_headers):
+    # RDC only requires email, so phone only will fail because email is missing
     contact = MinistryContactFactory(emli_contact_type_code='RDC')
     data = marshal(contact, MINISTRY_CONTACT_MODEL)
+    data['phone_number'] = '250-111-2222'
     data['email'] = None
 
     put_resp = test_client.put(
@@ -178,10 +179,29 @@ def test_put_rdc_contact_missing_email(test_client, db_session, auth_headers):
         headers=auth_headers['full_auth_header'])
 
     assert put_resp.status_code == 400
+    put_data = json.loads(put_resp.data.decode())
+    assert 'Email is required.' in put_data['message']
+
+
+def test_put_rdc_contact_missing_both(test_client, db_session, auth_headers):
+    # RDC requires email
+    contact = MinistryContactFactory(emli_contact_type_code='RDC')
+    data = marshal(contact, MINISTRY_CONTACT_MODEL)
+    data['email'] = None
+    data['phone_number'] = None
+
+    put_resp = test_client.put(
+        f'/ministry-contacts/{contact.contact_guid}',
+        json=data,
+        headers=auth_headers['full_auth_header'])
+
+    assert put_resp.status_code == 400
+    put_data = json.loads(put_resp.data.decode())
+    assert 'Email is required.' in put_data['message']
 
 
 def test_put_non_rdc_contact_missing_phone(test_client, db_session, auth_headers):
-    # Non-RDC requires phone number
+    # Non-RDC requires both
     contact = MinistryContactFactory(emli_contact_type_code='ROE')
     data = marshal(contact, MINISTRY_CONTACT_MODEL)
     data['phone_number'] = None
@@ -194,4 +214,21 @@ def test_put_non_rdc_contact_missing_phone(test_client, db_session, auth_headers
 
     assert put_resp.status_code == 400
     put_data = json.loads(put_resp.data.decode())
-    assert 'Phone number is required.' in put_data['message']
+    assert 'Both email and phone number are required.' in put_data['message']
+
+
+def test_put_non_rdc_contact_missing_email(test_client, db_session, auth_headers):
+    # Non-RDC requires both
+    contact = MinistryContactFactory(emli_contact_type_code='ROE')
+    data = marshal(contact, MINISTRY_CONTACT_MODEL)
+    data['phone_number'] = '250-111-2222'
+    data['email'] = None
+
+    put_resp = test_client.put(
+        f'/ministry-contacts/{contact.contact_guid}',
+        json=data,
+        headers=auth_headers['full_auth_header'])
+
+    assert put_resp.status_code == 400
+    put_data = json.loads(put_resp.data.decode())
+    assert 'Both email and phone number are required.' in put_data['message']

--- a/services/core-api/tests/ministry_contacts/resources/test_ministry_contact.py
+++ b/services/core-api/tests/ministry_contacts/resources/test_ministry_contact.py
@@ -201,7 +201,7 @@ def test_put_rdc_contact_missing_both(test_client, db_session, auth_headers):
 
 
 def test_put_non_rdc_contact_missing_phone(test_client, db_session, auth_headers):
-    # Non-RDC requires both
+    # Non-RDC requires phone number
     contact = MinistryContactFactory(emli_contact_type_code='ROE')
     data = marshal(contact, MINISTRY_CONTACT_MODEL)
     data['phone_number'] = None
@@ -214,11 +214,11 @@ def test_put_non_rdc_contact_missing_phone(test_client, db_session, auth_headers
 
     assert put_resp.status_code == 400
     put_data = json.loads(put_resp.data.decode())
-    assert 'Both email and phone number are required.' in put_data['message']
+    assert 'Phone number is required.' in put_data['message']
 
 
 def test_put_non_rdc_contact_missing_email(test_client, db_session, auth_headers):
-    # Non-RDC requires both
+    # Non-RDC requires email
     contact = MinistryContactFactory(emli_contact_type_code='ROE')
     data = marshal(contact, MINISTRY_CONTACT_MODEL)
     data['phone_number'] = '250-111-2222'
@@ -231,4 +231,19 @@ def test_put_non_rdc_contact_missing_email(test_client, db_session, auth_headers
 
     assert put_resp.status_code == 400
     put_data = json.loads(put_resp.data.decode())
-    assert 'Both email and phone number are required.' in put_data['message']
+    assert 'Email is required.' in put_data['message']
+
+
+def test_put_general_contact_missing_phone(test_client, db_session, auth_headers):
+    # General contact (non-RDC) does not require phone number
+    contact = MinistryContactFactory(emli_contact_type_code='ROE', is_general_contact=True)
+    data = marshal(contact, MINISTRY_CONTACT_MODEL)
+    data['phone_number'] = None
+    data['email'] = 'test@example.com'
+
+    put_resp = test_client.put(
+        f'/ministry-contacts/{contact.contact_guid}',
+        json=data,
+        headers=auth_headers['full_auth_header'])
+
+    assert put_resp.status_code == 200

--- a/services/core-api/tests/ministry_contacts/resources/test_ministry_contact_list.py
+++ b/services/core-api/tests/ministry_contacts/resources/test_ministry_contact_list.py
@@ -85,9 +85,10 @@ def test_post_no_body(test_client, db_session, auth_headers):
     assert post_resp.status_code == 400
 
 
-def test_post_ministry_contacts_only_email(test_client, db_session, auth_headers):
+def test_post_rdc_contact_only_email(test_client, db_session, auth_headers):
+    # RDC only requires email, phone is optional
     data = {
-        'emli_contact_type_code': 'SHI',
+        'emli_contact_type_code': 'RDC',
         'mine_region_code': 'SW',
         'email': 'onlyemail@email.com',
         'phone_number': None,
@@ -99,9 +100,10 @@ def test_post_ministry_contacts_only_email(test_client, db_session, auth_headers
     assert post_resp.status_code == 200
 
 
-def test_post_ministry_contacts_only_phone(test_client, db_session, auth_headers):
+def test_post_rdc_contact_missing_email(test_client, db_session, auth_headers):
+    # RDC requires email
     data = {
-        'emli_contact_type_code': 'SHI',
+        'emli_contact_type_code': 'RDC',
         'mine_region_code': 'SW',
         'email': None,
         'phone_number': '250-111-8888',
@@ -110,14 +112,15 @@ def test_post_ministry_contacts_only_phone(test_client, db_session, auth_headers
     post_resp = test_client.post(
         f'/ministry-contacts', json=data, headers=auth_headers['full_auth_header'])
 
-    assert post_resp.status_code == 200
+    assert post_resp.status_code == 400
 
 
-def test_post_ministry_contacts_missing_both(test_client, db_session, auth_headers):
+def test_post_non_rdc_contact_missing_phone(test_client, db_session, auth_headers):
+    # Non-RDC requires phone number
     data = {
         'emli_contact_type_code': 'SHI',
         'mine_region_code': 'SW',
-        'email': None,
+        'email': 'test@email.com',
         'phone_number': None,
         'major_mine': True
     }
@@ -126,4 +129,4 @@ def test_post_ministry_contacts_missing_both(test_client, db_session, auth_heade
 
     assert post_resp.status_code == 400
     post_data = json.loads(post_resp.data.decode())
-    assert 'Either email or phone number is required' in post_data['message']
+    assert 'Phone number is required.' in post_data['message']

--- a/services/core-api/tests/ministry_contacts/resources/test_ministry_contact_list.py
+++ b/services/core-api/tests/ministry_contacts/resources/test_ministry_contact_list.py
@@ -135,7 +135,7 @@ def test_post_rdc_contact_missing_both(test_client, db_session, auth_headers):
 
 
 def test_post_non_rdc_contact_missing_phone(test_client, db_session, auth_headers):
-    # Non-RDC requires both
+    # Non-RDC requires phone number
     data = {
         'emli_contact_type_code': 'SHI',
         'mine_region_code': 'SW',
@@ -148,11 +148,11 @@ def test_post_non_rdc_contact_missing_phone(test_client, db_session, auth_header
 
     assert post_resp.status_code == 400
     post_data = json.loads(post_resp.data.decode())
-    assert 'Both email and phone number are required.' in post_data['message']
+    assert 'Phone number is required.' in post_data['message']
 
 
 def test_post_non_rdc_contact_missing_email(test_client, db_session, auth_headers):
-    # Non-RDC requires both
+    # Non-RDC requires email
     data = {
         'emli_contact_type_code': 'SHI',
         'mine_region_code': 'SW',
@@ -165,4 +165,20 @@ def test_post_non_rdc_contact_missing_email(test_client, db_session, auth_header
 
     assert post_resp.status_code == 400
     post_data = json.loads(post_resp.data.decode())
-    assert 'Both email and phone number are required.' in post_data['message']
+    assert 'Email is required.' in post_data['message']
+
+
+def test_post_general_contact_missing_phone(test_client, db_session, auth_headers):
+    # General contact (non-RDC) does not require phone number
+    data = {
+        'emli_contact_type_code': 'SHI',
+        'mine_region_code': 'SW',
+        'email': 'test@email.com',
+        'phone_number': None,
+        'is_general_contact': True,
+        'major_mine': True
+    }
+    post_resp = test_client.post(
+        f'/ministry-contacts', json=data, headers=auth_headers['full_auth_header'])
+
+    assert post_resp.status_code == 200

--- a/services/core-api/tests/ministry_contacts/resources/test_ministry_contact_list.py
+++ b/services/core-api/tests/ministry_contacts/resources/test_ministry_contact_list.py
@@ -83,3 +83,47 @@ def test_post_no_body(test_client, db_session, auth_headers):
     post_resp = test_client.post(
         f'/ministry-contacts', headers=auth_headers['full_auth_header'], json=data)
     assert post_resp.status_code == 400
+
+
+def test_post_ministry_contacts_only_email(test_client, db_session, auth_headers):
+    data = {
+        'emli_contact_type_code': 'SHI',
+        'mine_region_code': 'SW',
+        'email': 'onlyemail@email.com',
+        'phone_number': None,
+        'major_mine': True
+    }
+    post_resp = test_client.post(
+        f'/ministry-contacts', json=data, headers=auth_headers['full_auth_header'])
+
+    assert post_resp.status_code == 200
+
+
+def test_post_ministry_contacts_only_phone(test_client, db_session, auth_headers):
+    data = {
+        'emli_contact_type_code': 'SHI',
+        'mine_region_code': 'SW',
+        'email': None,
+        'phone_number': '250-111-8888',
+        'major_mine': True
+    }
+    post_resp = test_client.post(
+        f'/ministry-contacts', json=data, headers=auth_headers['full_auth_header'])
+
+    assert post_resp.status_code == 200
+
+
+def test_post_ministry_contacts_missing_both(test_client, db_session, auth_headers):
+    data = {
+        'emli_contact_type_code': 'SHI',
+        'mine_region_code': 'SW',
+        'email': None,
+        'phone_number': None,
+        'major_mine': True
+    }
+    post_resp = test_client.post(
+        f'/ministry-contacts', json=data, headers=auth_headers['full_auth_header'])
+
+    assert post_resp.status_code == 400
+    post_data = json.loads(post_resp.data.decode())
+    assert 'Either email or phone number is required' in post_data['message']

--- a/services/core-api/tests/ministry_contacts/resources/test_ministry_contact_list.py
+++ b/services/core-api/tests/ministry_contacts/resources/test_ministry_contact_list.py
@@ -86,7 +86,7 @@ def test_post_no_body(test_client, db_session, auth_headers):
 
 
 def test_post_rdc_contact_only_email(test_client, db_session, auth_headers):
-    # RDC only requires email, phone is optional
+    # RDC only requires email or phone (either or)
     data = {
         'emli_contact_type_code': 'RDC',
         'mine_region_code': 'SW',
@@ -100,8 +100,8 @@ def test_post_rdc_contact_only_email(test_client, db_session, auth_headers):
     assert post_resp.status_code == 200
 
 
-def test_post_rdc_contact_missing_email(test_client, db_session, auth_headers):
-    # RDC requires email
+def test_post_rdc_contact_only_phone(test_client, db_session, auth_headers):
+    # RDC only requires email, so phone only will fail because email is missing
     data = {
         'emli_contact_type_code': 'RDC',
         'mine_region_code': 'SW',
@@ -113,10 +113,29 @@ def test_post_rdc_contact_missing_email(test_client, db_session, auth_headers):
         f'/ministry-contacts', json=data, headers=auth_headers['full_auth_header'])
 
     assert post_resp.status_code == 400
+    post_data = json.loads(post_resp.data.decode())
+    assert 'Email is required.' in post_data['message']
+
+
+def test_post_rdc_contact_missing_both(test_client, db_session, auth_headers):
+    # RDC requires email
+    data = {
+        'emli_contact_type_code': 'RDC',
+        'mine_region_code': 'SW',
+        'email': None,
+        'phone_number': None,
+        'major_mine': True
+    }
+    post_resp = test_client.post(
+        f'/ministry-contacts', json=data, headers=auth_headers['full_auth_header'])
+
+    assert post_resp.status_code == 400
+    post_data = json.loads(post_resp.data.decode())
+    assert 'Email is required.' in post_data['message']
 
 
 def test_post_non_rdc_contact_missing_phone(test_client, db_session, auth_headers):
-    # Non-RDC requires phone number
+    # Non-RDC requires both
     data = {
         'emli_contact_type_code': 'SHI',
         'mine_region_code': 'SW',
@@ -129,4 +148,21 @@ def test_post_non_rdc_contact_missing_phone(test_client, db_session, auth_header
 
     assert post_resp.status_code == 400
     post_data = json.loads(post_resp.data.decode())
-    assert 'Phone number is required.' in post_data['message']
+    assert 'Both email and phone number are required.' in post_data['message']
+
+
+def test_post_non_rdc_contact_missing_email(test_client, db_session, auth_headers):
+    # Non-RDC requires both
+    data = {
+        'emli_contact_type_code': 'SHI',
+        'mine_region_code': 'SW',
+        'email': None,
+        'phone_number': '250-111-8888',
+        'major_mine': True
+    }
+    post_resp = test_client.post(
+        f'/ministry-contacts', json=data, headers=auth_headers['full_auth_header'])
+
+    assert post_resp.status_code == 400
+    post_data = json.loads(post_resp.data.decode())
+    assert 'Both email and phone number are required.' in post_data['message']

--- a/services/core-web/src/components/Forms/MinistryContacts/MinistryContactForm.tsx
+++ b/services/core-web/src/components/Forms/MinistryContacts/MinistryContactForm.tsx
@@ -21,7 +21,7 @@ import FormWrapper from "@mds/common/components/forms/FormWrapper";
 import RenderCancelButton from "@mds/common/components/forms/RenderCancelButton";
 import RenderSubmitButton from "@mds/common/components/forms/RenderSubmitButton";
 import { IMinistryContact } from "@mds/common/interfaces";
-import { MinistryContactTypeCodes } from "@mds/common/constants/enums";
+import { MinistryContactTypeCodes, officeContactTypeCodes } from "@mds/common/constants/enums";
 
 interface IOption {
   value: string | number;
@@ -43,7 +43,7 @@ const majorMineOfficeCode = MinistryContactTypeCodes.MMO;
 const chiefPermittingCode = MinistryContactTypeCodes.CHP;
 const chiefInspectorCode = MinistryContactTypeCodes.CHI;
 const reportDesignatedContactCode = MinistryContactTypeCodes.RDC;
-const officeCodes = [regionalOfficeCode, majorMineOfficeCode];
+const officeCodes = officeContactTypeCodes;
 
 export const MinistryContactForm: FC<MinistryContactFormProps> = (props) => {
   const formValues: any = useSelector((state) => getFormValues(FORM.MINISTRY_CONTACT_FORM)(state)) || {};

--- a/services/core-web/src/components/Forms/MinistryContacts/MinistryContactForm.tsx
+++ b/services/core-web/src/components/Forms/MinistryContacts/MinistryContactForm.tsx
@@ -116,7 +116,11 @@ export const MinistryContactForm: FC<MinistryContactFormProps> = (props) => {
             if (!values.email) {
               errors.email = "This is a required field";
             }
-            if (values.emli_contact_type_code !== reportDesignatedContactCode && !values.phone_number) {
+            const isPhoneRequired =
+              values.emli_contact_type_code !== reportDesignatedContactCode &&
+              !values.is_general_contact;
+
+            if (isPhoneRequired && !values.phone_number) {
               errors.phone_number = "This is a required field";
             }
 
@@ -235,7 +239,7 @@ export const MinistryContactForm: FC<MinistryContactFormProps> = (props) => {
               label="Phone Number"
               placeholder="e.g. xxx-xxx-xxxx"
               component={renderConfig.FIELD}
-              required={formValues.emli_contact_type_code !== reportDesignatedContactCode}
+              required={formValues.emli_contact_type_code !== reportDesignatedContactCode && !formValues.is_general_contact}
               validate={[phoneNumber, maxLength(12)]}
               normalize={normalizePhone}
               disabled={!formValues.emli_contact_type_code}

--- a/services/core-web/src/components/Forms/MinistryContacts/MinistryContactForm.tsx
+++ b/services/core-web/src/components/Forms/MinistryContacts/MinistryContactForm.tsx
@@ -40,12 +40,13 @@ const regionalOfficeCode = "ROE";
 const majorMineOfficeCode = "MMO";
 const chiefPermittingCode = "CHP";
 const chiefInspectorCode = "CHI";
+const reportDesignatedContactCode = "RDC";
 const officeCodes = [regionalOfficeCode, majorMineOfficeCode];
 
 export const MinistryContactForm: FC<MinistryContactFormProps> = (props) => {
   const formValues: any = useSelector((state) => getFormValues(FORM.MINISTRY_CONTACT_FORM)(state)) || {};
   const regionDropdownOptions: IOption[] = useSelector(getMineRegionDropdownOptions);
-  const MinistryContactTypes: IOption[] = useSelector(getDropdownMinistryContactTypes);
+  const MinistryContactTypes: IOption[] = useSelector((state) => getDropdownMinistryContactTypes(state, false));
 
   const filteredContactTypes = () => {
     const codes: string[] = [];
@@ -77,7 +78,10 @@ export const MinistryContactForm: FC<MinistryContactFormProps> = (props) => {
         codes.push(chiefInspectorCode);
       }
     }
-    return MinistryContactTypes.filter(({ value }) => !codes.includes(value as string));
+    return MinistryContactTypes.filter(({ value, isActive }) => {
+      const isCurrentValue = value === props.initialValues?.emli_contact_type_code;
+      return (isActive || isCurrentValue) && !codes.includes(value as string);
+    });
   };
 
   return (
@@ -89,6 +93,26 @@ export const MinistryContactForm: FC<MinistryContactFormProps> = (props) => {
         reduxFormConfig={{
           touchOnBlur: false,
           enableReinitialize: true,
+          validate: (values) => {
+            const errors: any = {};
+            const isMajorOrGeneral = values.is_major_mine || values.is_general_contact;
+
+            if (isMajorOrGeneral) {
+              if (!values.first_name) {
+                errors.first_name = "This is a required field";
+              }
+              if (!values.last_name) {
+                errors.last_name = "This is a required field";
+              }
+            }
+
+            if (!values.email && !values.phone_number) {
+              errors.email = "Either Email or Phone Number is required";
+              errors.phone_number = "Either Email or Phone Number is required";
+            }
+
+            return errors;
+          }
         }}
       >
         <Row gutter={16}>
@@ -132,14 +156,13 @@ export const MinistryContactForm: FC<MinistryContactFormProps> = (props) => {
               label={"Mine Region"}
               placeholder="Select a mine Region"
               component={renderConfig.SELECT}
-              required={!formValues.is_major_mine}
+              required={!formValues.is_major_mine && formValues.emli_contact_type_code !== reportDesignatedContactCode}
               validate={
-                formValues.is_major_mine
+                formValues.is_major_mine || formValues.emli_contact_type_code === reportDesignatedContactCode
                   ? []
                   : [required]
               }
               data={regionDropdownOptions}
-              disabled={props.isEdit}
             />
           </Col>
           <Col md={12} xs={24}>
@@ -164,8 +187,7 @@ export const MinistryContactForm: FC<MinistryContactFormProps> = (props) => {
                 name="first_name"
                 label="First Name"
                 component={renderConfig.FIELD}
-                required
-                validate={[required]}
+                required={formValues.is_major_mine || formValues.is_general_contact}
                 disabled={!formValues.emli_contact_type_code}
               />
             </Col>
@@ -175,8 +197,7 @@ export const MinistryContactForm: FC<MinistryContactFormProps> = (props) => {
                 name="last_name"
                 label="Surname"
                 component={renderConfig.FIELD}
-                required
-                validate={[required]}
+                required={formValues.is_major_mine || formValues.is_general_contact}
                 disabled={!formValues.emli_contact_type_code}
               />
             </Col>
@@ -190,8 +211,8 @@ export const MinistryContactForm: FC<MinistryContactFormProps> = (props) => {
               name="email"
               label="Email"
               component={renderConfig.FIELD}
-              required
-              validate={[email, required]}
+              required={!formValues.phone_number}
+              validate={[email]}
               disabled={!formValues.emli_contact_type_code}
             />
           </Col>
@@ -204,8 +225,8 @@ export const MinistryContactForm: FC<MinistryContactFormProps> = (props) => {
               label="Phone Number"
               placeholder="e.g. xxx-xxx-xxxx"
               component={renderConfig.FIELD}
-              required
-              validate={[required, phoneNumber, maxLength(12)]}
+              required={!formValues.email}
+              validate={[phoneNumber, maxLength(12)]}
               normalize={normalizePhone}
               disabled={!formValues.emli_contact_type_code}
             />

--- a/services/core-web/src/components/Forms/MinistryContacts/MinistryContactForm.tsx
+++ b/services/core-web/src/components/Forms/MinistryContacts/MinistryContactForm.tsx
@@ -26,6 +26,7 @@ import { MinistryContactTypeCodes } from "@mds/common/constants/enums";
 interface IOption {
   value: string | number;
   label: string;
+  isActive?: boolean;
 }
 
 export interface MinistryContactFormProps {
@@ -94,18 +95,21 @@ export const MinistryContactForm: FC<MinistryContactFormProps> = (props) => {
         reduxFormConfig={{
           touchOnBlur: false,
           enableReinitialize: true,
-          validate: (values) => {
+          validate: (values: IMinistryContact) => {
             const errors: any = {};
-            const isMajorOrGeneral =
-              (values.is_major_mine || values.is_general_contact) &&
-              !officeCodes.includes(values.emli_contact_type_code);
+            const isRDC = values.emli_contact_type_code === reportDesignatedContactCode;
+            const isOffice = officeCodes.includes(
+              values.emli_contact_type_code as MinistryContactTypeCodes
+            );
 
-            if (isMajorOrGeneral) {
-              if (!values.first_name) {
-                errors.first_name = "This is a required field";
-              }
-              if (!values.last_name) {
-                errors.last_name = "This is a required field";
+            if (!isOffice) {
+              if (!isRDC) {
+                if (!values.first_name) {
+                  errors.first_name = "This is a required field";
+                }
+                if (!values.last_name) {
+                  errors.last_name = "This is a required field";
+                }
               }
             }
 
@@ -193,7 +197,7 @@ export const MinistryContactForm: FC<MinistryContactFormProps> = (props) => {
                 name="first_name"
                 label="First Name"
                 component={renderConfig.FIELD}
-                required={formValues.is_major_mine || formValues.is_general_contact}
+                required={formValues.emli_contact_type_code && formValues.emli_contact_type_code !== reportDesignatedContactCode}
                 disabled={!formValues.emli_contact_type_code}
               />
             </Col>
@@ -203,7 +207,7 @@ export const MinistryContactForm: FC<MinistryContactFormProps> = (props) => {
                 name="last_name"
                 label="Surname"
                 component={renderConfig.FIELD}
-                required={formValues.is_major_mine || formValues.is_general_contact}
+                required={formValues.emli_contact_type_code && formValues.emli_contact_type_code !== reportDesignatedContactCode}
                 disabled={!formValues.emli_contact_type_code}
               />
             </Col>

--- a/services/core-web/src/components/Forms/MinistryContacts/MinistryContactForm.tsx
+++ b/services/core-web/src/components/Forms/MinistryContacts/MinistryContactForm.tsx
@@ -21,6 +21,7 @@ import FormWrapper from "@mds/common/components/forms/FormWrapper";
 import RenderCancelButton from "@mds/common/components/forms/RenderCancelButton";
 import RenderSubmitButton from "@mds/common/components/forms/RenderSubmitButton";
 import { IMinistryContact } from "@mds/common/interfaces";
+import { MinistryContactTypeCodes } from "@mds/common/constants/enums";
 
 interface IOption {
   value: string | number;
@@ -36,11 +37,11 @@ export interface MinistryContactFormProps {
   distributionListOptions: IOption[];
 }
 
-const regionalOfficeCode = "ROE";
-const majorMineOfficeCode = "MMO";
-const chiefPermittingCode = "CHP";
-const chiefInspectorCode = "CHI";
-const reportDesignatedContactCode = "RDC";
+const regionalOfficeCode = MinistryContactTypeCodes.ROE;
+const majorMineOfficeCode = MinistryContactTypeCodes.MMO;
+const chiefPermittingCode = MinistryContactTypeCodes.CHP;
+const chiefInspectorCode = MinistryContactTypeCodes.CHI;
+const reportDesignatedContactCode = MinistryContactTypeCodes.RDC;
 const officeCodes = [regionalOfficeCode, majorMineOfficeCode];
 
 export const MinistryContactForm: FC<MinistryContactFormProps> = (props) => {
@@ -95,7 +96,9 @@ export const MinistryContactForm: FC<MinistryContactFormProps> = (props) => {
           enableReinitialize: true,
           validate: (values) => {
             const errors: any = {};
-            const isMajorOrGeneral = values.is_major_mine || values.is_general_contact;
+            const isMajorOrGeneral =
+              (values.is_major_mine || values.is_general_contact) &&
+              !officeCodes.includes(values.emli_contact_type_code);
 
             if (isMajorOrGeneral) {
               if (!values.first_name) {
@@ -106,9 +109,11 @@ export const MinistryContactForm: FC<MinistryContactFormProps> = (props) => {
               }
             }
 
-            if (!values.email && !values.phone_number) {
-              errors.email = "Either Email or Phone Number is required";
-              errors.phone_number = "Either Email or Phone Number is required";
+            if (!values.email) {
+              errors.email = "This is a required field";
+            }
+            if (values.emli_contact_type_code !== reportDesignatedContactCode && !values.phone_number) {
+              errors.phone_number = "This is a required field";
             }
 
             return errors;
@@ -212,7 +217,7 @@ export const MinistryContactForm: FC<MinistryContactFormProps> = (props) => {
               name="email"
               label="Email"
               component={renderConfig.FIELD}
-              required={!formValues.phone_number}
+              required
               validate={[email]}
               disabled={!formValues.emli_contact_type_code}
             />
@@ -226,7 +231,7 @@ export const MinistryContactForm: FC<MinistryContactFormProps> = (props) => {
               label="Phone Number"
               placeholder="e.g. xxx-xxx-xxxx"
               component={renderConfig.FIELD}
-              required={!formValues.email}
+              required={formValues.emli_contact_type_code !== reportDesignatedContactCode}
               validate={[phoneNumber, maxLength(12)]}
               normalize={normalizePhone}
               disabled={!formValues.emli_contact_type_code}

--- a/services/core-web/src/components/Forms/MinistryContacts/MinistryContactForm.tsx
+++ b/services/core-web/src/components/Forms/MinistryContacts/MinistryContactForm.tsx
@@ -163,6 +163,7 @@ export const MinistryContactForm: FC<MinistryContactFormProps> = (props) => {
                   : [required]
               }
               data={regionDropdownOptions}
+              disabled={props.isEdit}
             />
           </Col>
           <Col md={12} xs={24}>

--- a/services/core-web/src/components/admin/contacts/MinistryContacts/MineSpaceMinistryContactManagement.tsx
+++ b/services/core-web/src/components/admin/contacts/MinistryContacts/MineSpaceMinistryContactManagement.tsx
@@ -23,6 +23,7 @@ import MinistryContactsTable from "@/components/admin/contacts/MinistryContacts/
 import AddButton from "@/components/common/buttons/AddButton";
 import { IMinistryContact } from "@mds/common/interfaces";
 import ResponsivePagination from "@mds/common/components/common/ResponsivePagination";
+import { MinistryContactTypeCodes } from "@mds/common/constants/enums";
 
 export const MineSpaceMinistryContactManagement: FC = () => {
   const dispatch = useAppDispatch();
@@ -85,12 +86,13 @@ export const MineSpaceMinistryContactManagement: FC = () => {
     );
   };
 
-  const officeCodes = ["ROE", "MMO"];
+  const officeCodes = [MinistryContactTypeCodes.ROE, MinistryContactTypeCodes.MMO];
   const offices = ministryContacts.filter(({ emli_contact_type_code }) =>
-    officeCodes.includes(emli_contact_type_code)
+    officeCodes.includes(emli_contact_type_code as MinistryContactTypeCodes)
   );
   const contacts = ministryContacts.filter(
-    ({ emli_contact_type_code }) => !officeCodes.includes(emli_contact_type_code)
+    ({ emli_contact_type_code }) =>
+      !officeCodes.includes(emli_contact_type_code as MinistryContactTypeCodes)
   );
 
   return (

--- a/services/core-web/src/components/admin/contacts/MinistryContacts/MineSpaceMinistryContactManagement.tsx
+++ b/services/core-web/src/components/admin/contacts/MinistryContacts/MineSpaceMinistryContactManagement.tsx
@@ -23,7 +23,7 @@ import MinistryContactsTable from "@/components/admin/contacts/MinistryContacts/
 import AddButton from "@/components/common/buttons/AddButton";
 import { IMinistryContact } from "@mds/common/interfaces";
 import ResponsivePagination from "@mds/common/components/common/ResponsivePagination";
-import { MinistryContactTypeCodes } from "@mds/common/constants/enums";
+import { MinistryContactTypeCodes, officeContactTypeCodes } from "@mds/common/constants/enums";
 
 export const MineSpaceMinistryContactManagement: FC = () => {
   const dispatch = useAppDispatch();
@@ -86,7 +86,7 @@ export const MineSpaceMinistryContactManagement: FC = () => {
     );
   };
 
-  const officeCodes = [MinistryContactTypeCodes.ROE, MinistryContactTypeCodes.MMO];
+  const officeCodes = officeContactTypeCodes;
   const offices = ministryContacts.filter(({ emli_contact_type_code }) =>
     officeCodes.includes(emli_contact_type_code as MinistryContactTypeCodes)
   );

--- a/services/core-web/src/tests/components/Forms/MinistryContacts/__snapshots__/MinistryContactForm.spec.tsx.snap
+++ b/services/core-web/src/tests/components/Forms/MinistryContacts/__snapshots__/MinistryContactForm.spec.tsx.snap
@@ -1268,7 +1268,7 @@ exports[`MinistryContactForm renders properly for editing contact 1`] = `
                   >
                     <div
                       aria-required="true"
-                      class="ant-select ant-select-in-form-item ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled ant-select-show-search"
+                      class="ant-select ant-select-in-form-item ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
                       data-cy="mine_region_code"
                     >
                       <div
@@ -1281,13 +1281,11 @@ exports[`MinistryContactForm renders properly for editing contact 1`] = `
                             aria-activedescendant="mine_region_code_list_0"
                             aria-autocomplete="list"
                             aria-controls="mine_region_code_list"
-                            aria-expanded="false"
                             aria-haspopup="listbox"
                             aria-owns="mine_region_code_list"
                             aria-required="true"
                             autocomplete="off"
                             class="ant-select-selection-search-input"
-                            disabled=""
                             id="mine_region_code"
                             role="combobox"
                             type="search"

--- a/services/core-web/src/tests/components/Forms/MinistryContacts/__snapshots__/MinistryContactForm.spec.tsx.snap
+++ b/services/core-web/src/tests/components/Forms/MinistryContacts/__snapshots__/MinistryContactForm.spec.tsx.snap
@@ -1268,7 +1268,7 @@ exports[`MinistryContactForm renders properly for editing contact 1`] = `
                   >
                     <div
                       aria-required="true"
-                      class="ant-select ant-select-in-form-item ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
+                      class="ant-select ant-select-in-form-item ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled ant-select-show-search"
                       data-cy="mine_region_code"
                     >
                       <div
@@ -1281,11 +1281,13 @@ exports[`MinistryContactForm renders properly for editing contact 1`] = `
                             aria-activedescendant="mine_region_code_list_0"
                             aria-autocomplete="list"
                             aria-controls="mine_region_code_list"
+                            aria-expanded="false"
                             aria-haspopup="listbox"
                             aria-owns="mine_region_code_list"
                             aria-required="true"
                             autocomplete="off"
                             class="ant-select-selection-search-input"
+                            disabled=""
                             id="mine_region_code"
                             role="combobox"
                             type="search"

--- a/services/core-web/src/tests/components/Forms/MinistryContacts/__snapshots__/MinistryContactsForm.spec.tsx.snap
+++ b/services/core-web/src/tests/components/Forms/MinistryContacts/__snapshots__/MinistryContactsForm.spec.tsx.snap
@@ -151,7 +151,7 @@ exports[`MinistryContactForm renders properly 1`] = `
                   >
                     <div
                       aria-required="true"
-                      class="ant-select ant-select-in-form-item ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled ant-select-show-search"
+                      class="ant-select ant-select-in-form-item ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
                       data-cy="mine_region_code"
                     >
                       <div
@@ -164,13 +164,11 @@ exports[`MinistryContactForm renders properly 1`] = `
                             aria-activedescendant="mine_region_code_list_0"
                             aria-autocomplete="list"
                             aria-controls="mine_region_code_list"
-                            aria-expanded="false"
                             aria-haspopup="listbox"
                             aria-owns="mine_region_code_list"
                             aria-required="true"
                             autocomplete="off"
                             class="ant-select-selection-search-input"
-                            disabled=""
                             id="mine_region_code"
                             role="combobox"
                             type="search"

--- a/services/core-web/src/tests/components/Forms/MinistryContacts/__snapshots__/MinistryContactsForm.spec.tsx.snap
+++ b/services/core-web/src/tests/components/Forms/MinistryContacts/__snapshots__/MinistryContactsForm.spec.tsx.snap
@@ -362,14 +362,18 @@ exports[`MinistryContactForm renders properly 1`] = `
                 class="ant-col ant-form-item-label"
               >
                 <label
-                  class="ant-form-item-required"
+                  class=""
                   for="MINISTRY_CONTACT_FORM_first_name"
                   title=""
                 >
-                  <div
-                    style="width: 100%;"
-                  >
+                  <div>
                     First Name
+                     
+                    <span
+                      class="form-item-optional"
+                    >
+                       (optional)
+                    </span>
                   </div>
                 </label>
               </div>
@@ -425,14 +429,18 @@ exports[`MinistryContactForm renders properly 1`] = `
                 class="ant-col ant-form-item-label"
               >
                 <label
-                  class="ant-form-item-required"
+                  class=""
                   for="MINISTRY_CONTACT_FORM_last_name"
                   title=""
                 >
-                  <div
-                    style="width: 100%;"
-                  >
+                  <div>
                     Surname
+                     
+                    <span
+                      class="form-item-optional"
+                    >
+                       (optional)
+                    </span>
                   </div>
                 </label>
               </div>

--- a/services/core-web/src/tests/components/Forms/MinistryContacts/__snapshots__/MinistryContactsForm.spec.tsx.snap
+++ b/services/core-web/src/tests/components/Forms/MinistryContacts/__snapshots__/MinistryContactsForm.spec.tsx.snap
@@ -151,7 +151,7 @@ exports[`MinistryContactForm renders properly 1`] = `
                   >
                     <div
                       aria-required="true"
-                      class="ant-select ant-select-in-form-item ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
+                      class="ant-select ant-select-in-form-item ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled ant-select-show-search"
                       data-cy="mine_region_code"
                     >
                       <div
@@ -164,11 +164,13 @@ exports[`MinistryContactForm renders properly 1`] = `
                             aria-activedescendant="mine_region_code_list_0"
                             aria-autocomplete="list"
                             aria-controls="mine_region_code_list"
+                            aria-expanded="false"
                             aria-haspopup="listbox"
                             aria-owns="mine_region_code_list"
                             aria-required="true"
                             autocomplete="off"
                             class="ant-select-selection-search-input"
+                            disabled=""
                             id="mine_region_code"
                             role="combobox"
                             type="search"

--- a/services/core-web/src/tests/components/modalContent/__snapshots__/MinistryContactModal.spec.tsx.snap
+++ b/services/core-web/src/tests/components/modalContent/__snapshots__/MinistryContactModal.spec.tsx.snap
@@ -152,7 +152,7 @@ exports[`MinistryContactModal renders properly 1`] = `
                     >
                       <div
                         aria-required="true"
-                        class="ant-select ant-select-in-form-item ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
+                        class="ant-select ant-select-in-form-item ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled ant-select-show-search"
                         data-cy="mine_region_code"
                       >
                         <div
@@ -165,11 +165,13 @@ exports[`MinistryContactModal renders properly 1`] = `
                               aria-activedescendant="mine_region_code_list_0"
                               aria-autocomplete="list"
                               aria-controls="mine_region_code_list"
+                              aria-expanded="false"
                               aria-haspopup="listbox"
                               aria-owns="mine_region_code_list"
                               aria-required="true"
                               autocomplete="off"
                               class="ant-select-selection-search-input"
+                              disabled=""
                               id="mine_region_code"
                               role="combobox"
                               type="search"

--- a/services/core-web/src/tests/components/modalContent/__snapshots__/MinistryContactModal.spec.tsx.snap
+++ b/services/core-web/src/tests/components/modalContent/__snapshots__/MinistryContactModal.spec.tsx.snap
@@ -152,7 +152,7 @@ exports[`MinistryContactModal renders properly 1`] = `
                     >
                       <div
                         aria-required="true"
-                        class="ant-select ant-select-in-form-item ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-disabled ant-select-show-search"
+                        class="ant-select ant-select-in-form-item ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
                         data-cy="mine_region_code"
                       >
                         <div
@@ -165,13 +165,11 @@ exports[`MinistryContactModal renders properly 1`] = `
                               aria-activedescendant="mine_region_code_list_0"
                               aria-autocomplete="list"
                               aria-controls="mine_region_code_list"
-                              aria-expanded="false"
                               aria-haspopup="listbox"
                               aria-owns="mine_region_code_list"
                               aria-required="true"
                               autocomplete="off"
                               class="ant-select-selection-search-input"
-                              disabled=""
                               id="mine_region_code"
                               role="combobox"
                               type="search"
@@ -363,14 +361,18 @@ exports[`MinistryContactModal renders properly 1`] = `
                   class="ant-col ant-form-item-label"
                 >
                   <label
-                    class="ant-form-item-required"
+                    class=""
                     for="MINISTRY_CONTACT_FORM_first_name"
                     title=""
                   >
-                    <div
-                      style="width: 100%;"
-                    >
+                    <div>
                       First Name
+                       
+                      <span
+                        class="form-item-optional"
+                      >
+                         (optional)
+                      </span>
                     </div>
                   </label>
                 </div>
@@ -426,14 +428,18 @@ exports[`MinistryContactModal renders properly 1`] = `
                   class="ant-col ant-form-item-label"
                 >
                   <label
-                    class="ant-form-item-required"
+                    class=""
                     for="MINISTRY_CONTACT_FORM_last_name"
                     title=""
                   >
-                    <div
-                      style="width: 100%;"
-                    >
+                    <div>
                       Surname
+                       
+                      <span
+                        class="form-item-optional"
+                      >
+                         (optional)
+                      </span>
                     </div>
                   </label>
                 </div>


### PR DESCRIPTION
## Objective 

[MDS-6953](https://bcmines.atlassian.net/browse/MDS-6953)

## Form validation preventing updating of various MCM contact types
- Discovered that the current form validation was preventing the submission of changes to various contact types.  This was particularly difficult for "Report Designated Contacts" that didn't have a region, but the region field was both required and disabled.  
  - Adjusted the validation logic to relax certain requirements based on discussion with Rebecca

## Dynamic EMLI Contact Mine Region Edits & Incident Notification Resolution

  ### Context / Background

  Recently, EMLI contact management transitioned to using dynamically managed dynamic distribution lists (e.g.,  Incidents ,  Variances , etc.). However, after this change:

  1. On-call inspectors were not receiving incident notifications: This occurred because the new  Incidents  distribution list started out empty, and administrators were blocked from editing the on-call inspector contact (
  mineincidents@gov.bc.ca  — an  RDC  contact type) to add it to the distribution list.
  2. Mine Region was required and disabled on edit: Users were unable to save  RDC  contacts (which do not have/need a mine region) because the form validation required it, but the dropdown was disabled during editing. Additionally, the
  backend  PUT  endpoint did not support updating the  mine_region_code , which is why the field was disabled in the first place.