### PR TITLE
[MDS-6956] - File Viewer Redis Cache Migration & S3 Enhancements

### DIFF
--- a/services/filesystem-provider/ej2-amazon-s3-aspcore-file-provider/Controllers/PdfViewerController.cs
+++ b/services/filesystem-provider/ej2-amazon-s3-aspcore-file-provider/Controllers/PdfViewerController.cs
@@ -70,7 +70,10 @@ namespace EJ2AmazonS3ASPCoreFileProvider.Controllers
                         {
                             return NotFound(jsonObject["document"] + " is not found");
                         }
-                        fsr.FileStream.CopyTo(stream);
+                        using (fsr.FileStream)
+                        {
+                            fsr.FileStream.CopyTo(stream);
+                        }
                     }
                     else if (jsonObject.TryGetValue("document", out var base64))
                     {
@@ -230,6 +233,7 @@ namespace EJ2AmazonS3ASPCoreFileProvider.Controllers
                         return NotFound(jsonObject["importedData"] + " is not found");
                     }
 
+                    using (fsr.FileStream)
                     using (MemoryStream ms = new MemoryStream())
                     {
                         fsr.FileStream.CopyTo(ms);

--- a/services/filesystem-provider/ej2-amazon-s3-aspcore-file-provider/Controllers/PdfViewerController.cs
+++ b/services/filesystem-provider/ej2-amazon-s3-aspcore-file-provider/Controllers/PdfViewerController.cs
@@ -191,22 +191,24 @@ namespace EJ2AmazonS3ASPCoreFileProvider.Controllers
         [HttpPost]
         [Route("ImportAnnotations")]
         [Authorize("View")]
-        // NOTE: This is not implemented properly as it will need to get the document from the S3 bucket.
         public IActionResult ImportAnnotations([FromBody] Dictionary<string, string> jsonObject)
         {
             PdfRenderer pdfviewer = new PdfRenderer(_cache);
-            string jsonResult = string.Empty;
-            object JsonResult;
+
             if (jsonObject != null && jsonObject.ContainsKey("fileName"))
             {
-                string documentPath = GetDocumentPath(jsonObject["fileName"]);
-                if (!string.IsNullOrEmpty(documentPath))
+                string path = Path.GetDirectoryName(jsonObject["fileName"]) + "/";
+                string filename = Path.GetFileName(jsonObject["fileName"]);
+                FileStreamResult fsr = this.operation.Download(path, new string[] { filename });
+
+                if (fsr == null)
                 {
-                    jsonResult = System.IO.File.ReadAllText(documentPath);
+                    return NotFound(jsonObject["fileName"] + " is not found");
                 }
-                else
+
+                using (StreamReader reader = new StreamReader(fsr.FileStream))
                 {
-                    return this.Content(jsonObject["document"] + " is not found");
+                    return Content(reader.ReadToEnd());
                 }
             }
             else
@@ -214,27 +216,30 @@ namespace EJ2AmazonS3ASPCoreFileProvider.Controllers
                 string extension = Path.GetExtension(jsonObject["importedData"]);
                 if (extension != ".xfdf")
                 {
-                    JsonResult = pdfviewer.ImportAnnotation(jsonObject);
+                    object JsonResult = pdfviewer.ImportAnnotation(jsonObject);
                     return Content(JsonConvert.SerializeObject(JsonResult));
                 }
                 else
                 {
-                    string documentPath = GetDocumentPath(jsonObject["importedData"]);
-                    if (!string.IsNullOrEmpty(documentPath))
+                    string path = Path.GetDirectoryName(jsonObject["importedData"]) + "/";
+                    string filename = Path.GetFileName(jsonObject["importedData"]);
+                    FileStreamResult fsr = this.operation.Download(path, new string[] { filename });
+
+                    if (fsr == null)
                     {
-                        byte[] bytes = System.IO.File.ReadAllBytes(documentPath);
+                        return NotFound(jsonObject["importedData"] + " is not found");
+                    }
+
+                    using (MemoryStream ms = new MemoryStream())
+                    {
+                        fsr.FileStream.CopyTo(ms);
+                        byte[] bytes = ms.ToArray();
                         jsonObject["importedData"] = Convert.ToBase64String(bytes);
-                        JsonResult = pdfviewer.ImportAnnotation(jsonObject);
+                        object JsonResult = pdfviewer.ImportAnnotation(jsonObject);
                         return Content(JsonConvert.SerializeObject(JsonResult));
                     }
-                    else
-                    {
-                        return this.Content(jsonObject["document"] + " is not found");
-                    }
                 }
-
             }
-            return Content(jsonResult);
         }
 
         [AcceptVerbs("Post")]
@@ -256,22 +261,6 @@ namespace EJ2AmazonS3ASPCoreFileProvider.Controllers
             PdfRenderer pdfviewer = new PdfRenderer(_cache);
             object jsonResult = pdfviewer.ImportFormFields(jsonObject);
             return Content(JsonConvert.SerializeObject(jsonResult));
-        }
-
-        private string GetDocumentPath(string document)
-        {
-            string documentPath = string.Empty;
-            if (!System.IO.File.Exists(document))
-            {
-                var path = _hostingEnvironment.ContentRootPath;
-                if (System.IO.File.Exists(path + "\\Data\\" + document))
-                    documentPath = path + "\\Data\\" + document;
-            }
-            else
-            {
-                documentPath = document;
-            }
-            return documentPath;
         }
     }
 

--- a/services/filesystem-provider/ej2-amazon-s3-aspcore-file-provider/Controllers/PdfViewerController.cs
+++ b/services/filesystem-provider/ej2-amazon-s3-aspcore-file-provider/Controllers/PdfViewerController.cs
@@ -2,7 +2,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Caching.Distributed;
 using Syncfusion.EJ2.FileManager.AmazonS3FileProvider;
 using Newtonsoft.Json;
 using Syncfusion.EJ2.PdfViewer;
