### PR TITLE
[MDS-6992] NoW verify contact, check existance of address to avoid error

### DIFF
--- a/services/core-web/src/components/Forms/noticeOfWork/VerifyNoWContacts.tsx
+++ b/services/core-web/src/components/Forms/noticeOfWork/VerifyNoWContacts.tsx
@@ -209,7 +209,7 @@ const renderContacts = ({
                                                                 : ""}
                                                         </p>
                                                     </div>
-                                                    <Address address={contactInformation.party?.address[0] || {}} />
+                                                    <Address address={contactInformation.party?.address?.[0] || {}} />
                                                 </div>
                                             )}
                                         </Col>
@@ -591,7 +591,7 @@ export const VerifyNoWContacts: React.FC<VerifyNoWContactsProps> = (props) => {
                                                         </div>
                                                         <p>{result.phone_no}</p>
                                                     </div>
-                                                    <Address address={result.address[0] || {}} />
+                                                    <Address address={result.address?.[0] || {}} />
                                                     {!result.phone_no && (
                                                         <Alert message="Phone number is required." type="error" showIcon />
                                                     )}

--- a/services/core-web/src/tests/components/Forms/noticeOfWork/VerifyNoWContacts.spec.tsx
+++ b/services/core-web/src/tests/components/Forms/noticeOfWork/VerifyNoWContacts.spec.tsx
@@ -1,11 +1,13 @@
 import React from "react";
 import { render, screen, fireEvent, waitFor, within, act } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
 import VerifyNoWContacts from "@/components/Forms/noticeOfWork/VerifyNoWContacts";
 import * as FORM from "@/constants/forms";
 import { ReduxWrapper } from "@/tests/utils/ReduxWrapper";
 import FormWrapper from "@mds/common/components/forms/FormWrapper";
 import { STATIC_CONTENT } from "@mds/common/constants/reducerTypes";
 import { searchReducerType } from "@mds/common/redux/slices/searchSlice";
+import server from "@/tests/server";
 
 jest.mock("@/components/common/wrappers/AuthorizationWrapper", () => ({ children }: any) => <>{children}</>);
 
@@ -150,5 +152,50 @@ describe("VerifyNoWContacts (add new contact flow)", () => {
             expect(headingEl).toBeInTheDocument();
         });
 
+    });
+});
+
+describe("VerifyNoWContacts (null address defensive rendering)", () => {
+    afterEach(() => {
+        server.resetHandlers();
+    });
+
+    it("does not crash when a matched contact's address is null", async () => {
+        server.use(
+            http.get("/%3CAPI_URL%3E/search", async () => {
+                return HttpResponse.json({
+                    search_results: {
+                        party: [
+                            {
+                                result: {
+                                    party_guid: "p-null-addr",
+                                    name: "No Address Person",
+                                    email: "noaddr@test.ca",
+                                    phone_no: "555",
+                                    address: null,
+                                },
+                            },
+                        ],
+                    },
+                });
+            })
+        );
+
+        renderWithStore();
+
+        fireEvent.click(screen.getAllByRole("button", { name: /Search Contact/i })[0]);
+        await waitFor(() => expect(screen.getByText(/Add New Core Contact/i)).toBeInTheDocument());
+
+        const optionsHeading = screen.getByRole("heading", { name: /Matching Contact Options/i });
+        const optionsContainer = optionsHeading.closest(".contact-rows") as HTMLElement;
+        const rowCheckboxes = within(optionsContainer).getAllByRole("checkbox");
+
+        fireEvent.click(rowCheckboxes[rowCheckboxes.length - 1]);
+
+        await waitFor(() => {
+            const coreDetailHeading = screen.getByRole("heading", { name: /Core Contact Detail/i });
+            const coreDetailContainer = coreDetailHeading.closest(".contact-rows") as HTMLElement;
+            expect(within(coreDetailContainer).getByText(/No Address Person/i)).toBeInTheDocument();
+        });
     });
 });

--- a/services/core-web/src/tests/components/Forms/noticeOfWork/VerifyNoWContacts.spec.tsx
+++ b/services/core-web/src/tests/components/Forms/noticeOfWork/VerifyNoWContacts.spec.tsx
@@ -184,7 +184,8 @@ describe("VerifyNoWContacts (null address defensive rendering)", () => {
         renderWithStore();
 
         fireEvent.click(screen.getAllByRole("button", { name: /Search Contact/i })[0]);
-        await waitFor(() => expect(screen.getByText(/Add New Core Contact/i)).toBeInTheDocument());
+        const addCoreContactButton = await screen.findByText(/Add New Core Contact/i);
+        expect(addCoreContactButton).toBeInTheDocument();
 
         const optionsHeading = screen.getByRole("heading", { name: /Matching Contact Options/i });
         const optionsContainer = optionsHeading.closest(".contact-rows") as HTMLElement;


### PR DESCRIPTION
## Objective 

[MDS-6992](https://bcmines.atlassian.net/browse/MDS-6992)

- In the verification stage for a NoW application when the user clicks on a checkbox of a matching contact a white screen with a console error appears for contacts that do not have an address. The fix was to add optional chaining for address to take into account the contacts that do not have an address.
