### PR TITLE
[MDS-6962] - Update formatting of shared s3 endpoint variable in tusd

### DIFF
--- a/services/tusd/hooks/post-finish
+++ b/services/tusd/hooks/post-finish
@@ -1,7 +1,11 @@
 #!/bin/sh
 
+# tusd reads this script's stdout and tries to parse it as a JSON
+# HookResponse; anything else logs as a HookInvocationError even on success.
+# Keep all diagnostic output on stderr so stdout stays empty.
+
 # print a message to the tusd log
-echo "post-finish hook called"
+echo "post-finish hook called" >&2
 
 # Set the AWS credentials
 export AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID
@@ -17,14 +21,17 @@ upload=$(echo "$stdin_data" | jq -r '.Event.Upload')
 # check if the upload object has version_guid in MetaData
 version_guid=$(echo "$upload" | jq -r '.MetaData."version_guid"')
 
-# Extract all the HTTP headers from the JSON-encoded object
-headers=$(echo "$stdin_data" | jq -r '.Event.HTTPRequest.Header | to_entries | map("\(.key): \(.value | join(","))") | join("\n")')
+# Only forward the Authorization header from the original request - the
+# tusd-hooks endpoint requires it for auth and reads nothing else. Forwarding
+# the full raw header set (previous behavior) included Host, which corrupts
+# the outgoing request to document-manager.
+authorization=$(echo "$stdin_data" | jq -r '.Event.HTTPRequest.Header.Authorization[0] // empty')
 
 # Extract the ID and Size properties from the Upload object
 id=$(echo "$upload" | jq -r '.ID')
 size=$(echo "$upload" | jq -r '.Size')
 
-echo "Upload ID $id ($size bytes) finished"
+echo "Upload ID $id ($size bytes) finished" >&2
 
 S3_PREFIX_CLEAN=$(echo $S3_PREFIX | sed 's/\/$//')
 storageKey="$S3_PREFIX_CLEAN$(echo "$upload" | jq -r '.MetaData.path')"
@@ -35,7 +42,7 @@ if [ $version_guid != "null" ]; then
 
   aws_exit_code=$?
   if [ $aws_exit_code -ne 0 ]; then
-    echo "aws command failed with exit code $aws_exit_code"
+    echo "aws command failed with exit code $aws_exit_code" >&2
   fi
 
   # Forward the request through the hooks-http option
@@ -44,4 +51,4 @@ else
   json_data=$(echo "{\"Upload\": $upload}" | tr -d '\r\n' | tr -d '\0')
 fi
 
-curl --retry 5 --retry-delay 2 --retry-all-errors -X POST -H "Content-Type: application/json" -H "$headers" -H "Hook-Name: post-finish" -d "$json_data" $DOCUMENT_MANAGER_URL/tusd-hooks
+curl -s -o /dev/null -w "tusd-hooks response status: %{http_code}\n" --retry 5 --retry-delay 2 --retry-all-errors -X POST -H "Content-Type: application/json" -H "Authorization: $authorization" -H "Hook-Name: post-finish" -d "$json_data" $DOCUMENT_MANAGER_URL/tusd-hooks >&2

--- a/services/tusd/hooks/post-finish
+++ b/services/tusd/hooks/post-finish
@@ -51,4 +51,13 @@ else
   json_data=$(echo "{\"Upload\": $upload}" | tr -d '\r\n' | tr -d '\0')
 fi
 
-curl -s -o /dev/null -w "tusd-hooks response status: %{http_code}\n" --retry 5 --retry-delay 2 --retry-all-errors -X POST -H "Content-Type: application/json" -H "Authorization: $authorization" -H "Hook-Name: post-finish" -d "$json_data" $DOCUMENT_MANAGER_URL/tusd-hooks >&2
+response=$(curl -s -w "\n%{http_code}" --retry 5 --retry-delay 2 --retry-all-errors -X POST -H "Content-Type: application/json" -H "Authorization: $authorization" -H "Hook-Name: post-finish" -d "$json_data" $DOCUMENT_MANAGER_URL/tusd-hooks)
+status=$(echo "$response" | tail -n1)
+body=$(echo "$response" | sed '$d')
+
+if [ "$status" -lt 200 ] || [ "$status" -ge 300 ]; then
+  echo "tusd-hooks request failed with status $status: $body" >&2
+  exit 1
+fi
+
+echo "tusd-hooks request succeeded with status $status" >&2

