### PR TITLE
[MDS-6932] Fix for placeholder text showing up in issued permits

### DIFF
--- a/services/core-api/app/api/now_applications/resources/now_application_status_resource.py
+++ b/services/core-api/app/api/now_applications/resources/now_application_status_resource.py
@@ -20,6 +20,8 @@ from app.api.services.issue_to_orgbook_service import OrgBookIssuerService
 from app.api.mines.mine.models.mine_type import MineType
 from app.api.mines.mine.models.mine_type_detail import MineTypeDetail
 from app.api.mines.permits.permit_conditions.tasks import export_and_index_permit_amendments
+from app.api.now_applications.now_template_transformer import (
+    calculate_liability, transform_variables_to_data, replace_condition_value_with_data)
 
 
 class NOWApplicationStatusCodeResource(Resource, UserMixin):
@@ -164,6 +166,27 @@ class NOWApplicationStatusResource(Resource, UserMixin):
                 permit_amendment.security_not_required = now_application_identity.now_application.security_not_required
                 permit_amendment.security_not_required_reason = now_application_identity.now_application.security_not_required_reason
                 permit_amendment.save(commit=False)
+
+                if permit_amendment.is_generated_in_core:
+                    now_application = now_application_identity.now_application
+                    mine = now_application_identity.mine
+                    total_liability = calculate_liability(now_application)
+                    condition_variables = transform_variables_to_data(
+                        now_application, permit_amendment, mine, total_liability)
+
+                    def _resolve_condition_variables(condition):
+                        if condition.condition:
+                            condition.condition = replace_condition_value_with_data(
+                                condition.condition, condition_variables)
+                        for sub_condition in condition.sub_conditions:
+                            _resolve_condition_variables(sub_condition)
+
+                    for condition in permit_amendment.conditions:
+                        _resolve_condition_variables(condition)
+
+                    if permit_amendment.preamble_text:
+                        permit_amendment.preamble_text = replace_condition_value_with_data(
+                            permit_amendment.preamble_text, condition_variables)
 
                 # transfer site_properties to permit
                 def get_disturbance_codes(site_property):

--- a/services/core-api/tests/now_applications/resources/test_now_application_status_resource.py
+++ b/services/core-api/tests/now_applications/resources/test_now_application_status_resource.py
@@ -1,5 +1,6 @@
 import json
 from datetime import datetime, timedelta
+from unittest.mock import MagicMock, patch, PropertyMock
 
 from app.api.now_applications.models.now_application_status import NOWApplicationStatus
 from tests.now_application_factories import NOWApplicationIdentityFactory, NOWApplicationFactory
@@ -50,3 +51,93 @@ class TestNOWApplicationStatus:
             },
             headers=auth_headers['full_auth_header'])
         assert put_resp.status_code == 200, put_resp.response
