### PR TITLE
[MDS-6973] - Greyed Out Action Button

### DIFF
--- a/services/common/src/components/documents/DocumentTable.tsx
+++ b/services/common/src/components/documents/DocumentTable.tsx
@@ -27,7 +27,7 @@ import FileOutlined from "@ant-design/icons/FileOutlined";
 import InboxOutlined from "@ant-design/icons/InboxOutlined";
 import SyncOutlined from "@ant-design/icons/SyncOutlined";
 import { openDocument } from "@mds/common/components/syncfusion/DocumentViewer";
-import { Button, Col, Row, Typography } from "antd";
+import { Button, Col, Row, Tooltip, Typography } from "antd";
 import { useFeatureFlag } from "@mds/common/providers/featureFlags/useFeatureFlag";
 import DocumentTableProps from "@mds/common/interfaces/document/documentTableProps.interface";
 import ArchiveDocumentModal from "./ArchiveDocumentModal";
@@ -299,6 +299,10 @@ export const DocumentTable: FC<DocumentTableProps> = ({
     }
   ].filter((a) => allowedTableActions[a.key]);
 
+  const bulkActionsTooltipText = documentsCanBulkDropDown
+    ? "Select one or more files below using the checkboxes to download or archive them."
+    : "Select one or more files below using the checkboxes to download them.";
+
   const renderBulkActions = () => {
     let element = (
       <Button
@@ -320,9 +324,17 @@ export const DocumentTable: FC<DocumentTableProps> = ({
       );
     }
 
+    // wrap in a span: antd disables pointer events on disabled buttons, which
+    // would otherwise prevent the tooltip from showing on hover
+    element = (
+      <Tooltip title={bulkActionsTooltipText}>
+        <span>{element}</span>
+      </Tooltip>
+    );
+
     const hasHeader = Boolean(props.header);
 
-    return (enableBulkActions || hasHeader) && <Row justify={hasHeader ? "space-between" : "end"} align="bottom" className="document-table-header">
+    return (enableBulkActions || hasHeader) && <Row justify={hasHeader ? "space-between" : "end"} align="middle" className="document-table-header">
       {hasHeader && <Col>{props.header}</Col>}
       {enableBulkActions && <Col className="document-table-actions">{element}</Col>}
     </Row>;

--- a/services/common/src/components/project/envApplication/__snapshots__/EnvDocumentsTab.spec.tsx.snap
+++ b/services/common/src/components/project/envApplication/__snapshots__/EnvDocumentsTab.spec.tsx.snap
@@ -538,20 +538,22 @@ exports[`EnvDocumentsTab renders properly 1`] = `
         <div>
           <div />
           <div
-            class="ant-row ant-row-end ant-row-bottom document-table-header"
+            class="ant-row ant-row-end ant-row-middle document-table-header"
           >
             <div
               class="ant-col document-table-actions"
             >
-              <button
-                class="ant-btn ant-btn-primary"
-                disabled=""
-                type="button"
-              >
-                <div>
-                  Download
-                </div>
-              </button>
+              <span>
+                <button
+                  class="ant-btn ant-btn-primary"
+                  disabled=""
+                  type="button"
+                >
+                  <div>
+                    Download
+                  </div>
+                </button>
+              </span>
             </div>
           </div>
           <div

--- a/services/common/src/components/projects/ProjectDocumentsTab.tsx
+++ b/services/common/src/components/projects/ProjectDocumentsTab.tsx
@@ -271,7 +271,7 @@ const ProjectDocumentsTab: FC<ProjectDocumentsTabProps> = ({ project }) => {
             <Typography.Paragraph className="margin-small--bottom">
               To add new spatial files, go to{" "}
               <Link to={documentUploadHref}>Project Description &gt; Document Upload</Link>. This
-              tab supports replacing, archiving, and downloading files already submitted.
+              tab supports downloading and viewing the details of files already submitted.
             </Typography.Paragraph>
           )}
           <SpatialDocumentTable documents={pdSpatialDocuments} categoryText={spatialCategoryText} />

--- a/services/common/src/components/projects/ProjectDocumentsTab.tsx
+++ b/services/common/src/components/projects/ProjectDocumentsTab.tsx
@@ -1,4 +1,5 @@
 import React, { FC, useEffect, useState } from "react";
+import { Link } from "react-router-dom";
 import { useAppDispatch, useAppSelector } from "@mds/common/redux/rootState";
 import ScrollSidePageWrapper from "../common/ScrollSidePageWrapper";
 import { ScrollSideMenuProps } from "../common/ScrollSideMenu";
@@ -119,6 +120,21 @@ const ProjectDocumentsTab: FC<ProjectDocumentsTabProps> = ({ project }) => {
 
   const canModifySummaryDocs = !areDocumentFieldsDisabled(systemFlag, project?.project_summary?.status_code);
   const canModifyMmaDocs = !areDocumentFieldsDisabled(systemFlag, project?.major_mine_application?.status_code);
+
+  // New supporting/spatial documents can only be added from the Project Description
+  // Document Upload step, not from this tab, which only supports managing existing files.
+  const isProjectDescriptionEditableStatus = !["DFT", "CHR"].includes(
+    project?.project_summary?.status_code
+  );
+  const documentUploadHref =
+    !isCore && project?.project_summary?.project_summary_guid
+      ? GLOBAL_ROUTES?.EDIT_PROJECT_SUMMARY?.dynamicRoute(
+          project.project_guid,
+          project.project_summary.project_summary_guid,
+          "document-upload",
+          isProjectDescriptionEditableStatus
+        )
+      : null;
 
   const projectSummaryDocs =
     project?.project_summary?.documents?.map(
@@ -251,6 +267,13 @@ const ProjectDocumentsTab: FC<ProjectDocumentsTabProps> = ({ project }) => {
       content: (
         <>
           <Typography.Title level={4}>Spatial Components</Typography.Title>
+          {documentUploadHref && canModifySummaryDocs && (
+            <Typography.Paragraph className="margin-small--bottom">
+              To add new spatial files, go to{" "}
+              <Link to={documentUploadHref}>Project Description &gt; Document Upload</Link>. This
+              tab supports replacing, archiving, and downloading files already submitted.
+            </Typography.Paragraph>
+          )}
           <SpatialDocumentTable documents={pdSpatialDocuments} categoryText={spatialCategoryText} />
         </>
       ),
@@ -259,14 +282,28 @@ const ProjectDocumentsTab: FC<ProjectDocumentsTabProps> = ({ project }) => {
       href: "pd-supporting-documents",
       title: <div className="sub-tab-1">Supporting Documents</div>,
       content: (
-        <ProjectDocumentsTabSection
-          id="pd-supporting-documents"
-          title="Supporting Documents"
-          documents={pdSupportingDocuments}
-          onArchivedDocuments={refreshData}
-          canReplace={canModifySummaryDocs}
-          canArchive={canModifySummaryDocs}
-        />
+        <>
+          <Typography.Title level={4}>Supporting Documents</Typography.Title>
+          <ProjectDocumentsTabSection
+            id="pd-supporting-documents"
+            title=""
+            documents={pdSupportingDocuments}
+            onArchivedDocuments={refreshData}
+            canReplace={canModifySummaryDocs}
+            canArchive={canModifySummaryDocs}
+            header={
+              documentUploadHref &&
+              canModifySummaryDocs && (
+                <Typography.Text>
+                  To add new supporting documents, go to{" "}
+                  <Link to={documentUploadHref}>Project Description &gt; Document Upload</Link>.
+                  This tab supports replacing, archiving, and downloading files already
+                  submitted.
+                </Typography.Text>
+              )
+            }
+          />
+        </>
       ),
     },
     {
@@ -289,16 +326,16 @@ const ProjectDocumentsTab: FC<ProjectDocumentsTabProps> = ({ project }) => {
       content: (
         <>
           <Typography.Title level={3}>Application</Typography.Title>
-          <Typography.Paragraph>Below are the documents submitted as part of the Major Mine Application.</Typography.Paragraph>
+          <Typography.Paragraph>
+            Below are the documents submitted as part of the Major Mine Application.
+          </Typography.Paragraph>
         </>
-      )
+      ),
     },
     {
       href: "mines-act",
       title: <div className="sub-tab-1">Mines Act</div>,
-      content: (
-        <Typography.Title level={4}>Mines Act</Typography.Title>
-      )
+      content: <Typography.Title level={4}>Mines Act</Typography.Title>,
     },
     {
       href: "mma-primary-document",
@@ -358,20 +395,21 @@ const ProjectDocumentsTab: FC<ProjectDocumentsTabProps> = ({ project }) => {
         />
       ),
     },
-    amsSections.length > 1 && isAmsDocumentsEnabled && {
-      href: "ENV Applications",
-      title: <div className="sub-tab-1">ENV Applications</div>,
-      content: (
-        <>
-          <Typography.Title level={4}>ENV Applications</Typography.Title>
-          <Alert
-            className={isCore ? "ant-alert-grey" : ""}
-            description="Some informative text for ENV Applications"
-            showIcon
-          />
-        </>
-      ),
-    },
+    amsSections.length > 1 &&
+      isAmsDocumentsEnabled && {
+        href: "ENV Applications",
+        title: <div className="sub-tab-1">ENV Applications</div>,
+        content: (
+          <>
+            <Typography.Title level={4}>ENV Applications</Typography.Title>
+            <Alert
+              className={isCore ? "ant-alert-grey" : ""}
+              description="Some informative text for ENV Applications"
+              showIcon
+            />
+          </>
+        ),
+      },
     ...amsSections,
     isCore && {
       href: "ministry-decision-documentation",
@@ -388,12 +426,7 @@ const ProjectDocumentsTab: FC<ProjectDocumentsTabProps> = ({ project }) => {
     },
     isFeatureEnabled(Feature.MAJOR_PROJECT_ARCHIVE_FILE) && {
       href: "archived-documents",
-      content: (
-        <ArchivedDocumentsSection
-          documents={archivedDocs}
-          showCategory={false}
-        />
-      ),
+      content: <ArchivedDocumentsSection documents={archivedDocs} showCategory={false} />,
     },
   ].filter(Boolean);
 

--- a/services/common/src/components/projects/ProjectDocumentsTabSection.tsx
+++ b/services/common/src/components/projects/ProjectDocumentsTabSection.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from "react";
+import React, { FC, ReactNode } from "react";
 import { Row, Col, Typography } from "antd";
 import DocumentTable from "../documents/DocumentTable";
 import { MineDocument } from "@mds/common/models/documents/document";
@@ -14,6 +14,7 @@ interface ProjectDocumentsTabSectionProps {
   canArchive?: boolean;
   canReplace?: boolean;
   infoText?: string;
+  header?: ReactNode;
 }
 const ProjectDocumentsTabSection: FC<ProjectDocumentsTabSectionProps> = ({
   documents,
@@ -24,6 +25,7 @@ const ProjectDocumentsTabSection: FC<ProjectDocumentsTabSectionProps> = ({
   canArchive = true,
   canReplace = true,
   infoText = null,
+  header = null,
 }) => {
   const sectionTitle = title ?? formatUrlToUpperCaseString(id);
 
@@ -49,6 +51,7 @@ const ProjectDocumentsTabSection: FC<ProjectDocumentsTabSectionProps> = ({
           onArchivedDocuments={onArchivedDocuments}
           showVersionHistory={true}
           enableBulkActions={true}
+          header={header}
         />
       </Col>
     </Row>

--- a/services/common/src/components/projects/__snapshots__/ProjectDocumentsTabSection.spec.tsx.snap
+++ b/services/common/src/components/projects/__snapshots__/ProjectDocumentsTabSection.spec.tsx.snap
@@ -21,41 +21,43 @@ exports[`ProjectDocumentsTab renders properly 1`] = `
       <div>
         <div />
         <div
-          class="ant-row ant-row-end ant-row-bottom document-table-header"
+          class="ant-row ant-row-end ant-row-middle document-table-header"
         >
           <div
             class="ant-col document-table-actions"
           >
-            <button
-              class="ant-btn ant-btn-primary ant-dropdown-trigger actions-dropdown-button"
-              data-testid=""
-              disabled=""
-              type="button"
-            >
-              <span>
-                Action
-              </span>
-              <span
-                aria-label="down"
-                class="anticon anticon-down"
-                role="img"
+            <span>
+              <button
+                class="ant-btn ant-btn-primary ant-dropdown-trigger actions-dropdown-button"
+                data-testid=""
+                disabled=""
+                type="button"
               >
-                <svg
-                  aria-hidden="true"
-                  class=""
-                  data-icon="down"
-                  fill="currentColor"
-                  focusable="false"
-                  height="1em"
-                  viewBox="64 64 896 896"
-                  width="1em"
+                <span>
+                  Action
+                </span>
+                <span
+                  aria-label="down"
+                  class="anticon anticon-down"
+                  role="img"
                 >
-                  <path
-                    d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
-                  />
-                </svg>
-              </span>
-            </button>
+                  <svg
+                    aria-hidden="true"
+                    class=""
+                    data-icon="down"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                    />
+                  </svg>
+                </span>
+              </button>
+            </span>
           </div>
         </div>
         <div

--- a/services/core-web/src/tests/components/mine/Projects/__snapshots__/DecisionPackageTab.spec.tsx.snap
+++ b/services/core-web/src/tests/components/mine/Projects/__snapshots__/DecisionPackageTab.spec.tsx.snap
@@ -416,41 +416,43 @@ exports[`DecisionPackageTab renders properly 1`] = `
       <div>
         <div />
         <div
-          class="ant-row ant-row-end ant-row-bottom document-table-header"
+          class="ant-row ant-row-end ant-row-middle document-table-header"
         >
           <div
             class="ant-col document-table-actions"
           >
-            <button
-              class="ant-btn ant-btn-primary ant-dropdown-trigger actions-dropdown-button"
-              data-testid=""
-              disabled=""
-              type="button"
-            >
-              <span>
-                Action
-              </span>
-              <span
-                aria-label="down"
-                class="anticon anticon-down"
-                role="img"
+            <span>
+              <button
+                class="ant-btn ant-btn-primary ant-dropdown-trigger actions-dropdown-button"
+                data-testid=""
+                disabled=""
+                type="button"
               >
-                <svg
-                  aria-hidden="true"
-                  class=""
-                  data-icon="down"
-                  fill="currentColor"
-                  focusable="false"
-                  height="1em"
-                  viewBox="64 64 896 896"
-                  width="1em"
+                <span>
+                  Action
+                </span>
+                <span
+                  aria-label="down"
+                  class="anticon anticon-down"
+                  role="img"
                 >
-                  <path
-                    d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
-                  />
-                </svg>
-              </span>
-            </button>
+                  <svg
+                    aria-hidden="true"
+                    class=""
+                    data-icon="down"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                    />
+                  </svg>
+                </span>
+              </button>
+            </span>
           </div>
         </div>
         <div
@@ -813,41 +815,43 @@ exports[`DecisionPackageTab renders properly 1`] = `
       <div>
         <div />
         <div
-          class="ant-row ant-row-end ant-row-bottom document-table-header"
+          class="ant-row ant-row-end ant-row-middle document-table-header"
         >
           <div
             class="ant-col document-table-actions"
           >
-            <button
-              class="ant-btn ant-btn-primary ant-dropdown-trigger actions-dropdown-button"
-              data-testid=""
-              disabled=""
-              type="button"
-            >
-              <span>
-                Action
-              </span>
-              <span
-                aria-label="down"
-                class="anticon anticon-down"
-                role="img"
+            <span>
+              <button
+                class="ant-btn ant-btn-primary ant-dropdown-trigger actions-dropdown-button"
+                data-testid=""
+                disabled=""
+                type="button"
               >
-                <svg
-                  aria-hidden="true"
-                  class=""
-                  data-icon="down"
-                  fill="currentColor"
-                  focusable="false"
-                  height="1em"
-                  viewBox="64 64 896 896"
-                  width="1em"
+                <span>
+                  Action
+                </span>
+                <span
+                  aria-label="down"
+                  class="anticon anticon-down"
+                  role="img"
                 >
-                  <path
-                    d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
-                  />
-                </svg>
-              </span>
-            </button>
+                  <svg
+                    aria-hidden="true"
+                    class=""
+                    data-icon="down"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                    />
+                  </svg>
+                </span>
+              </button>
+            </span>
           </div>
         </div>
         <div
@@ -1267,41 +1271,43 @@ exports[`DecisionPackageTab renders properly 1`] = `
       <div>
         <div />
         <div
-          class="ant-row ant-row-end ant-row-bottom document-table-header"
+          class="ant-row ant-row-end ant-row-middle document-table-header"
         >
           <div
             class="ant-col document-table-actions"
           >
-            <button
-              class="ant-btn ant-btn-primary ant-dropdown-trigger actions-dropdown-button"
-              data-testid=""
-              disabled=""
-              type="button"
-            >
-              <span>
-                Action
-              </span>
-              <span
-                aria-label="down"
-                class="anticon anticon-down"
-                role="img"
+            <span>
+              <button
+                class="ant-btn ant-btn-primary ant-dropdown-trigger actions-dropdown-button"
+                data-testid=""
+                disabled=""
+                type="button"
               >
-                <svg
-                  aria-hidden="true"
-                  class=""
-                  data-icon="down"
-                  fill="currentColor"
-                  focusable="false"
-                  height="1em"
-                  viewBox="64 64 896 896"
-                  width="1em"
+                <span>
+                  Action
+                </span>
+                <span
+                  aria-label="down"
+                  class="anticon anticon-down"
+                  role="img"
                 >
-                  <path
-                    d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
-                  />
-                </svg>
-              </span>
-            </button>
+                  <svg
+                    aria-hidden="true"
+                    class=""
+                    data-icon="down"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                    />
+                  </svg>
+                </span>
+              </button>
+            </span>
           </div>
         </div>
         <div

--- a/services/core-web/src/tests/components/mine/Projects/__snapshots__/MajorMineApplicationTab.spec.tsx.snap
+++ b/services/core-web/src/tests/components/mine/Projects/__snapshots__/MajorMineApplicationTab.spec.tsx.snap
@@ -570,41 +570,43 @@ exports[`MajorMineApplicationTab renders properly 1`] = `
           <div>
             <div />
             <div
-              class="ant-row ant-row-end ant-row-bottom document-table-header"
+              class="ant-row ant-row-end ant-row-middle document-table-header"
             >
               <div
                 class="ant-col document-table-actions"
               >
-                <button
-                  class="ant-btn ant-btn-primary ant-dropdown-trigger actions-dropdown-button"
-                  data-testid=""
-                  disabled=""
-                  type="button"
-                >
-                  <span>
-                    Action
-                  </span>
-                  <span
-                    aria-label="down"
-                    class="anticon anticon-down"
-                    role="img"
+                <span>
+                  <button
+                    class="ant-btn ant-btn-primary ant-dropdown-trigger actions-dropdown-button"
+                    data-testid=""
+                    disabled=""
+                    type="button"
                   >
-                    <svg
-                      aria-hidden="true"
-                      class=""
-                      data-icon="down"
-                      fill="currentColor"
-                      focusable="false"
-                      height="1em"
-                      viewBox="64 64 896 896"
-                      width="1em"
+                    <span>
+                      Action
+                    </span>
+                    <span
+                      aria-label="down"
+                      class="anticon anticon-down"
+                      role="img"
                     >
-                      <path
-                        d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
-                      />
-                    </svg>
-                  </span>
-                </button>
+                      <svg
+                        aria-hidden="true"
+                        class=""
+                        data-icon="down"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                        />
+                      </svg>
+                    </span>
+                  </button>
+                </span>
               </div>
             </div>
             <div
@@ -953,41 +955,43 @@ exports[`MajorMineApplicationTab renders properly 1`] = `
           <div>
             <div />
             <div
-              class="ant-row ant-row-end ant-row-bottom document-table-header"
+              class="ant-row ant-row-end ant-row-middle document-table-header"
             >
               <div
                 class="ant-col document-table-actions"
               >
-                <button
-                  class="ant-btn ant-btn-primary ant-dropdown-trigger actions-dropdown-button"
-                  data-testid=""
-                  disabled=""
-                  type="button"
-                >
-                  <span>
-                    Action
-                  </span>
-                  <span
-                    aria-label="down"
-                    class="anticon anticon-down"
-                    role="img"
+                <span>
+                  <button
+                    class="ant-btn ant-btn-primary ant-dropdown-trigger actions-dropdown-button"
+                    data-testid=""
+                    disabled=""
+                    type="button"
                   >
-                    <svg
-                      aria-hidden="true"
-                      class=""
-                      data-icon="down"
-                      fill="currentColor"
-                      focusable="false"
-                      height="1em"
-                      viewBox="64 64 896 896"
-                      width="1em"
+                    <span>
+                      Action
+                    </span>
+                    <span
+                      aria-label="down"
+                      class="anticon anticon-down"
+                      role="img"
                     >
-                      <path
-                        d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
-                      />
-                    </svg>
-                  </span>
-                </button>
+                      <svg
+                        aria-hidden="true"
+                        class=""
+                        data-icon="down"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                        />
+                      </svg>
+                    </span>
+                  </button>
+                </span>
               </div>
             </div>
             <div
@@ -1336,41 +1340,43 @@ exports[`MajorMineApplicationTab renders properly 1`] = `
           <div>
             <div />
             <div
-              class="ant-row ant-row-end ant-row-bottom document-table-header"
+              class="ant-row ant-row-end ant-row-middle document-table-header"
             >
               <div
                 class="ant-col document-table-actions"
               >
-                <button
-                  class="ant-btn ant-btn-primary ant-dropdown-trigger actions-dropdown-button"
-                  data-testid=""
-                  disabled=""
-                  type="button"
-                >
-                  <span>
-                    Action
-                  </span>
-                  <span
-                    aria-label="down"
-                    class="anticon anticon-down"
-                    role="img"
+                <span>
+                  <button
+                    class="ant-btn ant-btn-primary ant-dropdown-trigger actions-dropdown-button"
+                    data-testid=""
+                    disabled=""
+                    type="button"
                   >
-                    <svg
-                      aria-hidden="true"
-                      class=""
-                      data-icon="down"
-                      fill="currentColor"
-                      focusable="false"
-                      height="1em"
-                      viewBox="64 64 896 896"
-                      width="1em"
+                    <span>
+                      Action
+                    </span>
+                    <span
+                      aria-label="down"
+                      class="anticon anticon-down"
+                      role="img"
                     >
-                      <path
-                        d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
-                      />
-                    </svg>
-                  </span>
-                </button>
+                      <svg
+                        aria-hidden="true"
+                        class=""
+                        data-icon="down"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                        />
+                      </svg>
+                    </span>
+                  </button>
+                </span>
               </div>
             </div>
             <div
@@ -1719,41 +1725,43 @@ exports[`MajorMineApplicationTab renders properly 1`] = `
           <div>
             <div />
             <div
-              class="ant-row ant-row-end ant-row-bottom document-table-header"
+              class="ant-row ant-row-end ant-row-middle document-table-header"
             >
               <div
                 class="ant-col document-table-actions"
               >
-                <button
-                  class="ant-btn ant-btn-primary ant-dropdown-trigger actions-dropdown-button"
-                  data-testid=""
-                  disabled=""
-                  type="button"
-                >
-                  <span>
-                    Action
-                  </span>
-                  <span
-                    aria-label="down"
-                    class="anticon anticon-down"
-                    role="img"
+                <span>
+                  <button
+                    class="ant-btn ant-btn-primary ant-dropdown-trigger actions-dropdown-button"
+                    data-testid=""
+                    disabled=""
+                    type="button"
                   >
-                    <svg
-                      aria-hidden="true"
-                      class=""
-                      data-icon="down"
-                      fill="currentColor"
-                      focusable="false"
-                      height="1em"
-                      viewBox="64 64 896 896"
-                      width="1em"
+                    <span>
+                      Action
+                    </span>
+                    <span
+                      aria-label="down"
+                      class="anticon anticon-down"
+                      role="img"
                     >
-                      <path
-                        d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
-                      />
-                    </svg>
-                  </span>
-                </button>
+                      <svg
+                        aria-hidden="true"
+                        class=""
+                        data-icon="down"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                        />
+                      </svg>
+                    </span>
+                  </button>
+                </span>
               </div>
             </div>
             <div
@@ -2102,41 +2110,43 @@ exports[`MajorMineApplicationTab renders properly 1`] = `
           <div>
             <div />
             <div
-              class="ant-row ant-row-end ant-row-bottom document-table-header"
+              class="ant-row ant-row-end ant-row-middle document-table-header"
             >
               <div
                 class="ant-col document-table-actions"
               >
-                <button
-                  class="ant-btn ant-btn-primary ant-dropdown-trigger actions-dropdown-button"
-                  data-testid=""
-                  disabled=""
-                  type="button"
-                >
-                  <span>
-                    Action
-                  </span>
-                  <span
-                    aria-label="down"
-                    class="anticon anticon-down"
-                    role="img"
+                <span>
+                  <button
+                    class="ant-btn ant-btn-primary ant-dropdown-trigger actions-dropdown-button"
+                    data-testid=""
+                    disabled=""
+                    type="button"
                   >
-                    <svg
-                      aria-hidden="true"
-                      class=""
-                      data-icon="down"
-                      fill="currentColor"
-                      focusable="false"
-                      height="1em"
-                      viewBox="64 64 896 896"
-                      width="1em"
+                    <span>
+                      Action
+                    </span>
+                    <span
+                      aria-label="down"
+                      class="anticon anticon-down"
+                      role="img"
                     >
-                      <path
-                        d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
-                      />
-                    </svg>
-                  </span>
-                </button>
+                      <svg
+                        aria-hidden="true"
+                        class=""
+                        data-icon="down"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                        />
+                      </svg>
+                    </span>
+                  </button>
+                </span>
               </div>
             </div>
             <div

--- a/services/minespace-web/src/tests/components/Forms/projects/majorMineApplication/__snapshots__/MajorMineApplicationReviewSubmit.spec.tsx.snap
+++ b/services/minespace-web/src/tests/components/Forms/projects/majorMineApplication/__snapshots__/MajorMineApplicationReviewSubmit.spec.tsx.snap
@@ -148,7 +148,7 @@ exports[`MajorMineApplicationReviewSubmit renders properly as on MajorMineApplic
       <div>
         <div />
         <div
-          class="ant-row ant-row-space-between ant-row-bottom document-table-header"
+          class="ant-row ant-row-space-between ant-row-middle document-table-header"
         >
           <div
             class="ant-col"
@@ -162,15 +162,17 @@ exports[`MajorMineApplicationReviewSubmit renders properly as on MajorMineApplic
           <div
             class="ant-col document-table-actions"
           >
-            <button
-              class="ant-btn ant-btn-primary"
-              disabled=""
-              type="button"
-            >
-              <div>
-                Download
-              </div>
-            </button>
+            <span>
+              <button
+                class="ant-btn ant-btn-primary"
+                disabled=""
+                type="button"
+              >
+                <div>
+                  Download
+                </div>
+              </button>
+            </span>
           </div>
         </div>
         <div
@@ -604,7 +606,7 @@ exports[`MajorMineApplicationReviewSubmit renders properly as on MajorMineApplic
       <div>
         <div />
         <div
-          class="ant-row ant-row-space-between ant-row-bottom document-table-header"
+          class="ant-row ant-row-space-between ant-row-middle document-table-header"
         >
           <div
             class="ant-col"
@@ -618,15 +620,17 @@ exports[`MajorMineApplicationReviewSubmit renders properly as on MajorMineApplic
           <div
             class="ant-col document-table-actions"
           >
-            <button
-              class="ant-btn ant-btn-primary"
-              disabled=""
-              type="button"
-            >
-              <div>
-                Download
-              </div>
-            </button>
+            <span>
+              <button
+                class="ant-btn ant-btn-primary"
+                disabled=""
+                type="button"
+              >
+                <div>
+                  Download
+                </div>
+              </button>
+            </span>
           </div>
         </div>
         <div
@@ -1719,7 +1723,7 @@ exports[`MajorMineApplicationReviewSubmit renders properly as on MajorMineApplic
       <div>
         <div />
         <div
-          class="ant-row ant-row-space-between ant-row-bottom document-table-header"
+          class="ant-row ant-row-space-between ant-row-middle document-table-header"
         >
           <div
             class="ant-col"
@@ -1733,15 +1737,17 @@ exports[`MajorMineApplicationReviewSubmit renders properly as on MajorMineApplic
           <div
             class="ant-col document-table-actions"
           >
-            <button
-              class="ant-btn ant-btn-primary"
-              disabled=""
-              type="button"
-            >
-              <div>
-                Download
-              </div>
-            </button>
+            <span>
+              <button
+                class="ant-btn ant-btn-primary"
+                disabled=""
+                type="button"
+              >
+                <div>
+                  Download
+                </div>
+              </button>
+            </span>
           </div>
         </div>
         <div
@@ -2975,7 +2981,7 @@ exports[`MajorMineApplicationReviewSubmit renders properly as on ProjectPage 1`]
       <div>
         <div />
         <div
-          class="ant-row ant-row-space-between ant-row-bottom document-table-header"
+          class="ant-row ant-row-space-between ant-row-middle document-table-header"
         >
           <div
             class="ant-col"
@@ -2989,15 +2995,17 @@ exports[`MajorMineApplicationReviewSubmit renders properly as on ProjectPage 1`]
           <div
             class="ant-col document-table-actions"
           >
-            <button
-              class="ant-btn ant-btn-primary"
-              disabled=""
-              type="button"
-            >
-              <div>
-                Download
-              </div>
-            </button>
+            <span>
+              <button
+                class="ant-btn ant-btn-primary"
+                disabled=""
+                type="button"
+              >
+                <div>
+                  Download
+                </div>
+              </button>
+            </span>
           </div>
         </div>
         <div
@@ -3431,7 +3439,7 @@ exports[`MajorMineApplicationReviewSubmit renders properly as on ProjectPage 1`]
       <div>
         <div />
         <div
-          class="ant-row ant-row-space-between ant-row-bottom document-table-header"
+          class="ant-row ant-row-space-between ant-row-middle document-table-header"
         >
           <div
             class="ant-col"
@@ -3445,15 +3453,17 @@ exports[`MajorMineApplicationReviewSubmit renders properly as on ProjectPage 1`]
           <div
             class="ant-col document-table-actions"
           >
-            <button
-              class="ant-btn ant-btn-primary"
-              disabled=""
-              type="button"
-            >
-              <div>
-                Download
-              </div>
-            </button>
+            <span>
+              <button
+                class="ant-btn ant-btn-primary"
+                disabled=""
+                type="button"
+              >
+                <div>
+                  Download
+                </div>
+              </button>
+            </span>
           </div>
         </div>
         <div
@@ -4546,7 +4556,7 @@ exports[`MajorMineApplicationReviewSubmit renders properly as on ProjectPage 1`]
       <div>
         <div />
         <div
-          class="ant-row ant-row-space-between ant-row-bottom document-table-header"
+          class="ant-row ant-row-space-between ant-row-middle document-table-header"
         >
           <div
             class="ant-col"
@@ -4560,15 +4570,17 @@ exports[`MajorMineApplicationReviewSubmit renders properly as on ProjectPage 1`]
           <div
             class="ant-col document-table-actions"
           >
-            <button
-              class="ant-btn ant-btn-primary"
-              disabled=""
-              type="button"
-            >
-              <div>
-                Download
-              </div>
-            </button>
+            <span>
+              <button
+                class="ant-btn ant-btn-primary"
+                disabled=""
+                type="button"
+              >
+                <div>
+                  Download
+                </div>
+              </button>
+            </span>
           </div>
         </div>
         <div

--- a/services/minespace-web/src/tests/components/project/DocumentsPage/__snapshots__/DocumentsPage.spec.tsx.snap
+++ b/services/minespace-web/src/tests/components/project/DocumentsPage/__snapshots__/DocumentsPage.spec.tsx.snap
@@ -20,41 +20,43 @@ exports[`DocumentsPage renders properly 1`] = `
       <div>
         <div />
         <div
-          class="ant-row ant-row-end ant-row-bottom document-table-header"
+          class="ant-row ant-row-end ant-row-middle document-table-header"
         >
           <div
             class="ant-col document-table-actions"
           >
-            <button
-              class="ant-btn ant-btn-primary ant-dropdown-trigger actions-dropdown-button"
-              data-testid=""
-              disabled=""
-              type="button"
-            >
-              <span>
-                Action
-              </span>
-              <span
-                aria-label="down"
-                class="anticon anticon-down"
-                role="img"
+            <span>
+              <button
+                class="ant-btn ant-btn-primary ant-dropdown-trigger actions-dropdown-button"
+                data-testid=""
+                disabled=""
+                type="button"
               >
-                <svg
-                  aria-hidden="true"
-                  class=""
-                  data-icon="down"
-                  fill="currentColor"
-                  focusable="false"
-                  height="1em"
-                  viewBox="64 64 896 896"
-                  width="1em"
+                <span>
+                  Action
+                </span>
+                <span
+                  aria-label="down"
+                  class="anticon anticon-down"
+                  role="img"
                 >
-                  <path
-                    d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
-                  />
-                </svg>
-              </span>
-            </button>
+                  <svg
+                    aria-hidden="true"
+                    class=""
+                    data-icon="down"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                    />
+                  </svg>
+                </span>
+              </button>
+            </span>
           </div>
         </div>
         <div

--- a/services/minespace-web/src/tests/components/project/informationRequirementsTablePage/__snapshots__/InformationRequirementsTablePage.spec.tsx.snap
+++ b/services/minespace-web/src/tests/components/project/informationRequirementsTablePage/__snapshots__/InformationRequirementsTablePage.spec.tsx.snap
@@ -353,6 +353,7 @@ exports[`InformationRequirementsTablePage renders properly 1`] = `
                       </div>
                       <div
                         class="ant-tabs-ink-bar ant-tabs-ink-bar-animated"
+                        style="top: 0px; height: 0px;"
                       />
                     </div>
                   </div>

--- a/services/minespace-web/src/tests/components/project/informationRequirementsTablePage/__snapshots__/InformationRequirementsTablePage.spec.tsx.snap
+++ b/services/minespace-web/src/tests/components/project/informationRequirementsTablePage/__snapshots__/InformationRequirementsTablePage.spec.tsx.snap
@@ -353,7 +353,6 @@ exports[`InformationRequirementsTablePage renders properly 1`] = `
                       </div>
                       <div
                         class="ant-tabs-ink-bar ant-tabs-ink-bar-animated"
-                        style="top: 0px; height: 0px;"
                       />
                     </div>
                   </div>


### PR DESCRIPTION
… document upload links

## Objective 

[MDS-](https://bcmines.atlassian.net/browse/MDS-0000)

## [MDS-6973] Fix greyed out actions button on Documents tab

### Problem

After a proponent submits a Major Mines Application/Project Description, the **Documents** tab (`/projects/:projectGuid/documents`) offers no way to add new supporting or spatial files. The only control above each document table is the bulk-actions button, which is disabled by default until a row checkbox is selected — with no rows to select (or none yet uploaded), the button reads as permanently broken, and users have no indication that new files must be added elsewhere.

Investigation confirmed the document-editing permission logic (`areDocumentFieldsDisabled`) is correct — it already keeps documents editable post-submission. The actual gap is that this tab only supports **replacing, archiving, and downloading existing files**; adding brand-new files is only possible from **Project Description > Document Upload**.

### Changes

- **Point users to the working upload flow.** The Supporting Documents and Spatial Components sections on the Documents tab now show inline text linking directly to the Document Upload step of the Project Description form, shown only when the section is actually editable for the current submission status.
- **Clarify the bulk-actions button itself.** Added a tooltip to the bulk-actions button explaining that it operates on the files selected via the checkboxes below, since the button is disabled by default and gives no context on its own.

_Why are you making this change? Provide a short explanation and/or screenshots_