--- a/services/tusd/init.sh
+++ b/services/tusd/init.sh
@@ -1,4 +1,14 @@
 #!/bin/sh
 
 chmod +x ./hooks/post-finish
-tusd -port 1080 -s3-endpoint=${S3_ENDPOINT} -s3-bucket=${S3_BUCKET_ID} -s3-object-prefix=${S3_PREFIX} --hooks-enabled-events post-finish --hooks-dir ./hooks
+
+# aws-sdk-go-v2 requires the S3 endpoint to be a full URI including scheme.
+# S3_ENDPOINT is shared with other services (docman, filesystem-provider, etc.)
+# that expect a bare hostname and prepend the scheme themselves, so default to
+# https:// here rather than changing what the shared value looks like.
+case "${S3_ENDPOINT}" in
+  http://*|https://*) S3_ENDPOINT_URL=${S3_ENDPOINT} ;;
+  *) S3_ENDPOINT_URL="https://${S3_ENDPOINT}" ;;
+esac
+
+tusd -port 1080 -s3-endpoint=${S3_ENDPOINT_URL} -s3-bucket=${S3_BUCKET_ID} -s3-object-prefix=${S3_PREFIX} --hooks-enabled-events post-finish --hooks-dir ./hooks

--- a/services/tusd/init.sh
+++ b/services/tusd/init.sh
@@ -2,6 +2,13 @@
 
 chmod +x ./hooks/post-finish
 
+# aws-sdk-go-v2 defaults to attaching a CRC32 request checksum on S3 API
+# calls. BC gov's NRS object store (non-AWS S3-compatible) doesn't validate
+# that the way AWS does, causing XAmzContentSHA256Mismatch. Opt back into the
+# pre-v2-integrity-update behavior of only checksumming when the API requires it.
+export AWS_REQUEST_CHECKSUM_CALCULATION=when_required
+export AWS_RESPONSE_CHECKSUM_VALIDATION=when_required
+
 # aws-sdk-go-v2 requires the S3 endpoint to be a full URI including scheme.
 # S3_ENDPOINT is shared with other services (docman, filesystem-provider, etc.)
 # that expect a bare hostname and prepend the scheme themselves, so default to
@@ -11,4 +18,4 @@ case "${S3_ENDPOINT}" in
   *) S3_ENDPOINT_URL="https://${S3_ENDPOINT}" ;;
 esac
 
-tusd -port 1080 -s3-endpoint=${S3_ENDPOINT_URL} -s3-bucket=${S3_BUCKET_ID} -s3-object-prefix=${S3_PREFIX} --hooks-enabled-events post-finish --hooks-dir ./hooks
+tusd -port 1080 -s3-endpoint=${S3_ENDPOINT_URL} -s3-bucket=${S3_BUCKET_ID} -s3-object-prefix=${S3_PREFIX} -s3-disable-content-hashes --hooks-enabled-events post-finish --hooks-dir ./hooks


