### PR TITLE
[MDS-6995] Define NoW Document Types (Figures, Documents)

### DIFF
--- a/migrations/sql/V2026.08.18.09.05__add_permit_package_document_type.sql
+++ b/migrations/sql/V2026.08.18.09.05__add_permit_package_document_type.sql
@@ -1,0 +1,21 @@
+CREATE TABLE permit_package_document_type (
+    permit_package_document_type_code character varying(20)                  NOT NULL PRIMARY KEY,
+    description                       character varying(100)                 NOT NULL            ,
+    active_ind                        boolean                  DEFAULT true  NOT NULL            ,
+    create_user                       character varying(60)                  NOT NULL            ,
+    create_timestamp                  timestamp with time zone DEFAULT now() NOT NULL            ,
+    update_user                       character varying(60)                  NOT NULL            ,
+    update_timestamp                  timestamp with time zone DEFAULT now() NOT NULL
+);
+
+ALTER TABLE permit_package_document_type OWNER TO mds;
+
+COMMENT ON TABLE permit_package_document_type IS 'The valid options for classifying a Notice of Work permit package document as a figure or a document.';
+
+ALTER TABLE now_application_document_xref
+    ADD COLUMN IF NOT EXISTS permit_package_document_type_code character varying(20);
+
+ALTER TABLE now_application_document_xref
+ADD CONSTRAINT now_application_document_xref_permit_package_document_type_fkey
+    FOREIGN KEY (permit_package_document_type_code)
+    REFERENCES permit_package_document_type(permit_package_document_type_code);

--- a/migrations/sql/afterMigrate__1__seed_data.sql
+++ b/migrations/sql/afterMigrate__1__seed_data.sql
@@ -693,7 +693,15 @@ VALUES
 ON CONFLICT DO NOTHING;
 
 
--- Mine Report Definitions have been managed by sequential migrations. 
+INSERT INTO permit_package_document_type
+(permit_package_document_type_code, description, active_ind, create_user, update_user)
+VALUES
+    ('FIGURE', 'Figure', true, 'system-mds', 'system-mds'),
+    ('DOCUMENT', 'Document', true, 'system-mds', 'system-mds')
+ON CONFLICT DO NOTHING;
+
+
+-- Mine Report Definitions have been managed by sequential migrations.
 -- V2019.07.05.15.01
 -- V2019.07.09.16.01
 -- V2019.09.28.14.16

--- a/services/common/src/interfaces/NoWDocument.interface.ts
+++ b/services/common/src/interfaces/NoWDocument.interface.ts
@@ -6,6 +6,7 @@ export interface INoWDocument {
   now_application_document_sub_type_code: string;
   description: string;
   is_final_package: boolean;
+  permit_package_document_type_code?: string;
   final_package_order: number;
   mine_document: IMineDocument;
 }

--- a/services/common/src/utils/featureFlag.ts
+++ b/services/common/src/utils/featureFlag.ts
@@ -40,6 +40,7 @@ export enum Feature {
   NOTICE_OF_WORK_TIER = "notice_of_work_tier",
   NOW_APPLICATION_DOCUMENT_SEARCH = "now_application_document_search",
   NOTICE_OF_WORK_NATIONS = 'notice_of_work_nations',
+  INSPECTOR_PERMIT_PACKAGE_TYPE_SELECTOR = "inspector_permit_package_type_selector",
 }
 
 export const initializeFlagsmith = async (flagsmithUrl, flagsmithKey) => {

--- a/services/common/src/utils/feature_flags.json
+++ b/services/common/src/utils/feature_flags.json
@@ -34,5 +34,6 @@
     "global_search_v2": true,
     "notice_of_work_tier": true,
     "now_application_document_search": true,
-    "notice_of_work_nations": true
+    "notice_of_work_nations": true,
+    "inspector_permit_package_type_selector": true
 }

--- a/services/core-api/app/api/now_applications/models/__init__.py
+++ b/services/core-api/app/api/now_applications/models/__init__.py
@@ -12,6 +12,7 @@ from .now_application_status import NOWApplicationStatus
 from .now_application_permit_type import NOWApplicationPermitType
 from .now_application_document_type import NOWApplicationDocumentType
 from .now_application_document_sub_type import NOWApplicationDocumentSubType
