### PR TITLE
[MDS-6952] - NoD restricted to major mines

### DIFF
--- a/services/core-web/src/components/mine/MineNavigation.tsx
+++ b/services/core-web/src/components/mine/MineNavigation.tsx
@@ -71,10 +71,10 @@ const MineNavigation: FC<MineNavigationProps> = ({ mine, activeButton, openSubMe
           key: "external-authorizations",
           label: <Link to={routes.MINE_EXTERNAL_AUTHORIZATIONS.dynamicRoute(mine.mine_guid)}>Other Ministry Applications and Authorizations</Link>
         },
-        {
+        ...(isMajorMine ? [{
           key: "nods",
           label: <Link to={routes.MINE_NOTICES_OF_DEPARTURE.dynamicRoute(mine.mine_guid)}>Notices of Departure</Link>
-        },
+        }] : []),
         {
           key: "tailings",
           label: <Link to={routes.MINE_TAILINGS.dynamicRoute(mine.mine_guid)}>Tailings Storage Facilities</Link>

--- a/services/core-web/src/components/mine/NoticeOfDeparture/MineNoticeOfDeparture.tsx
+++ b/services/core-web/src/components/mine/NoticeOfDeparture/MineNoticeOfDeparture.tsx
@@ -16,6 +16,7 @@ import { IMine, INoticeOfDeparture } from "@mds/common/interfaces";
 import { getUserAccessData } from "@mds/common/redux/selectors/authenticationSelectors";
 import { modalConfig } from "@/components/modalContent/config";
 import { MINE_NOTICES_OF_DEPARTURE } from "@/constants/routes";
+import PageNotFound from "@/components/common/PageNotFound";
 import MineNoticeOfDepartureTable from "./MineNoticeOfDepartureTable";
 import * as Permission from "@/constants/permissions";
 import { ActionCreator } from "@mds/common/interfaces/actionCreator";
@@ -105,6 +106,10 @@ export const MineNoticeOfDeparture: React.FC<IMineNoticeOfDepartureProps & Props
       <br />
     </div>
   );
+
+  if (mine && !mine.major_mine_ind) {
+    return <PageNotFound />;
+  }
 
   return (
     <div className="tab__content">

--- a/services/core-web/src/tests/components/mine/MineNavigation.spec.tsx
+++ b/services/core-web/src/tests/components/mine/MineNavigation.spec.tsx
@@ -1,0 +1,70 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import MineNavigation from "@/components/mine/MineNavigation";
+import { IMine } from "@mds/common/interfaces";
+
+// antd's horizontal Menu only renders submenu contents in a lazily-mounted
+// popup/portal on hover, which isn't reliably testable in jsdom. Since what
+// we actually want to cover here is MineNavigation's own logic (which menu
+// items get included for major vs. regional mines), we replace antd's Menu
+// with a simple flattened renderer so every item/child label is present in
+// the DOM synchronously.
+jest.mock("antd", () => {
+  const actual = jest.requireActual("antd");
+  const renderItems = (items: any[]) =>
+    items
+      .filter(Boolean)
+      .map((item) => (
+        <div key={item.key} data-testid={item.key}>
+          {item.label}
+          {item.children && renderItems(item.children)}
+        </div>
+      ));
+  return {
+    ...actual,
+    Menu: ({ items }: { items: any[] }) => <div>{renderItems(items)}</div>,
+  };
+});
+
+const baseMine = {
+  mine_guid: "18133c75-49ad-4101-85f3-a43e35ae989a",
+} as IMine;
+
+const props = {
+  activeButton: "permits-and-approvals",
+  openSubMenuKey: [],
+};
+
+const renderMenu = (mine: IMine) =>
+  render(
+    <MemoryRouter>
+      <MineNavigation mine={mine} {...props} />
+    </MemoryRouter>
+  );
+
+describe("MineNavigation", () => {
+  it("renders properly for a major mine", () => {
+    const { container } = renderMenu({ ...baseMine, major_mine_ind: true });
+    expect(container).toMatchSnapshot();
+  });
+
+  it("shows Major Projects and Notices of Departure for a major mine", () => {
+    const { getByText } = renderMenu({ ...baseMine, major_mine_ind: true });
+    expect(getByText("Major Projects")).toBeInTheDocument();
+    expect(getByText("Notices of Departure")).toBeInTheDocument();
+  });
+
+  it("hides Major Projects and Notices of Departure for a regional mine", () => {
+    const { queryByText } = renderMenu({ ...baseMine, major_mine_ind: false });
+    expect(queryByText("Major Projects")).not.toBeInTheDocument();
+    expect(queryByText("Notices of Departure")).not.toBeInTheDocument();
+  });
+
+  it("still shows mine-type-agnostic menu items for a regional mine", () => {
+    const { getByText } = renderMenu({ ...baseMine, major_mine_ind: false });
+    expect(getByText("Permits")).toBeInTheDocument();
+    expect(getByText("Variances")).toBeInTheDocument();
+    expect(getByText("Applications")).toBeInTheDocument();
+  });
+});

--- a/services/core-web/src/tests/components/mine/NoticeOfDeparture/MineNoticeOfDeparture.spec.tsx
+++ b/services/core-web/src/tests/components/mine/NoticeOfDeparture/MineNoticeOfDeparture.spec.tsx
@@ -3,6 +3,9 @@ import MineNoticeOfDeparture from "@/components/mine/NoticeOfDeparture/MineNotic
 import * as MOCK from "@mds/common/tests/mocks/dataMocks";
 import matchMedia from "@/tests/mocks/matchMedia";
 import { renderWithProvider } from "@/tests/mocks/utils";
+import { store } from "@/App";
+import * as actionTypes from "@mds/common/constants/actionTypes";
+import { MemoryRouter } from "react-router-dom";
 
 const dispatchProps: any = {
   openModal: jest.fn(),
@@ -44,5 +47,24 @@ describe("MineNoticeOfDeparture", () => {
       <MineNoticeOfDeparture {...dispatchProps} {...reducerProps} />
     );
     expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it("renders PageNotFound for a regional mine", () => {
+    const regionalMineGuid = MOCK.MINES.mineIds[0];
+    store.dispatch({
+      type: actionTypes.STORE_MINE,
+      payload: { ...MOCK.MINES.mines[regionalMineGuid], major_mine_ind: false },
+      id: regionalMineGuid,
+    });
+    const { getByText } = renderWithProvider(
+      <MemoryRouter>
+        <MineNoticeOfDeparture
+          {...dispatchProps}
+          {...reducerProps}
+          mineGuid={regionalMineGuid}
+        />
+      </MemoryRouter>
+    );
+    expect(getByText("Uh Oh!")).toBeInTheDocument();
   });
 });

--- a/services/core-web/src/tests/components/mine/__snapshots__/MineNavigation.spec.tsx.snap
+++ b/services/core-web/src/tests/components/mine/__snapshots__/MineNavigation.spec.tsx.snap
@@ -1,0 +1,182 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MineNavigation renders properly for a major mine 1`] = `
+<div>
+  <div>
+    <div
+      data-testid="mine-information"
+    >
+      Mine Information
+      <div
+        data-testid="general"
+      >
+        <a
+          href="/mine-dashboard/18133c75-49ad-4101-85f3-a43e35ae989a/mine-information/general"
+        >
+          General
+        </a>
+      </div>
+      <div
+        data-testid="contacts"
+      >
+        <a
+          href="/mine-dashboard/18133c75-49ad-4101-85f3-a43e35ae989a/mine-information/contacts"
+        >
+          Contacts
+        </a>
+      </div>
+      <div
+        data-testid="mms-archive"
+      >
+        <a
+          href="/mine-dashboard/18133c75-49ad-4101-85f3-a43e35ae989a/mine-information/mms-archive"
+        >
+          Archived MMS Files
+        </a>
+      </div>
+      <div
+        data-testid="user-access"
+      >
+        <a
+          href="/mine-dashboard/18133c75-49ad-4101-85f3-a43e35ae989a/mine-information/user-access"
+        >
+          User Access
+        </a>
+      </div>
+    </div>
+    <div
+      data-testid="permits-and-approvals"
+    >
+      Permits & Approvals
+      <div
+        data-testid="permits"
+      >
+        <a
+          href="/mine-dashboard/18133c75-49ad-4101-85f3-a43e35ae989a/permits-and-approvals/permits"
+        >
+          Permits
+        </a>
+      </div>
+      <div
+        data-testid="securities"
+      >
+        <a
+          href="/mine-dashboard/18133c75-49ad-4101-85f3-a43e35ae989a/permits-and-approvals/securities"
+        >
+          Securities
+        </a>
+      </div>
+      <div
+        data-testid="variances"
+      >
+        <a
+          href="/mine-dashboard/18133c75-49ad-4101-85f3-a43e35ae989a/permits-and-approvals/variances"
+        >
+          Variances
+        </a>
+      </div>
+      <div
+        data-testid="pre-applications"
+      >
+        <a
+          data-cy="major-projects-link"
+          href="/mine-dashboard/18133c75-49ad-4101-85f3-a43e35ae989a/permits-and-approvals/pre-applications"
+        >
+          Major Projects
+        </a>
+      </div>
+      <div
+        data-testid="notices-of-work"
+      >
+        <a
+          href="/mine-dashboard/18133c75-49ad-4101-85f3-a43e35ae989a/permits-and-approvals/applications"
+        >
+          Applications
+        </a>
+      </div>
+      <div
+        data-testid="external-authorizations"
+      >
+        <a
+          href="/mine-dashboard/18133c75-49ad-4101-85f3-a43e35ae989a/external-authorizations"
+        >
+          Other Ministry Applications and Authorizations
+        </a>
+      </div>
+      <div
+        data-testid="nods"
+      >
+        <a
+          href="/mine-dashboard/18133c75-49ad-4101-85f3-a43e35ae989a/permits-and-approvals/notices-of-departure"
+        >
+          Notices of Departure
+        </a>
+      </div>
+      <div
+        data-testid="tailings"
+      >
+        <a
+          href="/mine-dashboard/18133c75-49ad-4101-85f3-a43e35ae989a/permits-and-approvals/tailings"
+        >
+          Tailings Storage Facilities
+        </a>
+      </div>
+    </div>
+    <div
+      data-testid="oversight"
+    >
+      Oversight
+      <div
+        data-testid="inspections-and-audits"
+      >
+        <a
+          href="/mine-dashboard/18133c75-49ad-4101-85f3-a43e35ae989a/oversight/inspections-and-audits"
+        >
+          Inspections & Audits
+        </a>
+      </div>
+      <div
+        data-testid="incidents-and-investigations"
+      >
+        <a
+          href="/mine-dashboard/18133c75-49ad-4101-85f3-a43e35ae989a/oversight/incidents-and-investigations"
+        >
+          Incidents & Investigations
+        </a>
+      </div>
+    </div>
+    <div
+      data-testid="reports"
+    >
+      Reports
+      <div
+        data-testid="code-required-reports"
+      >
+        <a
+          href="/mine-dashboard/18133c75-49ad-4101-85f3-a43e35ae989a/required-reports/code-required-reports"
+        >
+          Code Required Reports
+        </a>
+      </div>
+      <div
+        data-testid="permit-required-reports"
+      >
+        <a
+          href="/mine-dashboard/18133c75-49ad-4101-85f3-a43e35ae989a/required-reports/permit-required-reports"
+        >
+          Permit Required Reports
+        </a>
+      </div>
+      <div
+        data-testid="tailings-reports"
+      >
+        <a
+          href="/mine-dashboard/18133c75-49ad-4101-85f3-a43e35ae989a/reports/tailings-reports"
+        >
+          Tailings Storage Facilities Reports
+        </a>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/services/minespace-web/src/components/dashboard/mine/MineDashboard.tsx
+++ b/services/minespace-web/src/components/dashboard/mine/MineDashboard.tsx
@@ -72,7 +72,11 @@ const MineDashboard: FC = () => {
   const dynamicRoute = (key: string) => {
     return MINE_DASHBOARD.dynamicRoute(mine?.mine_guid, key, "");
   };
-  const items = getMineDashboardRoutes(showApplications, reportsBadgeCount).map((item) => ({
+  const items = getMineDashboardRoutes(
+    showApplications,
+    reportsBadgeCount,
+    mine?.major_mine_ind
+  ).map((item) => ({
     ...item,
     path: dynamicRoute(item.key),
   }));

--- a/services/minespace-web/src/components/dashboard/mine/MineDashboardRoutes.tsx
+++ b/services/minespace-web/src/components/dashboard/mine/MineDashboardRoutes.tsx
@@ -28,7 +28,11 @@ import {
   faCircleQuestion,
 } from "@fortawesome/pro-light-svg-icons";
 
-export const getMineDashboardRoutes = (showApplications, reportsBadgeCount?: number) =>
+export const getMineDashboardRoutes = (
+  showApplications,
+  reportsBadgeCount?: number,
+  isMajorMine?: boolean
+) =>
   [
     {
       key: "overview",
@@ -75,7 +79,7 @@ export const getMineDashboardRoutes = (showApplications, reportsBadgeCount?: num
       icon: <FontAwesomeIcon icon={faBrakeWarning} style={{ width: "24px" }} />,
       component: Incidents,
     },
-    {
+    isMajorMine && {
       key: "nods",
       label: "Notices of Departure",
       icon: <FontAwesomeIcon icon={faHexagonExclamation} style={{ width: "24px" }} />,

--- a/services/minespace-web/src/tests/components/dashboard/mine/MineDashboardRoutes.spec.tsx
+++ b/services/minespace-web/src/tests/components/dashboard/mine/MineDashboardRoutes.spec.tsx
@@ -22,6 +22,19 @@ describe("MineDashboardRoutes", () => {
     expect(applications).toBeUndefined();
   });
 
+  it("includes Notices of Departure when isMajorMine is true", () => {
+    const routes = getMineDashboardRoutes(true, 0, true);
+    const nods = getRouteByKey(routes, "nods");
+    expect(nods).toBeTruthy();
+    expect(nods.label).toBe("Notices of Departure");
+  });
+
+  it("omits Notices of Departure when isMajorMine is false", () => {
+    const routes = getMineDashboardRoutes(true, 0, false);
+    const nods = getRouteByKey(routes, "nods");
+    expect(nods).toBeUndefined();
+  });
+
   it("wraps Reports icon in a red Badge with the overdue count", () => {
     const overdueCount = 7;
     const routes = getMineDashboardRoutes(true, overdueCount);

--- a/services/minespace-web/src/tests/components/dashboard/mine/__snapshots__/MineDashboardRoutes.spec.tsx.snap
+++ b/services/minespace-web/src/tests/components/dashboard/mine/__snapshots__/MineDashboardRoutes.spec.tsx.snap
@@ -226,35 +226,6 @@ exports[`MineDashboardRoutes matches snapshot when navigated to the reports rout
           </li>
           <li
             class="ant-menu-item"
-            data-menu-id="rc-menu-uuid-test-nods"
-            path="/nods"
-            role="menuitem"
-            tabindex="-1"
-          >
-            <svg
-              aria-hidden="true"
-              class="svg-inline--fa fa-hexagon-exclamation ant-menu-item-icon"
-              data-icon="hexagon-exclamation"
-              data-prefix="fal"
-              focusable="false"
-              role="img"
-              style="width: 24px;"
-              viewBox="0 0 512 512"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M16 288c-11.4-19.8-11.4-44.2 0-64L108.3 64.2c11.4-19.8 32.6-32 55.4-32H348.3c22.9 0 44 12.2 55.4 32L496 224c11.4 19.8 11.4 44.2 0 64L403.7 447.8c-11.4 19.8-32.6 32-55.4 32H163.7c-22.9 0-44-12.2-55.4-32L16 288zm27.7-48c-5.7 9.9-5.7 22.1 0 32L136 431.8c5.7 9.9 16.3 16 27.7 16H348.3c11.4 0 22-6.1 27.7-16L468.3 272c5.7-9.9 5.7-22.1 0-32L376 80.2c-5.7-9.9-16.3-16-27.7-16l-184.6 0c-11.4 0-22 6.1-27.7 16L43.7 240zM256 128c8.8 0 16 7.2 16 16V272c0 8.8-7.2 16-16 16s-16-7.2-16-16V144c0-8.8 7.2-16 16-16zM232 352a24 24 0 1 1 48 0 24 24 0 1 1 -48 0z"
-                fill="currentColor"
-              />
-            </svg>
-            <span
-              class="ant-menu-title-content"
-            >
-              Notices of Departure
-            </span>
-          </li>
-          <li
-            class="ant-menu-item"
             data-menu-id="rc-menu-uuid-test-variances"
             path="/variances"
             role="menuitem"


### PR DESCRIPTION
## Objective 
## Restrict Notice of Departure (NoD) to Major Mines

[MDS-6952](https://bcmines.atlassian.net/browse/MDS-6952)

### Summary

NoD (Notice of Departure) functionality is intended for Major Mines permitting processes only, but was previously available for Regional Mines as well. This PR restricts NoD access to Major Mines in both MineSpace and Core.

### Changes

**MineSpace**
- The "Notices of Departure" sidebar tab is now only shown for Major Mines (`mine.major_mine_ind`), following the same pattern already used for the "Applications" tab.
- Since sidebar routes are generated from the same `items` list used to render the nav, hiding the tab also removes the underlying route for Regional Mines — direct navigation to the NoD URL is no longer possible.

**Core**
- The "Notices of Departure" item in the Permits & Approvals nav menu is now gated by `isMajorMine`, matching the existing pattern used for "Major Projects".
- Added a page-level guard on `MineNoticeOfDeparture` so that Regional Mines render `PageNotFound` even if the page is reached directly (e.g. via a stale notification link or search result), rather than relying solely on the nav item being hidden.


### Test plan

- [ ] Manually verify in MineSpace: NoD tab hidden for a Regional Mine, visible for a Major Mine
- [ ] Manually verify in Core: NoD nav item hidden for a Regional Mine, direct URL to NoD page shows 404 for a Regional Mine, unaffected for a Major Mine

<img width="1860" height="867" alt="image" src="https://github.com/user-attachments/assets/dcd1c303-38c5-4c47-ab53-03137b669647" />
<img width="1871" height="913" alt="image" src="https://github.com/user-attachments/assets/182b116c-c907-41d4-9662-f1c3e04b1d94" />


