### PR TITLE
[MDS-6957] [Core] Update condition data variable drop-down menu functionality

### DIFF
--- a/services/common/src/components/permits/VariableConditionMenu.spec.tsx
+++ b/services/common/src/components/permits/VariableConditionMenu.spec.tsx
@@ -10,7 +10,7 @@ describe("VariableConditionMenu", () => {
         <VariableConditionMenu conditionForm="MOCK_CONDITION_FORM" isManagementView />
       </ReduxWrapper>
     );
-    fireEvent.mouseEnter(container.firstChild);
+    fireEvent.click(container.querySelector("button"));
     expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/services/common/src/components/permits/VariableConditionMenu.tsx
+++ b/services/common/src/components/permits/VariableConditionMenu.tsx
@@ -27,7 +27,6 @@ const VariableConditionMenu: FC<VariableConditionMenuProps> = ({
   const reclamationSummary = useSelector(getNOWReclamationSummary);
   const activityTypeOptions = useSelector(getDropdownNoticeOfWorkActivityTypeOptions);
   const [open, setOpen] = useState(false);
-  const closeTimeout = React.useRef<NodeJS.Timeout | null>(null);
 
   const handleClick: MenuProps['onClick'] = async (event) => {
     if (inputRef.current) {
@@ -130,25 +129,18 @@ const VariableConditionMenu: FC<VariableConditionMenuProps> = ({
     ]
 
     return (
-        <Row className="condition-editor-toolbar"
-          onMouseEnter={() => {
-            if (closeTimeout.current) clearTimeout(closeTimeout.current);
-            setOpen(true);
-          }}
-          onMouseLeave={() => {
-            if (closeTimeout.current) clearTimeout(closeTimeout.current);
-            closeTimeout.current = setTimeout(() => setOpen(false), 400);
-          }}
-        >
+        <Row className="condition-editor-toolbar">
           <Dropdown
             menu={{ items, onClick: handleClick}}
+            trigger={["click"]}
             open={open}
-            onOpenChange={() => {}}
+            onOpenChange={(nextOpen) => setOpen(nextOpen)}
+            placement="topLeft"
             getPopupContainer={triggerNode => triggerNode.parentNode as HTMLElement}
           >
             <Button>
               Condition Data Variables
-              <Tooltip title={"Hover your mouse over the menus until you find the variable data you'd like to enter. Put it into your edited Permit Condition by clicking on it. This will populate the edited condition with a variable in the Draft permit screen. The Data from the Application tab will show up correctly in the PDF Draft permit in place of the variable. Please ensure all variable data fields you select have the correct information in the Application tab before adding these fields to your draft permit."}
+              <Tooltip title={"Click to open the menu, then hover over the categories until you find the variable data you'd like to enter. Put it into your edited Permit Condition by clicking on it. This will populate the edited condition with a variable in the Draft permit screen. The Data from the Application tab will show up correctly in the PDF Draft permit in place of the variable. Please ensure all variable data fields you select have the correct information in the Application tab before adding these fields to your draft permit."}
                 placement="right" mouseEnterDelay={0.3} overlayClassName="core-tooltip" >
                 <QuestionCircleOutlined className="icon-sm" style={{ marginLeft: 8 }} />
               </Tooltip>

--- a/services/common/src/components/permits/__snapshots__/VariableConditionMenu.spec.tsx.snap
+++ b/services/common/src/components/permits/__snapshots__/VariableConditionMenu.spec.tsx.snap
@@ -5,6 +5,7 @@ exports[`VariableConditionMenu renders correctly and matches the snapshot 1`] = 
   class="ant-row condition-editor-toolbar"
 >
   <button
+    ant-click-animating-without-extra-node="false"
     class="ant-btn ant-btn-default ant-dropdown-trigger ant-dropdown-open"
     type="button"
   >

--- a/services/core-web/src/components/noticeOfWork/applications/NoticeOfWorkPageHeader.tsx
+++ b/services/core-web/src/components/noticeOfWork/applications/NoticeOfWorkPageHeader.tsx
@@ -69,7 +69,6 @@ export const NoticeOfWorkPageHeader: FC<NoticeOfWorkPageHeaderProps> = (props) =
     props.noticeOfWork.now_application_tier_created_date ===
     props.noticeOfWork.now_application_tier_updated_date;
 
-  console.log('isInitialIntake', isInitialIntake)
 
   if (isInitialIntake) {
     nowTierCategoryName = `${nowTierCategoryName} (initial intake)`;


### PR DESCRIPTION
## Objective 

[MDS-6957](https://bcmines.atlassian.net/browse/MDS-6957)

_Why are you making this change? Provide a short explanation and/or screenshots_

Users reported that the 'Condition Data Variables' menu can be quite annoying - prior to these code changes the menu opened on hover (from the entire grey bar anchored to the top-left of the active condition's text box), and the menu overlays on top of the condition text being written. This meant that while drafting a NoW, the menu would constantly pop-open and get in the way. 

This PR changes the functionality of Condition Data Variables dropdown - users must now click on the dropdown to open it, and the dropdown menu now opens _above_ the permit condition textarea, not on top of it. Unit tests have been updated accordingly.

See below the new position of the menu (above the condition text area, instead of on top):
<img width="647" height="531" alt="image" src="https://github.com/user-attachments/assets/68113a60-2286-4361-9d3e-a4a7b8955eff" />