@@ -19,13 +19,13 @@ namespace EJ2AmazonS3ASPCoreFileProvider.Controllers
     public class PdfViewerController : ControllerBase
     {
         public AmazonS3FileProvider operation;
-        public IMemoryCache _mCache;
+        public IDistributedCache _cache;
 
         private IWebHostEnvironment _hostingEnvironment;
 
-        public PdfViewerController(IWebHostEnvironment hostingEnvironment, IMemoryCache cache)
+        public PdfViewerController(IWebHostEnvironment hostingEnvironment, IDistributedCache cache)
         {
-            _mCache = cache;
+            _cache = cache;
             _hostingEnvironment = hostingEnvironment;
             this.operation = new AmazonS3FileProvider();
 
@@ -56,7 +56,7 @@ namespace EJ2AmazonS3ASPCoreFileProvider.Controllers
                     ? basePath
                     : basePath + Path.DirectorySeparatorChar;
 
-                PdfRenderer pdfviewer = new PdfRenderer(_mCache);
+                PdfRenderer pdfviewer = new PdfRenderer(_cache);
                 MemoryStream stream = new MemoryStream();
                 object jsonResult = new object();
                 if (jsonObject != null && jsonObject.ContainsKey("document"))
@@ -95,7 +95,7 @@ namespace EJ2AmazonS3ASPCoreFileProvider.Controllers
         [Authorize("View")]
         public IActionResult Bookmarks([FromBody] Dictionary<string, string> jsonObject)
         {
-            PdfRenderer pdfviewer = new PdfRenderer(_mCache);
+            PdfRenderer pdfviewer = new PdfRenderer(_cache);
             object jsonResult = pdfviewer.GetBookmarks(jsonObject);
             return Content(JsonConvert.SerializeObject(jsonResult));
         }
@@ -106,7 +106,7 @@ namespace EJ2AmazonS3ASPCoreFileProvider.Controllers
         [Authorize("View")]
         public IActionResult RenderPdfPages([FromBody] Dictionary<string, string> jsonObject)
         {
-            PdfRenderer pdfviewer = new PdfRenderer(_mCache);
+            PdfRenderer pdfviewer = new PdfRenderer(_cache);
             object jsonResult = pdfviewer.GetPage(jsonObject);
             return Content(JsonConvert.SerializeObject(jsonResult));
         }
@@ -117,7 +117,7 @@ namespace EJ2AmazonS3ASPCoreFileProvider.Controllers
         [Authorize("View")]
         public IActionResult RenderPdfTexts([FromBody] Dictionary<string, string> jsonObject)
         {
-            PdfRenderer pdfviewer = new PdfRenderer(_mCache);
+            PdfRenderer pdfviewer = new PdfRenderer(_cache);
             object jsonResult = pdfviewer.GetDocumentText(jsonObject);
             return Content(JsonConvert.SerializeObject(jsonResult));
         }
@@ -128,7 +128,7 @@ namespace EJ2AmazonS3ASPCoreFileProvider.Controllers
         [Authorize("View")]
         public IActionResult RenderAnnotationComments([FromBody] Dictionary<string, string> jsonObject)
         {
-            PdfRenderer pdfviewer = new PdfRenderer(_mCache);
+            PdfRenderer pdfviewer = new PdfRenderer(_cache);
             object jsonResult = pdfviewer.GetAnnotationComments(jsonObject);
             return Content(JsonConvert.SerializeObject(jsonResult));
         }
@@ -139,7 +139,7 @@ namespace EJ2AmazonS3ASPCoreFileProvider.Controllers
         [Authorize("View")]
         public IActionResult Unload([FromBody] Dictionary<string, string> jsonObject)
         {
-            PdfRenderer pdfviewer = new PdfRenderer(_mCache);
+            PdfRenderer pdfviewer = new PdfRenderer(_cache);
             pdfviewer.ClearCache(jsonObject);
             return this.Content("Document cache is cleared");
         }
@@ -150,7 +150,7 @@ namespace EJ2AmazonS3ASPCoreFileProvider.Controllers
         [Authorize("View")]
         public IActionResult RenderThumbnailImages([FromBody] Dictionary<string, string> jsonObject)
         {
-            PdfRenderer pdfviewer = new PdfRenderer(_mCache);
+            PdfRenderer pdfviewer = new PdfRenderer(_cache);
             object result = pdfviewer.GetThumbnailImages(jsonObject);
             return Content(JsonConvert.SerializeObject(result));
         }
@@ -160,7 +160,7 @@ namespace EJ2AmazonS3ASPCoreFileProvider.Controllers
         [Authorize("View")]
         public IActionResult Download([FromBody] Dictionary<string, string> jsonObject)
         {
-            PdfRenderer pdfviewer = new PdfRenderer(_mCache);
+            PdfRenderer pdfviewer = new PdfRenderer(_cache);
             string documentBase = pdfviewer.GetDocumentAsBase64(jsonObject);
             return Content(documentBase);
         }
@@ -171,7 +171,7 @@ namespace EJ2AmazonS3ASPCoreFileProvider.Controllers
         [Authorize("View")]
         public IActionResult PrintImages([FromBody] Dictionary<string, string> jsonObject)
         {
-            PdfRenderer pdfviewer = new PdfRenderer(_mCache);
+            PdfRenderer pdfviewer = new PdfRenderer(_cache);
             object pageImage = pdfviewer.GetPrintImage(jsonObject);
             return Content(JsonConvert.SerializeObject(pageImage));
         }
@@ -182,7 +182,7 @@ namespace EJ2AmazonS3ASPCoreFileProvider.Controllers
         [Authorize("View")]
         public IActionResult ExportAnnotations([FromBody] Dictionary<string, string> jsonObject)
         {
-            PdfRenderer pdfviewer = new PdfRenderer(_mCache);
+            PdfRenderer pdfviewer = new PdfRenderer(_cache);
             string jsonResult = pdfviewer.ExportAnnotation(jsonObject);
             return Content(jsonResult);
         }
@@ -194,7 +194,7 @@ namespace EJ2AmazonS3ASPCoreFileProvider.Controllers
         // NOTE: This is not implemented properly as it will need to get the document from the S3 bucket.
         public IActionResult ImportAnnotations([FromBody] Dictionary<string, string> jsonObject)
         {
-            PdfRenderer pdfviewer = new PdfRenderer(_mCache);
+            PdfRenderer pdfviewer = new PdfRenderer(_cache);
             string jsonResult = string.Empty;
             object JsonResult;
             if (jsonObject != null && jsonObject.ContainsKey("fileName"))
@@ -243,7 +243,7 @@ namespace EJ2AmazonS3ASPCoreFileProvider.Controllers
         [Authorize("View")]
         public IActionResult ExportFormFields(Dictionary<string, string> jsonObject)
         {
-            PdfRenderer pdfviewer = new PdfRenderer(_mCache);
+            PdfRenderer pdfviewer = new PdfRenderer(_cache);
             string jsonResult = pdfviewer.ExportFormFields(jsonObject);
             return Content(jsonResult);
         }
@@ -253,7 +253,7 @@ namespace EJ2AmazonS3ASPCoreFileProvider.Controllers
         [Authorize("View")]
         public IActionResult ImportFormFields(Dictionary<string, string> jsonObject)
         {
-            PdfRenderer pdfviewer = new PdfRenderer(_mCache);
+            PdfRenderer pdfviewer = new PdfRenderer(_cache);
             object jsonResult = pdfviewer.ImportFormFields(jsonObject);
             return Content(JsonConvert.SerializeObject(jsonResult));
         }

--- a/services/filesystem-provider/ej2-amazon-s3-aspcore-file-provider/EJ2AmazonS3ASPCoreFileProvider.csproj
+++ b/services/filesystem-provider/ej2-amazon-s3-aspcore-file-provider/EJ2AmazonS3ASPCoreFileProvider.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.106" />
+    <PackageReference Include="AWSSDK.S3" Version="4.0.17" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.7" />
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="7.0.7" />
     <PackageReference Include="DotNetEnv" Version="2.5.0" />

--- a/services/filesystem-provider/ej2-amazon-s3-aspcore-file-provider/EJ2AmazonS3ASPCoreFileProvider.csproj
+++ b/services/filesystem-provider/ej2-amazon-s3-aspcore-file-provider/EJ2AmazonS3ASPCoreFileProvider.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
@@ -12,6 +12,7 @@
   <ItemGroup>
     <PackageReference Include="AWSSDK.S3" Version="3.7.106" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="7.0.7" />
     <PackageReference Include="DotNetEnv" Version="2.5.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="7.0.7" />
     <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />

--- a/services/filesystem-provider/ej2-amazon-s3-aspcore-file-provider/EJ2AmazonS3ASPCoreFileProvider.csproj
+++ b/services/filesystem-provider/ej2-amazon-s3-aspcore-file-provider/EJ2AmazonS3ASPCoreFileProvider.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="AWSSDK.S3" Version="4.0.17" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.7" />
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="7.0.7" />
+    <PackageReference Include="System.Drawing.Common" Version="7.0.0" />
     <PackageReference Include="DotNetEnv" Version="2.5.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="7.0.7" />
     <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />

--- a/services/filesystem-provider/ej2-amazon-s3-aspcore-file-provider/Models/AmazonS3FileProvider.cs
+++ b/services/filesystem-provider/ej2-amazon-s3-aspcore-file-provider/Models/AmazonS3FileProvider.cs
@@ -1,4 +1,4 @@
-﻿using Amazon.S3;
+using Amazon.S3;
 using Amazon.S3.Model;
 using System;
 using System.Collections.Generic;
@@ -44,7 +44,11 @@ namespace Syncfusion.EJ2.FileManager.AmazonS3FileProvider
             };
 
             client = new AmazonS3Client(creds, config);
-            fileTransferUtility = new TransferUtility(client);
+            var transferUtilityConfig = new TransferUtilityConfig
+            {
+                ConcurrentServiceRequests = 10
+            };
+            fileTransferUtility = new TransferUtility(client, transferUtilityConfig);
         }
 
         // Define the root directory to the file manager
@@ -64,25 +68,29 @@ namespace Syncfusion.EJ2.FileManager.AmazonS3FileProvider
             try
             {
                 if (path == "/") ListingObjectsAsync("/", RootName, false).Wait(); else ListingObjectsAsync("/", this.RootName.Replace("/", "") + path, false).Wait();
+                var s3Objects = response.S3Objects ?? new List<S3Object>();
+                var commonPrefixes = response.CommonPrefixes ?? new List<string>();
                 if (path == "/")
                 {
-                    FileManagerDirectoryContent[] s = response.S3Objects.Where(x => x.Key == RootName).Select(y => CreateDirectoryContentInstance(y.Key.ToString().Replace("/", ""), true, "png", y.Size, new DateTime(), new DateTime(), this.checkChild(y.Key), null)).ToArray();
+                    FileManagerDirectoryContent[] s = s3Objects.Where(x => x.Key == RootName).Select(y => CreateDirectoryContentInstance(y.Key.ToString().Replace("/", ""), true, "png", y.Size ?? 0, new DateTime(), new DateTime(), this.checkChild(y.Key), null)).ToArray();
                     if (s.Length > 0) cwd = s[0];
                 }
                 else
-                    cwd = CreateDirectoryContentInstance(path.Split("/")[path.Split("/").Length - 2], false, "Folder", 0, new DateTime(), new DateTime(), (response.CommonPrefixes.Count > 0) ? true : false, null);
+                    cwd = CreateDirectoryContentInstance(path.Split("/")[path.Split("/").Length - 2], false, "Folder", 0, new DateTime(), new DateTime(), (commonPrefixes.Count > 0) ? true : false, null);
             }
             catch (Exception ex) { throw ex; }
             try
             {
-                if (response.CommonPrefixes.Count > 0)
-                    files = response.CommonPrefixes.Select((y, i) => CreateDirectoryContentInstance(response.CommonPrefixes[i].Replace(RootName.Replace("/", "") + path, "").Replace("/", ""), false, "Folder", 0, new DateTime(), new DateTime(), this.checkChild(response.CommonPrefixes[i]), null)).ToList();
+                var commonPrefixesVal = response.CommonPrefixes ?? new List<string>();
+                if (commonPrefixesVal.Count > 0)
+                    files = commonPrefixesVal.Select((y, i) => CreateDirectoryContentInstance(commonPrefixesVal[i].Replace(RootName.Replace("/", "") + path, "").Replace("/", ""), false, "Folder", 0, new DateTime(), new DateTime(), this.checkChild(commonPrefixesVal[i]), null)).ToList();
             }
             catch (Exception ex) { throw ex; }
             try
             {
-                if (response.S3Objects.Count > 0)
-                    filesS3 = response.S3Objects.Where(x => x.Key != RootName.Replace("/", "") + path).Select(y => CreateDirectoryContentInstance(y.Key.ToString().Replace(RootName.Replace("/", "") + path, "").Replace("/", ""), true, Path.GetExtension(y.Key.ToString()), y.Size, y.LastModified, y.LastModified, this.checkChild(y.Key), null)).ToList();
+                var s3ObjectsVal = response.S3Objects ?? new List<S3Object>();
+                if (s3ObjectsVal.Count > 0)
+                    filesS3 = s3ObjectsVal.Where(x => x.Key != RootName.Replace("/", "") + path).Select(y => CreateDirectoryContentInstance(y.Key.ToString().Replace(RootName.Replace("/", "") + path, "").Replace("/", ""), true, Path.GetExtension(y.Key.ToString()), y.Size ?? 0, y.LastModified ?? DateTime.MinValue, y.LastModified ?? DateTime.MinValue, this.checkChild(y.Key), null)).ToList();
             }
             catch (Exception ex) { throw ex; }
             if (filesS3.Count != 0) files = files.Union(filesS3).ToList();
@@ -127,22 +135,24 @@ namespace Syncfusion.EJ2.FileManager.AmazonS3FileProvider
                 List<FileManagerDirectoryContent> files = new List<FileManagerDirectoryContent>();
                 GetBucketList();
                 if (path == "/") ListingObjectsAsync("/", RootName, false).Wait(); else ListingObjectsAsync("/", this.RootName.Replace("/", "") + path, false).Wait();
+                var commonPrefixes = response.CommonPrefixes ?? new List<string>();
+                var s3Objects = response.S3Objects ?? new List<S3Object>();
                 foreach (string name in names)
                 {
-                    if (response.CommonPrefixes.Count > 1)
+                    if (commonPrefixes.Count > 1)
                     {
-                        foreach (string commonPrefix in response.CommonPrefixes)
+                        foreach (string commonPrefix in commonPrefixes)
                         {
                             if (commonPrefix == this.RootName.Replace("/", "") + path + name)
                                 files.Add(CreateDirectoryContentInstance(commonPrefix.Split("/")[commonPrefix.Split("/").Length - 2], false, "Folder", 0, new DateTime(), new DateTime(), false, ""));
                         }
                     }
-                    if (response.S3Objects.Count > 1)
+                    if (s3Objects.Count > 1)
                     {
-                        foreach (S3Object S3Object in response.S3Objects)
+                        foreach (S3Object S3Object in s3Objects)
                         {
                             if (S3Object.Key == this.RootName.Replace("/", "") + path + name)
-                                files.Add(CreateDirectoryContentInstance(S3Object.Key.Split("/").Last(), true, Path.GetExtension(S3Object.Key), S3Object.Size, S3Object.LastModified, S3Object.LastModified, false, ""));
+                                files.Add(CreateDirectoryContentInstance(S3Object.Key.Split("/").Last(), true, Path.GetExtension(S3Object.Key), S3Object.Size ?? 0, S3Object.LastModified ?? DateTime.MinValue, S3Object.LastModified ?? DateTime.MinValue, false, ""));
                         }
                     }
                 }
@@ -178,10 +188,12 @@ namespace Syncfusion.EJ2.FileManager.AmazonS3FileProvider
                 GetBucketList();
                 FileManagerResponse readResponse = new FileManagerResponse();
                 if (targetPath == "/") ListingObjectsAsync("/", RootName, false).Wait(); else ListingObjectsAsync("/", this.RootName.Replace("/", "") + targetPath, false).Wait();
+                var s3Objects = response.S3Objects ?? new List<S3Object>();
+                var commonPrefixes = response.CommonPrefixes ?? new List<string>();
                 if (targetPath == "/")
-                    cwd = response.S3Objects.Where(x => x.Key == RootName).Select(y => CreateDirectoryContentInstance(y.Key.ToString().Replace("/", ""), true, "folder", y.Size, new DateTime(), new DateTime(), false, "")).ToArray()[0];
-                else if (response.CommonPrefixes.Count > 0)
-                    cwd = CreateDirectoryContentInstance(names[0].Contains("/") ? names[0].Split("/")[names[0].Split("/").Length - 2] : (path == "/" ? "Files" : path.Split("/")[path.Split("/").Length - 2]), false, "Folder", 0, new DateTime(), new DateTime(), (response.CommonPrefixes.Count > 0) ? true : false, "");
+                    cwd = s3Objects.Where(x => x.Key == RootName).Select(y => CreateDirectoryContentInstance(y.Key.ToString().Replace("/", ""), true, "folder", y.Size ?? 0, new DateTime(), new DateTime(), false, "")).ToArray()[0];
+                else if (commonPrefixes.Count > 0)
+                    cwd = CreateDirectoryContentInstance(names[0].Contains("/") ? names[0].Split("/")[names[0].Split("/").Length - 2] : (path == "/" ? "Files" : path.Split("/")[path.Split("/").Length - 2]), false, "Folder", 0, new DateTime(), new DateTime(), (commonPrefixes.Count > 0) ? true : false, "");
                 GetBucketList();
                 if (names[0].Contains("/"))
                 {
@@ -191,20 +203,22 @@ namespace Syncfusion.EJ2.FileManager.AmazonS3FileProvider
                         string n = "";
                         n = name.EndsWith("/") ? name.Split("/")[name.Split("/").Length - 2] : name.Split("/").Last();
                         if (path == "/") ListingObjectsAsync("/", RootName, false).Wait(); else ListingObjectsAsync("/", this.RootName.Replace("/", "") + path, false).Wait();
-                        if (response.CommonPrefixes.Count > 0)
+                        var innerPrefixes = response.CommonPrefixes ?? new List<string>();
+                        var innerObjects = response.S3Objects ?? new List<S3Object>();
+                        if (innerPrefixes.Count > 0)
                         {
-                            foreach (string commonPrefix in response.CommonPrefixes)
+                            foreach (string commonPrefix in innerPrefixes)
                             {
                                 if (commonPrefix == this.RootName + name + "/")
                                     files.Add(CreateDirectoryContentInstance(commonPrefix, false, "Folder", 0, new DateTime(), new DateTime(), false, ""));
                             }
                         }
-                        if (response.S3Objects.Count > 0)
+                        if (innerObjects.Count > 0)
                         {
-                            foreach (S3Object S3Object in response.S3Objects)
+                            foreach (S3Object S3Object in innerObjects)
                             {
                                 if (S3Object.Key == this.RootName.Replace("/", "") + path + n)
-                                    files.Add(CreateDirectoryContentInstance(S3Object.Key, true, Path.GetExtension(S3Object.Key), S3Object.Size, S3Object.LastModified, S3Object.LastModified, false, ""));
+                                    files.Add(CreateDirectoryContentInstance(S3Object.Key, true, Path.GetExtension(S3Object.Key), S3Object.Size ?? 0, S3Object.LastModified ?? DateTime.MinValue, S3Object.LastModified ?? DateTime.MinValue, false, ""));
                             }
                         }
                     }
@@ -212,9 +226,11 @@ namespace Syncfusion.EJ2.FileManager.AmazonS3FileProvider
                 else
                 {
                     if (path == "/") ListingObjectsAsync("/", RootName, false).Wait(); else ListingObjectsAsync("/", this.RootName.Replace("/", "") + path, false).Wait();
-                    if (response.CommonPrefixes.Count > 1)
+                    var innerPrefixes = response.CommonPrefixes ?? new List<string>();
+                    var innerObjects = response.S3Objects ?? new List<S3Object>();
+                    if (innerPrefixes.Count > 1)
                     {
-                        foreach (string commonPrefix in response.CommonPrefixes)
+                        foreach (string commonPrefix in innerPrefixes)
                         {
                             foreach (string n in names)
                             {
@@ -225,15 +241,15 @@ namespace Syncfusion.EJ2.FileManager.AmazonS3FileProvider
                             }
                         }
                     }
-                    if (response.S3Objects.Count > 1)
+                    if (innerObjects.Count > 1)
                     {
-                        foreach (S3Object S3Object in response.S3Objects)
+                        foreach (S3Object S3Object in innerObjects)
                         {
                             foreach (string n in names)
                             {
                                 if (S3Object.Key == this.RootName.Replace("/", "") + path + n)
                                 {
-                                    files.Add(CreateDirectoryContentInstance(S3Object.Key.Split("/").Last(), true, Path.GetExtension(S3Object.Key), S3Object.Size, S3Object.LastModified, S3Object.LastModified, false, ""));
+                                    files.Add(CreateDirectoryContentInstance(S3Object.Key.Split("/").Last(), true, Path.GetExtension(S3Object.Key), S3Object.Size ?? 0, S3Object.LastModified ?? DateTime.MinValue, S3Object.LastModified ?? DateTime.MinValue, false, ""));
                                 }
                             }
                         }
@@ -341,7 +357,7 @@ namespace Syncfusion.EJ2.FileManager.AmazonS3FileProvider
             }
             if (replacedItemNames.Length == 0 && existFiles.Count > 0)
             {
-                ErrorDetails er = new ErrorDetails();
+                var er = new Syncfusion.EJ2.FileManager.Base.ErrorDetails();
                 er.FileExists = existFiles;
                 er.Code = "400";
                 er.Message = "File Already Exists";
@@ -381,23 +397,28 @@ namespace Syncfusion.EJ2.FileManager.AmazonS3FileProvider
                     ListingObjectsAsync("/", RootName.Replace("/", "") + (names.Length < 1 ? path.Substring(0, path.Length - 1) : path + data[0].Name), false).Wait();
                 if (data.Length == 1)
                 {
+                    var s3Objects = response.S3Objects ?? new List<S3Object>();
+                    var commonPrefixes = response.CommonPrefixes ?? new List<string>();
                     if (names.Length == 0 || data[i - 1].Type == "Folder")
                     {
-                        if (response.CommonPrefixes.Count > 0)
-                            location = response.CommonPrefixes[0].Substring(0, response.CommonPrefixes[0].Length - 1);
+                        if (commonPrefixes.Count > 0)
+                            location = commonPrefixes[0].Substring(0, commonPrefixes[0].Length - 1);
                     }
-                    else if (response.S3Objects.Count > 0)
-                        location = response.S3Objects[0].Key;
+                    else if (s3Objects.Count > 0)
+                        location = s3Objects[0].Key;
                 }
                 else location = "Various Files or Folders";
                 foreach (string name in names)
                 {
                     ListingObjectsAsync("/", RootName.Replace("/", "") + path + name + ((data[i - 1].Type == "Folder") ? "/" : ""), false).Wait();
                     i--;
-                    foreach (S3Object key in response.S3Objects) { sizeValue = sizeValue + key.Size; }
-                    if (response.CommonPrefixes.Count > 0) this.getChildObjects(response.CommonPrefixes, true, "");
+                    var s3Objects = response.S3Objects ?? new List<S3Object>();
+                    var commonPrefixes = response.CommonPrefixes ?? new List<string>();
+                    foreach (S3Object key in s3Objects) { sizeValue = sizeValue + (key.Size ?? 0); }
+                    if (commonPrefixes.Count > 0) this.getChildObjects(commonPrefixes, true, "");
                 }
-                if (names.Length < 1) this.getChildObjects(response.CommonPrefixes, true, "");
+                var finalPrefixes = response.CommonPrefixes ?? new List<string>();
+                if (names.Length < 1) this.getChildObjects(finalPrefixes, true, "");
                 FileDetails detailFiles = new FileDetails();
                 detailFiles = new FileDetails
                 {
@@ -421,16 +442,18 @@ namespace Syncfusion.EJ2.FileManager.AmazonS3FileProvider
             GetBucketList();
             ListingObjectsAsync("/", RootName.Replace("/", "") + path, false).Wait();
             bool checkExist = false;
-            if (response.CommonPrefixes.Count > 0)
+            var commonPrefixes = response.CommonPrefixes ?? new List<string>();
+            var s3Objects = response.S3Objects ?? new List<S3Object>();
+            if (commonPrefixes.Count > 0)
             {
-                foreach (string commonPrefix in response.CommonPrefixes)
+                foreach (string commonPrefix in commonPrefixes)
                 {
                     if (commonPrefix.Split("/")[commonPrefix.Split("/").Length - 2].ToLower() == name.ToLower()) { checkExist = true; break; }
                 }
             }
-            if (response.S3Objects.Count > 0)
+            if (s3Objects.Count > 0)
             {
-                foreach (S3Object s3Object in response.S3Objects)
+                foreach (S3Object s3Object in s3Objects)
                 {
                     if (s3Object.Key.ToLower() == (RootName.Replace("/", "") + path + name).ToLower()) { checkExist = true; break; }
                 }
@@ -444,7 +467,7 @@ namespace Syncfusion.EJ2.FileManager.AmazonS3FileProvider
             FileManagerResponse createResponse = new FileManagerResponse();
             if (checkFileExist(path, name))
             {
-                ErrorDetails er = new ErrorDetails();
+                var er = new Syncfusion.EJ2.FileManager.Base.ErrorDetails();
                 er.Code = "400";
                 er.Message = "A file or folder with the name " + name + " already exists.";
                 createResponse.Error = er;
@@ -481,14 +504,16 @@ namespace Syncfusion.EJ2.FileManager.AmazonS3FileProvider
                 List<FileManagerDirectoryContent> files = new List<FileManagerDirectoryContent>();
                 List<FileManagerDirectoryContent> filesS3 = new List<FileManagerDirectoryContent>();
                 char[] j = new Char[] { '*' };
-                if (response.CommonPrefixes.Count > 0)
-                    files = response.CommonPrefixes.Where(x => x.Split("/")[x.Split("/").Length - 2].ToLower().Contains(searchString.TrimStart(j).TrimEnd(j).ToLower())).Select(x => CreateDirectoryContentInstance(x.Split("/")[x.Split("/").Length - 2], false, "Folder", 0, new DateTime(), new DateTime(), this.checkChild(x), x.Substring(0, x.Length - x.Split("/")[x.Split("/").Length - 2].Length - 1).Substring(RootName.Length - 1))).ToList();
-                if (response.S3Objects.Count > 1)
+                var commonPrefixes = response.CommonPrefixes ?? new List<string>();
+                var s3Objects = response.S3Objects ?? new List<S3Object>();
+                if (commonPrefixes.Count > 0)
+                    files = commonPrefixes.Where(x => x.Split("/")[x.Split("/").Length - 2].ToLower().Contains(searchString.TrimStart(j).TrimEnd(j).ToLower())).Select(x => CreateDirectoryContentInstance(x.Split("/")[x.Split("/").Length - 2], false, "Folder", 0, new DateTime(), new DateTime(), this.checkChild(x), x.Substring(0, x.Length - x.Split("/")[x.Split("/").Length - 2].Length - 1).Substring(RootName.Length - 1))).ToList();
+                if (s3Objects.Count > 1)
                 { // Ensure HasChild property
-                    filesS3 = response.S3Objects.Where(x => (x.Key != RootName && x.Key.Split("/")[x.Key.Split("/").Length - 1].ToLower().Contains(searchString.TrimStart(j).TrimEnd(j).ToLower()))).Select(y =>
-                    CreateDirectoryContentInstance(y.Key.Split("/").Last(), true, Path.GetExtension(y.Key.ToString()), y.Size, y.LastModified, y.LastModified, false, y.Key.Substring(0, y.Key.Length - y.Key.Split("/")[y.Key.Split("/").Length - 1].Length).Substring(RootName.Length - 1))).ToList();
+                    filesS3 = s3Objects.Where(x => (x.Key != RootName && x.Key.Split("/")[x.Key.Split("/").Length - 1].ToLower().Contains(searchString.TrimStart(j).TrimEnd(j).ToLower()))).Select(y =>
+                    CreateDirectoryContentInstance(y.Key.Split("/").Last(), true, Path.GetExtension(y.Key.ToString()), y.Size ?? 0, y.LastModified ?? DateTime.MinValue, y.LastModified ?? DateTime.MinValue, false, y.Key.Substring(0, y.Key.Length - y.Key.Split("/")[y.Key.Split("/").Length - 1].Length).Substring(RootName.Length - 1))).ToList();
                 }
-                if (response.CommonPrefixes.Count > 0) getChildObjects(response.CommonPrefixes, false, searchString);
+                if (commonPrefixes.Count > 0) getChildObjects(commonPrefixes, false, searchString);
                 if (filesS3.Count != 0) files = files.Union(filesS3).ToList();
                 if (s3ObjectFiles.Count != 0) files = files.Union(s3ObjectFiles).ToList();
                 searchResponse.Files = files;
@@ -510,7 +535,7 @@ namespace Syncfusion.EJ2.FileManager.AmazonS3FileProvider
             List<FileManagerDirectoryContent> files = new List<FileManagerDirectoryContent>();
             if (checkFileExist(path, newName))
             {
-                ErrorDetails er = new ErrorDetails();
+                var er = new Syncfusion.EJ2.FileManager.Base.ErrorDetails();
                 er.Code = "400";
                 er.Message = "Cannot rename " + name + " to " + newName + ": destination already exists.";
                 renameResponse.Error = er;
@@ -524,26 +549,30 @@ namespace Syncfusion.EJ2.FileManager.AmazonS3FileProvider
                     GetBucketList();
                     FileManagerResponse readResponse = new FileManagerResponse();
                     if (path == "/") ListingObjectsAsync("/", RootName, false).Wait(); else ListingObjectsAsync("/", this.RootName.Replace("/", "") + path, false).Wait();
+                    var s3Objects = response.S3Objects ?? new List<S3Object>();
+                    var commonPrefixes = response.CommonPrefixes ?? new List<string>();
                     if (path == "/")
-                        cwd = response.S3Objects.Where(x => x.Key == RootName).Select(y => CreateDirectoryContentInstance(y.Key.ToString().Replace("/", ""), true, "folder", y.Size, new DateTime(), new DateTime(), false, "")).ToArray()[0];
-                    else if (response.CommonPrefixes.Count > 0)
-                        cwd = CreateDirectoryContentInstance(path.Split("/")[path.Split("/").Length - 2], false, "Folder", 0, new DateTime(), new DateTime(), (response.CommonPrefixes.Count > 0) ? true : false, "");
+                        cwd = s3Objects.Where(x => x.Key == RootName).Select(y => CreateDirectoryContentInstance(y.Key.ToString().Replace("/", ""), true, "folder", y.Size ?? 0, new DateTime(), new DateTime(), false, "")).ToArray()[0];
+                    else if (commonPrefixes.Count > 0)
+                        cwd = CreateDirectoryContentInstance(path.Split("/")[path.Split("/").Length - 2], false, "Folder", 0, new DateTime(), new DateTime(), (commonPrefixes.Count > 0) ? true : false, "");
                     GetBucketList();
                     if (path == "/") ListingObjectsAsync("/", RootName, false).Wait(); else ListingObjectsAsync("/", this.RootName.Replace("/", "") + path, false).Wait();
-                    if (response.CommonPrefixes.Count > 1)
+                    var innerPrefixes = response.CommonPrefixes ?? new List<string>();
+                    var innerObjects = response.S3Objects ?? new List<S3Object>();
+                    if (innerPrefixes.Count > 1)
                     {
-                        foreach (string commonPrefix in response.CommonPrefixes)
+                        foreach (string commonPrefix in innerPrefixes)
                         {
                             if (commonPrefix == this.RootName.Replace("/", "") + path + newName + "/")
                                 files.Add(CreateDirectoryContentInstance(commonPrefix.Split("/")[commonPrefix.Split("/").Length - 2], false, "Folder", 0, new DateTime(), new DateTime(), false, ""));
                         }
                     }
-                    if (response.S3Objects.Count > 1)
+                    if (innerObjects.Count > 1)
                     {
-                        foreach (S3Object S3Object in response.S3Objects)
+                        foreach (S3Object S3Object in innerObjects)
                         {
                             if (S3Object.Key == this.RootName.Replace("/", "") + path + newName)
-                                files.Add(CreateDirectoryContentInstance(S3Object.Key.Split("/").Last(), true, Path.GetExtension(S3Object.Key), S3Object.Size, S3Object.LastModified, S3Object.LastModified, false, ""));
+                                files.Add(CreateDirectoryContentInstance(S3Object.Key.Split("/").Last(), true, Path.GetExtension(S3Object.Key), S3Object.Size ?? 0, S3Object.LastModified ?? DateTime.MinValue, S3Object.LastModified ?? DateTime.MinValue, false, ""));
                         }
                     }
                 }
@@ -646,7 +675,7 @@ namespace Syncfusion.EJ2.FileManager.AmazonS3FileProvider
                             }
                             else
                             {
-                                ErrorDetails er = new ErrorDetails();
+                                var er = new Syncfusion.EJ2.FileManager.Base.ErrorDetails();
                                 er.Code = "404";
                                 er.Message = "File not found.";
                                 uploadResponse.Error = er;
@@ -656,7 +685,7 @@ namespace Syncfusion.EJ2.FileManager.AmazonS3FileProvider
                 }
                 if (existFiles.Count != 0)
                 {
-                    ErrorDetails er = new ErrorDetails();
+                    var er = new Syncfusion.EJ2.FileManager.Base.ErrorDetails();
                     er.FileExists = existFiles;
                     er.Code = "400";
                     er.Message = "File Already Exists";
@@ -675,7 +704,13 @@ namespace Syncfusion.EJ2.FileManager.AmazonS3FileProvider
                 GetBucketList();
                 ListingObjectsAsync("/", RootName.Replace("/", "") + path, false).Wait();
                 string fileName = path.ToString().Split("/").Last();
-                Stream stream = fileTransferUtility.OpenStream(bucketName, RootName.Replace("/", "") + path);
+                var streamRequest = new TransferUtilityOpenStreamRequest
+                {
+                    BucketName = bucketName,
+                    Key = RootName.Replace("/", "") + path
+                };
+                var streamResponse = fileTransferUtility.OpenStreamWithResponseAsync(streamRequest).GetAwaiter().GetResult();
+                Stream stream = streamResponse.ResponseStream;
                 return new FileStreamResult(stream, "APPLICATION/octet-stream");
             }
             catch (Exception ex) { throw ex; }
@@ -696,13 +731,20 @@ namespace Syncfusion.EJ2.FileManager.AmazonS3FileProvider
                 GetBucketList();
                 ListingObjectsAsync("/", RootName.Replace("/", "") + path + Names[0], false).Wait();
             }
-            if (Names.Length == 1 && response.CommonPrefixes.Count == 0)
+            var commonPrefixes = response.CommonPrefixes ?? new List<string>();
+            if (Names.Length == 1 && commonPrefixes.Count == 0)
             {
                 try
                 {
                     GetBucketList();
                     ListingObjectsAsync("/", RootName.Replace("/", "") + path, false).Wait();
-                    Stream stream = await fileTransferUtility.OpenStreamAsync(bucketName, RootName.Replace("/", "") + path + Names[0]);
+                    var streamRequest = new TransferUtilityOpenStreamRequest
+                    {
+                        BucketName = bucketName,
+                        Key = RootName.Replace("/", "") + path + Names[0]
+                    };
+                    var streamResponse = await fileTransferUtility.OpenStreamWithResponseAsync(streamRequest);
+                    Stream stream = streamResponse.ResponseStream;
                     fileStreamResult = new FileStreamResult(stream, "APPLICATION/octet-stream");
                     fileStreamResult.FileDownloadName = Names[0].Contains("/") ? Names[0].Split("/").Last() : Names[0];
                 }
@@ -721,7 +763,8 @@ namespace Syncfusion.EJ2.FileManager.AmazonS3FileProvider
                         fileName = (Names[0].Contains("/")) ? Path.Combine(tempFolder, folderName.Split("/").Last()) : Path.Combine(tempFolder, folderName.Split("/").Last());
                         GetBucketList();
                         ListingObjectsAsync("/", RootName.Replace("/", "") + path + folderName, false).Wait();
-                        if (response.CommonPrefixes.Count == 0)
+                        var innerPrefixes = response.CommonPrefixes ?? new List<string>();
+                        if (innerPrefixes.Count == 0)
                         {
                             if (Directory.Exists(fileName)) Directory.Delete(fileName); else if (System.IO.File.Exists(fileName)) System.IO.File.Delete(fileName);
                             FileStream fs = System.IO.File.Create(fileName);
@@ -762,7 +805,8 @@ namespace Syncfusion.EJ2.FileManager.AmazonS3FileProvider
                 {
                     ListObjectsRequest listObjectsRequest = new ListObjectsRequest { BucketName = bucketName, Prefix = RootName.Replace("/", "") + path + name + (String.IsNullOrEmpty(Path.GetExtension(name)) ? "/" : ""), Delimiter = String.IsNullOrEmpty(Path.GetExtension(name)) ? null : "/" };
                     ListObjectsResponse listObjectsResponse = await client.ListObjectsAsync(listObjectsRequest);
-                    foreach (S3Object s3Object in listObjectsResponse.S3Objects) { deleteObjectsRequest.AddKey(s3Object.Key); }
+                    var s3Objects = listObjectsResponse.S3Objects ?? new List<S3Object>();
+                    foreach (S3Object s3Object in s3Objects) { deleteObjectsRequest.AddKey(s3Object.Key); }
                 }
                 await client.DeleteObjectsAsync(deleteObjectsRequest);
                 ListingObjectsAsync("/", RootName.Replace("/", "") + path + names[0], false).Wait();
@@ -780,14 +824,15 @@ namespace Syncfusion.EJ2.FileManager.AmazonS3FileProvider
                 do
                 {
                     ListObjectsResponse listObjectsResponse = await client.ListObjectsAsync(listObjectsRequest);
-                    foreach (S3Object s3Object in listObjectsResponse.S3Objects)
+                    var s3Objects = listObjectsResponse.S3Objects ?? new List<S3Object>();
+                    foreach (S3Object s3Object in s3Objects)
                     {
                         string newKey = s3Object.Key.Replace(!isFile ? sourceKey : sourceKey.Substring(0, sourceKey.Length - 1), !isFile ? destinationKey : destinationKey.Substring(0, destinationKey.Length - 1));
                         CopyObjectRequest copyObjectRequest = new CopyObjectRequest() { SourceBucket = bucketName, DestinationBucket = bucketName, SourceKey = s3Object.Key, DestinationKey = newKey };
                         CopyObjectResponse copyObectResponse = await client.CopyObjectAsync(copyObjectRequest);
                         if (deleteS3Objects) deleteObjectsRequest.AddKey(s3Object.Key);
                     }
-                    if (listObjectsResponse.IsTruncated) listObjectsRequest.Marker = listObjectsResponse.NextMarker; else listObjectsRequest = null;
+                    if (listObjectsResponse.IsTruncated ?? false) listObjectsRequest.Marker = listObjectsResponse.NextMarker; else listObjectsRequest = null;
                 } while (listObjectsRequest != null);
                 await client.DeleteObjectsAsync(deleteObjectsRequest);
             }
@@ -803,22 +848,24 @@ namespace Syncfusion.EJ2.FileManager.AmazonS3FileProvider
                 {
                     ListingObjectsAsync("/", commonPrefix, false).Wait();
                     char[] j = new Char[] { '*' };
-                    foreach (S3Object s3Key in response.S3Objects)
+                    var s3Objects = response.S3Objects ?? new List<S3Object>();
+                    var innerPrefixes = response.CommonPrefixes ?? new List<string>();
+                    foreach (S3Object s3Key in s3Objects)
                     {
                         if (isDetailsRequest)
-                            sizeValue = sizeValue + s3Key.Size;
+                            sizeValue = sizeValue + (s3Key.Size ?? 0);
                         else if (s3Key.Key != RootName && s3Key.Key.Split("/")[s3Key.Key.Split("/").Length - 1].ToLower().Contains(searchString.TrimStart(j).TrimEnd(j).ToLower()))
                         {
-                            FileManagerDirectoryContent innerFiles = CreateDirectoryContentInstance(s3Key.Key.Split("/").Last(), true, Path.GetExtension(s3Key.Key.ToString()), s3Key.Size, s3Key.LastModified, s3Key.LastModified, false, s3Key.Key.Substring(0, s3Key.Key.Length - s3Key.Key.Split("/")[s3Key.Key.Split("/").Length - 1].Length).Substring(RootName.Length - 1));
+                            FileManagerDirectoryContent innerFiles = CreateDirectoryContentInstance(s3Key.Key.Split("/").Last(), true, Path.GetExtension(s3Key.Key.ToString()), s3Key.Size ?? 0, s3Key.LastModified ?? DateTime.MinValue, s3Key.LastModified ?? DateTime.MinValue, false, s3Key.Key.Substring(0, s3Key.Key.Length - s3Key.Key.Split("/")[s3Key.Key.Split("/").Length - 1].Length).Substring(RootName.Length - 1));
                             s3ObjectFiles.Add(innerFiles);
                         }
                     }
-                    if (response.CommonPrefixes.Count > 0)
+                    if (innerPrefixes.Count > 0)
                     {
-                        List<FileManagerDirectoryContent> innerFiles = response.CommonPrefixes.Where(x => x.Split("/")[x.Split("/").Length - 2].ToLower().Contains(searchString.TrimStart(j).TrimEnd(j).ToLower())).Select(x =>
+                        List<FileManagerDirectoryContent> innerFiles = innerPrefixes.Where(x => x.Split("/")[x.Split("/").Length - 2].ToLower().Contains(searchString.TrimStart(j).TrimEnd(j).ToLower())).Select(x =>
                         CreateDirectoryContentInstance(x.Split("/")[x.Split("/").Length - 2], false, "Folder", 0, new DateTime(), new DateTime(), this.checkChild(x), x.Substring(0, x.Length - x.Split("/")[x.Split("/").Length - 2].Length - 1).Substring(RootName.Length - 1))).ToList();
                         if (innerFiles.Count > 0) s3ObjectFiles = s3ObjectFiles != null ? s3ObjectFiles.Union(innerFiles).ToList() : innerFiles;
-                        this.getChildObjects(response.CommonPrefixes, isDetailsRequest, searchString);
+                        this.getChildObjects(innerPrefixes, isDetailsRequest, searchString);
                     }
                 }
             }
@@ -841,7 +888,8 @@ namespace Syncfusion.EJ2.FileManager.AmazonS3FileProvider
         public bool checkChild(string path)
         {
             try { ListingObjectsAsync("/", path, true).Wait(); } catch (AmazonS3Exception amazonS3Exception) { throw amazonS3Exception; }
-            return childResponse.CommonPrefixes.Count > 0 ? true : false;
+            var commonPrefixes = childResponse.CommonPrefixes ?? new List<string>();
+            return commonPrefixes.Count > 0 ? true : false;
         }
 
         public static async Task ListingObjectsAsync(string delimiter, string prefix, bool childCheck)

--- a/services/filesystem-provider/ej2-amazon-s3-aspcore-file-provider/Models/AmazonS3FileProvider.cs
+++ b/services/filesystem-provider/ej2-amazon-s3-aspcore-file-provider/Models/AmazonS3FileProvider.cs
@@ -710,7 +710,7 @@ namespace Syncfusion.EJ2.FileManager.AmazonS3FileProvider
                     Key = RootName.Replace("/", "") + path
                 };
                 var streamResponse = fileTransferUtility.OpenStreamWithResponseAsync(streamRequest).GetAwaiter().GetResult();
-                Stream stream = streamResponse.ResponseStream;
+                Stream stream = new DisposableStream(streamResponse.ResponseStream, streamResponse);
                 return new FileStreamResult(stream, "APPLICATION/octet-stream");
             }
             catch (Exception ex) { throw ex; }
@@ -744,7 +744,7 @@ namespace Syncfusion.EJ2.FileManager.AmazonS3FileProvider
                         Key = RootName.Replace("/", "") + path + Names[0]
                     };
                     var streamResponse = await fileTransferUtility.OpenStreamWithResponseAsync(streamRequest);
-                    Stream stream = streamResponse.ResponseStream;
+                    Stream stream = new DisposableStream(streamResponse.ResponseStream, streamResponse);
                     fileStreamResult = new FileStreamResult(stream, "APPLICATION/octet-stream");
                     fileStreamResult.FileDownloadName = Names[0].Contains("/") ? Names[0].Split("/").Last() : Names[0];
                 }
@@ -915,6 +915,66 @@ namespace Syncfusion.EJ2.FileManager.AmazonS3FileProvider
         public string ToCamelCase(FileManagerResponse userData)
         {
             return JsonConvert.SerializeObject(userData, new JsonSerializerSettings { ContractResolver = new DefaultContractResolver { NamingStrategy = new CamelCaseNamingStrategy() } });
+        }
+    }
+
+    internal class DisposableStream : Stream, IAsyncDisposable
+    {
+        private readonly Stream _stream;
+        private readonly IDisposable _disposable;
+
+        public DisposableStream(Stream stream, IDisposable disposable)
+        {
+            _stream = stream ?? throw new ArgumentNullException(nameof(stream));
+            _disposable = disposable ?? throw new ArgumentNullException(nameof(disposable));
+        }
+
+        public override bool CanRead => _stream.CanRead;
+        public override bool CanSeek => _stream.CanSeek;
+        public override bool CanWrite => _stream.CanWrite;
+        public override long Length => _stream.Length;
+        public override long Position
+        {
+            get => _stream.Position;
+            set => _stream.Position = value;
+        }
+
+        public override void Flush() => _stream.Flush();
+        public override Task FlushAsync(System.Threading.CancellationToken cancellationToken) => _stream.FlushAsync(cancellationToken);
+        
+        public override int Read(byte[] buffer, int offset, int count) => _stream.Read(buffer, offset, count);
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, System.Threading.CancellationToken cancellationToken) => _stream.ReadAsync(buffer, offset, count, cancellationToken);
+        
+        public override long Seek(long offset, SeekOrigin origin) => _stream.Seek(offset, origin);
+        public override void SetLength(long value) => _stream.SetLength(value);
+        
+        public override void Write(byte[] buffer, int offset, int count) => _stream.Write(buffer, offset, count);
+        public override Task WriteAsync(byte[] buffer, int offset, int count, System.Threading.CancellationToken cancellationToken) => _stream.WriteAsync(buffer, offset, count, cancellationToken);
+
+        public override Task CopyToAsync(Stream destination, int bufferSize, System.Threading.CancellationToken cancellationToken) => _stream.CopyToAsync(destination, bufferSize, cancellationToken);
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _stream.Dispose();
+                _disposable.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        public override async ValueTask DisposeAsync()
+        {
+            await _stream.DisposeAsync().ConfigureAwait(false);
+            if (_disposable is IAsyncDisposable asyncDisposable)
+            {
+                await asyncDisposable.DisposeAsync().ConfigureAwait(false);
+            }
+            else
+            {
+                _disposable.Dispose();
+            }
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/services/filesystem-provider/ej2-amazon-s3-aspcore-file-provider/Models/AmazonS3FileProvider.cs
+++ b/services/filesystem-provider/ej2-amazon-s3-aspcore-file-provider/Models/AmazonS3FileProvider.cs
@@ -748,13 +748,21 @@ namespace Syncfusion.EJ2.FileManager.AmazonS3FileProvider
                     fileStreamResult = new FileStreamResult(stream, "APPLICATION/octet-stream");
                     fileStreamResult.FileDownloadName = Names[0].Contains("/") ? Names[0].Split("/").Last() : Names[0];
                 }
