### PR TITLE
[MDS-6817] Hide permit condition assigned reviewer for Minespace users

### DIFF
--- a/services/common/src/components/permits/PermitConditionViewEdit.tsx
+++ b/services/common/src/components/permits/PermitConditionViewEdit.tsx
@@ -69,6 +69,7 @@ const PermitConditionViewEdit: FC<PermitConditionViewEditProps> = ({
     setLoading,
     isStandardConditionEditor,
     isNowEditor,
+    isCore,
     refreshData,
   } = usePermitConditions();
 
@@ -277,7 +278,7 @@ const PermitConditionViewEdit: FC<PermitConditionViewEditProps> = ({
               </Row>
             )}
           </Row>
-          {featureModifyConditions && userCanEdit && !isStandardConditions && !isNowEditor && (
+          {isCore && featureModifyConditions && userCanEdit && !isStandardConditions && !isNowEditor && (
             <PermitConditionReviewAssignment category={category?.condition_category} />
           )}
         </Col>

--- a/services/common/src/components/permits/PermitConditions.tsx
+++ b/services/common/src/components/permits/PermitConditions.tsx
@@ -479,6 +479,7 @@ const PermitConditions: FC<PermitConditionProps> = ({
           latestAmendment,
           previousAmendment,
           currentAmendment,
+          isCore,
           loading: loading,
           setLoading,
           refreshData,

--- a/services/common/src/components/permits/PermitConditionsContext.tsx
+++ b/services/common/src/components/permits/PermitConditionsContext.tsx
@@ -10,6 +10,7 @@ interface PermitConditionsContextType {
   standardConditionType?: string;
   isStandardConditionEditor?: boolean;
   isNowEditor?: boolean;
+  isCore?: boolean;
   loading: boolean;
   setLoading: (loading: boolean) => void;
   refreshData: () => Promise<any>;
@@ -48,6 +49,7 @@ export const PermitConditionsProvider: FC<{
   const defaultValue = {
     isNowEditor: false,
     isStandardConditionEditor: false,
+    isCore: false,
     activeConditionId: null,
     setActiveConditionId: () => { },
     clearActiveConditionId: () => { },

--- a/services/common/src/tests/permits/PermitConditionViewEdit.spec.tsx
+++ b/services/common/src/tests/permits/PermitConditionViewEdit.spec.tsx
@@ -63,6 +63,7 @@ const providerValue = {
     refreshData: jest.fn().mockResolvedValue(undefined),
     isStandardConditionEditor: false,
     isNowEditor: false,
+    isCore: true,
 };
 
 describe("PermitConditionViewEdit", () => {
@@ -160,5 +161,52 @@ describe("PermitConditionViewEdit", () => {
         await waitFor(() => {
             expect(screen.getByLabelText('Cancel')).toBeInTheDocument();
         });
+    });
+
+    it("shows the assigned reviewer field in Core (isCore: true)", () => {
+        render(
+            <ReduxWrapper initialState={initialState}>
+                <PermitConditionsProvider value={{ ...providerValue, isCore: true }}>
+                    <PermitConditionViewEdit
+                        userCanEdit
+                        formattedCategories={formattedCategories as any}
+                        isExtracted
+                        userReviewCategoryCodes={[baseCategory.condition_category_code]}
+                        editingFormName={""}
+                        setEditingFormName={jest.fn()}
+                        addingToCategoryCode={null}
+                        setAddingToCategoryCode={jest.fn()}
+                    />
+                </PermitConditionsProvider>
+            </ReduxWrapper>
+        );
+
+        // "Assigned Reviewer:" renders whether the field is the interactive dropdown
+        // (core_edit_template_conditions) or the read-only view (without it) - either way
+        // it must be visible here, since isCore: true means we're in Core Web.
+        expect(screen.getByText("Assigned Reviewer:")).toBeInTheDocument();
+    });
+
+    it("never shows the assigned reviewer field outside Core, even when userCanEdit is true (isCore: false)", () => {
+        render(
+            <ReduxWrapper initialState={initialState}>
+                <PermitConditionsProvider value={{ ...providerValue, isCore: false }}>
+                    <PermitConditionViewEdit
+                        userCanEdit
+                        formattedCategories={formattedCategories as any}
+                        isExtracted
+                        userReviewCategoryCodes={[baseCategory.condition_category_code]}
+                        editingFormName={""}
+                        setEditingFormName={jest.fn()}
+                        addingToCategoryCode={null}
+                        setAddingToCategoryCode={jest.fn()}
+                    />
+                </PermitConditionsProvider>
+            </ReduxWrapper>
+        );
+
+        // Neither the dropdown nor the read-only variant should ever appear outside Core.
+        expect(screen.queryByText("Assigned Reviewer:")).not.toBeInTheDocument();
+        expect(document.querySelectorAll('[data-cy="assigned_review_user"]').length).toBe(0);
     });
 });

--- a/services/core-web/src/tests/components/mine/Permit/PermitConditions.spec.tsx
+++ b/services/core-web/src/tests/components/mine/Permit/PermitConditions.spec.tsx
@@ -65,6 +65,25 @@ const noPermissionState = {
   },
 };
 
+// viewing from MineSpace, but the account carries Core roles (e.g. a shared/composite account).
+// MineSpace only shows the Conditions tab once the review is complete, so mark it complete here.
+const minespaceState = {
+  ...initialState,
+  [PERMITS]: {
+    ...initialState[PERMITS],
+    latestPermitAmendments: {
+      [MOCK.PERMITS[0].permit_guid]: {
+        ...MOCK.PERMITS[0].permit_amendments[0],
+        conditions_review_completed: true,
+      },
+    },
+  },
+  [AUTHENTICATION]: {
+    systemFlag: SystemFlagEnum.ms,
+    userAccessData: [USER_ROLES.role_admin, USER_ROLES.role_edit_permits, USER_ROLES.role_edit_template_conditions],
+  },
+};
+
 function mockFunction() {
   const original = jest.requireActual("react-router-dom");
   return {
@@ -207,6 +226,19 @@ describe("PermitConditions", () => {
     expect(editCategory).not.toBeInTheDocument();
     const templateBtn = queryByText("Insert Template Conditions");
     expect(templateBtn).not.toBeInTheDocument();
+  });
+
+  it("never shows the assigned reviewer field in MineSpace, even for an account with Core edit roles", async () => {
+    const { container } = render(
+      <ReduxWrapper initialState={minespaceState}>
+        <BrowserRouter>
+          <ViewPermit />
+        </BrowserRouter>
+      </ReduxWrapper>
+    );
+
+    const assignReviewer = container.querySelectorAll('[data-cy="assigned_review_user"]');
+    expect(Array.from(assignReviewer)).toEqual([]);
   });
 
   it("does not allow editing without being assigned to the category", async () => {


### PR DESCRIPTION
## Objective 

[MDS-6817](https://bcmines.atlassian.net/browse/MDS-6817)

_Why are you making this change? Provide a short explanation and/or screenshots_

When a Ministry person assigns a reviewer for permit conditions, the reviewer should only be viewable in Core and not MineSpace. It was found that if a user had the right combination of Keycloak roles and navigated to Minespace from Core (or any other way where the Keycloak roles could follow the user), the assigned reviewer component was visible to them.

This PR adds the `isCore` flag to the assigned reviewer dropdown component, to prevent Minespace users from being able to see/edit that value, even if their Keycloak roles allow them to. 

No changes to the Keycloak roles were needed.