### PR DESCRIPTION
[MDS-6962] - (https://bcmines.atlassian.net/browse/MDS-6962)

## Fix tusd v2.10.0 upload failures (S3 endpoint, checksum, and post-finish hook)

### Summary

Following the tusd `v1.3.0` → `v2.10.0` upgrade, file uploads failed in production with `Attempt to retrieve create file url with status 502` (surfaced to users as a generic error during Notice of Work file generation). Investigation traced this to three separate breaking changes introduced by tusd's move to `aws-sdk-go-v2`, plus one latent bug in the custom `post-finish` hook script that the same migration exposed. Production has been rolled back to `v1.3.0` in the meantime; this PR contains the fixes needed to re-attempt the `v2.10.0` upgrade.

### Root causes & fixes

**1. Invalid S3 endpoint URI** (`services/tusd/init.sh`)
`aws-sdk-go-v2` requires `-s3-endpoint` to be a full URI including scheme. `S3_ENDPOINT` (from the shared `object-store-credentials` secret) is a bare hostname (`nrs.objectstore.gov.bc.ca`), which every other consumer of that secret (docman, docman-worker, filesystem-provider, the permits import script) already handles by prepending `https://` in their own code. tusd was the outlier, passing the bare value straight through.
- Fix: normalize `S3_ENDPOINT` to `https://<host>` in `init.sh` only if it doesn't already include a scheme — no change to the shared secret or any other consumer.

**2. `XAmzContentSHA256Mismatch` on every S3 write** (`services/tusd/init.sh`)
`aws-sdk-go-v2` now attaches a CRC32 request checksum by default on S3 API calls. BC gov's NRS object store (a non-AWS S3-compatible backend) doesn't validate it the way AWS does, so every `PutObject`/`CreateMultipartUpload` failed.
- Fix: export the standard SDK-recognized env vars `AWS_REQUEST_CHECKSUM_CALCULATION=when_required` and `AWS_RESPONSE_CHECKSUM_VALIDATION=when_required`, opting back into pre-2024 checksum behavior. No code/binary changes required — these are read automatically by the SDK's default config loader. Also added `-s3-disable-content-hashes` as defense-in-depth (tusd's own content-hash flag).

**3. Corrupted `post-finish` webhook request** (`services/tusd/hooks/post-finish`)
The `v2.10.0` migration switched from tusd's built-in `--hooks-http` mechanism (which only forwarded the `Authorization` header via `-hooks-http-forward-headers=Authorization`) to a custom file-based hook script that forwarded **all** of the original upload request's headers — including `Host` — into a single malformed `curl -H` argument. This corrupted the outgoing request to docman's `/tusd-hooks` endpoint, which crashed with `ValueError: Port could not be cast to integer value as '5001,tusd:1080'` on every retry, indefinitely. Since `/tusd-hooks` never returned success, the document's status stayed "In Progress" forever, and core-api's client-side poll timed out after 60s with `Timed out while waiting for file upload to finish`.
- Fix: forward only the `Authorization` header, matching what the endpoint actually requires (`@requires_any_of` auth decorator; it reads nothing else from headers) and restoring the pre-upgrade behavior.

**4. False-alarm `HookInvocationError` on successful uploads** (`services/tusd/hooks/post-finish`)
tusd reads the hook script's stdout and tries to parse it as a JSON `HookResponse`. The script's own diagnostic `echo` statements and curl's unsuppressed progress meter/response body were all going to stdout, so tusd failed to parse it and logged an `ERROR`-level `HookInvocationError` on **every successful upload** — noisy and indistinguishable from a real failure in logs/monitoring.
- Fix: redirect all diagnostic output to stderr and run curl with `-s -o /dev/null -w "..."` so stdout stays empty, which tusd accepts as a no-op response.

### Testing

All four fixes were verified locally via `docker compose` against a real S3-backed upload flow (tusd → docman → core-api), confirming:
- File creation (`POST`) and chunk upload (`PATCH`) both succeed without S3 errors
- The `post-finish` webhook reaches docman successfully (`204`) and completes with a clean `HookInvocationFinish`, no `HookInvocationError`
- End-to-end upload through the actual app (real JWT) completes without timing out, with document status correctly reaching "Success"

### Files changed
- `services/tusd/init.sh`
- `services/tusd/hooks/post-finish`

### Deployment notes
- No changes to the `object-store-credentials` secret or any other service's environment — this PR is scoped entirely to tusd's own script layer.
- Recommend re-promoting through `dev` → `test` → `prod` with the same verification steps used locally, given the prior incident.

_Why are you making this change? Provide a short explanation and/or screenshots_