-                catch (AmazonS3Exception amazonS3Exception) { throw amazonS3Exception; }
+                catch (AmazonS3Exception amazonS3Exception)
+                {
+                    if (amazonS3Exception.StatusCode == System.Net.HttpStatusCode.NotFound || amazonS3Exception.ErrorCode == "NoSuchKey")
+                    {
+                        return null;
+                    }
+                    throw amazonS3Exception;
+                }
             }
             else
             {
                 try
                 {
-                    string tempFolder = Path.Combine(Path.GetTempPath(), "tempFolder");
+                    string uniqueId = Guid.NewGuid().ToString();
+                    string tempFolder = Path.Combine(Path.GetTempPath(), "tempFolder_" + uniqueId);
                     if (System.IO.File.Exists(tempFolder)) System.IO.File.Delete(tempFolder); else if (Directory.Exists(tempFolder)) Directory.Delete(tempFolder, true);
                     Directory.CreateDirectory(tempFolder);
                     foreach (string folderName in Names)
@@ -781,12 +789,12 @@ namespace Syncfusion.EJ2.FileManager.AmazonS3FileProvider
                                 fileTransferUtility.DownloadDirectory(bucketName, RootName.Replace("/", "") + path + folderName, fileName);
                         }
                     }
-                    string tempPath = Path.Combine(Path.GetTempPath(), "tempFolder.zip");
+                    string tempPath = Path.Combine(Path.GetTempPath(), "tempFolder_" + uniqueId + ".zip");
                     ZipFile.CreateFromDirectory(tempFolder, tempPath);
                     FileStream fileStreamInput = new FileStream(tempPath, FileMode.Open, FileAccess.Read, FileShare.Delete);
                     fileStreamResult = new FileStreamResult(fileStreamInput, "APPLICATION/octet-stream");
                     fileStreamResult.FileDownloadName = "Files.zip";
