### PR TITLE
[MDS-6943] - Save "Last Indexed" now document search time

### DIFF
--- a/migrations/sql/V2026.08.21.17.22__add_now_application_document_index_run_table.sql
+++ b/migrations/sql/V2026.08.21.17.22__add_now_application_document_index_run_table.sql
@@ -1,0 +1,19 @@
+CREATE TABLE now_application_document_index_run (
+	create_user VARCHAR(60) NOT NULL,
+	create_timestamp TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+	update_user VARCHAR(60) NOT NULL,
+	update_timestamp TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+	now_application_document_index_run_id UUID NOT NULL DEFAULT gen_random_uuid(),
+	now_application_guid UUID NOT NULL,
+	status VARCHAR(255) NOT NULL,
+	document_count INTEGER NOT NULL DEFAULT 0,
+	items_processed INTEGER NOT NULL DEFAULT 0,
+	error_count INTEGER NOT NULL DEFAULT 0,
+	error_message VARCHAR,
+	last_run_start TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+	last_run_end TIMESTAMP WITHOUT TIME ZONE,
+	core_status_task_id VARCHAR(255),
+	PRIMARY KEY (now_application_document_index_run_id),
+	FOREIGN KEY(now_application_guid) REFERENCES now_application_identity (now_application_guid)
+);
+CREATE INDEX IF NOT EXISTS now_application_document_index_run_guid_idx ON now_application_document_index_run (now_application_guid);