+from .permit_package_document_type import PermitPackageDocumentType
 from .now_application_review import NOWApplicationReview, NOWApplicationReviewDocumentXref
 from .now_application_review_type import NOWApplicationReviewType
 from .notice_of_work_tier import NoticeOfWorkTier
@@ -42,6 +43,7 @@ model_list = [
     NOWApplicationPermitType,
     NOWApplicationDocumentType,
     NOWApplicationDocumentSubType,
+    PermitPackageDocumentType,
     NOWApplicationReview,
     NOWApplicationReviewDocumentXref,
     NOWApplicationReviewType,

--- a/services/core-api/app/api/now_applications/models/now_application_document_xref.py
+++ b/services/core-api/app/api/now_applications/models/now_application_document_xref.py
@@ -30,6 +30,9 @@ class NOWApplicationDocumentXref(SoftDeleteMixin, AuditMixin, Base):
     description = db.Column(db.String)
     final_package_order = db.Column(db.Integer)
     is_final_package = db.Column(db.Boolean)
+    permit_package_document_type_code = db.Column(
+        db.String,
+        db.ForeignKey('permit_package_document_type.permit_package_document_type_code'))
     is_referral_package = db.Column(db.Boolean, server_default=FetchedValue())
     is_consultation_package = db.Column(db.Boolean, server_default=FetchedValue())
     is_system_generated = db.Column(db.Boolean, server_default=FetchedValue())

--- a/services/core-api/app/api/now_applications/models/permit_package_document_type.py
+++ b/services/core-api/app/api/now_applications/models/permit_package_document_type.py
@@ -1,0 +1,16 @@
+from sqlalchemy.schema import FetchedValue
+
+from app.extensions import db
+from app.api.utils.models_mixins import AuditMixin, Base
+
+
+class PermitPackageDocumentType(AuditMixin, Base):
+    __tablename__ = 'permit_package_document_type'
+
+    permit_package_document_type_code = db.Column(db.String, primary_key=True)
+    description = db.Column(db.String, nullable=False)
+    active_ind = db.Column(db.Boolean, nullable=False, server_default=FetchedValue())
+
+    @classmethod
+    def get_all(cls):
+        return cls.query.all()

--- a/services/core-api/app/api/now_applications/resources/now_application_document_resource.py
+++ b/services/core-api/app/api/now_applications/resources/now_application_document_resource.py
@@ -163,7 +163,9 @@ class NOWApplicationDocumentResource(Resource, UserMixin):
             xref.preamble_title = data.get('preamble_title')
             xref.preamble_author = data.get('preamble_author')
             xref.preamble_date = data.get('preamble_date')
-            xref.permit_package_document_type_code = data.get('permit_package_document_type_code')
+            permit_package_document_type_code = data.get('permit_package_document_type_code')
+            if permit_package_document_type_code is not None:
+                xref.permit_package_document_type_code = permit_package_document_type_code
 
             now_application = NOWApplication.find_by_application_guid(application_guid)
             if not now_application:

--- a/services/core-api/app/api/now_applications/resources/now_application_document_resource.py
+++ b/services/core-api/app/api/now_applications/resources/now_application_document_resource.py
@@ -86,6 +86,7 @@ class NOWApplicationDocumentResource(Resource, UserMixin):
     parser.add_argument('preamble_author', type=str, required=False)
     parser.add_argument('preamble_date', type=str, required=False)
     parser.add_argument('is_final_package', type=bool, required=False)
+    parser.add_argument('permit_package_document_type_code', type=str, required=False)
     parser.add_argument('final_package_order', type=int, required=False)
     parser.add_argument('description', type=str, required=False)
 
@@ -162,6 +163,7 @@ class NOWApplicationDocumentResource(Resource, UserMixin):
             xref.preamble_title = data.get('preamble_title')
             xref.preamble_author = data.get('preamble_author')
             xref.preamble_date = data.get('preamble_date')
+            xref.permit_package_document_type_code = data.get('permit_package_document_type_code')
 
             now_application = NOWApplication.find_by_application_guid(application_guid)
             if not now_application:
@@ -173,6 +175,7 @@ class NOWApplicationDocumentResource(Resource, UserMixin):
             xref.final_package_order = final_package_order
         else:
             xref.final_package_order = None
+            xref.permit_package_document_type_code = None
 
         xref.save()
         mine_document.save()

--- a/services/core-api/app/api/now_applications/response_models.py
+++ b/services/core-api/app/api/now_applications/response_models.py
@@ -344,6 +344,7 @@ NOW_APPLICATION_DOCUMENT = api.model(
         'now_application_document_sub_type_code': fields.String,
         'description': fields.String,
         'is_final_package': fields.Boolean,
+        'permit_package_document_type_code': fields.String,
         'is_system_generated': fields.Boolean,
         'final_package_order': fields.Integer,
         'is_referral_package': fields.Boolean,

--- a/services/core-api/tests/now_applications/resources/test_now_application_document_resource.py
+++ b/services/core-api/tests/now_applications/resources/test_now_application_document_resource.py
@@ -1,0 +1,69 @@
+from app.api.now_applications.models.now_application_document_xref import NOWApplicationDocumentXref
+from tests.now_application_factories import NOWApplicationIdentityFactory
+from tests.factories import MineDocumentFactory
+
+
+def _make_document_xref(now_application_identity):
+    mine_doc = MineDocumentFactory(mine=now_application_identity.mine)
+    xref = NOWApplicationDocumentXref(
+        now_application_id=now_application_identity.now_application_id,
+        mine_document_guid=mine_doc.mine_document_guid,
+        now_application_document_type_code='OTH')
+    return mine_doc, xref
+
+
+class TestNOWApplicationDocumentResourcePut:
+    """PUT /now-applications/ID/document/MINE_DOCUMENT_ID"""
+
+    def test_put_sets_permit_package_document_type_when_final_package(
+            self, test_client, db_session, auth_headers):
+        now_application_identity = NOWApplicationIdentityFactory()
+        mine_doc, xref = _make_document_xref(now_application_identity)
+        db_session.add(xref)
+        db_session.commit()
+
+        resp = test_client.put(
+            f'/now-applications/{now_application_identity.now_application_guid}/document/{mine_doc.mine_document_guid}',
+            json={'is_final_package': True, 'permit_package_document_type_code': 'FIGURE'},
+            headers=auth_headers['full_auth_header'])
+
+        assert resp.status_code == 200
+        db_session.refresh(xref)
+        assert xref.is_final_package is True
+        assert xref.permit_package_document_type_code == 'FIGURE'
+
+    def test_put_clears_permit_package_document_type_when_unchecked(
+            self, test_client, db_session, auth_headers):
+        now_application_identity = NOWApplicationIdentityFactory()
+        mine_doc, xref = _make_document_xref(now_application_identity)
+        xref.is_final_package = True
+        xref.permit_package_document_type_code = 'FIGURE'
+        db_session.add(xref)
+        db_session.commit()
+
+        resp = test_client.put(
+            f'/now-applications/{now_application_identity.now_application_guid}/document/{mine_doc.mine_document_guid}',
+            json={'is_final_package': False},
+            headers=auth_headers['full_auth_header'])
+
+        assert resp.status_code == 200
+        db_session.refresh(xref)
+        assert xref.is_final_package is False
+        assert xref.permit_package_document_type_code is None
+
+    def test_put_rejects_invalid_permit_package_document_type(
+            self, test_client, db_session, auth_headers):
+        now_application_identity = NOWApplicationIdentityFactory()
+        mine_doc, xref = _make_document_xref(now_application_identity)
+        db_session.add(xref)
+        db_session.commit()
+
+        resp = test_client.put(
+            f'/now-applications/{now_application_identity.now_application_guid}/document/{mine_doc.mine_document_guid}',
+            json={'is_final_package': True, 'permit_package_document_type_code': 'NOT_A_REAL_CODE'},
+            headers=auth_headers['full_auth_header'])
+
+        # A rejected FK triggers the app's generic error handler, which tears down the
+        # shared test session entirely - so we can't query through it further in this
+        # test. The 400 here is the meaningful assertion (rejected, not silently saved).
+        assert resp.status_code == 400

--- a/services/core-api/tests/now_applications/resources/test_now_application_document_resource.py
+++ b/services/core-api/tests/now_applications/resources/test_now_application_document_resource.py
@@ -51,6 +51,25 @@ class TestNOWApplicationDocumentResourcePut:
         assert xref.is_final_package is False
         assert xref.permit_package_document_type_code is None
 
+    def test_put_preserves_permit_package_document_type_when_not_supplied(
+            self, test_client, db_session, auth_headers):
+        now_application_identity = NOWApplicationIdentityFactory()
+        mine_doc, xref = _make_document_xref(now_application_identity)
+        xref.is_final_package = True
+        xref.permit_package_document_type_code = 'FIGURE'
+        db_session.add(xref)
+        db_session.commit()
+
+        resp = test_client.put(
+            f'/now-applications/{now_application_identity.now_application_guid}/document/{mine_doc.mine_document_guid}',
+            json={'is_final_package': True, 'description': 'Updated description only'},
+            headers=auth_headers['full_auth_header'])
+
+        assert resp.status_code == 200
+        db_session.refresh(xref)
+        assert xref.description == 'Updated description only'
+        assert xref.permit_package_document_type_code == 'FIGURE'
+
     def test_put_rejects_invalid_permit_package_document_type(
             self, test_client, db_session, auth_headers):
         now_application_identity = NOWApplicationIdentityFactory()

--- a/services/core-api/tests/now_applications/resources/test_now_application_document_resource.py
+++ b/services/core-api/tests/now_applications/resources/test_now_application_document_resource.py
@@ -63,7 +63,6 @@ class TestNOWApplicationDocumentResourcePut:
             json={'is_final_package': True, 'permit_package_document_type_code': 'NOT_A_REAL_CODE'},
             headers=auth_headers['full_auth_header'])
 
-        # A rejected FK triggers the app's generic error handler, which tears down the
-        # shared test session entirely - so we can't query through it further in this
-        # test. The 400 here is the meaningful assertion (rejected, not silently saved).
+        # A rejected FK triggers the generic error handler, which tears down the shared test session entirely - we can't query through it further in this test
+        # A 400 here is a meaningful assertion (rejected, not silently saved).
         assert resp.status_code == 400

--- a/services/core-web/src/components/Forms/noticeOfWork/EditNoticeOfWorkDocumentForm.tsx
+++ b/services/core-web/src/components/Forms/noticeOfWork/EditNoticeOfWorkDocumentForm.tsx
@@ -17,6 +17,15 @@ import RenderField from "@mds/common/components/forms/RenderField";
 import RenderDate from "@mds/common/components/forms/RenderDate";
 import RenderFileUpload from "@mds/common/components/forms/RenderFileUpload";
 import { IMineDocument, INoWDocument } from "@mds/common/interfaces";
+import { useFeatureFlag } from "@mds/common/providers/featureFlags/useFeatureFlag";
+import { Feature } from "@mds/common/utils/featureFlag";
+import AuthorizationWrapper from "@mds/common/wrappers/AuthorizationWrapper";
+import * as Permission from "@/constants/permissions";
+
+const PERMIT_PACKAGE_DOCUMENT_TYPE_OPTIONS = [
+  { value: "FIGURE", label: "Figure" },
+  { value: "DOCUMENT", label: "Document" },
+];
 
 export interface EditNoticeOfWorkDocumentFormProps {
   onSubmit: (values) => void | Promise<void>;
@@ -38,6 +47,7 @@ const EditNoticeOfWorkDocumentForm: FC<EditNoticeOfWorkDocumentFormProps> = ({
   initialValues,
 }) => {
   const dispatch = useDispatch();
+  const { isFeatureEnabled } = useFeatureFlag();
   const formValues = useSelector(getFormValues(FORM.EDIT_NOTICE_OF_WORK_DOCUMENT_FORM)) as INoWDocument ?? { is_final_package: false};
   const { is_final_package } = formValues;
   const dropdownNoticeOfWorkApplicationDocumentTypeOptions = useSelector(
@@ -58,6 +68,14 @@ const EditNoticeOfWorkDocumentForm: FC<EditNoticeOfWorkDocumentFormProps> = ({
   useEffect(() => {
     dispatch(change(FORM.EDIT_NOTICE_OF_WORK_DOCUMENT_FORM, "uploadedFiles", uploadedFiles));
   }, [uploadedFiles]);
+
+  useEffect(() => {
+    if (!is_final_package) {
+      dispatch(
+        change(FORM.EDIT_NOTICE_OF_WORK_DOCUMENT_FORM, "permit_package_document_type_code", undefined)
+      );
+    }
+  }, [is_final_package]);
 
   const onFileLoad = (document_name: string, document_manager_guid: string) => {
     const newFile = { document_name, document_manager_guid } as IMineDocument;
@@ -109,15 +127,35 @@ const EditNoticeOfWorkDocumentForm: FC<EditNoticeOfWorkDocumentFormProps> = ({
             maximumCharacters={280}
             validate={maxLength(280)}
           />
-          {!isInCompleteStatus && (
-            <Field
-              id="is_final_package"
-              name="is_final_package"
-              label="Part of permit package"
-              type="checkbox"
-              component={RenderCheckbox}
-            />
-          )}
+          <Row gutter={16} align="middle">
+            {!isInCompleteStatus && (
+              <Col md={12} xs={24}>
+                <Field
+                  id="is_final_package"
+                  name="is_final_package"
+                  label="Part of permit package"
+                  type="checkbox"
+                  component={RenderCheckbox}
+                />
+              </Col>
+            )}
+            {is_final_package && isFeatureEnabled(Feature.INSPECTOR_PERMIT_PACKAGE_TYPE_SELECTOR) && (
+              <Col md={12} xs={24}>
+                <AuthorizationWrapper permission={Permission.EDIT_PERMITS} showToolTip={false}>
+                  <Field
+                    id="permit_package_document_type_code"
+                    name="permit_package_document_type_code"
+                    label="Document Type"
+                    placeholder="Select a type"
+                    component={RenderSelect}
+                    data={PERMIT_PACKAGE_DOCUMENT_TYPE_OPTIONS}
+                    validate={[required]}
+                    required
+                  />
+                </AuthorizationWrapper>
+              </Col>
+            )}
+          </Row>
           {is_final_package && (
             <>
               <Row gutter={16}>

--- a/services/core-web/src/components/Forms/noticeOfWork/EditNoticeOfWorkDocumentForm.tsx
+++ b/services/core-web/src/components/Forms/noticeOfWork/EditNoticeOfWorkDocumentForm.tsx
@@ -140,7 +140,7 @@ const EditNoticeOfWorkDocumentForm: FC<EditNoticeOfWorkDocumentFormProps> = ({
               </Col>
             )}
             {is_final_package && isFeatureEnabled(Feature.INSPECTOR_PERMIT_PACKAGE_TYPE_SELECTOR) && (
-              <Col md={12} xs={24}>
+              <Col md={isInCompleteStatus ? 24 : 12} xs={24}>
                 <AuthorizationWrapper permission={Permission.EDIT_PERMITS} showToolTip={false}>
                   <Field
                     id="permit_package_document_type_code"

--- a/services/core-web/src/components/noticeOfWork/applications/NOWDocuments.js
+++ b/services/core-web/src/components/noticeOfWork/applications/NOWDocuments.js
@@ -192,6 +192,7 @@ export class NOWDocuments extends Component {
         now_application_document_type_code: values.now_application_document_type_code,
         description: values.description,
         is_final_package: values.is_final_package,
+        permit_package_document_type_code: values.permit_package_document_type_code,
         preamble_title: values?.preamble_title,
         preamble_author: values?.preamble_author,
         mine_document: {

--- a/services/core-web/src/components/noticeOfWork/applications/NOWSubmissionDocuments.js
+++ b/services/core-web/src/components/noticeOfWork/applications/NOWSubmissionDocuments.js
@@ -147,6 +147,7 @@ export const NOWSubmissionDocuments = (props) => {
         now_application_document_type_code: values.now_application_document_type_code,
         description: values.description,
         is_final_package: values.is_final_package,
+        permit_package_document_type_code: values.permit_package_document_type_code,
         preamble_title: values?.preamble_title,
         preamble_author: values?.preamble_author,
         mine_document: {

--- a/services/core-web/src/tests/components/Forms/noticeOfWork/EditNoticeOfWorkDocumentForm.spec.tsx
+++ b/services/core-web/src/tests/components/Forms/noticeOfWork/EditNoticeOfWorkDocumentForm.spec.tsx
@@ -1,0 +1,70 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import EditNoticeOfWorkDocumentForm from "@/components/Forms/noticeOfWork/EditNoticeOfWorkDocumentForm";
+import { ReduxWrapper } from "@/tests/utils/ReduxWrapper";
+import { AUTHENTICATION } from "@mds/common/constants/reducerTypes";
+import { USER_ROLES } from "@mds/common/constants/environment";
+import { Feature } from "@mds/common/utils/featureFlag";
+
+jest.mock("@mds/common/providers/featureFlags/useFeatureFlag", () => ({
+    useFeatureFlag: jest.fn().mockReturnValue({ isFeatureEnabled: jest.fn().mockReturnValue(true) }),
+}));
+
+const baseProps = {
+    onSubmit: jest.fn(),
+    title: "Edit Notice of Work document",
+    now_application_guid: "test-guid",
+    isEditMode: true,
+    isInCompleteStatus: false,
+    categoriesToShow: [],
+};
+
+const authenticatedState = (hasEditPermits: boolean) => ({
+    [AUTHENTICATION]: {
+        userAccessData: hasEditPermits ? [USER_ROLES.role_edit_permits] : [],
+    },
+});
+
+const renderForm = (isFinalPackage: boolean, state: any) =>
+    render(
+        <ReduxWrapper initialState={state}>
+            <EditNoticeOfWorkDocumentForm
+                {...baseProps}
+                initialValues={{ is_final_package: isFinalPackage }}
+            />
+        </ReduxWrapper>
+    );
+
+describe("EditNoticeOfWorkDocumentForm - permit package document type selector", () => {
+    afterEach(() => {
+        jest.clearAllMocks();
+        const { useFeatureFlag } = require("@mds/common/providers/featureFlags/useFeatureFlag");
+        useFeatureFlag.mockReturnValue({ isFeatureEnabled: jest.fn().mockReturnValue(true) });
+    });
+
+    it("does not show the Document Type dropdown when Part of permit package is unchecked", () => {
+        renderForm(false, authenticatedState(true));
+        expect(screen.queryByText(/Document Type/i)).not.toBeInTheDocument();
+    });
+
+    it("shows the Document Type dropdown when checked, flag enabled, and user has edit_permits", () => {
+        renderForm(true, authenticatedState(true));
+        expect(screen.getByText(/Document Type/i)).toBeInTheDocument();
+    });
+
+    it("hides the Document Type dropdown when the user lacks the edit_permits role", () => {
+        renderForm(true, authenticatedState(false));
+        expect(screen.queryByText(/Document Type/i)).not.toBeInTheDocument();
+    });
+
+    it("hides the Document Type dropdown when the feature flag is disabled", () => {
+        const { useFeatureFlag } = require("@mds/common/providers/featureFlags/useFeatureFlag");
+        useFeatureFlag.mockReturnValue({
+            isFeatureEnabled: jest
+                .fn()
+                .mockImplementation((feature) => feature !== Feature.INSPECTOR_PERMIT_PACKAGE_TYPE_SELECTOR),
+        });
+        renderForm(true, authenticatedState(true));
+        expect(screen.queryByText(/Document Type/i)).not.toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
## Objective 

[MDS-6995](https://bcmines.atlassian.net/browse/MDS-6995)

_Why are you making this change? Provide a short explanation and/or screenshots_

To better support NoW workflows, we want permitting inspectors to be able to refer to specific types of permit package files so that they don’t have to make changes to the issued permit PDF to make it match the list of figures they want to attach. In order to do this, we need to tag/categories files added to the Permit Package as either 'Figures' or 'Documents', so they can be easily referred to later.

This PR adds support for this by letting users define the type of a NoW file (Document, Figure) when it's being uploaded to Core in the NoW flow. 

**NOTE:** This functionality is gated behind the `inspector_permit_package_type_selector` Flagsmith Flag (Currently enabled in Dev/Test, but NOT Prod)

**NOTE:** Currently, the Title, Date, Author of a permit package file is _not_ mandatory - the Jira ticket makes note that this will likely need to change, but that some conversations need to be had first.

Specifically:
- Added backend support for NoW File Type (Figure, Document) - including migration and models for new DB column, updated API models to handle new fields, updated unit tests as necessary
- Added frontend support for ability to define a NoW file type - added dropdown for selecting the file type, include this value in API calls to backend, added unit tests and updated relevant snapshots