### PR TITLE
[MDS-6962] - Upgrade tusd to latest version

### DIFF
--- a/services/tusd/Dockerfile
+++ b/services/tusd/Dockerfile
@@ -1,4 +1,4 @@
-FROM tusproject/tusd:v1.3.0
+FROM tusproject/tusd:v2.10.0
 
 COPY init.sh .
 COPY ./hooks/post-finish ./hooks/
@@ -8,9 +8,7 @@ USER root
 RUN chmod +x ./hooks/post-finish
 
 RUN apk add --no-cache curl \
-    && apk add --no-cache python3 \
-    && pip3 install --upgrade pip \
-    && pip3 install awscli \
+    && apk add --no-cache aws-cli \
     && apk add --no-cache jq \
     && chmod +x ./hooks/post-finish
 

--- a/services/tusd/Dockerfile.ci
+++ b/services/tusd/Dockerfile.ci
@@ -1,4 +1,4 @@
-FROM tusproject/tusd:v1.3.0
+FROM tusproject/tusd:v2.10.0
 
 COPY init.sh .
 COPY ./hooks/post-finish ./hooks/
@@ -8,9 +8,7 @@ USER root
 RUN chmod +x ./hooks/post-finish
 
 RUN apk add --no-cache curl \
-    && apk add --no-cache python3 \
-    && pip3 install --upgrade pip \
-    && pip3 install awscli \
+    && apk add --no-cache aws-cli \
     && apk add --no-cache jq \
     && chmod +x ./hooks/post-finish
 

--- a/services/tusd/hooks/post-finish
+++ b/services/tusd/hooks/post-finish
@@ -44,4 +44,4 @@ else
   json_data=$(echo "{\"Upload\": $upload}" | tr -d '\r\n' | tr -d '\0')
 fi
 
-curl -X POST -H "Content-Type: application/json" -H "$headers" -H "Hook-Name: post-finish" -d "$json_data" $DOCUMENT_MANAGER_URL/tusd-hooks
+curl --retry 5 --retry-delay 2 --retry-all-errors -X POST -H "Content-Type: application/json" -H "$headers" -H "Hook-Name: post-finish" -d "$json_data" $DOCUMENT_MANAGER_URL/tusd-hooks

--- a/services/tusd/hooks/post-finish
+++ b/services/tusd/hooks/post-finish
@@ -12,13 +12,13 @@ export S3_PREFIX=$S3_PREFIX
 read -r stdin_data
 
 # Extract the Upload object from the JSON-encoded object
-upload=$(echo "$stdin_data" | jq -r '.Upload')
+upload=$(echo "$stdin_data" | jq -r '.Event.Upload')
 
 # check if the upload object has version_guid in MetaData
 version_guid=$(echo "$upload" | jq -r '.MetaData."version_guid"')
 
 # Extract all the HTTP headers from the JSON-encoded object
-headers=$(echo "$stdin_data" | jq -r '.HTTPRequest.Header | to_entries | map("\(.key): \(.value | join(","))") | join("\n")')
+headers=$(echo "$stdin_data" | jq -r '.Event.HTTPRequest.Header | to_entries | map("\(.key): \(.value | join(","))") | join("\n")')
 
 # Extract the ID and Size properties from the Upload object
 id=$(echo "$upload" | jq -r '.ID')

--- a/services/tusd/init.sh
+++ b/services/tusd/init.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 chmod +x ./hooks/post-finish
-tusd -s3-endpoint=${S3_ENDPOINT} -s3-bucket=${S3_BUCKET_ID} -s3-object-prefix=${S3_PREFIX} --hooks-enabled-events post-finish --hooks-dir ./hooks --hooks-http ${DOCUMENT_MANAGER_URL}/tusd-hooks --hooks-http-retry 5 --hooks-http-backoff 2 -hooks-http-forward-headers=Authorization
+tusd -port 1080 -s3-endpoint=${S3_ENDPOINT} -s3-bucket=${S3_BUCKET_ID} -s3-object-prefix=${S3_PREFIX} --hooks-enabled-events post-finish --hooks-dir ./hooks


### PR DESCRIPTION
## Objective 
# Upgrade `tusd` service to v2.10.0

## Summary
Upgrades the `tusd` resumable upload server from `v1.3.0` to the latest `v2.10.0` release. This upgrade brings improved network resilience, updated protocol support, and security fixes while maintaining full compatibility with the existing Document Manager backend API.

---

## Key Changes & Rationale

### 1. Base Image & Dependency Package Management (`Dockerfile` & `Dockerfile.ci`)
* **Base Image Update**: Updated base image tag from `tusproject/tusd:v1.3.0` to `tusproject/tusd:v2.10.0`.
* **Alpine Package Optimization**: Replaced `python3`/`pip3` installation of `awscli` with Alpine's native `aws-cli` package (`apk add --no-cache aws-cli`). 
  * *Rationale*: Newer Alpine releases used in `tusd` v2 images split `python3` and `pip`, causing `pip3` installation commands to fail. Installing `aws-cli` via `apk` is cleaner, faster, and avoids managing Python virtual environments or `pip` system package flags.

### 2. Startup CLI Configuration (`init.sh`)
* **Explicit Port Flag (`-port 1080`)**: Added `-port 1080` to the `tusd` execution flags.
  * *Rationale*: `tusd` v2 changed its default listening port from `1080` to `8080`. Passing `-port 1080` preserves existing container port bindings and deployment routing.
* **CLI Hook Cleanup**: Removed deprecated `--hooks-http`, `--hooks-http-retry`, `--hooks-http-backoff`, and `-hooks-http-forward-headers` CLI flags.
  * *Rationale*: `tusd` v2 restricts CLI hook configuration to a single backend mechanism per process. Since our architecture uses the file hook system (`--hooks-dir ./hooks`), the `post-finish` executable shell script handles the `curl` POST request to `$DOCUMENT_MANAGER_URL/tusd-hooks` directly, making duplicate HTTP hook flags redundant.

### 3. Hook Event Payload Schema Update (`hooks/post-finish`)
* **Updated `jq` Selectors**: Modified `jq` queries in `./hooks/post-finish`:
  * `.Upload` ➔ `.Event.Upload`
  * `.HTTPRequest.Header` ➔ `.Event.HTTPRequest.Header`
  * *Rationale*: `tusd` v2 redesigned its hook event JSON structure to wrap upload and HTTP context inside an `Event` object (`{"Type": "post-finish", "Event": {"Upload": ..., "HTTPRequest": ...}}`). Updating the selectors ensures upload metadata and authentication headers (`Authorization`) are properly parsed and forwarded to the Document Manager endpoint.

---

## Testing & Verification

- [x] **Container Build**: Built `mds-tusd:latest` image successfully using `docker-compose build tusd`.
- [x] **Startup Verification**: Confirmed `tusd` container initializes on port `1080` with file hooks registered for `post-finish` events.
- [x] **Hook Execution Test**: Verified end-to-end hook execution inside the container by supplying a mock v2 event payload to `./hooks/post-finish` and validating that headers and payload were extracted and posted to `document_manager_backend`.

[MDS-](https://bcmines.atlassian.net/browse/MDS-0000)

_Why are you making this change? Provide a short explanation and/or screenshots_
