### PR TITLE
[MDS-6989] Fix for new document headers showing up in conditions during extraction

### DIFF
--- a/services/permits/app/pipelines/permit_condition_extraction/components/filter_conditions_paragraphs.py
+++ b/services/permits/app/pipelines/permit_condition_extraction/components/filter_conditions_paragraphs.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import re
 from typing import Any, Dict, List, Optional
 
 from app.common.types.context import context
@@ -225,4 +226,82 @@ def _identify_bottom_of_first_page_header(paragraphs):
             and is_like_page_header
         ):
             return paragraphs[page_header_end_idx].meta["bounding_box"]["bottom"]
+
+    # Document Intelligence does not always tag a page header with the 'pageHeader'
+    # role - this has been observed for headers laid out as multi-column tables
+    # where the header comes back as several ordinary (role=None) paragraphs instead of one recognized
+    # header block. Fall back to detecting a block of boilerplate text that repeats
+    # near the top of multiple pages, regardless of the role Document Intelligence
+    # assigned it.
+    return _identify_bottom_of_repeating_header_fallback(paragraphs)
+
+HEADER_ADJACENCY_TOLERANCE = 0.05
+
+
+def _normalize_header_text(text):
+    return re.sub(r"\s+", " ", text or "").strip().lower()
+
+
+def _build_repeated_paragraph_texts(paragraphs, min_pages=3):
+    """
+    Find paragraph text that repeats across several different pages
+    """
+    text_to_pages = {}
+    for p in paragraphs:
+        page = p.meta.get("page")
+        text = _normalize_header_text(p.content.get("text"))
+        if not text or page is None:
+            continue
+        text_to_pages.setdefault(text, set()).add(page)
+
+    return {text for text, pages in text_to_pages.items() if len(pages) >= min_pages}
+
+
+def _identify_bottom_of_repeating_header_fallback(paragraphs, min_pages=3):
+    """
+    Identify the bottom of a repeating header block without relying on Document
+    Intelligence's 'pageHeader' role. For each page, checks whether the first
+    paragraph on that page is repeated on min_pages. The first
+    page/paragraph where this holds is used to compute the header cutoff.
+    """
+    repeated_texts = _build_repeated_paragraph_texts(paragraphs, min_pages=min_pages)
+
+    if not repeated_texts:
+        return None
+
+    seen_pages = set()
+
+    for idx, p in enumerate(paragraphs):
+        page = p.meta.get("page")
+
+        if page is None or page in seen_pages:
+            continue
+        seen_pages.add(page)
+
+        if _normalize_header_text(p.content.get("text")) not in repeated_texts:
+            continue
+
+        header_end_idx = idx
+        header_bottom = p.meta["bounding_box"]["bottom"]
+
+        for next_idx, next_p in enumerate(paragraphs[idx + 1 :], start=idx + 1):
+            if next_p.meta.get("page") != page:
+                break
+
+            text_repeats = (
+                _normalize_header_text(next_p.content.get("text")) in repeated_texts
+            )
+            touches_header_block = (
+                next_p.meta["bounding_box"]["top"] - header_bottom
+                <= HEADER_ADJACENCY_TOLERANCE
+            )
+
+            if not text_repeats and not touches_header_block:
+                break
+
+            header_end_idx = next_idx
+            header_bottom = next_p.meta["bounding_box"]["bottom"]
+
+        return paragraphs[header_end_idx].meta["bounding_box"]["bottom"]
+
     return None

