### PR TITLE
[MDS-6949] - Separate template report requirements

### DIFF
--- a/migrations/sql/V2026.08.05.10.00__scope_standard_report_name_uniqueness_by_template.sql
+++ b/migrations/sql/V2026.08.05.10.00__scope_standard_report_name_uniqueness_by_template.sql
@@ -1,0 +1,36 @@
+-- Report requirement names for standard/template conditions were only unique globally
+-- (report_name), preventing the same report name from being used across different
+-- permit condition templates. Scope uniqueness to the template instead, where a
+-- template is identified by notice_of_work_type.
+
+ALTER TABLE mine_report_permit_requirement
+    ADD COLUMN condition_category_code VARCHAR REFERENCES permit_condition_category(condition_category_code),
+    ADD COLUMN notice_of_work_type VARCHAR REFERENCES notice_of_work_type(notice_of_work_type_code);
+
+ALTER TABLE mine_report_permit_requirement_version
+    ADD COLUMN condition_category_code VARCHAR,
+    ADD COLUMN notice_of_work_type VARCHAR;
+
+-- Backfill existing standard report requirements from one of their linked standard conditions
+UPDATE mine_report_permit_requirement mrpr
+SET condition_category_code = linked.condition_category_code,
+    notice_of_work_type = linked.notice_of_work_type
+FROM (
+    SELECT DISTINCT ON (xref.mine_report_permit_requirement_id)
+        xref.mine_report_permit_requirement_id,
+        spc.condition_category_code,
+        spc.notice_of_work_type
+    FROM mine_report_req_permit_condition_xref xref
+    JOIN standard_permit_conditions spc
+        ON spc.standard_permit_condition_id = xref.standard_permit_condition_id
+    WHERE xref.is_standard = TRUE AND xref.deleted_ind = FALSE
+) linked
+WHERE mrpr.mine_report_permit_requirement_id = linked.mine_report_permit_requirement_id
+    AND mrpr.is_standard = TRUE;
+
+DROP INDEX unique_standard_report_name_idx;
+
+CREATE UNIQUE INDEX unique_standard_report_name_idx
+ON mine_report_permit_requirement (report_name, notice_of_work_type)
+WHERE is_standard = TRUE AND report_name IS NOT NULL;
+

--- a/migrations/sql/V2026.08.05.10.00__scope_standard_report_name_uniqueness_by_template.sql
+++ b/migrations/sql/V2026.08.05.10.00__scope_standard_report_name_uniqueness_by_template.sql
@@ -24,6 +24,7 @@ FROM (
     JOIN standard_permit_conditions spc
         ON spc.standard_permit_condition_id = xref.standard_permit_condition_id
     WHERE xref.is_standard = TRUE AND xref.deleted_ind = FALSE
+    ORDER BY xref.mine_report_permit_requirement_id, spc.standard_permit_condition_id ASC
 ) linked
 WHERE mrpr.mine_report_permit_requirement_id = linked.mine_report_permit_requirement_id
     AND mrpr.is_standard = TRUE;

