### PR TITLE
[MDS-7007] [Bug Fix] Ensure 'system-generated documents' table always displays in NoW (for Administrative Amendments)

### DIFF
--- a/services/core-web/src/components/noticeOfWork/applications/manageDocuments/NOWApplicationManageDocuments.js
+++ b/services/core-web/src/components/noticeOfWork/applications/manageDocuments/NOWApplicationManageDocuments.js
@@ -1,5 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
+import { isEmpty } from "lodash";
 import CustomPropTypes from "@/customPropTypes";
 import FinalPermitDocuments from "@/components/noticeOfWork/applications/FinalPermitDocuments";
 import NOWDocuments from "@/components/noticeOfWork/applications//NOWDocuments";
@@ -25,6 +26,10 @@ const defaultProps = { importNowSubmissionDocumentsJob: {}, isViewMode: false };
 export const NOWApplicationManageDocuments = (props) => {
   const isNoWApplication = props.noticeOfWork.application_type_code === "NOW";
   const applicationFilesTypes = ["AAF", "MDO", "SDO"];
+  // default to true, as the preferred flow has permit conditions.
+  const hasPermitConditionsFlow = !isEmpty(props.draftPermitAmendment)
+    ? props.draftPermitAmendment.has_permit_conditions
+    : true;
   const tableDescription = isNoWApplication
     ? "In this table, you can see all documents submitted during initial application, revision and new files requested from the proponent. Documents added in this section will not show up in the permit package unless otherwise specified."
     : "In this table, you can see all documents uploaded to the application, revision and new files requested from the proponent. Documents added in this section will not show up in the permit package unless otherwise specified.";
@@ -110,10 +115,10 @@ export const NOWApplicationManageDocuments = (props) => {
           showDescription
         />
       </ScrollContentWrapper>
-      {(isNoWApplication || props.draftPermitAmendment?.has_permit_conditions) && (
+      {(isNoWApplication || hasPermitConditionsFlow) && (
         <ScrollContentWrapper
           id="generated-documents"
-          title="System-generated documents"
+          title="System-generated Documents"
           isLoaded={props.isLoaded}
         >
           <NOWDocuments

--- a/services/core-web/src/components/noticeOfWork/applications/review/ReviewAdminAmendmentApplication.js
+++ b/services/core-web/src/components/noticeOfWork/applications/review/ReviewAdminAmendmentApplication.js
@@ -205,7 +205,7 @@ export const ReviewAdminAmendmentApplication = (props) => {
                 now_application_document_sub_type_code === "AAF" ||
                 now_application_document_sub_type_code === "MDO"
             )}
-            isViewMode={!props.isViewMode}
+            isViewMode={props.isViewMode}
             disclaimerText="Attach any file revisions or new files requested from the proponent here."
             categoriesToShow={["AAF", "MDO"]}
             isStandardDocuments

--- a/services/core-web/src/constants/NOWConditions.js
+++ b/services/core-web/src/constants/NOWConditions.js
@@ -328,7 +328,7 @@ export const sideMenuOptions = (tab, hasPermitConditionsFlow = true, hasLegacyFu
       },
       {
         href: "generated-documents",
-        title: "System-generated documents",
+        title: "System-generated Documents",
         alwaysVisible: hasPermitConditionsFlow,
         children: [],
         applicationType: ["NOW", "ADA"],

--- a/services/core-web/src/tests/components/noticeOfWork/applications/documents/ManageDocumentsTab.spec.tsx
+++ b/services/core-web/src/tests/components/noticeOfWork/applications/documents/ManageDocumentsTab.spec.tsx
@@ -11,7 +11,7 @@ const dispatchProps = {
   fetchImportedNoticeOfWorkApplication: jest.fn(),
   fetchNoticeOfWorkApplicationReviews: jest.fn(),
 };
-// Covers the System-generated documents filter's AEF/PMT/PMA/DRAFT branches: a non-permit AEF
+// Covers the System-generated Documents filter's AEF/PMT/PMA/DRAFT branches: a non-permit AEF
 // doc (included), a draft PMT (included via the DRAFT name check), and a final PMA (excluded).
 const SYSTEM_GENERATED_DOCUMENTS_TEST_DOCS = [
   {

--- a/services/core-web/src/tests/components/noticeOfWork/applications/documents/NOWApplicationManageDocuments.spec.tsx
+++ b/services/core-web/src/tests/components/noticeOfWork/applications/documents/NOWApplicationManageDocuments.spec.tsx
@@ -12,7 +12,7 @@ const dispatchProps = {
   fetchNoticeOfWorkApplicationReviews: jest.fn(),
 };
 
-// Covers the System-generated documents filter's AEF/PMT/PMA/DRAFT branches: a non-permit AEF
+// Covers the System-generated Documents filter's AEF/PMT/PMA/DRAFT branches: a non-permit AEF
 // doc (included), a draft PMT (included via the DRAFT name check), and a final PMA (excluded).
 const SYSTEM_GENERATED_DOCUMENTS_TEST_DOCS = [
   {
@@ -74,7 +74,7 @@ describe("NOWApplicationManageDocuments", () => {
     expect(component).toMatchSnapshot();
   });
 
-  it("shows System-generated documents for an ADA application with drafted permit conditions", () => {
+  it("shows System-generated Documents for an ADA application with drafted permit conditions", () => {
     const { getByText } = render(
       <BrowserRouter>
         <ReduxWrapper initialState={initialState}>
@@ -87,12 +87,14 @@ describe("NOWApplicationManageDocuments", () => {
         </ReduxWrapper>
       </BrowserRouter>
     );
-    expect(getByText("System-generated documents")).toBeInTheDocument();
+    expect(getByText("System-generated Documents")).toBeInTheDocument();
     expect(getByText("This table shows generated Draft Permit PDFs.")).toBeInTheDocument();
   });
 
-  it("hides System-generated documents for an ADA application without drafted permit conditions", () => {
-    const { queryByText } = render(
+  it("shows System-generated Documents (empty state) for an ADA application before a draft permit amendment exists", () => {
+    // No draftPermitAmendment prop passed - defaults to {}, which should default to visible,
+    // matching NOWSideMenu's hasPermitConditionsFlow fallback.
+    const { getByText } = render(
       <BrowserRouter>
         <ReduxWrapper initialState={initialState}>
           <NOWApplicationManageDocuments
@@ -103,6 +105,23 @@ describe("NOWApplicationManageDocuments", () => {
         </ReduxWrapper>
       </BrowserRouter>
     );
-    expect(queryByText("System-generated documents")).not.toBeInTheDocument();
+    expect(getByText("System-generated Documents")).toBeInTheDocument();
+    expect(getByText("This table shows generated Draft Permit PDFs.")).toBeInTheDocument();
+  });
+
+  it("hides System-generated Documents for an ADA application when the draft permit amendment explicitly has no permit conditions", () => {
+    const { queryByText } = render(
+      <BrowserRouter>
+        <ReduxWrapper initialState={initialState}>
+          <NOWApplicationManageDocuments
+            {...dispatchProps}
+            {...reducerProps}
+            noticeOfWork={{ ...reducerProps.noticeOfWork, application_type_code: "ADA" }}
+            draftPermitAmendment={{ has_permit_conditions: false }}
+          />
+        </ReduxWrapper>
+      </BrowserRouter>
+    );
+    expect(queryByText("System-generated Documents")).not.toBeInTheDocument();
   });
 });

--- a/services/core-web/src/tests/components/noticeOfWork/applications/documents/NOWApplicationManageDocuments.spec.tsx
+++ b/services/core-web/src/tests/components/noticeOfWork/applications/documents/NOWApplicationManageDocuments.spec.tsx
@@ -92,8 +92,7 @@ describe("NOWApplicationManageDocuments", () => {
   });
 
   it("shows System-generated Documents (empty state) for an ADA application before a draft permit amendment exists", () => {
-    // No draftPermitAmendment prop passed - defaults to {}, which should default to visible,
-    // matching NOWSideMenu's hasPermitConditionsFlow fallback.
+    // No draftPermitAmendment prop passed - defaults to {}, which should default to visible
     const { getByText } = render(
       <BrowserRouter>
         <ReduxWrapper initialState={initialState}>

--- a/services/core-web/src/tests/components/noticeOfWork/applications/documents/__snapshots__/ManageDocumentsTab.spec.tsx.snap
+++ b/services/core-web/src/tests/components/noticeOfWork/applications/documents/__snapshots__/ManageDocumentsTab.spec.tsx.snap
@@ -111,9 +111,9 @@ exports[`ManageDocumentsTab renders properly 1`] = `
               <a
                 class="ant-anchor-link-title"
                 href="#generated-documents"
-                title="System-generated documents"
+                title="System-generated Documents"
               >
-                System-generated documents
+                System-generated Documents
               </a>
             </div>
             <div
@@ -1325,7 +1325,7 @@ exports[`ManageDocumentsTab renders properly 1`] = `
                 class="scroll-wrapper--title"
               >
                 <h3>
-                  System-generated documents
+                  System-generated Documents
                 </h3>
               </div>
             </div>

--- a/services/core-web/src/tests/components/noticeOfWork/applications/documents/__snapshots__/NOWApplicationManageDocuments.spec.tsx.snap
+++ b/services/core-web/src/tests/components/noticeOfWork/applications/documents/__snapshots__/NOWApplicationManageDocuments.spec.tsx.snap
@@ -1192,7 +1192,7 @@ exports[`NOWApplicationManageDocuments renders properly 1`] = `
             class="scroll-wrapper--title"
           >
             <h3>
-              System-generated documents
+              System-generated Documents
             </h3>
           </div>
         </div>


### PR DESCRIPTION
## Objective 

[MDS-7007](https://bcmines.atlassian.net/browse/MDS-7007)

_Why are you making this change? Provide a short explanation and/or screenshots_

In QA it was found that if there were no "System-generated Documents" present within an 'Administrative Amendment' NoW application, then the "System-generated Documents" table was not rendered/displayed, despite the Nav link for it being present. 

This PR fixes that issue - the "System-generated Documents" table (and Nav link) are always shown, regardless of whether or not there are any documents to display:

<img width="1709" height="900" alt="image" src="https://github.com/user-attachments/assets/a0e7559d-778b-4dcf-b4bd-aed9c118e7de" />


I also fixed an unrelated logic bug that made it so that the ability to upload docs was **disabled** when in edit mode - it should have been **enabled**. Moving forward you can only upload documents when it edit mode. 
