### PR TITLE
[MDS-7003] - TSF Create new EOR/QP

### DIFF
--- a/services/common/src/interfaces/party/partyFetchParams.interface.ts
+++ b/services/common/src/interfaces/party/partyFetchParams.interface.ts
@@ -12,4 +12,5 @@ export interface IPartyFetchParams {
   sort_field?: string;
   sort_dir?: string;
   business_role?: string;
+  per_page?: number;
 }

--- a/services/minespace-web/src/components/Forms/contacts/AddContactFormDetails.tsx
+++ b/services/minespace-web/src/components/Forms/contacts/AddContactFormDetails.tsx
@@ -15,7 +15,7 @@ import RenderSelect from "@mds/common/components/forms/RenderSelect";
 import RenderSubmitButton from "@mds/common/components/forms/RenderSubmitButton";
 import RenderField from "@mds/common/components/forms/RenderField";
 import RenderAutoComplete from "@mds/common/components/forms/RenderAutoComplete";
-import { IOption, IParty } from "@mds/common/interfaces";
+import { IOption, IParty, IPartyFetchParams, ItemMap } from "@mds/common/interfaces";
 import { useAppDispatch, useAppSelector } from "@mds/common/redux/rootState";
 
 interface AddContactFormDetailsProps {
@@ -32,9 +32,10 @@ export const AddContactFormDetails: FC<AddContactFormDetailsProps> = (props) => 
   const isFormDirty = useAppSelector(isDirty(formName));
   const formValues = useAppSelector(getFormValues(FORM.ADD_CONTACT)) as IParty;
   const partyRelationshipTypesList = useAppSelector(getPartyRelationshipTypesList);
-  const organizations = useAppSelector(getParties) as IParty[];
+  const organizations = useAppSelector(getParties);
 
-  const handleFetchParties = (...args) => debounce(() => dispatch(fetchParties(...args)), 1000);
+  const handleFetchParties = (params: IPartyFetchParams) =>
+    debounce(() => dispatch(fetchParties(params)), 1000);
 
   const onSubmit = async (values) => {
     const party_type_code = "PER";
@@ -42,16 +43,18 @@ export const AddContactFormDetails: FC<AddContactFormDetailsProps> = (props) => 
 
     if (!values.party_guid) {
       // Party doesn't already exist, create it
-      const { data: party } = await dispatch(createParty(payload));
+      const { payload: party } = await dispatch(createParty(payload));
+
+      if (!party) return;
 
       props.onSubmit(party);
     } else if (isFormDirty) {
       // Selected party has been updated, update it
-      const response = await dispatch(updateParty({ data: payload, partyGuid: values.party_guid }));
+      const { payload: party } = await dispatch(
+        updateParty({ data: payload, partyGuid: values.party_guid })
+      );
 
-      if (!response) return;
-
-      const { data: party } = response;
+      if (!party) return;
 
       props.onSubmit(party);
     } else {
@@ -84,7 +87,7 @@ export const AddContactFormDetails: FC<AddContactFormDetailsProps> = (props) => 
     searchOrganizations("");
   }, []);
 
-  const transformOrganizations = (orgs: IParty[]) =>
+  const transformOrganizations = (orgs: ItemMap<IParty>) =>
     Object.values(orgs).map((org) => ({
       label: org.name,
       value: org.party_guid,

--- a/services/minespace-web/src/tests/components/project/informationRequirementsTablePage/__snapshots__/InformationRequirementsTablePage.spec.tsx.snap
+++ b/services/minespace-web/src/tests/components/project/informationRequirementsTablePage/__snapshots__/InformationRequirementsTablePage.spec.tsx.snap
@@ -353,6 +353,7 @@ exports[`InformationRequirementsTablePage renders properly 1`] = `
                       </div>
                       <div
                         class="ant-tabs-ink-bar ant-tabs-ink-bar-animated"
+                        style="top: 0px; height: 0px;"
                       />
                     </div>
                   </div>

--- a/services/minespace-web/src/tests/components/project/informationRequirementsTablePage/__snapshots__/InformationRequirementsTablePage.spec.tsx.snap
+++ b/services/minespace-web/src/tests/components/project/informationRequirementsTablePage/__snapshots__/InformationRequirementsTablePage.spec.tsx.snap
@@ -353,7 +353,6 @@ exports[`InformationRequirementsTablePage renders properly 1`] = `
                       </div>
                       <div
                         class="ant-tabs-ink-bar ant-tabs-ink-bar-animated"
-                        style="top: 0px; height: 0px;"
                       />
                     </div>
                   </div>


### PR DESCRIPTION
[MDS-7003](https://bcmines.atlassian.net/browse/MDS-7003)

## Summary

Fixes a bug where MineSpace users could not create a **new** TSF Qualified Person or Engineer of Record contact from the "Assign New" modal. The modal appeared to succeed (toast + fields stayed filled) but silently failed to save, threw an uncaught `party_guid` error, and the new contact never appeared in the "Select Contact" dropdown afterward.

Also added fixes for two pre-existing TypeScript errors surfaced in the same file while working the ticket.

## Root Cause

`AddContactFormDetails.tsx`'s submit handler destructured `{ data: party }` from the result of `dispatch(createParty(...))` / `dispatch(updateParty(...))`. RTK thunks resolve to `{ type, payload, meta }` — there is no `.data` field — so `party` was always `undefined`, regardless of whether the API call succeeded.

The `POST /party` request actually succeeded server-side (hence the "success" toast), but `props.onSubmit(undefined)` then crashed downstream in `QualifiedPerson.tsx` / `EngineerOfRecord.tsx` when they read `value.party_guid`. Because the throw happened before `dispatch(closeModal())`, the modal stayed open and the TSF form was never updated with the new contact, so it also never showed up later in "Select Contact".

Core-web's equivalent flow was unaffected because it never destructures the dispatch result — it reads the new party from the `lastCreatedParty` selector instead.

## Changes

- **`AddContactFormDetails.tsx`**: destructure `{ payload: party }` instead of `{ data: party }` for both the create and update branches; added `if (!party) return;` guards so a genuine thunk failure no longer propagates a crash into the parent handlers.
- **`AddContactFormDetails.tsx`**: fixed `organizations` typing — `getParties` returns `ItemMap<IParty>`, not `IParty[]`; removed the incorrect cast and retyped `transformOrganizations`'s param to match.
- **`AddContactFormDetails.tsx`**: fixed `handleFetchParties` — `fetchParties` takes a single `IPartyFetchParams` object, not variadic args; replaced the invalid spread with a correctly typed single parameter.
- **`partyFetchParams.interface.ts`**: added missing `per_page?: number` field, which this component was already passing at runtime but wasn't declared on the interface.