--- a/services/common/src/redux/slices/nowApplicationSearchSlice.ts
+++ b/services/common/src/redux/slices/nowApplicationSearchSlice.ts
@@ -28,7 +28,13 @@ export enum SearchEventType {
 
 export type NowApplicationSearchFilters = Array<{ category: string; value: string }>;
 
-export type NowIndexerStatusValue = "never_run" | "running" | "success" | "error" | "transientFailure";
+export type NowIndexerStatusValue =
+  | "never_run"
+  | "running"
+  | "success"
+  | "error"
+  | "transientFailure"
+  | "cancelled";
 
 export interface NowIndexerStatus {
   status: NowIndexerStatusValue;

--- a/services/common/src/redux/slices/nowApplicationSearchSlice.ts
+++ b/services/common/src/redux/slices/nowApplicationSearchSlice.ts
@@ -33,6 +33,7 @@ export type NowIndexerStatusValue = "never_run" | "running" | "success" | "error
 export interface NowIndexerStatus {
   status: NowIndexerStatusValue;
   items_processed: number;
+  document_count?: number;
   error_count: number;
   last_run_start: string | null;
   last_run_end: string | null;

--- a/services/core-api/app/api/now_applications/models/__init__.py
+++ b/services/core-api/app/api/now_applications/models/__init__.py
@@ -12,6 +12,7 @@ from .now_application_status import NOWApplicationStatus
 from .now_application_permit_type import NOWApplicationPermitType
 from .now_application_document_type import NOWApplicationDocumentType
 from .now_application_document_sub_type import NOWApplicationDocumentSubType
+from .now_application_document_index_run import NowApplicationDocumentIndexRun
 from .permit_package_document_type import PermitPackageDocumentType
 from .now_application_review import NOWApplicationReview, NOWApplicationReviewDocumentXref
 from .now_application_review_type import NOWApplicationReviewType
@@ -43,6 +44,7 @@ model_list = [
     NOWApplicationPermitType,
     NOWApplicationDocumentType,
     NOWApplicationDocumentSubType,
+    NowApplicationDocumentIndexRun,
     PermitPackageDocumentType,
     NOWApplicationReview,
     NOWApplicationReviewDocumentXref,

--- a/services/core-api/app/api/now_applications/models/now_application_document_index_run.py
+++ b/services/core-api/app/api/now_applications/models/now_application_document_index_run.py
@@ -1,0 +1,51 @@
+from app.api.utils.models_mixins import AuditMixin, Base
+from app.extensions import db
+from sqlalchemy.dialects.postgresql import UUID
+
+
+def to_utc_isoformat(dt):
+    """
+    Serializes a naive UTC datetime (e.g. from datetime.utcnow()) with an explicit
+    'Z' suffix so JS `new Date(...)` parses it as UTC instead of local time.
+    """
+    return f'{dt.isoformat()}Z' if dt else None
+
+
+class NowApplicationDocumentIndexRun(AuditMixin, Base):
+    __tablename__ = 'now_application_document_index_run'
+
+    now_application_document_index_run_id = db.Column(
+        UUID(as_uuid=True), primary_key=True, server_default=db.FetchedValue())
+
+    now_application_guid = db.Column(
+        UUID(as_uuid=True), db.ForeignKey('now_application_identity.now_application_guid'), nullable=False)
+
+    status = db.Column(db.String(255), nullable=False)
+    document_count = db.Column(db.Integer, nullable=False, server_default='0')
+    items_processed = db.Column(db.Integer, nullable=False, server_default='0')
+    error_count = db.Column(db.Integer, nullable=False, server_default='0')
+    error_message = db.Column(db.String, nullable=True)
+
+    last_run_start = db.Column(db.DateTime, nullable=False)
+    last_run_end = db.Column(db.DateTime, nullable=True)
+
+    # task_id for the core celery task responsible for polling permits and updating this row
+    core_status_task_id = db.Column(db.String(255), nullable=True)
+
+    now_application_identity = db.relationship(
+        'NOWApplicationIdentity',
+        lazy='select',
+        backref=db.backref(
+            'document_index_runs', lazy='select', order_by='NowApplicationDocumentIndexRun.create_timestamp.desc()'))
+
+    @classmethod
+    def get_latest_by_now_application_guid(cls, now_application_guid):
+        return cls.query.filter_by(now_application_guid=now_application_guid) \
+            .order_by(cls.create_timestamp.desc()).first()
+
+    @classmethod
+    def create(cls, **kwargs):
+        obj = cls(**kwargs)
+        db.session.add(obj)
+        db.session.commit()
+        return obj

--- a/services/core-api/app/api/now_applications/resources/now_application_document_search_resource.py
+++ b/services/core-api/app/api/now_applications/resources/now_application_document_search_resource.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from app.api.mines.response_models import NOW_DOCUMENT_SEARCH_MODEL
 from app.api.now_applications.models.now_application_document_index_run import (
@@ -87,14 +87,22 @@ class NOWApplicationDocumentIndexResource(Resource, UserMixin):
         if not documents:
             return {'message': 'No indexable documents found for this application.'}, 200
 
-        result = NowApplicationSearchService().index_documents(now_application_guid, documents)
-
         run = NowApplicationDocumentIndexRun.create(
             now_application_guid=now_application_guid,
             status='running',
             document_count=len(documents),
             last_run_start=datetime.utcnow(),
         )
+
+        try:
+            result = NowApplicationSearchService().index_documents(now_application_guid, documents)
+        except Exception as exc:
+            run.status = 'error'
+            run.error_message = str(exc)
+            run.last_run_end = datetime.utcnow()
+            run.save()
+            raise
+
         poll_task = poll_update_now_application_document_index_status.delay(
             str(run.now_application_document_index_run_id))
         run.core_status_task_id = poll_task.id
@@ -134,6 +142,14 @@ class NOWApplicationDocumentIndexStatusResource(Resource, UserMixin):
 
         run = NowApplicationDocumentIndexRun.get_latest_by_now_application_guid(now_application_guid)
         if run:
+            if run.status == 'running' and run.last_run_start and (
+                datetime.utcnow() - run.last_run_start
+            ) > timedelta(minutes=STALE_RUNNING_THRESHOLD_MINUTES):
+                run.status = 'error'
+                run.error_message = 'Indexing run timed out with no status update from the search service.'
+                run.last_run_end = datetime.utcnow()
+                run.save()
+
             status['last_run_start'] = to_utc_isoformat(run.last_run_start)
             status['last_run_end'] = to_utc_isoformat(run.last_run_end)
             status['document_count'] = run.document_count
@@ -151,6 +167,12 @@ class NOWApplicationDocumentIndexStatusResource(Resource, UserMixin):
 # ---------------------------------------------------------------------------
 
 SPATIAL_EXTENSIONS = {'.shp', '.shx', '.dbf', '.prj', '.kml', '.kmz', '.gdb', '.gpx', '.geojson'}
+
+# The polling task retries every 10s for up to 360 attempts (~1 hour) before giving up and
+# marking the run as errored. If the celery worker is restarted mid-poll, the task is lost
+# entirely and on_failure never fires, so this is a fallback so a run doesn't display as
+# "running" forever in that case.
+STALE_RUNNING_THRESHOLD_MINUTES = 90
 
 
 def _collect_indexable_documents(now_application) -> list:

--- a/services/core-api/app/api/now_applications/resources/now_application_document_search_resource.py
+++ b/services/core-api/app/api/now_applications/resources/now_application_document_search_resource.py
@@ -1,6 +1,15 @@
+from datetime import datetime
+
 from app.api.mines.response_models import NOW_DOCUMENT_SEARCH_MODEL
+from app.api.now_applications.models.now_application_document_index_run import (
+    NowApplicationDocumentIndexRun,
+    to_utc_isoformat,
+)
 from app.api.now_applications.models.now_application_identity import (
     NOWApplicationIdentity,
+)
+from app.api.now_applications.tasks import (
+    poll_update_now_application_document_index_status,
 )
 from app.api.search.search.now_application_search_service import (
     NowApplicationSearchService,
@@ -79,6 +88,18 @@ class NOWApplicationDocumentIndexResource(Resource, UserMixin):
             return {'message': 'No indexable documents found for this application.'}, 200
 
         result = NowApplicationSearchService().index_documents(now_application_guid, documents)
+
+        run = NowApplicationDocumentIndexRun.create(
+            now_application_guid=now_application_guid,
+            status='running',
+            document_count=len(documents),
+            last_run_start=datetime.utcnow(),
+        )
+        poll_task = poll_update_now_application_document_index_status.delay(
+            str(run.now_application_document_index_run_id))
+        run.core_status_task_id = poll_task.id
+        run.save()
+
         return result, 200
 
     @api.doc(description="Cancel the active indexing task for a Notice of Work application.")
@@ -89,7 +110,15 @@ class NOWApplicationDocumentIndexResource(Resource, UserMixin):
         if not now_application_identity:
             raise NotFound('Notice of Work application not found.')
 
-        return NowApplicationSearchService().cancel_indexing(now_application_guid), 200
+        result = NowApplicationSearchService().cancel_indexing(now_application_guid)
+
+        run = NowApplicationDocumentIndexRun.get_latest_by_now_application_guid(now_application_guid)
+        if run and run.status == 'running':
+            run.status = 'cancelled'
+            run.last_run_end = datetime.utcnow()
+            run.save()
+
+        return result, 200
 
 
 class NOWApplicationDocumentIndexStatusResource(Resource, UserMixin):
@@ -101,7 +130,20 @@ class NOWApplicationDocumentIndexStatusResource(Resource, UserMixin):
         if not now_application_identity:
             raise NotFound('Notice of Work application not found.')
 
-        return NowApplicationSearchService().get_index_status(now_application_guid), 200
+        status = NowApplicationSearchService().get_index_status(now_application_guid)
+
+        run = NowApplicationDocumentIndexRun.get_latest_by_now_application_guid(now_application_guid)
+        if run:
+            status['last_run_start'] = to_utc_isoformat(run.last_run_start)
+            status['last_run_end'] = to_utc_isoformat(run.last_run_end)
+            status['document_count'] = run.document_count
+            if run.status != 'running':
+                status['status'] = run.status
+                status['items_processed'] = run.items_processed
+                status['error_count'] = run.error_count
+                status['error_message'] = run.error_message
+
+        return status, 200
 
 
 # ---------------------------------------------------------------------------

--- a/services/core-api/app/api/now_applications/tasks.py
+++ b/services/core-api/app/api/now_applications/tasks.py
@@ -31,7 +31,10 @@ class NowApplicationIndexTaskBase(Task):
             run = NowApplicationDocumentIndexRun.query.get(now_application_document_index_run_id)
 
             if not run:
-                raise InternalServerError('NowApplicationDocumentIndexRun not found')
+                current_app.logger.error(
+                    f'NowApplicationDocumentIndexRun {now_application_document_index_run_id} not found '
+                    f'while handling task failure: {exc}')
+                return
 
             run.status = 'error'
             run.error_message = str(exc)

--- a/services/core-api/app/api/now_applications/tasks.py
+++ b/services/core-api/app/api/now_applications/tasks.py
@@ -1,0 +1,67 @@
+from datetime import datetime
+
+from app.api.now_applications.models.now_application_document_index_run import (
+    NowApplicationDocumentIndexRun,
+)
+from app.api.search.search.now_application_search_service import (
+    NowApplicationSearchService,
+)
+from app.tasks.celery import celery
+from celery import Task
+from flask import current_app
+from werkzeug.exceptions import InternalServerError
+
+
+class NowApplicationIndexTaskBase(Task):
+    """
+    Ensures a Celery failure while polling for indexing status is recorded on the
+    corresponding NowApplicationDocumentIndexRun row.
+    """
+
+    def __call__(self, *args, **kwargs):
+        from app.tasks.celery_entrypoint import celery_app
+
+        with celery_app.app_context():
+            return Task.__call__(self, *args, **kwargs)
+
+    def on_failure(self, exc, task_id, args, kwargs, einfo):
+        from app.tasks.celery_entrypoint import celery_app
+        with celery_app.app_context():
+            now_application_document_index_run_id = args[0]
+            run = NowApplicationDocumentIndexRun.query.get(now_application_document_index_run_id)
+
+            if not run:
+                raise InternalServerError('NowApplicationDocumentIndexRun not found')
+
+            run.status = 'error'
+            run.error_message = str(exc)
+            run.last_run_end = datetime.utcnow()
+            run.save()
+
+
+@celery.task(base=NowApplicationIndexTaskBase, max_retries=360)
+def poll_update_now_application_document_index_status(now_application_document_index_run_id):
+    """
+    Poll the permits service for the status of a NoW application document indexing
+    run every 10s until it reaches a terminal state (anything other than "running").
+    """
+    run = NowApplicationDocumentIndexRun.query.get(now_application_document_index_run_id)
+    if not run:
+        raise InternalServerError('NowApplicationDocumentIndexRun not found')
+
+    index_status = NowApplicationSearchService().get_index_status(str(run.now_application_guid))
+    status = index_status.get('status')
+
+    if status != 'running':
+        run.status = status
+        run.items_processed = index_status.get('items_processed') or 0
+        run.error_count = index_status.get('error_count') or 0
+        run.error_message = index_status.get('error_message')
+        run.last_run_end = datetime.utcnow()
+        run.save()
+        current_app.logger.info(
+            f'NoW application document index run {run.now_application_document_index_run_id} '
+            f'completed with status {status}')
+        return run
+    else:
+        poll_update_now_application_document_index_status.retry(countdown=10)

--- a/services/core-api/tests/now_applications/models/test_now_application_document_index_run.py
+++ b/services/core-api/tests/now_applications/models/test_now_application_document_index_run.py
@@ -1,0 +1,34 @@
+from datetime import datetime, timedelta
+
+from app.api.now_applications.models.now_application_document_index_run import (
+    NowApplicationDocumentIndexRun,
+)
+from tests.now_application_factories import NOWApplicationIdentityFactory
+
+
+def test_get_latest_by_now_application_guid_returns_most_recent_run(db_session):
+    now_application_identity = NOWApplicationIdentityFactory()
+
+    older = NowApplicationDocumentIndexRun.create(
+        now_application_guid=now_application_identity.now_application_guid,
+        status='success',
+        last_run_start=datetime.utcnow() - timedelta(hours=1),
+    )
+    newer = NowApplicationDocumentIndexRun.create(
+        now_application_guid=now_application_identity.now_application_guid,
+        status='running',
+        last_run_start=datetime.utcnow(),
+    )
+
+    latest = NowApplicationDocumentIndexRun.get_latest_by_now_application_guid(
+        now_application_identity.now_application_guid)
+
+    assert latest.now_application_document_index_run_id == newer.now_application_document_index_run_id
+    assert latest.now_application_document_index_run_id != older.now_application_document_index_run_id
+
+
+def test_get_latest_by_now_application_guid_returns_none_when_no_runs_exist(db_session):
+    now_application_identity = NOWApplicationIdentityFactory()
+
+    assert NowApplicationDocumentIndexRun.get_latest_by_now_application_guid(
+        now_application_identity.now_application_guid) is None

--- a/services/core-api/tests/now_applications/resources/test_now_application_document_search_resource.py
+++ b/services/core-api/tests/now_applications/resources/test_now_application_document_search_resource.py
@@ -1,6 +1,8 @@
 import json
+from datetime import datetime
 from unittest.mock import MagicMock, patch
 
+from app.api.now_applications.models.now_application_document_index_run import NowApplicationDocumentIndexRun
 from app.api.now_applications.models.now_application_document_xref import NOWApplicationDocumentXref
 from tests.now_application_factories import NOWApplicationIdentityFactory
 from tests.factories import MineDocumentFactory
@@ -27,6 +29,118 @@ def test_get_now_application_document_search_status(test_client, db_session, aut
         assert resp.json == {'status': 'success'}
 
 
+def test_get_now_application_document_search_status_includes_document_count(test_client, db_session, auth_headers):
+    now_application_identity = NOWApplicationIdentityFactory()
+    NowApplicationDocumentIndexRun.create(
+        now_application_guid=now_application_identity.now_application_guid,
+        status='success',
+        document_count=3,
+        items_processed=42,
+        last_run_start=datetime.utcnow(),
+        last_run_end=datetime.utcnow(),
+    )
+
+    with patch(
+        'app.api.now_applications.resources.now_application_document_search_resource.is_feature_enabled',
+        return_value=True,
+    ), patch(
+        'app.api.now_applications.resources.now_application_document_search_resource.NowApplicationSearchService.get_index_status'
+    ) as mock_get_status:
+
+        mock_get_status.return_value = {'status': 'success', 'items_processed': 42}
+
+        resp = test_client.get(
+            f'/now-applications/{now_application_identity.now_application_guid}/document-search/index/status',
+            headers=auth_headers['full_auth_header']
+        )
+
+        assert resp.status_code == 200
+        assert resp.json['document_count'] == 3
+
+
+def test_get_now_application_document_search_status_prefers_fresh_live_status_while_run_still_running(
+    test_client, db_session, auth_headers
+):
+    """
+    Regression test: if the persisted run row hasn't been updated to a terminal
+    status yet (the poll task hasn't ticked), the endpoint must return the live
+    status from permits rather than clobbering it with the stale "running" row.
+    """
+    now_application_identity = NOWApplicationIdentityFactory()
+    NowApplicationDocumentIndexRun.create(
+        now_application_guid=now_application_identity.now_application_guid,
+        status='running',
+        document_count=3,
+        items_processed=0,
+        last_run_start=datetime.utcnow(),
+    )
+
+    with patch(
+        'app.api.now_applications.resources.now_application_document_search_resource.is_feature_enabled',
+        return_value=True,
+    ), patch(
+        'app.api.now_applications.resources.now_application_document_search_resource.NowApplicationSearchService.get_index_status'
+    ) as mock_get_status:
+
+        mock_get_status.return_value = {
+            'status': 'success',
+            'items_processed': 99,
+            'error_count': 0,
+            'error_message': None,
+        }
+
+        resp = test_client.get(
+            f'/now-applications/{now_application_identity.now_application_guid}/document-search/index/status',
+            headers=auth_headers['full_auth_header']
+        )
+
+        assert resp.status_code == 200
+        assert resp.json['status'] == 'success'
+        assert resp.json['items_processed'] == 99
+        assert resp.json['document_count'] == 3
+
+
+def test_get_now_application_document_search_status_uses_persisted_status_once_run_is_terminal(
+    test_client, db_session, auth_headers
+):
+    """
+    Once the run row has reached a terminal status, its persisted values are
+    authoritative — this is what keeps status correct after permits' Redis-backed
+    task state has expired and it falls back to a different live status.
+    """
+    now_application_identity = NOWApplicationIdentityFactory()
+    NowApplicationDocumentIndexRun.create(
+        now_application_guid=now_application_identity.now_application_guid,
+        status='success',
+        document_count=3,
+        items_processed=42,
+        error_count=0,
+        error_message=None,
+        last_run_start=datetime.utcnow(),
+        last_run_end=datetime.utcnow(),
+    )
+
+    with patch(
+        'app.api.now_applications.resources.now_application_document_search_resource.is_feature_enabled',
+        return_value=True,
+    ), patch(
+        'app.api.now_applications.resources.now_application_document_search_resource.NowApplicationSearchService.get_index_status'
+    ) as mock_get_status:
+
+        # Simulate permits falling back to a different live status (e.g. Redis task
+        # keys expired) — the persisted run status should win.
+        mock_get_status.return_value = {'status': 'never_run', 'items_processed': 0}
+
+        resp = test_client.get(
+            f'/now-applications/{now_application_identity.now_application_guid}/document-search/index/status',
+            headers=auth_headers['full_auth_header']
+        )
+
+        assert resp.status_code == 200
+        assert resp.json['status'] == 'success'
+        assert resp.json['items_processed'] == 42
+
+
 def test_post_now_application_document_index(test_client, db_session, auth_headers):
     now_application_identity = NOWApplicationIdentityFactory()
     mine_doc = MineDocumentFactory(mine=now_application_identity.mine)
@@ -44,9 +158,12 @@ def test_post_now_application_document_index(test_client, db_session, auth_heade
         return_value=True,
     ), patch(
         'app.api.now_applications.resources.now_application_document_search_resource.NowApplicationSearchService.index_documents'
-    ) as mock_index:
+    ) as mock_index, patch(
+        'app.api.now_applications.resources.now_application_document_search_resource.poll_update_now_application_document_index_status.delay'
+    ) as mock_poll_delay:
 
         mock_index.return_value = {'status': 'running', 'queued': 1}
+        mock_poll_delay.return_value = MagicMock(id='test-task-id')
 
         resp = test_client.post(
             f'/now-applications/{now_application_identity.now_application_guid}/document-search/index',
@@ -55,6 +172,15 @@ def test_post_now_application_document_index(test_client, db_session, auth_heade
 
         assert resp.status_code == 200
         assert resp.json == {'status': 'running', 'queued': 1}
+        mock_poll_delay.assert_called_once()
+
+        run = NowApplicationDocumentIndexRun.get_latest_by_now_application_guid(
+            now_application_identity.now_application_guid)
+        assert run is not None
+        assert run.status == 'running'
+        assert run.document_count == 1
+        assert run.last_run_start is not None
+        assert run.core_status_task_id == 'test-task-id'
 
 
 def test_delete_now_application_document_index(test_client, db_session, auth_headers):
@@ -76,6 +202,66 @@ def test_delete_now_application_document_index(test_client, db_session, auth_hea
 
         assert resp.status_code == 200
         assert resp.json == {'message': 'cancelled'}
+
+
+def test_delete_now_application_document_index_marks_running_run_cancelled(test_client, db_session, auth_headers):
+    now_application_identity = NOWApplicationIdentityFactory()
+    run = NowApplicationDocumentIndexRun.create(
+        now_application_guid=now_application_identity.now_application_guid,
+        status='running',
+        document_count=2,
+        last_run_start=datetime.utcnow(),
+    )
+
+    with patch(
+        'app.api.now_applications.resources.now_application_document_search_resource.is_feature_enabled',
+        return_value=True,
+    ), patch(
+        'app.api.now_applications.resources.now_application_document_search_resource.NowApplicationSearchService.cancel_indexing'
+    ) as mock_cancel:
+
+        mock_cancel.return_value = {'message': 'cancelled'}
+
+        resp = test_client.delete(
+            f'/now-applications/{now_application_identity.now_application_guid}/document-search/index',
+            headers=auth_headers['full_auth_header']
+        )
+
+        assert resp.status_code == 200
+
+        refreshed = NowApplicationDocumentIndexRun.query.get(run.now_application_document_index_run_id)
+        assert refreshed.status == 'cancelled'
+        assert refreshed.last_run_end is not None
+
+
+def test_delete_now_application_document_index_does_not_touch_already_terminal_run(
+    test_client, db_session, auth_headers
+):
+    now_application_identity = NOWApplicationIdentityFactory()
+    run = NowApplicationDocumentIndexRun.create(
+        now_application_guid=now_application_identity.now_application_guid,
+        status='success',
+        document_count=2,
+        last_run_start=datetime.utcnow(),
+        last_run_end=datetime.utcnow(),
+    )
+
+    with patch(
+        'app.api.now_applications.resources.now_application_document_search_resource.is_feature_enabled',
+        return_value=True,
+    ), patch(
+        'app.api.now_applications.resources.now_application_document_search_resource.NowApplicationSearchService.cancel_indexing'
+    ) as mock_cancel:
+
+        mock_cancel.return_value = {'message': 'cancelled'}
+
+        test_client.delete(
+            f'/now-applications/{now_application_identity.now_application_guid}/document-search/index',
+            headers=auth_headers['full_auth_header']
+        )
+
+        refreshed = NowApplicationDocumentIndexRun.query.get(run.now_application_document_index_run_id)
+        assert refreshed.status == 'success'
 
 
 def test_post_now_application_document_search(test_client, db_session, auth_headers):

--- a/services/core-api/tests/now_applications/test_now_application_document_index_run_tasks.py
+++ b/services/core-api/tests/now_applications/test_now_application_document_index_run_tasks.py
@@ -1,0 +1,128 @@
+from datetime import datetime
+from unittest import mock
+
+import pytest
+from app.api.now_applications.models.now_application_document_index_run import (
+    NowApplicationDocumentIndexRun,
+)
+from app.api.now_applications.tasks import (
+    poll_update_now_application_document_index_status,
+)
+from app.tasks.celery import celery
+from tests.now_application_factories import NOWApplicationIdentityFactory
+
+
+@pytest.fixture
+def now_application_search_service_mock():
+    with mock.patch('app.api.now_applications.tasks.NowApplicationSearchService') as mc:
+        yield mc
+
+
+@pytest.fixture(scope='module')
+def celery_app(request, app):
+    celery.conf.update(CELERY_ALWAYS_EAGER=True)
+    return app
+
+
+def _create_run(now_application_guid):
+    return NowApplicationDocumentIndexRun.create(
+        now_application_guid=now_application_guid,
+        status='running',
+        last_run_start=datetime.utcnow(),
+    )
+
+
+def test_poll_update_now_application_document_index_status_success(
+    now_application_search_service_mock, celery_app, test_client, db_session
+):
+    now_application_identity = NOWApplicationIdentityFactory()
+    run = _create_run(now_application_identity.now_application_guid)
+
+    now_application_search_service_mock.return_value.get_index_status.return_value = {
+        'status': 'success',
+        'items_processed': 5,
+        'error_count': 0,
+        'error_message': None,
+    }
+
+    result = poll_update_now_application_document_index_status.apply(
+        args=(str(run.now_application_document_index_run_id),)
+    ).get()
+
+    assert result.status == 'success'
+    assert result.items_processed == 5
+    assert result.last_run_end is not None
+
+
+def test_poll_update_now_application_document_index_status_error(
+    now_application_search_service_mock, celery_app, test_client, db_session
+):
+    now_application_identity = NOWApplicationIdentityFactory()
+    run = _create_run(now_application_identity.now_application_guid)
+
+    now_application_search_service_mock.return_value.get_index_status.return_value = {
+        'status': 'error',
+        'items_processed': 1,
+        'error_count': 2,
+        'error_message': 'boom',
+    }
+
+    result = poll_update_now_application_document_index_status.apply(
+        args=(str(run.now_application_document_index_run_id),)
+    ).get()
+
+    assert result.status == 'error'
+    assert result.error_count == 2
+    assert result.error_message == 'boom'
+
+
+def test_poll_update_now_application_document_index_status_retries_while_running(
+    now_application_search_service_mock, celery_app, test_client, db_session
+):
+    now_application_identity = NOWApplicationIdentityFactory()
+    run = _create_run(now_application_identity.now_application_guid)
+
+    now_application_search_service_mock.return_value.get_index_status.return_value = {
+        'status': 'running',
+    }
+
+    with mock.patch(
+        'app.api.now_applications.tasks.poll_update_now_application_document_index_status.retry'
+    ) as retry_mock:
+        poll_update_now_application_document_index_status.apply(
+            args=(str(run.now_application_document_index_run_id),)
+        ).get()
+        retry_mock.assert_called_once_with(countdown=10)
+
+    refreshed = NowApplicationDocumentIndexRun.query.get(run.now_application_document_index_run_id)
+    assert refreshed.status == 'running'
+    assert refreshed.last_run_end is None
+
+
+def test_on_failure_finds_run_via_task_args_even_when_core_status_task_id_unset(
+    celery_app, test_client, db_session
+):
+    """
+    Regression test: on_failure must locate the run using the run id passed as the
+    task's own argument, not by looking up core_status_task_id. The resource sets
+    core_status_task_id on the run AFTER poll_update_now_application_document_index_status.delay()
+    returns, so if the task fails before that write lands, a lookup by
+    core_status_task_id would find nothing.
+    """
+    now_application_identity = NOWApplicationIdentityFactory()
+    run = _create_run(now_application_identity.now_application_guid)
+    run_id = str(run.now_application_document_index_run_id)
+    assert run.core_status_task_id is None
+
+    poll_update_now_application_document_index_status.on_failure(
+        exc=Exception('boom'),
+        task_id='some-unrelated-celery-task-id',
+        args=(run_id,),
+        kwargs={},
+        einfo=None,
+    )
+
+    refreshed = NowApplicationDocumentIndexRun.query.get(run_id)
+    assert refreshed.status == 'error'
+    assert refreshed.error_message == 'boom'
+    assert refreshed.last_run_end is not None

--- a/services/core-web/src/components/noticeOfWork/applications/search/NowApplicationDocumentSearch.spec.tsx
+++ b/services/core-web/src/components/noticeOfWork/applications/search/NowApplicationDocumentSearch.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { configureStore } from '@reduxjs/toolkit';
 import NowApplicationDocumentSearch from './NowApplicationDocumentSearch';
@@ -188,5 +188,132 @@ describe('NowApplicationDocumentSearch', () => {
         );
 
         expect(screen.queryByText('Showing results for:')).not.toBeInTheDocument();
+    });
+
+    describe('last indexed label', () => {
+        it('shows the last indexed date and document count once a run has completed', () => {
+            const store = createMockStore({
+                indexerStatus: {
+                    status: 'success',
+                    items_processed: 42,
+                    document_count: 3,
+                    error_count: 0,
+                    last_run_start: '2026-08-21T18:00:00.000Z',
+                    last_run_end: '2026-08-21T18:08:00.000Z',
+                    error_message: null,
+                },
+            });
+            const { container } = render(
+                <Provider store={store}>
+                    <NowApplicationDocumentSearch nowApplicationGuid="test-guid" />
+                </Provider>
+            );
+
+            expect(container.textContent).toContain('Last indexed:');
+            expect(container.textContent).toContain('3 documents');
+        });
+
+        it('uses singular "document" when only one document was indexed', () => {
+            const store = createMockStore({
+                indexerStatus: {
+                    status: 'success',
+                    items_processed: 1,
+                    document_count: 1,
+                    error_count: 0,
+                    last_run_start: '2026-08-21T18:00:00.000Z',
+                    last_run_end: '2026-08-21T18:08:00.000Z',
+                    error_message: null,
+                },
+            });
+            const { container } = render(
+                <Provider store={store}>
+                    <NowApplicationDocumentSearch nowApplicationGuid="test-guid" />
+                </Provider>
+            );
+
+            expect(container.textContent).toContain('1 document');
+            expect(container.textContent).not.toContain('1 documents');
+        });
+
+        it('does not show a last indexed label while indexing is running', () => {
+            const store = createMockStore({
+                indexerStatus: {
+                    status: 'running',
+                    percent: 50,
+                    document_count: 3,
+                    last_run_start: '2026-08-21T18:00:00.000Z',
+                    last_run_end: null,
+                },
+            });
+            const { container } = render(
+                <Provider store={store}>
+                    <NowApplicationDocumentSearch nowApplicationGuid="test-guid" />
+                </Provider>
+            );
+
+            expect(container.textContent).not.toContain('Last indexed:');
+        });
+
+        it('does not show a last indexed label before a run has ever completed', () => {
+            const store = createMockStore({
+                indexerStatus: { status: 'never_run' },
+            });
+            const { container } = render(
+                <Provider store={store}>
+                    <NowApplicationDocumentSearch nowApplicationGuid="test-guid" />
+                </Provider>
+            );
+
+            expect(container.textContent).not.toContain('Last indexed:');
+        });
+    });
+
+    describe('status polling', () => {
+        beforeEach(() => {
+            jest.useFakeTimers();
+        });
+
+        afterEach(() => {
+            jest.useRealTimers();
+        });
+
+        it('keeps polling for status while indexing is running', async () => {
+            mockAxios.get.mockResolvedValue({ data: { status: 'running', percent: 10 } });
+            const store = createMockStore({ indexerStatus: { status: 'running', percent: 10 } });
+            render(
+                <Provider store={store}>
+                    <NowApplicationDocumentSearch nowApplicationGuid="test-guid" />
+                </Provider>
+            );
+
+            const initialCalls = mockAxios.get.mock.calls.length;
+
+            await act(async () => {
+                await jest.advanceTimersByTimeAsync(2_000);
+            });
+
+            expect(mockAxios.get.mock.calls.length).toBeGreaterThan(initialCalls);
+        });
+
+        it('stops polling once indexing has reached a terminal status', async () => {
+            mockAxios.get.mockResolvedValue({ data: { status: 'success', document_count: 3 } });
+            const store = createMockStore({
+                indexerStatus: { status: 'success', document_count: 3 },
+            });
+            render(
+                <Provider store={store}>
+                    <NowApplicationDocumentSearch nowApplicationGuid="test-guid" />
+                </Provider>
+            );
+
+            const initialCalls = mockAxios.get.mock.calls.length;
+
+            // Advance well past what the old idle-polling interval (10s) would have fired.
+            await act(async () => {
+                await jest.advanceTimersByTimeAsync(30_000);
+            });
+
+            expect(mockAxios.get.mock.calls.length).toBe(initialCalls);
+        });
     });
 });

--- a/services/core-web/src/components/noticeOfWork/applications/search/NowApplicationDocumentSearch.tsx
+++ b/services/core-web/src/components/noticeOfWork/applications/search/NowApplicationDocumentSearch.tsx
@@ -83,6 +83,7 @@ function IndexerStatusBadge({ status }: { status: NowIndexerStatus | null }) {
     success: { color: "success", icon: <CheckCircleOutlined />, label: "Indexed" },
     error: { color: "error", icon: <CloseCircleOutlined />, label: "Index error" },
     transientFailure: { color: "warning", icon: <CloseCircleOutlined />, label: "Index warning" },
+    cancelled: { color: "default", icon: <CloseCircleOutlined />, label: "Index cancelled" },
   };
 
   const cfg = configs[status.status] ?? configs.never_run;
@@ -194,7 +195,7 @@ const NowApplicationDocumentSearch: React.FC<NowApplicationDocumentSearchProps> 
             <Tooltip title="Cancel Indexing">
               <CoreButton
                 aria-label="Cancel"
-                loading={loading}
+                loading={cancelling}
                 className={"form-btn margin-none"}
                 type={"primary"}
                 danger

--- a/services/core-web/src/components/noticeOfWork/applications/search/NowApplicationDocumentSearch.tsx
+++ b/services/core-web/src/components/noticeOfWork/applications/search/NowApplicationDocumentSearch.tsx
@@ -71,10 +71,8 @@ interface NowApplicationDocumentSearchProps {
  * The isolation guarantee lives in the backend. This component never passes
  * nowApplicationGuid as a filter to the query body — it goes in the URL path only.
  */
-// Poll frequently while indexing so the progress bar moves smoothly.
-// Falls back to a slower rate once indexing settles to reduce server load.
+// Poll frequently while indexing is in progress so the progress bar moves smoothly.
 const STATUS_POLL_INTERVAL_ACTIVE_MS = 2_000;
-const STATUS_POLL_INTERVAL_IDLE_MS = 10_000;
 
 function IndexerStatusBadge({ status }: { status: NowIndexerStatus | null }) {
   if (!status) return null;
@@ -88,19 +86,12 @@ function IndexerStatusBadge({ status }: { status: NowIndexerStatus | null }) {
   };
 
   const cfg = configs[status.status] ?? configs.never_run;
-  const lastRun = status.last_run_end ? new Date(status.last_run_end).toLocaleString() : null;
 
   return (
     <Space size="small" align="center">
       <Tag icon={cfg.icon} color={cfg.color}>
         {cfg.label}
       </Tag>
-      {lastRun && status.status !== "running" && (
-        <Typography.Text type="secondary" style={{ fontSize: 12 }}>
-          Last run: {lastRun}
-          {status.items_processed > 0 && ` · ${status.items_processed.toLocaleString()} chunks`}
-        </Typography.Text>
-      )}
       {status.status === "running" && (
         <Progress
           percent={status.percent ?? 0}
@@ -115,6 +106,20 @@ function IndexerStatusBadge({ status }: { status: NowIndexerStatus | null }) {
         </Typography.Text>
       )}
     </Space>
+  );
+}
+
+function LastIndexedLabel({ status }: { status: NowIndexerStatus | null }) {
+  if (!status || status.status === "running" || !status.last_run_end) return null;
+
+  const lastRun = new Date(status.last_run_end).toLocaleString();
+  const documentCount = status.document_count ?? 0;
+
+  return (
+    <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+      Last indexed: {lastRun}
+      {documentCount > 0 && ` · ${documentCount.toLocaleString()} document${documentCount === 1 ? "" : "s"}`}
+    </Typography.Text>
   );
 }
 
@@ -146,15 +151,13 @@ const NowApplicationDocumentSearch: React.FC<NowApplicationDocumentSearchProps> 
     refreshStatus();
   }, [nowApplicationGuid, indexing]);
 
-  // Auto-poll while the indexer is running; stop once it settles.
-  // Use a fast interval while active so progress bar movement is visible,
-  // and a slow interval otherwise to reduce unnecessary server load.
+  // Auto-poll only while the indexer is actually running, so progress bar
+  // movement is visible. Once it settles into a terminal status, stop —
+  // there's nothing left that will change until the user triggers another run.
   useEffect(() => {
     if (pollRef.current) clearInterval(pollRef.current);
     if (indexerStatus?.status === "running") {
       pollRef.current = setInterval(refreshStatus, STATUS_POLL_INTERVAL_ACTIVE_MS);
-    } else if (indexerStatus?.status) {
-      pollRef.current = setInterval(refreshStatus, STATUS_POLL_INTERVAL_IDLE_MS);
     }
     return () => {
       if (pollRef.current) clearInterval(pollRef.current);
@@ -177,48 +180,51 @@ const NowApplicationDocumentSearch: React.FC<NowApplicationDocumentSearchProps> 
   );
 
   const indexActions = (
-    <Space align="center">
-      <IndexerStatusBadge status={indexerStatus} />
-      {isRunning ? (
-        <Popconfirm
-          title="Cancel indexing? This will stop the current indexing job. You can re-index at any time."
-          okText="Cancel indexing"
-          okButtonProps={{ danger: true }}
-          cancelText="Keep running"
-          onConfirm={() => dispatch(cancelNowIndexing(nowApplicationGuid))}
-        >
-          <Tooltip title="Cancel Indexing">
-            <CoreButton
-              aria-label="Cancel"
-              loading={loading}
-              className={"form-btn margin-none"}
-              type={"primary"}
-              danger
-            >
-              Cancel
-            </CoreButton>
-          </Tooltip>
-        </Popconfirm>
-      ) : (
-        <Space size="middle">
-          {isIndexed ? (
-            <Popconfirm
-              title="Re-index documents? This will re-scan all application documents. It is only necessary if new documents have been added since the last time this was run."
-              onConfirm={() => dispatch(indexNowApplicationDocuments(nowApplicationGuid))}
-              okText="Re-index"
-              cancelText="Cancel"
-            >
-              {indexButton}
-            </Popconfirm>
-          ) : (
-            indexButton
-          )}
-          <CoreTooltip
-            icon="question"
-            title="This process downloads and analyzes all application documents to make their content searchable by the AI. This is only necessary if new documents have been added since the last index."
-          />
-        </Space>
-      )}
+    <Space direction="vertical" align="end" size="small">
+      <Space align="center">
+        <IndexerStatusBadge status={indexerStatus} />
+        {isRunning ? (
+          <Popconfirm
+            title="Cancel indexing? This will stop the current indexing job. You can re-index at any time."
+            okText="Cancel indexing"
+            okButtonProps={{ danger: true }}
+            cancelText="Keep running"
+            onConfirm={() => dispatch(cancelNowIndexing(nowApplicationGuid))}
+          >
+            <Tooltip title="Cancel Indexing">
+              <CoreButton
+                aria-label="Cancel"
+                loading={loading}
+                className={"form-btn margin-none"}
+                type={"primary"}
+                danger
+              >
+                Cancel
+              </CoreButton>
+            </Tooltip>
+          </Popconfirm>
+        ) : (
+          <Space size="middle">
+            {isIndexed ? (
+              <Popconfirm
+                title="Re-index documents? This will re-scan all application documents. It is only necessary if new documents have been added since the last time this was run."
+                onConfirm={() => dispatch(indexNowApplicationDocuments(nowApplicationGuid))}
+                okText="Re-index"
+                cancelText="Cancel"
+              >
+                {indexButton}
+              </Popconfirm>
+            ) : (
+              indexButton
+            )}
+            <CoreTooltip
+              icon="question"
+              title="This process downloads and analyzes all application documents to make their content searchable by the AI. This is only necessary if new documents have been added since the last index."
+            />
+          </Space>
+        )}
+      </Space>
+      <LastIndexedLabel status={indexerStatus} />
     </Space>
   );
 

--- a/services/core-web/src/tests/components/noticeOfWork/applications/search/__snapshots__/NowApplicationDocumentSearch.spec.tsx.snap
+++ b/services/core-web/src/tests/components/noticeOfWork/applications/search/__snapshots__/NowApplicationDocumentSearch.spec.tsx.snap
@@ -13,11 +13,11 @@ exports[`NowApplicationDocumentSearch renders in indexing state 1`] = `
         style="margin-bottom: 8px;"
       >
         <div
-          class="ant-space ant-space-horizontal ant-space-align-center"
+          class="ant-space ant-space-vertical ant-space-align-end"
         >
           <div
             class="ant-space-item"
-            style="margin-right: 8px;"
+            style="margin-bottom: 8px;"
           >
             <div
               class="ant-space ant-space-horizontal ant-space-align-center"
@@ -26,77 +26,89 @@ exports[`NowApplicationDocumentSearch renders in indexing state 1`] = `
                 class="ant-space-item"
                 style="margin-right: 8px;"
               >
-                <span
-                  class="ant-tag ant-tag-processing"
+                <div
+                  class="ant-space ant-space-horizontal ant-space-align-center"
                 >
-                  <span
-                    aria-label="sync"
-                    class="anticon anticon-sync"
-                    role="img"
+                  <div
+                    class="ant-space-item"
+                    style="margin-right: 8px;"
                   >
-                    <svg
-                      aria-hidden="true"
-                      class="anticon-spin"
-                      data-icon="sync"
-                      fill="currentColor"
-                      focusable="false"
-                      height="1em"
-                      viewBox="64 64 896 896"
-                      width="1em"
+                    <span
+                      class="ant-tag ant-tag-processing"
                     >
-                      <path
-                        d="M168 504.2c1-43.7 10-86.1 26.9-126 17.3-41 42.1-77.7 73.7-109.4S337 212.3 378 195c42.4-17.9 87.4-27 133.9-27s91.5 9.1 133.8 27A341.5 341.5 0 01755 268.8c9.9 9.9 19.2 20.4 27.8 31.4l-60.2 47a8 8 0 003 14.1l175.7 43c5 1.2 9.9-2.6 9.9-7.7l.8-180.9c0-6.7-7.7-10.5-12.9-6.3l-56.4 44.1C765.8 155.1 646.2 92 511.8 92 282.7 92 96.3 275.6 92 503.8a8 8 0 008 8.2h60c4.4 0 7.9-3.5 8-7.8zm756 7.8h-60c-4.4 0-7.9 3.5-8 7.8-1 43.7-10 86.1-26.9 126-17.3 41-42.1 77.8-73.7 109.4A342.45 342.45 0 01512.1 856a342.24 342.24 0 01-243.2-100.8c-9.9-9.9-19.2-20.4-27.8-31.4l60.2-47a8 8 0 00-3-14.1l-175.7-43c-5-1.2-9.9 2.6-9.9 7.7l-.7 181c0 6.7 7.7 10.5 12.9 6.3l56.4-44.1C258.2 868.9 377.8 932 512.2 932c229.2 0 415.5-183.7 419.8-411.8a8 8 0 00-8-8.2z"
-                      />
-                    </svg>
-                  </span>
-                  <span>
-                    Indexing…
-                  </span>
-                </span>
+                      <span
+                        aria-label="sync"
+                        class="anticon anticon-sync"
+                        role="img"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="anticon-spin"
+                          data-icon="sync"
+                          fill="currentColor"
+                          focusable="false"
+                          height="1em"
+                          viewBox="64 64 896 896"
+                          width="1em"
+                        >
+                          <path
+                            d="M168 504.2c1-43.7 10-86.1 26.9-126 17.3-41 42.1-77.7 73.7-109.4S337 212.3 378 195c42.4-17.9 87.4-27 133.9-27s91.5 9.1 133.8 27A341.5 341.5 0 01755 268.8c9.9 9.9 19.2 20.4 27.8 31.4l-60.2 47a8 8 0 003 14.1l175.7 43c5 1.2 9.9-2.6 9.9-7.7l.8-180.9c0-6.7-7.7-10.5-12.9-6.3l-56.4 44.1C765.8 155.1 646.2 92 511.8 92 282.7 92 96.3 275.6 92 503.8a8 8 0 008 8.2h60c4.4 0 7.9-3.5 8-7.8zm756 7.8h-60c-4.4 0-7.9 3.5-8 7.8-1 43.7-10 86.1-26.9 126-17.3 41-42.1 77.8-73.7 109.4A342.45 342.45 0 01512.1 856a342.24 342.24 0 01-243.2-100.8c-9.9-9.9-19.2-20.4-27.8-31.4l60.2-47a8 8 0 00-3-14.1l-175.7-43c-5-1.2-9.9 2.6-9.9 7.7l-.7 181c0 6.7 7.7 10.5 12.9 6.3l56.4-44.1C258.2 868.9 377.8 932 512.2 932c229.2 0 415.5-183.7 419.8-411.8a8 8 0 00-8-8.2z"
+                          />
+                        </svg>
+                      </span>
+                      <span>
+                        Indexing…
+                      </span>
+                    </span>
+                  </div>
+                  <div
+                    class="ant-space-item"
+                  >
+                    <div
+                      class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-small"
+                      role="progressbar"
+                      style="width: 140px; margin-bottom: 0px;"
+                    >
+                      <div
+                        class="ant-progress-outer"
+                      >
+                        <div
+                          class="ant-progress-inner"
+                        >
+                          <div
+                            class="ant-progress-bg"
+                            style="width: 45%; height: 6px;"
+                          />
+                        </div>
+                      </div>
+                      <span
+                        class="ant-progress-text"
+                        title="45%"
+                      >
+                        45%
+                      </span>
+                    </div>
+                  </div>
+                </div>
               </div>
               <div
                 class="ant-space-item"
               >
-                <div
-                  class="ant-progress ant-progress-line ant-progress-status-normal ant-progress-show-info ant-progress-small"
-                  role="progressbar"
-                  style="width: 140px; margin-bottom: 0px;"
+                <button
+                  aria-label="Cancel"
+                  class="ant-btn ant-btn-primary ant-btn-dangerous core-btn core-btn-primary form-btn margin-none"
+                  type="button"
                 >
-                  <div
-                    class="ant-progress-outer"
-                  >
-                    <div
-                      class="ant-progress-inner"
-                    >
-                      <div
-                        class="ant-progress-bg"
-                        style="width: 45%; height: 6px;"
-                      />
-                    </div>
-                  </div>
-                  <span
-                    class="ant-progress-text"
-                    title="45%"
-                  >
-                    45%
+                  <span>
+                    Cancel
                   </span>
-                </div>
+                </button>
               </div>
             </div>
           </div>
           <div
             class="ant-space-item"
-          >
-            <button
-              aria-label="Cancel"
-              class="ant-btn ant-btn-primary ant-btn-dangerous core-btn core-btn-primary form-btn margin-none"
-              type="button"
-            >
-              <span>
-                Cancel
-              </span>
-            </button>
-          </div>
+          />
         </div>
       </div>
       <div
@@ -620,120 +632,132 @@ exports[`NowApplicationDocumentSearch renders results when they exist 1`] = `
         style="margin-bottom: 8px;"
       >
         <div
-          class="ant-space ant-space-horizontal ant-space-align-center"
+          class="ant-space ant-space-vertical ant-space-align-end"
         >
           <div
             class="ant-space-item"
-            style="margin-right: 8px;"
+            style="margin-bottom: 8px;"
           >
             <div
               class="ant-space ant-space-horizontal ant-space-align-center"
             >
               <div
                 class="ant-space-item"
+                style="margin-right: 8px;"
               >
-                <span
-                  class="ant-tag ant-tag-success"
+                <div
+                  class="ant-space ant-space-horizontal ant-space-align-center"
                 >
-                  <span
-                    aria-label="check-circle"
-                    class="anticon anticon-check-circle"
-                    role="img"
+                  <div
+                    class="ant-space-item"
                   >
-                    <svg
-                      aria-hidden="true"
-                      class=""
-                      data-icon="check-circle"
-                      fill="currentColor"
-                      focusable="false"
-                      height="1em"
-                      viewBox="64 64 896 896"
-                      width="1em"
+                    <span
+                      class="ant-tag ant-tag-success"
                     >
-                      <path
-                        d="M699 353h-46.9c-10.2 0-19.9 4.9-25.9 13.3L469 584.3l-71.2-98.8c-6-8.3-15.6-13.3-25.9-13.3H325c-6.5 0-10.3 7.4-6.5 12.7l124.6 172.8a31.8 31.8 0 0051.7 0l210.6-292c3.9-5.3.1-12.7-6.4-12.7z"
-                      />
-                      <path
-                        d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
-                      />
-                    </svg>
-                  </span>
-                  <span>
-                    Indexed
-                  </span>
-                </span>
+                      <span
+                        aria-label="check-circle"
+                        class="anticon anticon-check-circle"
+                        role="img"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class=""
+                          data-icon="check-circle"
+                          fill="currentColor"
+                          focusable="false"
+                          height="1em"
+                          viewBox="64 64 896 896"
+                          width="1em"
+                        >
+                          <path
+                            d="M699 353h-46.9c-10.2 0-19.9 4.9-25.9 13.3L469 584.3l-71.2-98.8c-6-8.3-15.6-13.3-25.9-13.3H325c-6.5 0-10.3 7.4-6.5 12.7l124.6 172.8a31.8 31.8 0 0051.7 0l210.6-292c3.9-5.3.1-12.7-6.4-12.7z"
+                          />
+                          <path
+                            d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                          />
+                        </svg>
+                      </span>
+                      <span>
+                        Indexed
+                      </span>
+                    </span>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="ant-space-item"
+              >
+                <div
+                  class="ant-space ant-space-horizontal ant-space-align-center"
+                >
+                  <div
+                    class="ant-space-item"
+                    style="margin-right: 16px;"
+                  >
+                    <button
+                      class="ant-btn ant-btn-default margin-none"
+                      type="button"
+                    >
+                      <span
+                        aria-label="sync"
+                        class="anticon anticon-sync"
+                        role="img"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class=""
+                          data-icon="sync"
+                          fill="currentColor"
+                          focusable="false"
+                          height="1em"
+                          viewBox="64 64 896 896"
+                          width="1em"
+                        >
+                          <path
+                            d="M168 504.2c1-43.7 10-86.1 26.9-126 17.3-41 42.1-77.7 73.7-109.4S337 212.3 378 195c42.4-17.9 87.4-27 133.9-27s91.5 9.1 133.8 27A341.5 341.5 0 01755 268.8c9.9 9.9 19.2 20.4 27.8 31.4l-60.2 47a8 8 0 003 14.1l175.7 43c5 1.2 9.9-2.6 9.9-7.7l.8-180.9c0-6.7-7.7-10.5-12.9-6.3l-56.4 44.1C765.8 155.1 646.2 92 511.8 92 282.7 92 96.3 275.6 92 503.8a8 8 0 008 8.2h60c4.4 0 7.9-3.5 8-7.8zm756 7.8h-60c-4.4 0-7.9 3.5-8 7.8-1 43.7-10 86.1-26.9 126-17.3 41-42.1 77.8-73.7 109.4A342.45 342.45 0 01512.1 856a342.24 342.24 0 01-243.2-100.8c-9.9-9.9-19.2-20.4-27.8-31.4l60.2-47a8 8 0 00-3-14.1l-175.7-43c-5-1.2-9.9 2.6-9.9 7.7l-.7 181c0 6.7 7.7 10.5 12.9 6.3l56.4-44.1C258.2 868.9 377.8 932 512.2 932c229.2 0 415.5-183.7 419.8-411.8a8 8 0 00-8-8.2z"
+                          />
+                        </svg>
+                      </span>
+                      <span>
+                        Re-Index Documents
+                      </span>
+                    </button>
+                  </div>
+                  <div
+                    class="ant-space-item"
+                  >
+                    <span
+                      aria-label="question-circle"
+                      class="anticon anticon-question-circle info-tooltip icon-sm"
+                      role="img"
+                      style="color: rgb(94, 70, 161);"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class=""
+                        data-icon="question-circle"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                        />
+                        <path
+                          d="M623.6 316.7C593.6 290.4 554 276 512 276s-81.6 14.5-111.6 40.7C369.2 344 352 380.7 352 420v7.6c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V420c0-44.1 43.1-80 96-80s96 35.9 96 80c0 31.1-22 59.6-56.1 72.7-21.2 8.1-39.2 22.3-52.1 40.9-13.1 19-19.9 41.8-19.9 64.9V620c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8v-22.7a48.3 48.3 0 0130.9-44.8c59-22.7 97.1-74.7 97.1-132.5.1-39.3-17.1-76-48.3-103.3zM472 732a40 40 0 1080 0 40 40 0 10-80 0z"
+                        />
+                      </svg>
+                    </span>
+                  </div>
+                </div>
               </div>
             </div>
           </div>
           <div
             class="ant-space-item"
-          >
-            <div
-              class="ant-space ant-space-horizontal ant-space-align-center"
-            >
-              <div
-                class="ant-space-item"
-                style="margin-right: 16px;"
-              >
-                <button
-                  class="ant-btn ant-btn-default margin-none"
-                  type="button"
-                >
-                  <span
-                    aria-label="sync"
-                    class="anticon anticon-sync"
-                    role="img"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      class=""
-                      data-icon="sync"
-                      fill="currentColor"
-                      focusable="false"
-                      height="1em"
-                      viewBox="64 64 896 896"
-                      width="1em"
-                    >
-                      <path
-                        d="M168 504.2c1-43.7 10-86.1 26.9-126 17.3-41 42.1-77.7 73.7-109.4S337 212.3 378 195c42.4-17.9 87.4-27 133.9-27s91.5 9.1 133.8 27A341.5 341.5 0 01755 268.8c9.9 9.9 19.2 20.4 27.8 31.4l-60.2 47a8 8 0 003 14.1l175.7 43c5 1.2 9.9-2.6 9.9-7.7l.8-180.9c0-6.7-7.7-10.5-12.9-6.3l-56.4 44.1C765.8 155.1 646.2 92 511.8 92 282.7 92 96.3 275.6 92 503.8a8 8 0 008 8.2h60c4.4 0 7.9-3.5 8-7.8zm756 7.8h-60c-4.4 0-7.9 3.5-8 7.8-1 43.7-10 86.1-26.9 126-17.3 41-42.1 77.8-73.7 109.4A342.45 342.45 0 01512.1 856a342.24 342.24 0 01-243.2-100.8c-9.9-9.9-19.2-20.4-27.8-31.4l60.2-47a8 8 0 00-3-14.1l-175.7-43c-5-1.2-9.9 2.6-9.9 7.7l-.7 181c0 6.7 7.7 10.5 12.9 6.3l56.4-44.1C258.2 868.9 377.8 932 512.2 932c229.2 0 415.5-183.7 419.8-411.8a8 8 0 00-8-8.2z"
-                      />
-                    </svg>
-                  </span>
-                  <span>
-                    Re-Index Documents
-                  </span>
-                </button>
-              </div>
-              <div
-                class="ant-space-item"
-              >
-                <span
-                  aria-label="question-circle"
-                  class="anticon anticon-question-circle info-tooltip icon-sm"
-                  role="img"
-                  style="color: rgb(94, 70, 161);"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class=""
-                    data-icon="question-circle"
-                    fill="currentColor"
-                    focusable="false"
-                    height="1em"
-                    viewBox="64 64 896 896"
-                    width="1em"
-                  >
-                    <path
-                      d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
-                    />
-                    <path
-                      d="M623.6 316.7C593.6 290.4 554 276 512 276s-81.6 14.5-111.6 40.7C369.2 344 352 380.7 352 420v7.6c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V420c0-44.1 43.1-80 96-80s96 35.9 96 80c0 31.1-22 59.6-56.1 72.7-21.2 8.1-39.2 22.3-52.1 40.9-13.1 19-19.9 41.8-19.9 64.9V620c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8v-22.7a48.3 48.3 0 0130.9-44.8c59-22.7 97.1-74.7 97.1-132.5.1-39.3-17.1-76-48.3-103.3zM472 732a40 40 0 1080 0 40 40 0 10-80 0z"
-                    />
-                  </svg>
-                </span>
-              </div>
-            </div>
-          </div>
+          />
         </div>
       </div>
       <div
@@ -1257,120 +1281,132 @@ exports[`NowApplicationDocumentSearch renders splash screen when no results 1`] 
         style="margin-bottom: 8px;"
       >
         <div
-          class="ant-space ant-space-horizontal ant-space-align-center"
+          class="ant-space ant-space-vertical ant-space-align-end"
         >
           <div
             class="ant-space-item"
-            style="margin-right: 8px;"
+            style="margin-bottom: 8px;"
           >
             <div
               class="ant-space ant-space-horizontal ant-space-align-center"
             >
               <div
                 class="ant-space-item"
+                style="margin-right: 8px;"
               >
-                <span
-                  class="ant-tag ant-tag-success"
+                <div
+                  class="ant-space ant-space-horizontal ant-space-align-center"
                 >
-                  <span
-                    aria-label="check-circle"
-                    class="anticon anticon-check-circle"
-                    role="img"
+                  <div
+                    class="ant-space-item"
                   >
-                    <svg
-                      aria-hidden="true"
-                      class=""
-                      data-icon="check-circle"
-                      fill="currentColor"
-                      focusable="false"
-                      height="1em"
-                      viewBox="64 64 896 896"
-                      width="1em"
+                    <span
+                      class="ant-tag ant-tag-success"
                     >
-                      <path
-                        d="M699 353h-46.9c-10.2 0-19.9 4.9-25.9 13.3L469 584.3l-71.2-98.8c-6-8.3-15.6-13.3-25.9-13.3H325c-6.5 0-10.3 7.4-6.5 12.7l124.6 172.8a31.8 31.8 0 0051.7 0l210.6-292c3.9-5.3.1-12.7-6.4-12.7z"
-                      />
-                      <path
-                        d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
-                      />
-                    </svg>
-                  </span>
-                  <span>
-                    Indexed
-                  </span>
-                </span>
+                      <span
+                        aria-label="check-circle"
+                        class="anticon anticon-check-circle"
+                        role="img"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class=""
+                          data-icon="check-circle"
+                          fill="currentColor"
+                          focusable="false"
+                          height="1em"
+                          viewBox="64 64 896 896"
+                          width="1em"
+                        >
+                          <path
+                            d="M699 353h-46.9c-10.2 0-19.9 4.9-25.9 13.3L469 584.3l-71.2-98.8c-6-8.3-15.6-13.3-25.9-13.3H325c-6.5 0-10.3 7.4-6.5 12.7l124.6 172.8a31.8 31.8 0 0051.7 0l210.6-292c3.9-5.3.1-12.7-6.4-12.7z"
+                          />
+                          <path
+                            d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                          />
+                        </svg>
+                      </span>
+                      <span>
+                        Indexed
+                      </span>
+                    </span>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="ant-space-item"
+              >
+                <div
+                  class="ant-space ant-space-horizontal ant-space-align-center"
+                >
+                  <div
+                    class="ant-space-item"
+                    style="margin-right: 16px;"
+                  >
+                    <button
+                      class="ant-btn ant-btn-default margin-none"
+                      type="button"
+                    >
+                      <span
+                        aria-label="sync"
+                        class="anticon anticon-sync"
+                        role="img"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class=""
+                          data-icon="sync"
+                          fill="currentColor"
+                          focusable="false"
+                          height="1em"
+                          viewBox="64 64 896 896"
+                          width="1em"
+                        >
+                          <path
+                            d="M168 504.2c1-43.7 10-86.1 26.9-126 17.3-41 42.1-77.7 73.7-109.4S337 212.3 378 195c42.4-17.9 87.4-27 133.9-27s91.5 9.1 133.8 27A341.5 341.5 0 01755 268.8c9.9 9.9 19.2 20.4 27.8 31.4l-60.2 47a8 8 0 003 14.1l175.7 43c5 1.2 9.9-2.6 9.9-7.7l.8-180.9c0-6.7-7.7-10.5-12.9-6.3l-56.4 44.1C765.8 155.1 646.2 92 511.8 92 282.7 92 96.3 275.6 92 503.8a8 8 0 008 8.2h60c4.4 0 7.9-3.5 8-7.8zm756 7.8h-60c-4.4 0-7.9 3.5-8 7.8-1 43.7-10 86.1-26.9 126-17.3 41-42.1 77.8-73.7 109.4A342.45 342.45 0 01512.1 856a342.24 342.24 0 01-243.2-100.8c-9.9-9.9-19.2-20.4-27.8-31.4l60.2-47a8 8 0 00-3-14.1l-175.7-43c-5-1.2-9.9 2.6-9.9 7.7l-.7 181c0 6.7 7.7 10.5 12.9 6.3l56.4-44.1C258.2 868.9 377.8 932 512.2 932c229.2 0 415.5-183.7 419.8-411.8a8 8 0 00-8-8.2z"
+                          />
+                        </svg>
+                      </span>
+                      <span>
+                        Re-Index Documents
+                      </span>
+                    </button>
+                  </div>
+                  <div
+                    class="ant-space-item"
+                  >
+                    <span
+                      aria-label="question-circle"
+                      class="anticon anticon-question-circle info-tooltip icon-sm"
+                      role="img"
+                      style="color: rgb(94, 70, 161);"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class=""
+                        data-icon="question-circle"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
+                        />
+                        <path
+                          d="M623.6 316.7C593.6 290.4 554 276 512 276s-81.6 14.5-111.6 40.7C369.2 344 352 380.7 352 420v7.6c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V420c0-44.1 43.1-80 96-80s96 35.9 96 80c0 31.1-22 59.6-56.1 72.7-21.2 8.1-39.2 22.3-52.1 40.9-13.1 19-19.9 41.8-19.9 64.9V620c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8v-22.7a48.3 48.3 0 0130.9-44.8c59-22.7 97.1-74.7 97.1-132.5.1-39.3-17.1-76-48.3-103.3zM472 732a40 40 0 1080 0 40 40 0 10-80 0z"
+                        />
+                      </svg>
+                    </span>
+                  </div>
+                </div>
               </div>
             </div>
           </div>
           <div
             class="ant-space-item"
-          >
-            <div
-              class="ant-space ant-space-horizontal ant-space-align-center"
-            >
-              <div
-                class="ant-space-item"
-                style="margin-right: 16px;"
-              >
-                <button
-                  class="ant-btn ant-btn-default margin-none"
-                  type="button"
-                >
-                  <span
-                    aria-label="sync"
-                    class="anticon anticon-sync"
-                    role="img"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      class=""
-                      data-icon="sync"
-                      fill="currentColor"
-                      focusable="false"
-                      height="1em"
-                      viewBox="64 64 896 896"
-                      width="1em"
-                    >
-                      <path
-                        d="M168 504.2c1-43.7 10-86.1 26.9-126 17.3-41 42.1-77.7 73.7-109.4S337 212.3 378 195c42.4-17.9 87.4-27 133.9-27s91.5 9.1 133.8 27A341.5 341.5 0 01755 268.8c9.9 9.9 19.2 20.4 27.8 31.4l-60.2 47a8 8 0 003 14.1l175.7 43c5 1.2 9.9-2.6 9.9-7.7l.8-180.9c0-6.7-7.7-10.5-12.9-6.3l-56.4 44.1C765.8 155.1 646.2 92 511.8 92 282.7 92 96.3 275.6 92 503.8a8 8 0 008 8.2h60c4.4 0 7.9-3.5 8-7.8zm756 7.8h-60c-4.4 0-7.9 3.5-8 7.8-1 43.7-10 86.1-26.9 126-17.3 41-42.1 77.8-73.7 109.4A342.45 342.45 0 01512.1 856a342.24 342.24 0 01-243.2-100.8c-9.9-9.9-19.2-20.4-27.8-31.4l60.2-47a8 8 0 00-3-14.1l-175.7-43c-5-1.2-9.9 2.6-9.9 7.7l-.7 181c0 6.7 7.7 10.5 12.9 6.3l56.4-44.1C258.2 868.9 377.8 932 512.2 932c229.2 0 415.5-183.7 419.8-411.8a8 8 0 00-8-8.2z"
-                      />
-                    </svg>
-                  </span>
-                  <span>
-                    Re-Index Documents
-                  </span>
-                </button>
-              </div>
-              <div
-                class="ant-space-item"
-              >
-                <span
-                  aria-label="question-circle"
-                  class="anticon anticon-question-circle info-tooltip icon-sm"
-                  role="img"
-                  style="color: rgb(94, 70, 161);"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class=""
-                    data-icon="question-circle"
-                    fill="currentColor"
-                    focusable="false"
-                    height="1em"
-                    viewBox="64 64 896 896"
-                    width="1em"
-                  >
-                    <path
-                      d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"
-                    />
-                    <path
-                      d="M623.6 316.7C593.6 290.4 554 276 512 276s-81.6 14.5-111.6 40.7C369.2 344 352 380.7 352 420v7.6c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8V420c0-44.1 43.1-80 96-80s96 35.9 96 80c0 31.1-22 59.6-56.1 72.7-21.2 8.1-39.2 22.3-52.1 40.9-13.1 19-19.9 41.8-19.9 64.9V620c0 4.4 3.6 8 8 8h48c4.4 0 8-3.6 8-8v-22.7a48.3 48.3 0 0130.9-44.8c59-22.7 97.1-74.7 97.1-132.5.1-39.3-17.1-76-48.3-103.3zM472 732a40 40 0 1080 0 40 40 0 10-80 0z"
-                    />
-                  </svg>
-                </span>
-              </div>
-            </div>
-          </div>
+          />
         </div>
       </div>
       <div


### PR DESCRIPTION
[MDS-6943](https://bcmines.atlassian.net/browse/MDS-6943)

### Summary

Users indexing a Notice of Work (NoW) application's documents for search had no way to tell when it was last indexed, since nothing on the backend actually persisted that timestamp. The frontend already had a "Last run" badge wired up, but it read fields (`last_run_start`/`last_run_end`) that the permits service always returned as `None` — it only tracks in-flight indexing state in Redis with a 7-day TTL, and has no database of its own.

This PR adds durable persistence for indexing run history in core-api and surfaces it in the UI.

<img width="1306" height="708" alt="image" src="https://github.com/user-attachments/assets/5512dc78-4e22-42f9-9286-29a0eadf176f" />

### Backend changes (`core-api`)

- New table `now_application_document_index_run` (Flyway migration) + model `NowApplicationDocumentIndexRun` — one row per index run for a NoW application, storing status, document count, timestamps, and error info. Modeled on the existing `PermitExtractionTask` pattern for "async job runs in an external service, core-api tracks it durably."
- New Celery task `poll_update_now_application_document_index_status` — polls the permits service's existing status endpoint every 10s until the run reaches a terminal state, then persists the result. Failure handling records status via the task's own run-id argument (not a lookup by Celery task id, which can race with the id being written back to the row).
- `now_application_document_search_resource.py`:
  - `POST .../index` creates a run row and kicks off the poll task.
  - `DELETE .../index` marks an in-flight run `cancelled`.
  - `GET .../index/status` overlays persisted `last_run_start`/`last_run_end`/`document_count` onto the live permits response, and only falls back to the persisted `status`/counts once *our* run row has reached a terminal state — so a freshly-completed job's live status is never shadowed by a stale "running" row.
- Timestamps are serialized with an explicit UTC (`Z`) suffix so the frontend's `new Date(...)` doesn't misinterpret them as local time.

### Frontend changes (`core-web` / `common`)

- Added `document_count` to `NowIndexerStatus` — the "Last run" label now shows the number of whole **documents** processed (e.g. "3 documents") instead of Azure Search chunk counts, which had no meaningful interpretation for users.
- Moved the "Last indexed" label to sit directly under the Index/Re-Index Documents button rather than inline beside it.
- Fixed indexing-status polling: it was continuing to poll every 10s indefinitely after a run completed (`success`/`error`/`never_run`, etc.) instead of stopping once settled. Polling now only runs while a job is actively `running`.

### Testing

- Backend: added/updated unit tests for the new model, Celery task (success/error/retry/on-failure), and resource endpoints
- Frontend: added coverage for the "Last indexed" label (date + document count, singular/plural, hidden while running or never-run) and for the polling fix (asserts polling stops after a terminal status and continues while running), plus updated stale snapshots from the layout change.
