### PR TITLE
[MDS-6954] Improve error handling in core-api for stale pgsync/elasticsearch index issues

### DIFF
--- a/services/core-api/app/api/search/search/search_transformers.py
+++ b/services/core-api/app/api/search/search/search_transformers.py
@@ -1,5 +1,7 @@
 """Transformers for converting ES hits to API response format using Flask-RESTX marshalling."""
 
+import logging
+
 from flask_restx import marshal
 from app.api.search.response_models import (
     MINE_SEARCH_RESULT_MODEL,
@@ -11,6 +13,8 @@ from app.api.search.response_models import (
     NOD_SEARCH_RESULT_MODEL,
 )
 from .search_constants import INDEX_TO_TYPE
+
+logger = logging.getLogger(__name__)
 
 
 def prepare_mine_source(source):
@@ -174,19 +178,28 @@ def transform_es_results(hits):
         if doc_type not in results:
             results[doc_type] = []
 
-        # Prepare the source data for the specific type
-        prepare_fn = PREPARE_FUNCTIONS.get(doc_type)
-        prepared_source = prepare_fn(hit['_source']) if prepare_fn else hit['_source']
+        try:
+            # Prepare the source data for the specific type
+            prepare_fn = PREPARE_FUNCTIONS.get(doc_type)
+            prepared_source = prepare_fn(hit['_source']) if prepare_fn else hit['_source']
 
-        # Create the search result dict with score, type, and result
-        search_result = {
-            'score': hit['_score'],
-            'type': doc_type,
-            'result': prepared_source
-        }
+            # Create the search result dict with score, type, and result
+            search_result = {
+                'score': hit['_score'],
+                'type': doc_type,
+                'result': prepared_source
+            }
 
-        # Marshal using the appropriate search result model
-        marshalled_result = marshal(search_result, SEARCH_RESULT_MODELS[doc_type])
-        results[doc_type].append(marshalled_result)
+            # Marshal using the appropriate search result model
+            marshalled_result = marshal(search_result, SEARCH_RESULT_MODELS[doc_type])
+            results[doc_type].append(marshalled_result)
+        except Exception:
+            # A single malformed document (e.g. an Elasticsearch index whose
+            # mapping has drifted from what this code expects) should not
+            # take down results for every other type in the response.
+            logger.exception(
+                "Failed to transform search hit of type '%s' (id=%s); skipping.",
+                doc_type, hit.get('_id'),
+            )
 
     return results

--- a/services/core-api/app/api/search/search/simple_search_service.py
+++ b/services/core-api/app/api/search/search/simple_search_service.py
@@ -178,10 +178,20 @@ class SimpleSearchService:
 
             # Process each hit
             for hit in hits:
-                result = self._process_hit(hit, allowed_types)
-                if result:
-                    search_results.append(result)
-                    
+                try:
+                    result = self._process_hit(hit, allowed_types)
+                    if result:
+                        search_results.append(result)
+                except Exception as e:
+                    # A single malformed document (e.g. an Elasticsearch index
+                    # whose mapping has drifted from what this code expects)
+                    # should not take down the rest of the batch.
+                    current_app.logger.error(
+                        f"Failed to process search hit (index={hit.get('_index')}, "
+                        f"id={hit.get('_id')}): {e}"
+                    )
+                    current_app.logger.error(f"[DEBUG] full traceback:\n{traceback.format_exc()}")
+
         except Exception as e:
             current_app.logger.error(f"Elasticsearch error: {e}")
             current_app.logger.error(f"[DEBUG] full traceback:\n{traceback.format_exc()}")

--- a/services/core-api/tests/search/test_global_search_service.py
+++ b/services/core-api/tests/search/test_global_search_service.py
@@ -241,6 +241,47 @@ class TestGlobalSearchService:
         assert result['results']['mine'] == []
 
     @patch('app.api.search.search.global_search_service.ElasticSearchService')
+    def test_search_malformed_permit_does_not_blank_other_types(self, mock_es_service):
+        """Regression test for a production incident: a single malformed
+        permit document (Elasticsearch index mapping drifted out of sync
+        with the current PGSync schema, so mine_guids came back as flat
+        GUID strings instead of objects) caused the ENTIRE search response
+        to fall back to empty results for every type, not just permits.
+
+        Before the fix, transform_es_results() raised on the malformed
+        permit, GlobalSearchService.search()'s single broad try/except
+        caught it, and get_empty_results() wiped out the unrelated mine
+        result too. After the fix, only the malformed permit is dropped.
+        """
+        mock_es_service.search.return_value = {
+            'hits': {
+                'hits': [
+                    {
+                        '_index': 'mines',
+                        '_score': 10.0,
+                        '_source': {'mine_guid': 'mine-123', 'mine_name': 'Test Mine'}
+                    },
+                    {
+                        '_index': 'mine_permits',
+                        '_score': 9.0,
+                        '_source': {
+                            'permit_guid': 'bad-permit',
+                            'permit_no': 'BAD-001',
+                            'mine_guids': ['just-a-guid-string'],  # old, broken shape
+                        }
+                    }
+                ]
+            },
+            'aggregations': {}
+        }
+
+        result = GlobalSearchService.search('test', ['mine', 'permit'], {})
+
+        assert len(result['results']['mine']) == 1
+        assert result['results']['mine'][0]['result']['mine_name'] == 'Test Mine'
+        assert result['results']['permit'] == []
+
+    @patch('app.api.search.search.global_search_service.ElasticSearchService')
     def test_search_with_custom_size(self, mock_es_service):
         mock_es_service.search.return_value = {
             'hits': {'hits': []},

--- a/services/core-api/tests/search/test_search_transformers.py
+++ b/services/core-api/tests/search/test_search_transformers.py
@@ -342,6 +342,56 @@ class TestTransformESResults:
         
         assert results == {}
 
+    def test_transform_es_results_skips_malformed_permit_and_preserves_others(self):
+        """Regression test for a production incident: a malformed permit
+        document (mine_guids as flat GUID strings instead of
+        {mine_guid, mine_name, mine_no} objects, caused by an Elasticsearch
+        index mapping that drifted out of sync with the current PGSync
+        schema) should be skipped without breaking results for other
+        documents or types in the same batch.
+        """
+        hits = [
+            {
+                '_index': 'mines',
+                '_score': 10.0,
+                '_source': {'mine_guid': 'mine-1', 'mine_name': 'Good Mine'}
+            },
+            {
+                '_index': 'mine_permits',
+                '_score': 9.0,
+                '_id': 'bad-permit-guid',
+                '_source': {
+                    'permit_guid': 'bad-permit-guid',
+                    'permit_no': 'BAD-001',
+                    # Reproduces the real incident shape: mine_guids as flat
+                    # GUID strings instead of objects.
+                    'mine_guids': ['41d9de2c-8afd-4fe8-8076-06d28014f484'],
+                }
+            },
+            {
+                '_index': 'mine_permits',
+                '_score': 8.0,
+                '_source': {
+                    'permit_guid': 'good-permit-guid',
+                    'permit_no': 'GOOD-001',
+                    'mine_guids': [
+                        {'mine_guid': 'mine-guid-1', 'mine_name': 'Test Mine', 'mine_no': 'M-001'}
+                    ]
+                }
+            }
+        ]
+
+        results = transform_es_results(hits)
+
+        # The mine result is untouched by the unrelated permit failure.
+        assert len(results['mine']) == 1
+        assert results['mine'][0]['result']['mine_name'] == 'Good Mine'
+
+        # Only the well-formed permit made it through; the malformed one
+        # was skipped rather than raising and losing the whole batch.
+        assert len(results['permit']) == 1
+        assert results['permit'][0]['result']['permit_no'] == 'GOOD-001'
+
     def test_transform_es_results_groups_by_type(self):
         hits = [
             {

--- a/services/core-api/tests/search/test_simple_search_service.py
+++ b/services/core-api/tests/search/test_simple_search_service.py
@@ -371,6 +371,50 @@ class TestSimpleSearchService:
             assert result['search_results'][0].result['value'] == 'Test Mine'
     
     @patch('app.api.search.search.simple_search_service.ElasticSearchService.search')
+    def test_execute_search_skips_malformed_hit_preserves_others(self, mock_es_search, app, service):
+        """Regression test for a production incident: a single malformed
+        permit hit (mine_guids as flat GUID strings instead of objects,
+        caused by an Elasticsearch index mapping drifted out of sync with
+        the current PGSync schema) should be skipped without dropping other
+        hits in the same batch. The malformed hit is deliberately placed
+        FIRST so this doesn't depend on score-ordering luck.
+        """
+        with app.app_context():
+            mock_es_search.return_value = {
+                'hits': {
+                    'hits': [
+                        {
+                            '_index': 'mine_permits',
+                            '_score': 9.0,
+                            '_source': {
+                                'permit_guid': 'bad-permit',
+                                'permit_no': 'BAD-001',
+                                'mine_guids': ['just-a-guid-string'],  # old, broken shape
+                            },
+                            'highlight': {}
+                        },
+                        {
+                            '_index': 'mines',
+                            '_score': 5.0,
+                            '_source': {
+                                'mine_guid': 'mine-123',
+                                'mine_name': 'Good Mine',
+                                'mine_no': 'M-001',
+                                'mine_types': []
+                            },
+                            'highlight': {}
+                        }
+                    ]
+                },
+                'aggregations': {'by_index': {'buckets': []}}
+            }
+
+            result = service.execute_search('test', None, None)
+
+            values = [r.result['value'] for r in result['search_results']]
+            assert 'Good Mine' in values
+
+    @patch('app.api.search.search.simple_search_service.ElasticSearchService.search')
     def test_execute_search_with_mine_guid_filter(self, mock_es_search, app, service):
         """Test search execution with mine_guid filter."""
         with app.app_context():

--- a/services/pgsync/README.md
+++ b/services/pgsync/README.md
@@ -1,0 +1,75 @@
+# PGSync
+
+Syncs data from the `mds` Postgres database into Elasticsearch, as defined by `schema.json`. 
+On container start, `start.sh` runs `bootstrap` (one-time setup: creates the Elasticsearch index/mapping if missing, DB triggers, replication slot) 
+and then starts the long-running `pgsync` daemon.
+
+## ⚠️ Changing `schema.json`? Read this first.
+
+**Elasticsearch field mappings are immutable once an index is created.**
+`bootstrap` only creates an index if it does not already exist (`if not indices.exists(index=index): create(...)`) — 
+it will **never** alter the mapping of an index that's already there, no matter how many times you redeploy or restart the pod.
+
+This means: if your change to `schema.json` alters the **shape** of a field — for example, changing a relationship's `"variant"` from `scalar` to `object`,
+adding/removing a nested join, or changing a column's effective type — simply merging the change and letting it deploy is **not enough**. Every environment
+whose index was created before your change will silently keep writing/reading the *old* shape forever, with no error at deploy time. The failure only shows
+up later, indirectly, wherever application code reads that field and gets a different shape than it expects.
+
+### What you must do after a mapping-shape change
+
+For each environment (dev, test, prod) whose index was created before your change:
+
+1. Capture a baseline document count for the affected index, so you can confirm no data loss afterward:
+   ```
+   oc exec <pgsync-pod> -n <namespace> -- python3 -c "
+   import os, urllib.request, ssl, json, base64
+   ctx = ssl.create_default_context(cafile=os.environ['ELASTICSEARCH_CA_CERTS'])
+   auth = base64.b64encode(f\"{os.environ['ELASTICSEARCH_USER']}:{os.environ['ELASTICSEARCH_PASSWORD']}\".encode()).decode()
+   host = f\"https://{os.environ['ELASTICSEARCH_HOST']}:{os.environ['ELASTICSEARCH_PORT']}\"
+   headers = {'Authorization': f'Basic {auth}'}
+   c = urllib.request.Request(f'{host}/<INDEX_NAME>/_count', headers=headers)
+   print(json.dumps(json.load(urllib.request.urlopen(c, context=ctx)), indent=2))
+   "
+   ```
+
+2. Delete **only the affected index** (not the whole cluster, not other indices):
+   ```
+   oc exec <pgsync-pod> -n <namespace> -- python3 -c "
+   import os, urllib.request, ssl, json, base64
+   ctx = ssl.create_default_context(cafile=os.environ['ELASTICSEARCH_CA_CERTS'])
+   auth = base64.b64encode(f\"{os.environ['ELASTICSEARCH_USER']}:{os.environ['ELASTICSEARCH_PASSWORD']}\".encode()).decode()
+   host = f\"https://{os.environ['ELASTICSEARCH_HOST']}:{os.environ['ELASTICSEARCH_PORT']}\"
+   req = urllib.request.Request(f'{host}/<INDEX_NAME>', headers={'Authorization': f'Basic {auth}'}, method='DELETE')
+   print(json.dumps(json.load(urllib.request.urlopen(req, context=ctx)), indent=2))
+   "
+   ```
+
+3. Restart the deployment so `start.sh` re-runs `bootstrap` from scratch. With the index gone, bootstrap will recreate it with the current (correct)
+   mapping, and the daemon will do a full resync from Postgres (its checkpoint is reset automatically on every bootstrap run, so this is a real, complete resync, not just a resume):
+   ```
+   oc rollout restart deployment/pgsync -n <namespace>
+   oc rollout status deployment/pgsync -n <namespace>
+   ```
+
+4. Confirm the new pod's logs show a clean bootstrap (schema tree printed,
+   no tracebacks, ends in `Starting pgsync daemon...`), then re-check the
+   mapping and count match your baseline.
+
+No Kibana access is required for any of this — the PGSync pod already carries Elasticsearch credentials as env vars (`ELASTICSEARCH_HOST`, `_PORT`, `_USER`,
+`_PASSWORD`, `_CA_CERTS`), so the ES REST API can be queried directly via `oc exec` as shown above.
+
+### Do NOT do this
+
+The `pgsync` Python library ships a `pgsync.helper.teardown()` function.
+**Never call it.** 
+Its defaults are `drop_db=True` and `truncate_db=True` — by default it drops and truncates the actual Postgres database, not just Elasticsearch. 
+Nothing in the steps above touches Postgres; only the Elasticsearch index and the Kubernetes deployment are ever touched.
+
+## Incident history
+
+**2026-07:** Prod's `mine_permits` index was created before commits `d20f64c1d`/`ae55dcd87` changed the `mine_guids` relationship from a flat
+list of GUID strings (`"variant": "scalar"`) to a list of `{mine_guid, mine_name, mine_no}` objects (`"variant": "object"`). 
+Prod's code and config were fully up to date, but the existing index kept its old mapping indefinitely, causing `AttributeError: 'str' object has no attribute
+'get'` in core-api whenever a permit search result was processed — which, due to overly-broad exception handling further up the call stack, caused **all**
+search result types (not just permits) to come back empty in the "View All" results table. Resolved by deleting and rebuilding the index per the steps
+above (zero data loss: document count matched exactly before and after in both test and prod). The exception-handling issue was fixed separately (from the PR that added this Readme) so a future occurrence of this same mapping-drift problem would degrade gracefully (only the affected type missing) rather than blanking every search category.

--- a/services/pgsync/README.md
+++ b/services/pgsync/README.md
@@ -1,25 +1,19 @@
 # PGSync
 
-Syncs data from the `mds` Postgres database into Elasticsearch, as defined by `schema.json`. 
-On container start, `start.sh` runs `bootstrap` (one-time setup: creates the Elasticsearch index/mapping if missing, DB triggers, replication slot) 
-and then starts the long-running `pgsync` daemon.
+Syncs data from the `mds` Postgres database into Elasticsearch, as defined by `schema.json`. On container start, `start.sh` runs `bootstrap` (one-time setup: creates the Elasticsearch index/mapping if missing, DB triggers, replication slot) and then starts the long-running `pgsync` daemon.
 
 ## ⚠️ Changing `schema.json`? Read this first.
 
-**Elasticsearch field mappings are immutable once an index is created.**
-`bootstrap` only creates an index if it does not already exist (`if not indices.exists(index=index): create(...)`) — 
-it will **never** alter the mapping of an index that's already there, no matter how many times you redeploy or restart the pod.
+**Elasticsearch field mappings are immutable once an index is created.** `bootstrap` only creates an index if it does not already exist (`if not indices.exists(index=index): create(...)`) — it will **never** alter the mapping of an index that's already there, no matter how many times you redeploy or restart the pod.
 
-This means: if your change to `schema.json` alters the **shape** of a field — for example, changing a relationship's `"variant"` from `scalar` to `object`,
-adding/removing a nested join, or changing a column's effective type — simply merging the change and letting it deploy is **not enough**. Every environment
-whose index was created before your change will silently keep writing/reading the *old* shape forever, with no error at deploy time. The failure only shows
-up later, indirectly, wherever application code reads that field and gets a different shape than it expects.
+This means: if your change to `schema.json` alters the **shape** of a field — for example, changing a relationship's `"variant"` from `scalar` to `object`, adding/removing a nested join, or changing a column's effective type — simply merging the change and letting it deploy is **not enough**. Every environment whose index was created before your change will silently keep writing/reading the _old_ shape forever, with no error at deploy time. The failure only shows up later, indirectly, wherever application code reads that field and gets a different shape than it expects.
 
 ### What you must do after a mapping-shape change
 
 For each environment (dev, test, prod) whose index was created before your change:
 
 1. Capture a baseline document count for the affected index, so you can confirm no data loss afterward:
+
    ```
    oc exec <pgsync-pod> -n <namespace> -- python3 -c "
    import os, urllib.request, ssl, json, base64
@@ -33,6 +27,7 @@ For each environment (dev, test, prod) whose index was created before your chang
    ```
 
 2. Delete **only the affected index** (not the whole cluster, not other indices):
+
    ```
    oc exec <pgsync-pod> -n <namespace> -- python3 -c "
    import os, urllib.request, ssl, json, base64
@@ -44,32 +39,21 @@ For each environment (dev, test, prod) whose index was created before your chang
    "
    ```
 
-3. Restart the deployment so `start.sh` re-runs `bootstrap` from scratch. With the index gone, bootstrap will recreate it with the current (correct)
-   mapping, and the daemon will do a full resync from Postgres (its checkpoint is reset automatically on every bootstrap run, so this is a real, complete resync, not just a resume):
+3. Restart the deployment so `start.sh` re-runs `bootstrap` from scratch. With the index gone, bootstrap will recreate it with the current (correct) mapping, and the daemon will do a full resync from Postgres (its checkpoint is reset automatically on every bootstrap run, so this is a real, complete resync, not just a resume):
+
    ```
    oc rollout restart deployment/pgsync -n <namespace>
    oc rollout status deployment/pgsync -n <namespace>
    ```
 
-4. Confirm the new pod's logs show a clean bootstrap (schema tree printed,
-   no tracebacks, ends in `Starting pgsync daemon...`), then re-check the
-   mapping and count match your baseline.
+4. Confirm the new pod's logs show a clean bootstrap (schema tree printed, no tracebacks, ends in `Starting pgsync daemon...`), then re-check the mapping and count match your baseline.
 
-No Kibana access is required for any of this — the PGSync pod already carries Elasticsearch credentials as env vars (`ELASTICSEARCH_HOST`, `_PORT`, `_USER`,
-`_PASSWORD`, `_CA_CERTS`), so the ES REST API can be queried directly via `oc exec` as shown above.
+No Kibana access is required for any of this — the PGSync pod already carries Elasticsearch credentials as env vars (`ELASTICSEARCH_HOST`, `_PORT`, `_USER`, `_PASSWORD`, `_CA_CERTS`), so the ES REST API can be queried directly via `oc exec` as shown above.
 
 ### Do NOT do this
 
-The `pgsync` Python library ships a `pgsync.helper.teardown()` function.
-**Never call it.** 
-Its defaults are `drop_db=True` and `truncate_db=True` — by default it drops and truncates the actual Postgres database, not just Elasticsearch. 
-Nothing in the steps above touches Postgres; only the Elasticsearch index and the Kubernetes deployment are ever touched.
+The `pgsync` Python library ships a `pgsync.helper.teardown()` function. **Never call it.** Its defaults are `drop_db=True` and `truncate_db=True` — by default it drops and truncates the actual Postgres database, not just Elasticsearch. Nothing in the steps above touches Postgres; only the Elasticsearch index and the Kubernetes deployment are ever touched.
 
 ## Incident history
 
-**2026-07:** Prod's `mine_permits` index was created before commits `d20f64c1d`/`ae55dcd87` changed the `mine_guids` relationship from a flat
-list of GUID strings (`"variant": "scalar"`) to a list of `{mine_guid, mine_name, mine_no}` objects (`"variant": "object"`). 
-Prod's code and config were fully up to date, but the existing index kept its old mapping indefinitely, causing `AttributeError: 'str' object has no attribute
-'get'` in core-api whenever a permit search result was processed — which, due to overly-broad exception handling further up the call stack, caused **all**
-search result types (not just permits) to come back empty in the "View All" results table. Resolved by deleting and rebuilding the index per the steps
-above (zero data loss: document count matched exactly before and after in both test and prod). The exception-handling issue was fixed separately (from the PR that added this Readme) so a future occurrence of this same mapping-drift problem would degrade gracefully (only the affected type missing) rather than blanking every search category.
+**2026-07:** Prod's `mine_permits` index was created before commits `d20f64c1d`/`ae55dcd87` changed the `mine_guids` relationship from a flat list of GUID strings (`"variant": "scalar"`) to a list of `{mine_guid, mine_name, mine_no}` objects (`"variant": "object"`). Prod's code and config were fully up to date, but the existing index kept its old mapping indefinitely, causing `AttributeError: 'str' object has no attribute 'get'` in core-api whenever a permit search result was processed — which, due to overly-broad exception handling further up the call stack, caused **all** search result types (not just permits) to come back empty in the "View All" results table. Resolved by deleting and rebuilding the index per the steps above (zero data loss: document count matched exactly before and after in both test and prod). The exception-handling issue was fixed separately (from the PR that added this Readme) so a future occurrence of this same mapping-drift problem would degrade gracefully (only the affected type missing) rather than blanking every search category.


### PR DESCRIPTION
## Objective 

[MDS-6954](https://bcmines.atlassian.net/browse/MDS-6954)

_Why are you making this change? Provide a short explanation and/or screenshots_
### TL;DR
- A May 2026 PGSync schema change expected permit `mine_guids` as objects, but prod's ES index still had the old string mapping (mappings are immutable, so redeploys didn't fix it) - causing global search to fail entirely after the June 27th release. 
- Fixed by deleting and rebuilding the index from Postgres (zero data loss, verified), this PR updates to scoped error handling so one bad doc can't break all search results. 
- _No code changes we required to resolve the issue, the code changes in this PR are simply improvements to our error handling._

### Background
- Global search for permits started returning zero results in production after the June 27th prod release.
  - Affected both the search modal and the "View All" results table - the latter returned zero results for every category, not just permits.
- Test env worked correctly; could not replicate the issue there.
- Users searching for a permit (e.g. `m-40`) in prod got mine results in the search modal, but no permit results.
- Clicking "View All" (the full results table) returned **zero results for every category** - mines, people, permits, NoW, etc. - not just permits.
- Test environment worked correctly end-to-end for the same search.

### Investigation
- A production core-api pod log showed the actual crash:
  ```
  mines.append({'mine_guid': mine.get('mine_guid'), ...})
  AttributeError: 'str' object has no attribute 'get'
  ```
 - This came from `search_transformers.py - prepare_permit_source()`: the code assumed each entry in a permit's `mine_guids` was a dict, but prod's index was handing back plain strings (not the intended behaviour).

### Root Cause
- **Elasticsearch field mappings are immutable once an index is created**. 
- A May 2026 code change updated PGSync's schema so a permit's `mine_guids` field should be written as a list of _objects_ (`{mine_guid, mine_name, mine_no}`) instead of a flat list of GUID strings. 
- The change deployed to prod successfully at the code/config level, but prod's `mine_permits` Elasticsearch index had already been created before the change, under the old flat-string mapping. 
- PGSync's bootstrap logic only creates an index "if it doesn't already exist" - it never alters an existing index's mapping, no matter how many times the correct code redeploys.
- When the core-api code ran expecting an object, it errored out on receiving a string.

### The Fix 
- delete the `mine_permits` Elasticsearch index and restart the PGSync pod, forcing it to recreate the index fresh with the current mapping and fully resync from Postgres. 
- Verified zero data loss (see Outcome below) and confirmed working via the live UI. 
- The original error handling for core-api meant that a single malformed document corrupted *every* search category result, not just offending document
  - This has been updated so the impact of an issue like this in the future will be scoped to the single document, not the entire search results


### Outcome

| Environment | Baseline count | Post-rebuild count | Data loss? |
|---|---|---|---|
| Test | 8,842 | 8,842 | None |
| Prod | 9,244 | 9,244 | None |
- Postgres was never touched at any point in this procedure.
- Full guidance now lives in `services/pgsync/README.md` (created alongside this fix).

### Future Improvements
- Since Elasticsearch field mappings are immutable, in the future if we ever update an existing index we could run into this same issue again. 
- Below are proposed improvements to help mitigate that risk:
1. Look to add a post-deploy mapping-drift check: compare each index's live ES mapping against what the current `schema.json` would produce, and alert (could use the existing Discord webhook ) on mismatch. 
2. Auto-trigger the delete+rebuild as part of the deploy pipeline when a `schema.json` change is detected to alter relationship shape/type, removing the need to remember to delete the old index entirely, though this does mean the automation would run a delete which is always spooky...