+
+    def test_put_AIA_substitutes_variables_for_core_generated_permit(self, test_client, db_session, auth_headers):
+        """When is_generated_in_core=True, transform_variables_to_data and
+        replace_condition_value_with_data should be called during AIA issuance."""
+        mine = MineFactory(major_mine_ind=True, mine_permit_amendments=1)
+        now_application = NOWApplicationFactory(application_progress=None)
+        now_application_identity = NOWApplicationIdentityFactory(
+            now_application=now_application, mine=mine)
+
+        transformer_module = (
+            'app.api.now_applications.resources.now_application_status_resource')
+
+        mock_permit_amendment = MagicMock()
+        mock_permit_amendment.is_generated_in_core = True
+        mock_permit_amendment.permit_amendment_status_code = 'DFT'
+        mock_permit_amendment.conditions = []
+        mock_permit_amendment.preamble_text = '{mine_name} preamble'
+
+        mock_permit = MagicMock()
+        mock_permit.permit_status_code = 'O'
+
+        mock_site_property = MagicMock()
+        mock_site_property.mine_type_detail = []
+        mock_site_property.mine_tenure_type_code = None
+
+        with patch(f'{transformer_module}.Permit.find_by_now_application_guid', return_value=mock_permit), \
+             patch(f'{transformer_module}.PermitAmendment.find_by_now_application_guid', return_value=mock_permit_amendment), \
+             patch(f'{transformer_module}.transform_variables_to_data', return_value={'mine_name': 'Test Mine'}) as mock_transform, \
+             patch(f'{transformer_module}.replace_condition_value_with_data', return_value='Test Mine preamble') as mock_replace, \
+             patch(f'{transformer_module}.calculate_liability', return_value=0.0), \
+             patch(f'{transformer_module}.MinePartyAppointment.find_current_appointments', return_value=[]), \
+             patch(f'{transformer_module}.Permit.validate_exemption_fee_status'), \
+             patch(f'{transformer_module}.MineType.find_by_permit_guid', return_value=None), \
+             patch(f'{transformer_module}.MineType.create', return_value=MagicMock()), \
+             patch(f'{transformer_module}.export_and_index_permit_amendments'), \
+             patch('app.api.now_applications.models.now_application.NOWApplication.site_property',
+                   new_callable=PropertyMock, return_value=mock_site_property):
+
+            test_client.put(
+                f'/now-applications/{now_application_identity.now_application_guid}/status',
+                json={
+                    'issue_date': datetime.now().isoformat(),
+                    'auth_end_date': (datetime.now() + timedelta(days=30)).isoformat(),
+                    'now_application_status_code': 'AIA',
+                    'exemption_fee_status_code': 'fil',
+                },
+                headers=auth_headers['full_auth_header'])
+
+            mock_transform.assert_called_once()
+            mock_replace.assert_called()
+
+    def test_put_AIA_skips_substitution_for_non_core_permit(self, test_client, db_session, auth_headers):
+        """When is_generated_in_core=False, transform_variables_to_data should NOT be called."""
+        mine = MineFactory(major_mine_ind=True, mine_permit_amendments=1)
+        now_application = NOWApplicationFactory(application_progress=None)
+        now_application_identity = NOWApplicationIdentityFactory(
+            now_application=now_application, mine=mine)
+
+        transformer_module = (
+            'app.api.now_applications.resources.now_application_status_resource')
+
+        mock_permit_amendment = MagicMock()
+        mock_permit_amendment.is_generated_in_core = False
+        mock_permit_amendment.permit_amendment_status_code = 'DFT'
+        mock_permit_amendment.conditions = []
+        mock_permit_amendment.preamble_text = '{mine_name} preamble'
+
+        mock_permit = MagicMock()
+        mock_permit.permit_status_code = 'O'
+
+        with patch(f'{transformer_module}.Permit.find_by_now_application_guid', return_value=mock_permit), \
+             patch(f'{transformer_module}.PermitAmendment.find_by_now_application_guid', return_value=mock_permit_amendment), \
+             patch(f'{transformer_module}.transform_variables_to_data') as mock_transform, \
+             patch(f'{transformer_module}.MinePartyAppointment.find_current_appointments', return_value=[]), \
+             patch(f'{transformer_module}.Permit.validate_exemption_fee_status'), \
+             patch(f'{transformer_module}.MineType.find_by_permit_guid', return_value=None), \
+             patch(f'{transformer_module}.MineType.create', return_value=MagicMock()), \
+             patch(f'{transformer_module}.export_and_index_permit_amendments'):
+
+            test_client.put(
+                f'/now-applications/{now_application_identity.now_application_guid}/status',
+                json={
+                    'issue_date': datetime.now().isoformat(),
+                    'auth_end_date': (datetime.now() + timedelta(days=30)).isoformat(),
+                    'now_application_status_code': 'AIA',
+                    'exemption_fee_status_code': 'fil',
+                },
+                headers=auth_headers['full_auth_header'])
+
+            mock_transform.assert_not_called()

