### PR TITLE
[CHORE] Adjustment to final_package_order value being saved for system generated documents

### DIFF
--- a/services/core-api/app/api/now_applications/models/now_application.py
+++ b/services/core-api/app/api/now_applications/models/now_application.py
@@ -21,7 +21,7 @@ from app.api.now_submissions.models.document import Document
 from app.api.mines.permits.permit_amendment.models.permit_amendment import PermitAmendment
 from app.api.mines.mine.models.mine_type import MineType
 from app.api.mines.permits.permit_conditions.models.permit_conditions import PermitConditions
-from flask import current_app
+LOCKED_NTR_FINAL_PACKAGE_ORDER = -1
 
 
 class NOWApplication(Base, AuditMixin):
@@ -425,7 +425,7 @@ class NOWApplication(Base, AuditMixin):
         now_doc = NOWApplicationDocumentXref.find_by_guid(now_application_document_xref_guid)
         now_doc.is_final_package = True
         now_doc.is_system_generated = True
-        now_doc.final_package_order = self.next_document_final_package_order
+        now_doc.final_package_order = LOCKED_NTR_FINAL_PACKAGE_ORDER
         now_doc.description = description
         now_doc.preamble_title = "Notice of Work Application"
         now_doc.preamble_author = "N/A"

--- a/services/core-api/tests/now_applications/models/test_now_application.py
+++ b/services/core-api/tests/now_applications/models/test_now_application.py
@@ -103,7 +103,7 @@ class TestAddNowFormToFap:
     def test_sets_final_package_order_and_description(self, mock_export, mock_doc_resource,
                                                       mock_xref, app):
         """final_package_order and description must be set on the new document."""
-        from app.api.now_applications.models.now_application import NOWApplication
+        from app.api.now_applications.models.now_application import NOWApplication, LOCKED_NTR_FINAL_PACKAGE_ORDER
         mock_export.get_now_form_generate_token.return_value = 'token-abc'
         mock_doc_resource.generate_now_document.return_value = {
             'now_application_document_xref_guid': 'new-xref-guid'
@@ -114,7 +114,7 @@ class TestAddNowFormToFap:
         instance = self._make_now_application(NOWApplication)
         instance.add_now_form_to_fap('My custom description')
 
-        assert mock_now_doc.final_package_order == 5
+        assert mock_now_doc.final_package_order == LOCKED_NTR_FINAL_PACKAGE_ORDER
         assert mock_now_doc.description == 'My custom description'
         assert mock_now_doc.is_final_package is True
         mock_now_doc.save.assert_called_once()

--- a/services/core-web/src/components/noticeOfWork/applications/FinalPermitDocuments.js
+++ b/services/core-web/src/components/noticeOfWork/applications/FinalPermitDocuments.js
@@ -37,7 +37,6 @@ const defaultProps = {
 };
 
 const LOCKED_ROW_BASE = {
-  final_package_order: -1,
   isLockedApplicationForm: true,
   now_application_document_type_code: null,
   is_final_package: true,
@@ -47,6 +46,7 @@ const LOCKED_ROW_BASE = {
 
 const NA_ROW = {
   ...LOCKED_ROW_BASE,
+  final_package_order: -1,
   now_application_document_xref_guid: "application-form-1.1", // synthetic key — no real NTR doc exists yet
   preamble_title: "N/A",
   preamble_author: "N/A",

--- a/services/core-web/src/components/noticeOfWork/applications/NOWDocuments.js
+++ b/services/core-web/src/components/noticeOfWork/applications/NOWDocuments.js
@@ -93,6 +93,7 @@ const transformDocuments = (
   documents &&
   documents
     .sort((a, b) => {
+      if (a.isLockedApplicationForm && b.isLockedApplicationForm) return 0;
       if (a.isLockedApplicationForm) return -1;
       if (b.isLockedApplicationForm) return 1;
       return a.final_package_order - b.final_package_order;

--- a/services/core-web/src/components/noticeOfWork/applications/NOWDocuments.js
+++ b/services/core-web/src/components/noticeOfWork/applications/NOWDocuments.js
@@ -92,7 +92,11 @@ const transformDocuments = (
 ) =>
   documents &&
   documents
-    .sort((a, b) => a.final_package_order - b.final_package_order)
+    .sort((a, b) => {
+      if (a.isLockedApplicationForm) return -1;
+      if (b.isLockedApplicationForm) return 1;
+      return a.final_package_order - b.final_package_order;
+    })
     .map((document, index) => ({
       key: document.now_application_document_xref_guid,
       now_application_document_xref_guid: document.now_application_document_xref_guid,


### PR DESCRIPTION
## Objective 

[MDS-6981](https://bcmines.atlassian.net/browse/MDS-6981)

- I noticed in the now_application_document_xref database table the final_package_order for system generated documents don't really accurate represent when a document is the latest system generated document (would show up as 1.1 order in the permit package table on the front end). Instead we would have for example a document that is suppose to be a value to represent 1.1 but the final_package_order in the database might show it as 5.

- This pull request is purely for data correctness, for the future in case someone is working around the order of the permit package table and they want to make use of final_package_order to do something