--- a/services/common/src/components/permits/ReportPermitRequirementForm.tsx
+++ b/services/common/src/components/permits/ReportPermitRequirementForm.tsx
@@ -98,12 +98,22 @@ export const ReportPermitRequirementForm: FC<ReportPermitRequirementProps> = ({
   // filter to only those requirements matching the notice_of_work_type (template)
   // as the condition currently being edited.
   const currentTemplateCondition = condition as unknown as IStandardPermitCondition;
-  const standardRequirementsForTemplate = isStandardConditionEditor
-    ? standardRequirements.filter((r) => {
-      const nowType = r.notice_of_work_type || (conditionMap[r.permit_condition_ids?.[0]] as unknown as IStandardPermitCondition)?.notice_of_work_type;
-      return nowType === currentTemplateCondition?.notice_of_work_type;
-    })
-    : standardRequirements;
+  const targetNowType =
+    currentTemplateCondition?.notice_of_work_type ||
+    selectedRequirement?.notice_of_work_type ||
+    (selectedRequirement?.permit_condition_ids?.[0]
+      ? (conditionMap[selectedRequirement.permit_condition_ids[0]] as unknown as IStandardPermitCondition)?.notice_of_work_type
+      : undefined);
+
+  const standardRequirementsForTemplate =
+    isStandardConditionEditor && targetNowType
+      ? standardRequirements.filter((r) => {
+          const nowType =
+            r.notice_of_work_type ||
+            (conditionMap[r.permit_condition_ids?.[0]] as unknown as IStandardPermitCondition)?.notice_of_work_type;
+          return nowType === targetNowType;
+        })
+      : standardRequirements;
 
 
   const existingRequirements = isStandardConditionEditor ? standardRequirementsForTemplate : permitRequirements;

--- a/services/common/src/components/permits/ReportPermitRequirementForm.tsx
+++ b/services/common/src/components/permits/ReportPermitRequirementForm.tsx
@@ -5,6 +5,7 @@ import { useAppDispatch, useAppSelector } from "@mds/common/redux/rootState";
 import {
   IMineReportPermitRequirement,
   IPermitCondition,
+  IStandardPermitCondition,
 } from "@mds/common/interfaces";
 import { required, requiredRadioButton, maxLength, requiredList, notInList } from "@mds/common/redux/utils/Validate";
 import FormWrapper from "@mds/common/components/forms/FormWrapper";
@@ -82,12 +83,6 @@ export const ReportPermitRequirementForm: FC<ReportPermitRequirementProps> = ({
 
   const standardRequirements = useAppSelector(getStandardReportRequirements);
   const permitRequirements = useAppSelector(getMineReportPermitRequirementsByAmendment(permitGuid, currentAmendment?.permit_amendment_guid, isNowEditor));
-  const existingRequirements = isStandardConditionEditor ? standardRequirements : permitRequirements;
-
-  const hasExistingRequirements = existingRequirements?.length > 0;
-  const existingRequirementsOptions = existingRequirements.map((r) => { return { label: r.report_name, value: r.mine_report_permit_requirement_id } });
-  const disableFields = mineReportPermitRequirement?.mine_report_permit_requirement_id !== selectedRequirement?.mine_report_permit_requirement_id;
-  const multipleConditions = selectedRequirement?.permit_condition_ids.length > 1;
 
   const nowConditions = useAppSelector(getNowDraftConditionsFormatted);
   const permitConditions = useAppSelector(getPermitConditionCategories(permitGuid, currentAmendment?.permit_amendment_guid));
@@ -99,6 +94,24 @@ export const ReportPermitRequirementForm: FC<ReportPermitRequirementProps> = ({
 
   const { conditionMap, categoriesWithConditions } = conditions;
 
+  // Standard report requirements aren't filtered by template on the GET endpoint, so
+  // filter to only those requirements matching the notice_of_work_type (template)
+  // as the condition currently being edited.
+  const currentTemplateCondition = condition as unknown as IStandardPermitCondition;
+  const standardRequirementsForTemplate = isStandardConditionEditor
+    ? standardRequirements.filter((r) => {
+      const nowType = r.notice_of_work_type || (conditionMap[r.permit_condition_ids?.[0]] as unknown as IStandardPermitCondition)?.notice_of_work_type;
+      return nowType === currentTemplateCondition?.notice_of_work_type;
+    })
+    : standardRequirements;
+
+
+  const existingRequirements = isStandardConditionEditor ? standardRequirementsForTemplate : permitRequirements;
+
+  const hasExistingRequirements = existingRequirements?.length > 0;
+  const existingRequirementsOptions = existingRequirements.map((r) => { return { label: r.report_name, value: r.mine_report_permit_requirement_id } });
+  const disableFields = mineReportPermitRequirement?.mine_report_permit_requirement_id !== selectedRequirement?.mine_report_permit_requirement_id;
+  const multipleConditions = selectedRequirement?.permit_condition_ids.length > 1;
 
   const getLinkedConditionList = () => {
     if (!hasExistingRequirements || !selectedRequirement) {
@@ -176,6 +189,7 @@ export const ReportPermitRequirementForm: FC<ReportPermitRequirementProps> = ({
       resp = await dispatch(createMineReportPermitRequirement({ mineGuid, values }));
     }
     if (resp.payload) {
+      setSelectedRequirement(resp.payload);
       await refreshData();
       if (conditionId !== undefined) {
         clearActiveConditionId(conditionId);

--- a/services/common/src/interfaces/permits/mineReportPermitRequirements.interface.ts
+++ b/services/common/src/interfaces/permits/mineReportPermitRequirements.interface.ts
@@ -7,4 +7,7 @@ export interface IMineReportPermitRequirement {
   due_date_period_months: number;
   initial_due_date: string;
   permit_amendment_id?: number;
+  condition_category_code?: string;
+  notice_of_work_type?: string;
 }
+

--- a/services/common/src/tests/permits/ReportPermitRequirementForm.spec.tsx
+++ b/services/common/src/tests/permits/ReportPermitRequirementForm.spec.tsx
@@ -1,0 +1,105 @@
+import React from "react";
+import { fireEvent, render } from "@testing-library/react";
+import { ReduxWrapper } from "@mds/common/tests/utils/ReduxWrapper";
+import { PermitConditionsProvider } from "@mds/common/components/permits/PermitConditionsContext";
+import { ReportPermitRequirementForm } from "@mds/common/components/permits/ReportPermitRequirementForm";
+import { mineReportPermitRequirementReducerType } from "@mds/common/redux/slices/mineReportPermitRequirementSlice";
+
+// The condition currently being edited belongs to the "MIN" template.
+const condition: any = {
+  permit_condition_id: 999,
+  standard_permit_condition_id: 999,
+  condition_category_code: "GEC",
+  notice_of_work_type: "MIN",
+  sub_conditions: [],
+};
+
+const sameTemplateRequirement = {
+  mine_report_permit_requirement_id: 1,
+  report_name: "Same Template Report",
+  permit_condition_ids: [999],
+  condition_category_code: "GEC",
+  notice_of_work_type: "MIN",
+  due_date_period_months: 12,
+  cim_or_cpo: "CIM",
+  ministry_recipient: ["HS"],
+};
+
+const differentTemplateRequirement = {
+  mine_report_permit_requirement_id: 2,
+  report_name: "Different Template Report",
+  permit_condition_ids: [111],
+  condition_category_code: "GEC",
+  notice_of_work_type: "SAG",
+  due_date_period_months: 6,
+  cim_or_cpo: "CIM",
+  ministry_recipient: ["HS"],
+};
+
+const initialState = {
+  [mineReportPermitRequirementReducerType]: {
+    standardReportRequirements: [sameTemplateRequirement, differentTemplateRequirement],
+  },
+};
+
+const providerParams = {
+  mineGuid: "mine-guid",
+  isStandardConditionEditor: true,
+  currentAmendment: null,
+  loading: false,
+  setLoading: jest.fn(),
+  refreshData: jest.fn(),
+};
+
+const renderForm = () =>
+  render(
+    <ReduxWrapper initialState={initialState}>
+      <PermitConditionsProvider value={providerParams}>
+        <ReportPermitRequirementForm
+          canEditPermitConditions={true}
+          refreshData={jest.fn()}
+          condition={condition}
+          isModal
+        />
+      </PermitConditionsProvider>
+    </ReduxWrapper>
+  );
+
+describe("ReportPermitRequirementForm - standard condition template scoping", () => {
+  it("only offers existing reports from the same template in the 'Select an Existing Report' dropdown", async () => {
+    const { container, findByText, queryByText } = renderForm();
+
+    const combobox = container.querySelector('[id$="_mine_report_permit_requirement_id"]');
+    expect(combobox).toBeTruthy();
+    fireEvent.mouseDown(combobox);
+
+    await findByText("Same Template Report");
+    expect(queryByText("Different Template Report")).not.toBeInTheDocument();
+  });
+
+  it("does not show the report requirement selector when there are no reports for the current template", () => {
+    const emptyTemplateState = {
+      [mineReportPermitRequirementReducerType]: {
+        standardReportRequirements: [differentTemplateRequirement],
+      },
+    };
+
+    const { queryByText } = render(
+      <ReduxWrapper initialState={emptyTemplateState}>
+        <PermitConditionsProvider value={providerParams}>
+          <ReportPermitRequirementForm
+            canEditPermitConditions={true}
+            refreshData={jest.fn()}
+            condition={condition}
+            isModal
+          />
+        </PermitConditionsProvider>
+      </ReduxWrapper>
+    );
+
+    // The only existing report requirement belongs to a different template, so
+    // hasExistingRequirements should be false for the current (MIN) template and the
+    // "Select an Existing Report" field should not render at all.
+    expect(queryByText("Select an Existing Report")).not.toBeInTheDocument();
+  });
+});

--- a/services/common/src/tests/permits/ReportPermitRequirementForm.spec.tsx
+++ b/services/common/src/tests/permits/ReportPermitRequirementForm.spec.tsx
@@ -102,4 +102,44 @@ describe("ReportPermitRequirementForm - standard condition template scoping", ()
     // "Select an Existing Report" field should not render at all.
     expect(queryByText("Select an Existing Report")).not.toBeInTheDocument();
   });
+
+  it("correctly filters standard requirements by template when condition is undefined but requirement has notice_of_work_type", () => {
+    const anotherSameTemplateRequirement = {
+      mine_report_permit_requirement_id: 3,
+      report_name: "Another Same Template Report",
+      permit_condition_ids: [999],
+      condition_category_code: "GEC",
+      notice_of_work_type: "MIN",
+      due_date_period_months: 12,
+      cim_or_cpo: "CIM",
+      ministry_recipient: ["HS"],
+    };
+
+    const customState = {
+      [mineReportPermitRequirementReducerType]: {
+        standardReportRequirements: [
+          sameTemplateRequirement,
+          differentTemplateRequirement,
+          anotherSameTemplateRequirement,
+        ],
+      },
+    };
+
+    const { container } = render(
+      <ReduxWrapper initialState={customState}>
+        <PermitConditionsProvider value={providerParams}>
+          <ReportPermitRequirementForm
+            canEditPermitConditions={true}
+            refreshData={jest.fn()}
+            mineReportPermitRequirement={sameTemplateRequirement as any}
+            isModal
+          />
+        </PermitConditionsProvider>
+      </ReduxWrapper>
+    );
+
+    const input = container.querySelector('input[name="report_name"]');
+    expect(input).not.toBeNull();
+    expect(input).toHaveValue("Same Template Report");
+  });
 });

--- a/services/core-api/app/api/mines/permits/permit_conditions/resources/standard_report_permit_requirement_resource.py
+++ b/services/core-api/app/api/mines/permits/permit_conditions/resources/standard_report_permit_requirement_resource.py
@@ -55,7 +55,9 @@ class StandardReportPermitRequirementResource(Resource, UserMixin):
                 due_date_period_months=data.get("due_date_period_months"),
                 cim_or_cpo=cim_or_cpo,
                 ministry_recipient=data.get("ministry_recipient"),
-                permit_condition_ids=permit_condition_ids
+                permit_condition_ids=permit_condition_ids,
+                condition_category_code=permit_conditions[0].condition_category_code,
+                notice_of_work_type=permit_conditions[0].notice_of_work_type
             )
         except IntegrityError as e:
             current_app.logger.info(e)
@@ -89,6 +91,8 @@ class StandardReportPermitRequirementResource(Resource, UserMixin):
             
         cim_or_cpo = data.get("cim_or_cpo")
         data['cim_or_cpo'] = None if cim_or_cpo == "NONE" else CimOrCpo(cim_or_cpo)
+        data['condition_category_code'] = permit_conditions[0].condition_category_code
+        data['notice_of_work_type'] = permit_conditions[0].notice_of_work_type
 
         try:
             report_requirement.update(**data)

--- a/services/core-api/app/api/mines/permits/permit_conditions/resources/standard_report_permit_requirement_resource.py
+++ b/services/core-api/app/api/mines/permits/permit_conditions/resources/standard_report_permit_requirement_resource.py
@@ -41,11 +41,27 @@ class StandardReportPermitRequirementResource(Resource, UserMixin):
         data = self.parser.parse_args()
 
         permit_condition_ids = data.get("permit_condition_ids")
+        if not permit_condition_ids or len(permit_condition_ids) == 0:
+            raise BadRequest("Report requirement must be associated with one or more standard permit conditions.")
+
         permit_conditions = StandardPermitConditions.find_many_by_permit_condition_ids(permit_condition_ids)
 
         if not permit_conditions:
             raise NotFound("Standard Permit Conditions not found")
-        
+
+        if len(permit_conditions) != len(permit_condition_ids):
+            found_ids = {x.standard_permit_condition_id for x in permit_conditions}
+            not_found_ids = [pid for pid in permit_condition_ids if pid not in found_ids]
+            current_app.logger.info(f"Standard conditions with the following ids were not found: {', '.join(map(str, not_found_ids))}")
+            raise BadRequest(f"{len(not_found_ids)} standard conditions were not found")
+
+        now_types = {c.notice_of_work_type for c in permit_conditions}
+        if len(now_types) > 1:
+            raise BadRequest("All permit conditions must belong to the same Notice of Work type")
+
+        condition_map = {c.standard_permit_condition_id: c for c in permit_conditions}
+        ordered_permit_conditions = [condition_map[pid] for pid in permit_condition_ids if pid in condition_map]
+
         cim_or_cpo = data.get("cim_or_cpo")
         cim_or_cpo = None if cim_or_cpo == "NONE" else CimOrCpo(cim_or_cpo)
 
@@ -56,8 +72,8 @@ class StandardReportPermitRequirementResource(Resource, UserMixin):
                 cim_or_cpo=cim_or_cpo,
                 ministry_recipient=data.get("ministry_recipient"),
                 permit_condition_ids=permit_condition_ids,
-                condition_category_code=permit_conditions[0].condition_category_code,
-                notice_of_work_type=permit_conditions[0].notice_of_work_type
+                condition_category_code=ordered_permit_conditions[0].condition_category_code,
+                notice_of_work_type=ordered_permit_conditions[0].notice_of_work_type
             )
         except IntegrityError as e:
             current_app.logger.info(e)
@@ -82,17 +98,24 @@ class StandardReportPermitRequirementResource(Resource, UserMixin):
         if not permit_condition_ids or len(permit_condition_ids) == 0:
             raise BadRequest("Report requirement must be associated with one or more standard permit conditions.")
         
-        permit_conditions = StandardPermitConditions.find_many_by_permit_condition_ids(permit_condition_ids
-                                                                               )
+        permit_conditions = StandardPermitConditions.find_many_by_permit_condition_ids(permit_condition_ids)
         if len(permit_conditions) != len(permit_condition_ids):
-            not_found_ids = [x.permit_condition_id for x in permit_conditions if x.permit_condition_id not in permit_condition_ids]
+            found_ids = {x.standard_permit_condition_id for x in permit_conditions}
+            not_found_ids = [pid for pid in permit_condition_ids if pid not in found_ids]
             current_app.logger.info(f"Standard conditions with the following ids were not found: {', '.join(map(str, not_found_ids))}")
             raise BadRequest(f"{len(not_found_ids)} standard conditions were not found")
-            
+
+        now_types = {c.notice_of_work_type for c in permit_conditions}
+        if len(now_types) > 1:
+            raise BadRequest("All permit conditions must belong to the same Notice of Work type")
+
+        condition_map = {c.standard_permit_condition_id: c for c in permit_conditions}
+        ordered_permit_conditions = [condition_map[pid] for pid in permit_condition_ids if pid in condition_map]
+
         cim_or_cpo = data.get("cim_or_cpo")
         data['cim_or_cpo'] = None if cim_or_cpo == "NONE" else CimOrCpo(cim_or_cpo)
-        data['condition_category_code'] = permit_conditions[0].condition_category_code
-        data['notice_of_work_type'] = permit_conditions[0].notice_of_work_type
+        data['condition_category_code'] = ordered_permit_conditions[0].condition_category_code
+        data['notice_of_work_type'] = ordered_permit_conditions[0].notice_of_work_type
 
         try:
             report_requirement.update(**data)

--- a/services/core-api/app/api/mines/reports/models/mine_report_permit_requirement.py
+++ b/services/core-api/app/api/mines/reports/models/mine_report_permit_requirement.py
@@ -46,6 +46,14 @@ class MineReportPermitRequirement(SoftDeleteMixin, AuditMixin, HistoryMixin, Bas
     permit_amendment_id: int = db.Column(db.Integer, db.ForeignKey('permit_amendment.permit_amendment_id'))
     is_standard: bool = db.Column(db.Boolean, nullable=False, server_default='false')
 
+    # Only set for standard (template) report requirements, to scope report_name
+    # uniqueness to the template (condition_category_code + notice_of_work_type)
+    # rather than globally across all templates.
+    condition_category_code: Optional[str] = db.Column(
+        db.String, db.ForeignKey('permit_condition_category.condition_category_code'))
+    notice_of_work_type: Optional[str] = db.Column(
+        db.String, db.ForeignKey('notice_of_work_type.notice_of_work_type_code'))
+
     # creates a filter for the class so that all results returned by the cls.query have is_standard=False
     __mapper_args__ = {
         "polymorphic_on": is_standard,
@@ -252,7 +260,9 @@ class StandardReportPermitRequirement(MineReportPermitRequirement):
                due_date_period_months: int,
                cim_or_cpo: Optional[CimOrCpo],
                ministry_recipient: Optional[list[OfficeDestination]],
-               permit_condition_ids: list[int]
+               permit_condition_ids: list[int],
+               condition_category_code: Optional[str] = None,
+               notice_of_work_type: Optional[str] = None
                ) -> Self:
 
         standard_report_permit_requirement = cls(
@@ -260,6 +270,8 @@ class StandardReportPermitRequirement(MineReportPermitRequirement):
             due_date_period_months=due_date_period_months,\
             cim_or_cpo=cim_or_cpo,
             ministry_recipient=ministry_recipient,
+            condition_category_code=condition_category_code,
+            notice_of_work_type=notice_of_work_type,
         )
         for permit_condition_id in permit_condition_ids:
             xref = StandardReportReqPermitConditionXref.create(

--- a/services/core-api/app/api/mines/response_models.py
+++ b/services/core-api/app/api/mines/response_models.py
@@ -261,6 +261,8 @@ MINE_REPORT_PERMIT_REQUIREMENT = api.model(
         'permit_condition_ids': fields.List(fields.Integer),
         'permit_amendment_id': fields.Integer,
         'is_standard': fields.Boolean,
+        'condition_category_code': fields.String,
+        'notice_of_work_type': fields.String,
     }
 )
 

--- a/services/core-api/tests/mines/permit/resources/test_standard_report_permit_requirement_resource.py
+++ b/services/core-api/tests/mines/permit/resources/test_standard_report_permit_requirement_resource.py
@@ -1,4 +1,5 @@
 import json
+from app.api.now_applications.models.now_application_type import NOWApplicationType
 from tests.factories import StandardPermitConditionsFactory, StandardReportPermitRequirementFactory, StandardReportReqConditionXrefFactory
 
 def test_post_standard_report_permit_requirement(test_client, db_session, auth_headers):
@@ -94,7 +95,9 @@ def test_post_duplicate_standard_report_requirement_bad_request(test_client, db_
         due_date_period_months=6,
         cim_or_cpo='CIM',
         ministry_recipient=['HS'],
-        report_name="DUPLICATE_STANDARD_REPORT_NAME_TEST"
+        report_name="DUPLICATE_STANDARD_REPORT_NAME_TEST",
+        condition_category_code=standard_condition.condition_category_code,
+        notice_of_work_type=standard_condition.notice_of_work_type
     )
     StandardReportReqConditionXrefFactory(
         permit_condition=standard_condition,
@@ -117,4 +120,86 @@ def test_post_duplicate_standard_report_requirement_bad_request(test_client, db_
     )
     assert post_resp_2.status_code == 400
     data = json.loads(post_resp_2.data.decode())
+    assert "Report name must be unique" in data.get("message", "")
+
+def test_post_same_report_name_different_template_succeeds(test_client, db_session, auth_headers):
+    now_type_codes = [x.notice_of_work_type_code for x in NOWApplicationType.get_all()]
+    assert len(now_type_codes) >= 2, "Test requires at least two seeded notice_of_work_type codes"
+
+    condition_a = StandardPermitConditionsFactory(notice_of_work_type=now_type_codes[0])
+    condition_b = StandardPermitConditionsFactory(
+        notice_of_work_type=now_type_codes[1],
+        condition_category_code=condition_a.condition_category_code
+    )
+
+    report_req = StandardReportPermitRequirementFactory(
+        due_date_period_months=6,
+        cim_or_cpo='CIM',
+        ministry_recipient=['HS'],
+        report_name="SAME_NAME_DIFFERENT_TEMPLATE_TEST",
+        condition_category_code=condition_a.condition_category_code,
+        notice_of_work_type=condition_a.notice_of_work_type
+    )
+    StandardReportReqConditionXrefFactory(
+        permit_condition=condition_a,
+        mine_report_permit_requirement=report_req
+    )
+    db_session.commit()
+
+    # Same report_name, but linked to a condition belonging to a different template
+    # (different notice_of_work_type) -> should succeed.
+    submission_data = {
+        'due_date_period_months': 6,
+        'cim_or_cpo': 'CIM',
+        'ministry_recipient': ['HS'],
+        'permit_condition_ids': [condition_b.standard_permit_condition_id],
+        'report_name': "SAME_NAME_DIFFERENT_TEMPLATE_TEST"
+    }
+    post_resp = test_client.post(
+        '/mines/reports/standard-permit-requirements',
+        headers=auth_headers['full_auth_header'],
+        json=submission_data
+    )
+    assert post_resp.status_code == 201
+
+def test_post_same_report_name_different_category_same_template_fails(test_client, db_session, auth_headers):
+    # Standard conditions in the SAME template (same notice_of_work_type) but DIFFERENT condition_category_code
+    condition_cat1 = StandardPermitConditionsFactory(
+        notice_of_work_type='SAG',
+        condition_category_code='GNC'
+    )
+    condition_cat2 = StandardPermitConditionsFactory(
+        notice_of_work_type='SAG',
+        condition_category_code='HSC'
+    )
+
+    report_req = StandardReportPermitRequirementFactory(
+        due_date_period_months=6,
+        cim_or_cpo='CIM',
+        ministry_recipient=['HS'],
+        report_name="SAME_TEMPLATE_DIFF_CAT_TEST",
+        condition_category_code=condition_cat1.condition_category_code,
+        notice_of_work_type=condition_cat1.notice_of_work_type
+    )
+    StandardReportReqConditionXrefFactory(
+        permit_condition=condition_cat1,
+        mine_report_permit_requirement=report_req
+    )
+    db_session.commit()
+
+    # Attempting to use the same report_name in the same template under a different category should fail
+    submission_data = {
+        'due_date_period_months': 6,
+        'cim_or_cpo': 'CIM',
+        'ministry_recipient': ['HS'],
+        'permit_condition_ids': [condition_cat2.standard_permit_condition_id],
+        'report_name': "SAME_TEMPLATE_DIFF_CAT_TEST"
+    }
+    post_resp = test_client.post(
+        '/mines/reports/standard-permit-requirements',
+        headers=auth_headers['full_auth_header'],
+        json=submission_data
+    )
+    assert post_resp.status_code == 400
+    data = json.loads(post_resp.data.decode())
     assert "Report name must be unique" in data.get("message", "")

--- a/services/core-api/tests/mines/permit/resources/test_standard_report_permit_requirement_resource.py
+++ b/services/core-api/tests/mines/permit/resources/test_standard_report_permit_requirement_resource.py
@@ -166,7 +166,7 @@ def test_post_same_report_name_different_category_same_template_fails(test_clien
     # Standard conditions in the SAME template (same notice_of_work_type) but DIFFERENT condition_category_code
     condition_cat1 = StandardPermitConditionsFactory(
         notice_of_work_type='SAG',
-        condition_category_code='GNC'
+        condition_category_code='GEC'
     )
     condition_cat2 = StandardPermitConditionsFactory(
         notice_of_work_type='SAG',

--- a/services/core-api/tests/mines/permit/resources/test_standard_report_permit_requirement_resource.py
+++ b/services/core-api/tests/mines/permit/resources/test_standard_report_permit_requirement_resource.py
@@ -203,3 +203,64 @@ def test_post_same_report_name_different_category_same_template_fails(test_clien
     assert post_resp.status_code == 400
     data = json.loads(post_resp.data.decode())
     assert "Report name must be unique" in data.get("message", "")
+
+def test_post_mixed_now_types_bad_request(test_client, db_session, auth_headers):
+    condition_a = StandardPermitConditionsFactory(notice_of_work_type='SAG')
+    condition_b = StandardPermitConditionsFactory(notice_of_work_type='MIN')
+
+    submission_data = {
+        'due_date_period_months': 6,
+        'cim_or_cpo': 'CIM',
+        'ministry_recipient': ['HS'],
+        'permit_condition_ids': [
+            condition_a.standard_permit_condition_id,
+            condition_b.standard_permit_condition_id
+        ],
+        'report_name': "MIXED_NOW_TYPES_TEST"
+    }
+    post_resp = test_client.post(
+        '/mines/reports/standard-permit-requirements',
+        headers=auth_headers['full_auth_header'],
+        json=submission_data
+    )
+    assert post_resp.status_code == 400
+    data = json.loads(post_resp.data.decode())
+    assert "All permit conditions must belong to the same Notice of Work type" in data.get("message", "")
+
+def test_put_mixed_now_types_bad_request(test_client, db_session, auth_headers):
+    condition_a = StandardPermitConditionsFactory(notice_of_work_type='SAG')
+    condition_b = StandardPermitConditionsFactory(notice_of_work_type='MIN')
+
+    report_req = StandardReportPermitRequirementFactory(
+        due_date_period_months=6,
+        cim_or_cpo='CIM',
+        ministry_recipient=['HS'],
+        report_name="MIXED_NOW_TYPES_PUT_TEST",
+        condition_category_code=condition_a.condition_category_code,
+        notice_of_work_type=condition_a.notice_of_work_type
+    )
+    StandardReportReqConditionXrefFactory(
+        permit_condition=condition_a,
+        mine_report_permit_requirement=report_req
+    )
+    db_session.commit()
+
+    update_data = {
+        'mine_report_permit_requirement_id': report_req.mine_report_permit_requirement_id,
+        'due_date_period_months': 12,
+        'cim_or_cpo': 'CPO',
+        'ministry_recipient': ['MMO'],
+        'permit_condition_ids': [
+            condition_a.standard_permit_condition_id,
+            condition_b.standard_permit_condition_id
+        ],
+        'report_name': "MIXED_NOW_TYPES_PUT_TEST"
+    }
+    put_resp = test_client.put(
+        '/mines/reports/standard-permit-requirements',
+        headers=auth_headers['full_auth_header'],
+        json=update_data
+    )
+    assert put_resp.status_code == 400
+    data = json.loads(put_resp.data.decode())
+    assert "All permit conditions must belong to the same Notice of Work type" in data.get("message", "")


### PR DESCRIPTION

## Objective 

[MDS-6949](https://bcmines.atlassian.net/browse/MDS-6949)

## Summary

Fixes [MDS-6949]: report requirement names on permit condition templates were unique **globally** across every template, so adding a report (e.g. "Annual Reclamation") to one template (e.g. Sand and Gravel) blocked adding a report with the same name to any other template (e.g. MX), even though each template's report requirements should be entirely independent.

Report name uniqueness is now scoped to the template (`notice_of_work_type`), matching how the rest of the permit condition template system is scoped.

## Changes

**Database**
- Added `condition_category_code` and `notice_of_work_type` columns to `mine_report_permit_requirement` (and `mine_report_permit_requirement_version`), populated only for standard (template) report requirements.
- Backfilled existing standard report requirements from their linked `standard_permit_conditions`.
- Replaced the global `unique_standard_report_name_idx` (`UNIQUE (report_name) WHERE is_standard = TRUE`) with one scoped to the template: `UNIQUE (report_name, notice_of_work_type) WHERE is_standard = TRUE`.

**Backend**
- `StandardReportPermitRequirement.create()` now accepts and persists `condition_category_code`/`notice_of_work_type`.
- `StandardReportPermitRequirementResource` (`post`/`put`) derives these values from the linked `StandardPermitConditions` and passes them through, so every standard report requirement is tagged with its template on create/update.
- Exposed both fields on the `MINE_REPORT_PERMIT_REQUIREMENT` API response model.

**Frontend**
- `ReportPermitRequirementForm`: the "Select an Existing Report" dropdown and the client-side duplicate-name validator are now scoped to the current template's `notice_of_work_type` (falling back to a `conditionMap` lookup for older records without the field), instead of comparing against every template's reports.
- Fixed a UI race where, right after creating/updating a report requirement, the just-saved record (already present in the Redux store) would briefly fail the duplicate-name validation against itself before the form closed — `selectedRequirement` is now synced immediately on a successful save.

**Tests**
- Added/updated backend resource tests covering:
  - Same report name can be reused across two different templates (different `notice_of_work_type`) — now succeeds.
  - Same report name within the same template but a different condition category — still correctly rejected.
  - Existing duplicate-name-within-a-template test still passes.

## Expected result (from the ticket)

- ✅ Templates have their own distinct report requirements, independent of other templates.
- ✅ The same report name can be reused across different template types.
- ✅ "Select an Existing Report" is scoped to the current template, not all templates.
- Submitted reports were already correctly associated to a single template/permit and required no change (verified only).