--- a/services/core-api/tests/now_applications/test_now_template_transformer.py
+++ b/services/core-api/tests/now_applications/test_now_template_transformer.py
@@ -4,8 +4,9 @@ from app.api.now_applications import now_template_transformer as now_template_tr
 from werkzeug.exceptions import NotFound
 
 from app.api.utils.helpers import format_currency
-from tests.factories import PartyFactory, PermitAmendmentFactory, PermitFactory, create_mine_and_permit
+from tests.factories import PartyFactory, PermitAmendmentFactory, PermitConditionsFactory, PermitFactory, create_mine_and_permit
 from tests.now_application_factories import NOWApplicationFactory, NOWApplicationIdentityFactory
+from app.extensions import db
 
 def test_get_default_disturbance_or_cost_field_none(db_session):
     now_application = NOWApplicationFactory()
@@ -110,3 +111,54 @@ def test_transform_template_data_permit(db_session):
     assert 'security_adjustment' in template_data
     assert 'conditions' in template_data
     assert template_data['is_draft'] == False
+
+def test_replace_condition_value_with_data_on_nested_permit_conditions(db_session):
+    """The recursive resolution pattern used at issuance should substitute tokens
+    in both parent and child PermitConditions rows."""
+    mine, permit = create_mine_and_permit()
+    amendment = PermitAmendmentFactory(mine=mine, permit=permit, conditions=0)
+
+    parent = PermitConditionsFactory(permit_amendment=amendment, condition='{mine_name} permit condition.')
+    child = PermitConditionsFactory(permit_amendment=amendment, condition='Sub-condition for {mine_no}.')
+    child.parent_permit_condition_id = parent.permit_condition_id
+    db.session.flush()
+
+    condition_variables = {'mine_name': 'Red Mountain Mine', 'mine_no': 'M-123'}
+
+    def _resolve(condition):
+        if condition.condition:
+            condition.condition = now_template_transformer.replace_condition_value_with_data(
+                condition.condition, condition_variables)
+        for sub in condition.sub_conditions:
+            _resolve(sub)
+
+    _resolve(parent)
+
+    assert parent.condition == 'Red Mountain Mine permit condition.'
+    assert child.condition == 'Sub-condition for M-123.'
+    assert '{' not in parent.condition
+    assert '{' not in child.condition
+
+
+def test_replace_condition_value_with_data_preamble(db_session):
+    """preamble_text tokens should be substituted just like condition text."""
+    mine, permit = create_mine_and_permit()
+    amendment = PermitAmendmentFactory(mine=mine, permit=permit, conditions=0)
+    amendment.preamble_text = 'This permit is issued for {mine_name} (No. {mine_no}).'
+
+    now_application = NOWApplicationFactory()
+    now_application_identity = NOWApplicationIdentityFactory(now_application=now_application, mine=mine)
+    amendment.now_application_guid = now_application_identity.now_application_guid
+    now_application.now_application_identity = now_application_identity
+
+    total_liability = now_template_transformer.calculate_liability(now_application)
+    condition_variables = now_template_transformer.transform_variables_to_data(
+        now_application, amendment, mine, total_liability)
+
+    amendment.preamble_text = now_template_transformer.replace_condition_value_with_data(
+        amendment.preamble_text, condition_variables)
+
+    assert mine.mine_name in amendment.preamble_text
+    assert mine.mine_no in amendment.preamble_text
+    assert '{' not in amendment.preamble_text
+    assert '}' not in amendment.preamble_text


### PR DESCRIPTION
## Objective 

[MDS-6932](https://bcmines.atlassian.net/browse/MDS-6932)

- There was a bug where core generated permits that are issued would continue to show the condition data variables placeholder text in the permit condition page.

- The changes in this PR makes use of some existing functions that change the placeholder text of condition data variables to it's actual values. So now when the permit is issued in Core the placeholder text will be changed to the actual values. The existing functions were being used in the workflow that occurs when users download the draft permit document.