-                    if (System.IO.File.Exists(Path.Combine(Path.GetTempPath(), "tempFolder.zip"))) System.IO.File.Delete(Path.Combine(Path.GetTempPath(), "tempFolder.zip"));
+                    if (System.IO.File.Exists(tempPath)) System.IO.File.Delete(tempPath);
                     if (System.IO.File.Exists(tempFolder)) System.IO.File.Delete(tempFolder); else if (Directory.Exists(tempFolder)) Directory.Delete(tempFolder, true);
                 }
                 catch (AmazonS3Exception amazonS3Exception) { throw amazonS3Exception; }

--- a/services/filesystem-provider/ej2-amazon-s3-aspcore-file-provider/Startup.cs
+++ b/services/filesystem-provider/ej2-amazon-s3-aspcore-file-provider/Startup.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using System.Security.Claims;
@@ -21,6 +21,7 @@ using System.Collections.Specialized;
 using Microsoft.AspNetCore.Http;
 using System.Web;
 using Syncfusion.Licensing;
+using Microsoft.Extensions.Caching.Distributed;
 
 namespace EJ2FileManagerService
 {
@@ -39,7 +40,23 @@ namespace EJ2FileManagerService
 
 
 
-            services.AddMemoryCache();
+            string redisHost = System.Environment.GetEnvironmentVariable("CACHE_REDIS_HOST");
+            string redisPass = System.Environment.GetEnvironmentVariable("CACHE_REDIS_PASS");
+
+            if (!string.IsNullOrEmpty(redisHost))
+            {
+                services.AddStackExchangeRedisCache(options =>
+                {
+                    options.Configuration = string.IsNullOrEmpty(redisPass)
+                        ? $"{redisHost}:6379"
+                        : $"{redisHost}:6379,password={redisPass}";
+                    options.InstanceName = "FilesystemProvider:";
+                });
+            }
+            else
+            {
+                services.AddDistributedMemoryCache();
+            }
             services.AddMvc(options => options.EnableEndpointRouting = false).SetCompatibilityVersion(CompatibilityVersion.Version_3_0);
             services.AddCors(options =>
             {


### PR DESCRIPTION
## Description
This PR addresses the intermittent failures and pod restarts associated with the Core file viewer. Previously, the file viewer used `IMemoryCache` (in-memory caching of loaded files), which caused serving pods to exceed their memory limits and get OOM-killed (restarted) under heavy load.

To resolve this:
1. migrated the cache layer to use a distributed Redis cache (`IDistributedCache`), which offloads the RAM overhead to a dedicated Redis instance and supports state sharing across scaled pods.
2. upgraded the `AWSSDK.S3` dependency to `4.0.17` and implemented null-safety adjustments required by the newer SDK types.
3. resolved a concurrency issue during folder downloads by using request-scoped unique temp directories (`Guid`).
4. added elegant exception handling for missing S3 objects (404/NoSuchKey) to return a graceful `NotFound` result instead of an unhandled `500` error.

## Related Tickets & PRs
- GitOps PR: (Insert GitOps PR Link here)

## Acceptance Criteria Checklist
- [x] Memory cache is moved to Redis from internal pod memory.
- [x] Safe fallback to local in-memory caching is maintained for local development.
- [x] Pods can scale seamlessly without cache inconsistency.

## Changes Made
- **[Startup.cs](file:///home/mat/Code/mds/services/filesystem-provider/ej2-amazon-s3-aspcore-file-provider/Startup.cs)**: Updated service registration to use StackExchange Redis Cache when `CACHE_REDIS_HOST` is present; falls back to `AddDistributedMemoryCache` for local development.
- **[PdfViewerController.cs](file:///home/mat/Code/mds/services/filesystem-provider/ej2-amazon-s3-aspcore-file-provider/Controllers/PdfViewerController.cs)**: Swapped `IMemoryCache` injection for `IDistributedCache`. Modified `ImportAnnotations` to fetch files directly from S3 using the file provider client, removing state reliance on local pod filesystems.
- **[AmazonS3FileProvider.cs](file:///home/mat/Code/mds/services/filesystem-provider/ej2-amazon-s3-aspcore-file-provider/Models/AmazonS3FileProvider.cs)**:
  - Configured `TransferUtility` with `ConcurrentServiceRequests = 10` for optimized parallel uploads and directory downloads.
  - Implemented request-scoped temporary directories using `Guid` to prevent parallel download conflict errors.
  - Added null safety checks for metadata and size properties required by `AWSSDK.S3` version 4.
  - Handled `AmazonS3Exception` (404/NoSuchKey) to return `null` instead of throwing unhandled exceptions.
- **[EJ2AmazonS3ASPCoreFileProvider.csproj](file:///home/mat/Code/mds/services/filesystem-provider/ej2-amazon-s3-aspcore-file-provider/EJ2AmazonS3ASPCoreFileProvider.csproj)**: Upgraded `AWSSDK.S3` package to `4.0.17` and added `Microsoft.Extensions.Caching.StackExchangeRedis` version `7.0.7`.

## How to Test
1. Run the application locally (without `CACHE_REDIS_HOST` env set) and verify the file viewer functions correctly using the local in-memory fallback.
2. Run with a local Redis connection and inspect keys starting with `FilesystemProvider:` as documents are viewed.
3. Test loading a non-existent document key and verify the response is a graceful HTTP `404` instead of a `500` server exception.
4. Execute concurrent folder downloads to verify that unique Guid-based temp directories are created and cleaned up without locking errors.
