### PR TITLE
[MDS-7010] Bugfix: Orgbook lookup for 'Application Information' in major projects

### DIFF
--- a/services/common/src/components/projectSummary/Applicant.tsx
+++ b/services/common/src/components/projectSummary/Applicant.tsx
@@ -103,7 +103,7 @@ const Applicant: FC<ProjectSummaryFormComponentProps> = ({ fieldsDisabled }) => 
       if (credential_id !== credential.id)
         dispatch(change(FORM.ADD_EDIT_PROJECT_SUMMARY, "company_alias", null));
 
-      dispatch(change(FORM.ADD_EDIT_PROJECT_SUMMARY, "applicant.credential_id", credential.credential_id));
+      dispatch(change(FORM.ADD_EDIT_PROJECT_SUMMARY, "applicant.credential_id", credential.id));
       const orgBookEntity = {
         registration_id: credential.topic.source_id,
         business_name: credential.topic.local_name.text,


### PR DESCRIPTION
## Objective 

[MDS-7010](https://bcmines.atlassian.net/browse/MDS-7010)

_Why are you making this change? Provide a short explanation and/or screenshots_

After Prod release on Aug 26th (v2.7.7), Minespace major project's "Applicant Information" step started throwing errors if you tried to use 'Organization', due to a bug in the Orgbook lookup code. 

This PR fixes that lookup, so it no longer errors.