--- a/services/permits/tests/pipelines/permit_condition_extraction/components/test_filter_conditions_paragraphs.py
+++ b/services/permits/tests/pipelines/permit_condition_extraction/components/test_filter_conditions_paragraphs.py
@@ -1,0 +1,109 @@
+import json
+
+from haystack import Document
+
+from app.pipelines.permit_condition_extraction.components.filter_conditions_paragraphs import (
+    filter_paragraphs,
+)
+
+
+def _doc(text, role, page, top, bottom):
+    doc = Document(
+        content=json.dumps(
+            {
+                "id": f"{page}-{top}-{text[:8]}",
+                "text": text,
+                "role": role,
+                "sort_key": 1,
+            }
+        ),
+        meta={
+            "bounding_box": {"top": top, "bottom": bottom, "left": 0, "right": 1},
+            "role": role,
+            "page": page,
+        },
+    )
+    doc.content = json.loads(doc.content)
+    return doc
+
+
+def test_filter_paragraphs_excludes_header_tagged_with_page_header_role():
+    """
+    Existing behaviour: Document Intelligence tags the header with role='pageHeader'
+    (this is how the old MMO permit template header is classified). This must keep
+    working unchanged.
+    """
+    documents = [
+        _doc("CONDITIONS", "sectionHeading", 1, 0.30, 0.34),
+        _doc("1. The permittee must do a thing.", None, 1, 0.40, 0.60),
+        _doc("Old Co Ltd, Some Mine", "pageHeader", 2, 0.10, 0.20),
+        _doc("Permit No. M-1 Page 2 of 2", "pageHeader", 2, 0.20, 0.30),
+        _doc("2. The permittee must do another thing.", None, 2, 0.40, 0.60),
+    ]
+
+    filtered = filter_paragraphs(documents)
+    texts = [d.content["text"] for d in filtered]
+
+    assert "Old Co Ltd, Some Mine" not in texts
+    assert "Permit No. M-1 Page 2 of 2" not in texts
+    assert "1. The permittee must do a thing." in texts
+    assert "2. The permittee must do another thing." in texts
+
+
+def test_filter_paragraphs_excludes_repeating_header_without_page_header_role():
+    """
+    Document Intelligence does not tag this table-style, multi-column header with
+    role='pageHeader' - it comes back as several ordinary (role=None) paragraphs
+    per page instead. The filter must still recognize and exclude it by noticing
+    that the same fragments repeat near the top of most pages, even though none of
+    them carry the 'pageHeader' role.
+    """
+    documents = [
+        _doc("CONDITIONS", "sectionHeading", 1, 0.30, 0.34),
+        _doc("1. The permittee must do a thing.", None, 1, 0.40, 0.60),
+    ]
+
+    for page in range(2, 7):
+        documents += [
+            _doc("Province of British Columbia", None, page, 0.10, 0.14),
+            _doc("Mount Polley Mine", None, page, 0.10, 0.14),
+            _doc("Permit:", None, page, 0.14, 0.18),
+            _doc("M-200", None, page, 0.14, 0.18),
+            _doc("Page:", None, page, 0.18, 0.22),
+            _doc(f"{page} of 6", None, page, 0.18, 0.22),
+            _doc(f"{page}. The permittee must do condition {page}.", None, page, 0.40, 0.60),
+        ]
+
+    filtered = filter_paragraphs(documents)
+    texts = [d.content["text"] for d in filtered]
+
+    assert "Province of British Columbia" not in texts
+    assert "Mount Polley Mine" not in texts
+    assert "Permit:" not in texts
+    assert "M-200" not in texts
+    assert "Page:" not in texts
+    for page in range(2, 7):
+        assert f"{page} of 6" not in texts
+
+    assert "1. The permittee must do a thing." in texts
+    for page in range(2, 7):
+        assert f"{page}. The permittee must do condition {page}." in texts
+
+def test_filter_paragraphs_keeps_all_paragraphs_when_no_header_detected():
+    """
+    If nothing repeats across pages (e.g. a single-page document, or a document
+    with no boilerplate header at all), the fallback should not exclude anything -
+    it should never remove legitimate content just because it appears more than
+    once.
+    """
+    documents = [
+        _doc("CONDITIONS", "sectionHeading", 1, 0.05, 0.10),
+        _doc("1. The permittee must do a thing.", None, 1, 0.20, 0.40),
+        _doc("2. The permittee must do another thing.", None, 1, 0.40, 0.60),
+    ]
+
+    filtered = filter_paragraphs(documents)
+    texts = [d.content["text"] for d in filtered]
+
+    assert "1. The permittee must do a thing." in texts
+    assert "2. The permittee must do another thing." in texts


### PR DESCRIPTION
## Objective 

[MDS-6989](https://bcmines.atlassian.net/browse/MDS-6989)

-The issue was the document header is tagged by Azure as a "page header," so the pipeline already knew to skip it. The new template's header is laid out as a table instead, and Azure doesn't tag it that way — it just comes back as regular paragraphs. With no tag to catch it the header text was getting pulled in as conditions.

-Added a fall back where when no pageHeader tag is detected we determine the header block ourselves by identifying text that repeats at the top of a certain number of pages.