### PR TITLE
[MDS-6944] Add 'In Person' contact option for JOHSC representative

### DIFF
--- a/migrations/sql/V2026.08.21.10.00__add_in_person_contact_method.sql
+++ b/migrations/sql/V2026.08.21.10.00__add_in_person_contact_method.sql
@@ -1,0 +1,1 @@
+ALTER TYPE contact_method ADD VALUE IF NOT EXISTS 'INP';

--- a/services/common/src/constants/strings.tsx
+++ b/services/common/src/constants/strings.tsx
@@ -90,6 +90,7 @@ export const INCIDENT_FOLLOWUP_ACTIONS = {
 export const INCIDENT_CONTACT_METHOD_OPTIONS = [
   { label: "Phone", value: "PHN" },
   { label: "Email", value: "EML" },
+  { label: "In Person", value: "INP" },
   { label: "Direct phone", value: "PHN", inspectorOnly: true },
   { label: "Direct email", value: "EML", inspectorOnly: true },
   { label: "Ministry reporting phone line", value: "MRP", inspectorOnly: true },

--- a/services/common/src/interfaces/incidents/mineIncident.interface.ts
+++ b/services/common/src/interfaces/incidents/mineIncident.interface.ts
@@ -25,6 +25,8 @@ export interface IMineIncident {
   verbal_notification_provided: boolean;
   reported_to_inspector_party_guid: string;
   reported_to_inspector_contacted: boolean;
+  johsc_worker_rep_contacted: boolean;
+  johsc_management_rep_contacted: boolean;
   responsible_inspector_party_guid: string;
   mms_inspector_initials: string;
   determination_inspector_party_guid: string;

--- a/services/core-api/app/api/incidents/models/mine_incident.py
+++ b/services/core-api/app/api/incidents/models/mine_incident.py
@@ -271,7 +271,7 @@ class MineIncident(SoftDeleteMixin, AuditMixin, Base):
     @validates('reported_to_inspector_contact_method', 'johsc_worker_rep_contact_method', 'johsc_management_rep_contact_method')
     def validates_contact_method(self, key, value):
         if value:
-            if value not in ['PHN', 'EML', 'MRP', 'MRE']:
+            if value not in ['PHN', 'EML', 'MRP', 'MRE', 'INP']:
                 raise AssertionError(f'{key} must use a valid option')
         return value
 

--- a/services/core-api/tests/mines/incidents/test_mine_incident_resource.py
+++ b/services/core-api/tests/mines/incidents/test_mine_incident_resource.py
@@ -111,3 +111,54 @@ class TestPutMineIncident:
 
         assert all(x in data['dangerous_occurrence_subparagraph_ids'] for x in put_data['dangerous_occurrence_subparagraph_ids'])
         assert all(x in data['recommendations'] for x in put_data['recommendations'])
+
+    @patch('app.api.incidents.models.mine_incident.MineIncident.send_incidents_email')
+    @patch('app.api.incidents.models.mine_incident.MineIncident.send_awaiting_final_report_email')
+    @patch('app.api.incidents.models.mine_incident.MineIncident.send_final_report_received_email')
+    def test_put_mine_incident_johsc_contact_method_in_person(self, mock_send_final, mock_send_awaiting, mock_send_incidents, test_client, db_session, auth_headers):
+        """Should accept 'INP' (In Person) as a valid johsc contact method and round-trip it"""
+
+        mine_incident = MineIncidentFactory()
+        incident = MineIncidentFactory()
+        data = {
+            'incident_timestamp': '2019-01-01T18:17:12.136000+00:00',
+            'reported_timestamp': '2019-01-01T18:27:12.136000+00:00',
+            'incident_timezone': incident.incident_timezone,
+            'incident_description': incident.incident_description,
+            'incident_location': incident.incident_location,
+            'reported_by_name': incident.reported_by_name,
+            'reported_by_email': incident.reported_by_email,
+            'reported_by_phone_no': incident.reported_by_phone_no,
+            'reported_by_phone_ext': incident.reported_by_phone_ext,
+            'emergency_services_called': incident.emergency_services_called,
+            'number_of_injuries': incident.number_of_injuries,
+            'number_of_fatalities': incident.number_of_fatalities,
+            'reported_to_inspector_party_guid': incident.reported_to_inspector_party_guid,
+            'responsible_inspector_party_guid': incident.responsible_inspector_party_guid,
+            'determination_inspector_party_guid': incident.determination_inspector_party_guid,
+            'proponent_incident_no': incident.proponent_incident_no,
+            'determination_type_code': incident.determination_type_code,
+            'followup_investigation_type_code': incident.followup_investigation_type_code,
+            'followup_inspection': incident.followup_inspection,
+            'followup_inspection_date': '2019-01-01T18:27:12.136000+00:00',
+            'status_code': incident.status_code,
+            'dangerous_occurrence_subparagraph_ids': incident.dangerous_occurrence_subparagraph_ids,
+            'recommendations': incident.recommendations,
+            'immediate_measures_taken': incident.immediate_measures_taken,
+            'injuries_description': incident.injuries_description,
+            'johsc_worker_rep_name': incident.johsc_worker_rep_name,
+            'johsc_worker_rep_contacted': True,
+            'johsc_worker_rep_contact_method': 'INP',
+            'johsc_management_rep_name': incident.johsc_management_rep_name,
+            'johsc_management_rep_contacted': True,
+            'johsc_management_rep_contact_method': 'INP',
+        }
+
+        put_resp = test_client.put(
+            f'/mines/{mine_incident.mine_guid}/incidents/{mine_incident.mine_incident_guid}',
+            headers=auth_headers['full_auth_header'],
+            json=data)
+        put_data = json.loads(put_resp.data.decode())
+        assert put_resp.status_code == 200, put_resp.response
+        assert put_data['johsc_worker_rep_contact_method'] == 'INP'
+        assert put_data['johsc_management_rep_contact_method'] == 'INP'

--- a/services/core-web/src/components/Forms/incidents/IncidentFormInitialReport.tsx
+++ b/services/core-web/src/components/Forms/incidents/IncidentFormInitialReport.tsx
@@ -387,75 +387,82 @@ const IncidentFormInitialReport: FC<IncidentFormInitialReportProps> = ({
               />
             </Col>
             <Divider />
-            <Col md={12} xs={24}>
-              <Field
-                label="JOHSC/Worker Rep Name"
-                id="johsc_worker_rep_name"
-                name="johsc_worker_rep_name"
-                component={renderConfig.FIELD}
-                placeholder="Enter name of representative..."
-                validate={[maxLength(100)]}
-                disabled={!isEditMode}
-              />
+            <Col span={24}>
+              <Row gutter={16} style={{ marginBottom: 16 }}>
+                <Col md={12} xs={24}>
+                  <Field
+                    label="JOHSC/Worker Rep Name"
+                    id="johsc_worker_rep_name"
+                    name="johsc_worker_rep_name"
+                    component={renderConfig.FIELD}
+                    placeholder="Enter name of representative..."
+                    validate={[maxLength(100)]}
+                    disabled={!isEditMode}
+                  />
+                </Col>
+                <Col md={12} xs={24}>
+                  <Field
+                    label="Was this person contacted?"
+                    id="johsc_worker_rep_contacted"
+                    name="johsc_worker_rep_contacted"
+                    component={renderConfig.RADIO}
+                    disabled={!isEditMode}
+                  />
+                </Col>
+                {workerRepContacted && (
+                  <Col md={12} xs={24}>
+                    <Field
+                      label="Initial Contact Method"
+                      id="johsc_worker_rep_contact_method"
+                      name="johsc_worker_rep_contact_method"
+                      component={renderConfig.RADIO}
+                      customOptions={INCIDENT_CONTACT_METHOD_OPTIONS.filter((cm) => !cm?.inspectorOnly)}
+                      disabled={!isEditMode}
+                      required
+                      validate={[required]}
+                    />
+                  </Col>
+                )}
+              </Row>
             </Col>
-            <Col md={12} xs={24}>
-              <Field
-                label="Was this person contacted?"
-                id="johsc_worker_rep_contacted"
-                name="johsc_worker_rep_contacted"
-                component={renderConfig.RADIO}
-                disabled={!isEditMode}
-              />
+            <Col span={24}>
+              <Row gutter={16}>
+                <Col md={12} xs={24}>
+                  <Field
+                    label="JOHSC/Management Rep Name"
+                    id="johsc_management_rep_name"
+                    name="johsc_management_rep_name"
+                    component={renderConfig.FIELD}
+                    placeholder="Enter name of representative..."
+                    validate={[maxLength(100)]}
+                    disabled={!isEditMode}
+                  />
+                </Col>
+                <Col md={12} xs={24}>
+                  <Field
+                    label="Was this person contacted?"
+                    id="johsc_management_rep_contacted"
+                    name="johsc_management_rep_contacted"
+                    component={renderConfig.RADIO}
+                    disabled={!isEditMode}
+                  />
+                </Col>
+                {managementRepContacted && (
+                  <Col md={12} xs={24}>
+                    <Field
+                      label="Initial Contact Method"
+                      id="johsc_management_rep_contact_method"
+                      name="johsc_management_rep_contact_method"
+                      component={renderConfig.RADIO}
+                      customOptions={INCIDENT_CONTACT_METHOD_OPTIONS.filter((cm) => !cm?.inspectorOnly)}
+                      disabled={!isEditMode}
+                      required
+                      validate={[required]}
+                    />
+                  </Col>
+                )}
+              </Row>
             </Col>
-            {workerRepContacted && (
-              <Col md={12} xs={24}>
-                <Field
-                  label="Initial Contact Method"
-                  id="johsc_worker_rep_contact_method"
-                  name="johsc_worker_rep_contact_method"
-                  component={renderConfig.RADIO}
-                  customOptions={INCIDENT_CONTACT_METHOD_OPTIONS.filter((cm) => !cm?.inspectorOnly)}
-                  disabled={!isEditMode}
-                  required
-                  validate={[required]}
-                />
-              </Col>
-            )}
-            <Col md={12} xs={24}>
-              <Field
-                label="JOHSC/Management Rep Name"
-                id="johsc_management_rep_name"
-                name="johsc_management_rep_name"
-                component={renderConfig.FIELD}
-                placeholder="Enter name of representative..."
-                validate={[maxLength(100)]}
-                disabled={!isEditMode}
-              />
-            </Col>
-            <Col md={12} xs={24}>
-              <Field
-                label="Was this person contacted?"
-                id="johsc_management_rep_contacted"
-                name="johsc_management_rep_contacted"
-                component={renderConfig.RADIO}
-                disabled={!isEditMode}
-              />
-              <br />
-            </Col>
-            {managementRepContacted && (
-              <Col md={12} xs={24}>
-                <Field
-                  label="Initial Contact Method"
-                  id="johsc_management_rep_contact_method"
-                  name="johsc_management_rep_contact_method"
-                  component={renderConfig.RADIO}
-                  customOptions={INCIDENT_CONTACT_METHOD_OPTIONS.filter((cm) => !cm?.inspectorOnly)}
-                  disabled={!isEditMode}
-                  required
-                  validate={[required]}
-                />
-              </Col>
-            )}
           </Row>
           <br />
         </Col>

--- a/services/core-web/src/components/Forms/incidents/IncidentFormInitialReport.tsx
+++ b/services/core-web/src/components/Forms/incidents/IncidentFormInitialReport.tsx
@@ -51,11 +51,15 @@ const IncidentFormInitialReport: FC<IncidentFormInitialReportProps> = ({
   const incidentCategoryCodeOptions = useSelector(getDropdownIncidentCategoryCodeOptions);
   const [inspectorContactedValidation, setInspectorContactedValidation] = useState({});
   const [inspectorContacted, setInspectorContacted] = useState(null);
+  const [workerRepContacted, setWorkerRepContacted] = useState(null);
+  const [managementRepContacted, setManagementRepContacted] = useState(null);
 
   useEffect(() => {
     const inspectorSet = formValues?.reported_to_inspector_party_guid;
     setInspectorContactedValidation(inspectorSet ? { validate: [requiredRadioButton] } : {});
     setInspectorContacted(formValues?.reported_to_inspector_contacted);
+    setWorkerRepContacted(formValues?.johsc_worker_rep_contacted);
+    setManagementRepContacted(formValues?.johsc_management_rep_contacted);
   }, [formValues]);
 
   return (
@@ -403,6 +407,20 @@ const IncidentFormInitialReport: FC<IncidentFormInitialReportProps> = ({
                 disabled={!isEditMode}
               />
             </Col>
+            {workerRepContacted && (
+              <Col md={12} xs={24}>
+                <Field
+                  label="Initial Contact Method"
+                  id="johsc_worker_rep_contact_method"
+                  name="johsc_worker_rep_contact_method"
+                  component={renderConfig.RADIO}
+                  customOptions={INCIDENT_CONTACT_METHOD_OPTIONS.filter((cm) => !cm?.inspectorOnly)}
+                  disabled={!isEditMode}
+                  required
+                  validate={[required]}
+                />
+              </Col>
+            )}
             <Col md={12} xs={24}>
               <Field
                 label="JOHSC/Management Rep Name"
@@ -424,6 +442,20 @@ const IncidentFormInitialReport: FC<IncidentFormInitialReportProps> = ({
               />
               <br />
             </Col>
+            {managementRepContacted && (
+              <Col md={12} xs={24}>
+                <Field
+                  label="Initial Contact Method"
+                  id="johsc_management_rep_contact_method"
+                  name="johsc_management_rep_contact_method"
+                  component={renderConfig.RADIO}
+                  customOptions={INCIDENT_CONTACT_METHOD_OPTIONS.filter((cm) => !cm?.inspectorOnly)}
+                  disabled={!isEditMode}
+                  required
+                  validate={[required]}
+                />
+              </Col>
+            )}
           </Row>
           <br />
         </Col>

--- a/services/core-web/src/tests/components/Forms/incidents/IncidentForm.spec.tsx
+++ b/services/core-web/src/tests/components/Forms/incidents/IncidentForm.spec.tsx
@@ -32,4 +32,34 @@ describe("IncidentForm", () => {
     );
     expect(component).toMatchSnapshot();
   });
+
+  it("renders the JOHSC initial contact method fields when reps were contacted", () => {
+    const johscContactedProps = {
+      ...props,
+      incident: {
+        ...MOCK.INCIDENT,
+        johsc_worker_rep_contacted: true,
+        johsc_worker_rep_contact_method: "INP",
+        johsc_management_rep_contacted: true,
+        johsc_management_rep_contact_method: "INP",
+      },
+      initialValues: {
+        ...MOCK.INCIDENT,
+        johsc_worker_rep_contacted: true,
+        johsc_worker_rep_contact_method: "INP",
+        johsc_management_rep_contacted: true,
+        johsc_management_rep_contact_method: "INP",
+      },
+    };
+
+    const { getAllByText } = render(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[`/${mockedMineGuid}/${mockedMineIncidentGuid}`]}>
+          <IncidentForm {...johscContactedProps} />
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(getAllByText("In Person").length).toBeGreaterThan(0);
+  });
 });

--- a/services/core-web/src/tests/components/Forms/incidents/__snapshots__/IncidentForm.spec.tsx.snap
+++ b/services/core-web/src/tests/components/Forms/incidents/__snapshots__/IncidentForm.spec.tsx.snap
@@ -1798,347 +1798,366 @@ exports[`IncidentForm renders properly 1`] = `
                   role="separator"
                 />
                 <div
-                  class="ant-col ant-col-xs-24 ant-col-md-12"
+                  class="ant-col ant-col-24"
                   style="padding-left: 8px; padding-right: 8px;"
                 >
                   <div
-                    class="ant-form-item ant-form-item-with-help"
+                    class="ant-row"
+                    style="margin-left: -8px; margin-right: -8px; margin-bottom: 16px;"
                   >
                     <div
-                      class="ant-row ant-form-item-row"
+                      class="ant-col ant-col-xs-24 ant-col-md-12"
+                      style="padding-left: 8px; padding-right: 8px;"
                     >
                       <div
-                        class="ant-col ant-form-item-label"
-                      >
-                        <label
-                          class=""
-                          for="ADD_EDIT_INCIDENT_johsc_worker_rep_name"
-                          title=""
-                        >
-                          <div>
-                            JOHSC/Worker Rep Name
-                             
-                            <span
-                              class="form-item-optional"
-                            >
-                               (optional)
-                            </span>
-                          </div>
-                        </label>
-                      </div>
-                      <div
-                        class="ant-col ant-form-item-control"
+                        class="ant-form-item ant-form-item-with-help"
                       >
                         <div
-                          class="ant-form-item-control-input"
+                          class="ant-row ant-form-item-row"
                         >
                           <div
-                            class="ant-form-item-control-input-content"
+                            class="ant-col ant-form-item-label"
                           >
-                            <input
-                              aria-label="johsc_worker_rep_name"
-                              class="ant-input ant-input-disabled"
-                              data-testid="johsc_worker_rep_name"
-                              disabled=""
-                              id="johsc_worker_rep_name"
-                              name="johsc_worker_rep_name"
-                              placeholder="Enter name of representative..."
-                              type="text"
-                              value=""
-                            />
-                          </div>
-                        </div>
-                        <div
-                          style="display: flex; flex-wrap: nowrap;"
-                        >
-                          <div
-                            class="ant-form-item-explain ant-form-item-explain-connected"
-                            id="ADD_EDIT_INCIDENT_johsc_worker_rep_name_help"
-                            role="alert"
-                          >
-                            <div
+                            <label
                               class=""
-                            />
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <div
-                  class="ant-col ant-col-xs-24 ant-col-md-12"
-                  style="padding-left: 8px; padding-right: 8px;"
-                >
-                  <div
-                    class="ant-form-item ant-form-item-with-help"
-                  >
-                    <div
-                      class="ant-row ant-form-item-row"
-                    >
-                      <div
-                        class="ant-col ant-form-item-label"
-                      >
-                        <label
-                          class=""
-                          for="ADD_EDIT_INCIDENT_johsc_worker_rep_contacted"
-                          title=""
-                        >
-                          <div>
-                            Was this person contacted?
-                             
-                            <span
-                              class="form-item-optional"
+                              for="ADD_EDIT_INCIDENT_johsc_worker_rep_name"
+                              title=""
                             >
-                               (optional)
-                            </span>
+                              <div>
+                                JOHSC/Worker Rep Name
+                                 
+                                <span
+                                  class="form-item-optional"
+                                >
+                                   (optional)
+                                </span>
+                              </div>
+                            </label>
                           </div>
-                        </label>
-                      </div>
-                      <div
-                        class="ant-col ant-form-item-control"
-                      >
-                        <div
-                          class="ant-form-item-control-input"
-                        >
                           <div
-                            class="ant-form-item-control-input-content"
+                            class="ant-col ant-form-item-control"
                           >
                             <div
-                              class="ant-radio-group ant-radio-group-solid"
+                              class="ant-form-item-control-input"
                             >
-                              <label
-                                class="ant-radio-wrapper ant-radio-wrapper-disabled ant-radio-wrapper-in-form-item"
+                              <div
+                                class="ant-form-item-control-input-content"
                               >
-                                <span
-                                  class="ant-radio ant-radio-disabled"
-                                >
-                                  <input
-                                    class="ant-radio-input"
-                                    disabled=""
-                                    name="johsc_worker_rep_contacted"
-                                    type="radio"
-                                    value="true"
-                                  />
-                                  <span
-                                    class="ant-radio-inner"
-                                  />
-                                </span>
-                                <span>
-                                  Yes
-                                </span>
-                              </label>
-                              <label
-                                class="ant-radio-wrapper ant-radio-wrapper-disabled ant-radio-wrapper-in-form-item"
+                                <input
+                                  aria-label="johsc_worker_rep_name"
+                                  class="ant-input ant-input-disabled"
+                                  data-testid="johsc_worker_rep_name"
+                                  disabled=""
+                                  id="johsc_worker_rep_name"
+                                  name="johsc_worker_rep_name"
+                                  placeholder="Enter name of representative..."
+                                  type="text"
+                                  value=""
+                                />
+                              </div>
+                            </div>
+                            <div
+                              style="display: flex; flex-wrap: nowrap;"
+                            >
+                              <div
+                                class="ant-form-item-explain ant-form-item-explain-connected"
+                                id="ADD_EDIT_INCIDENT_johsc_worker_rep_name_help"
+                                role="alert"
                               >
-                                <span
-                                  class="ant-radio ant-radio-disabled"
-                                >
-                                  <input
-                                    class="ant-radio-input"
-                                    disabled=""
-                                    name="johsc_worker_rep_contacted"
-                                    type="radio"
-                                    value="false"
-                                  />
-                                  <span
-                                    class="ant-radio-inner"
-                                  />
-                                </span>
-                                <span>
-                                  No
-                                </span>
-                              </label>
+                                <div
+                                  class=""
+                                />
+                              </div>
                             </div>
                           </div>
                         </div>
-                        <div
-                          style="display: flex; flex-wrap: nowrap;"
-                        >
-                          <div
-                            class="ant-form-item-explain ant-form-item-explain-connected"
-                            id="ADD_EDIT_INCIDENT_johsc_worker_rep_contacted_help"
-                            role="alert"
-                          >
-                            <div
-                              class=""
-                            />
-                          </div>
-                        </div>
                       </div>
                     </div>
-                  </div>
-                </div>
-                <div
-                  class="ant-col ant-col-xs-24 ant-col-md-12"
-                  style="padding-left: 8px; padding-right: 8px;"
-                >
-                  <div
-                    class="ant-form-item ant-form-item-with-help"
-                  >
                     <div
-                      class="ant-row ant-form-item-row"
+                      class="ant-col ant-col-xs-24 ant-col-md-12"
+                      style="padding-left: 8px; padding-right: 8px;"
                     >
                       <div
-                        class="ant-col ant-form-item-label"
-                      >
-                        <label
-                          class=""
-                          for="ADD_EDIT_INCIDENT_johsc_management_rep_name"
-                          title=""
-                        >
-                          <div>
-                            JOHSC/Management Rep Name
-                             
-                            <span
-                              class="form-item-optional"
-                            >
-                               (optional)
-                            </span>
-                          </div>
-                        </label>
-                      </div>
-                      <div
-                        class="ant-col ant-form-item-control"
+                        class="ant-form-item ant-form-item-with-help"
                       >
                         <div
-                          class="ant-form-item-control-input"
+                          class="ant-row ant-form-item-row"
                         >
                           <div
-                            class="ant-form-item-control-input-content"
+                            class="ant-col ant-form-item-label"
                           >
-                            <input
-                              aria-label="johsc_management_rep_name"
-                              class="ant-input ant-input-disabled"
-                              data-testid="johsc_management_rep_name"
-                              disabled=""
-                              id="johsc_management_rep_name"
-                              name="johsc_management_rep_name"
-                              placeholder="Enter name of representative..."
-                              type="text"
-                              value=""
-                            />
-                          </div>
-                        </div>
-                        <div
-                          style="display: flex; flex-wrap: nowrap;"
-                        >
-                          <div
-                            class="ant-form-item-explain ant-form-item-explain-connected"
-                            id="ADD_EDIT_INCIDENT_johsc_management_rep_name_help"
-                            role="alert"
-                          >
-                            <div
+                            <label
                               class=""
-                            />
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <div
-                  class="ant-col ant-col-xs-24 ant-col-md-12"
-                  style="padding-left: 8px; padding-right: 8px;"
-                >
-                  <div
-                    class="ant-form-item ant-form-item-with-help"
-                  >
-                    <div
-                      class="ant-row ant-form-item-row"
-                    >
-                      <div
-                        class="ant-col ant-form-item-label"
-                      >
-                        <label
-                          class=""
-                          for="ADD_EDIT_INCIDENT_johsc_management_rep_contacted"
-                          title=""
-                        >
-                          <div>
-                            Was this person contacted?
-                             
-                            <span
-                              class="form-item-optional"
+                              for="ADD_EDIT_INCIDENT_johsc_worker_rep_contacted"
+                              title=""
                             >
-                               (optional)
-                            </span>
+                              <div>
+                                Was this person contacted?
+                                 
+                                <span
+                                  class="form-item-optional"
+                                >
+                                   (optional)
+                                </span>
+                              </div>
+                            </label>
                           </div>
-                        </label>
-                      </div>
-                      <div
-                        class="ant-col ant-form-item-control"
-                      >
-                        <div
-                          class="ant-form-item-control-input"
-                        >
                           <div
-                            class="ant-form-item-control-input-content"
+                            class="ant-col ant-form-item-control"
                           >
                             <div
-                              class="ant-radio-group ant-radio-group-solid"
+                              class="ant-form-item-control-input"
                             >
-                              <label
-                                class="ant-radio-wrapper ant-radio-wrapper-disabled ant-radio-wrapper-in-form-item"
+                              <div
+                                class="ant-form-item-control-input-content"
                               >
-                                <span
-                                  class="ant-radio ant-radio-disabled"
+                                <div
+                                  class="ant-radio-group ant-radio-group-solid"
                                 >
-                                  <input
-                                    class="ant-radio-input"
-                                    disabled=""
-                                    name="johsc_management_rep_contacted"
-                                    type="radio"
-                                    value="true"
-                                  />
-                                  <span
-                                    class="ant-radio-inner"
-                                  />
-                                </span>
-                                <span>
-                                  Yes
-                                </span>
-                              </label>
-                              <label
-                                class="ant-radio-wrapper ant-radio-wrapper-disabled ant-radio-wrapper-in-form-item"
+                                  <label
+                                    class="ant-radio-wrapper ant-radio-wrapper-disabled ant-radio-wrapper-in-form-item"
+                                  >
+                                    <span
+                                      class="ant-radio ant-radio-disabled"
+                                    >
+                                      <input
+                                        class="ant-radio-input"
+                                        disabled=""
+                                        name="johsc_worker_rep_contacted"
+                                        type="radio"
+                                        value="true"
+                                      />
+                                      <span
+                                        class="ant-radio-inner"
+                                      />
+                                    </span>
+                                    <span>
+                                      Yes
+                                    </span>
+                                  </label>
+                                  <label
+                                    class="ant-radio-wrapper ant-radio-wrapper-disabled ant-radio-wrapper-in-form-item"
+                                  >
+                                    <span
+                                      class="ant-radio ant-radio-disabled"
+                                    >
+                                      <input
+                                        class="ant-radio-input"
+                                        disabled=""
+                                        name="johsc_worker_rep_contacted"
+                                        type="radio"
+                                        value="false"
+                                      />
+                                      <span
+                                        class="ant-radio-inner"
+                                      />
+                                    </span>
+                                    <span>
+                                      No
+                                    </span>
+                                  </label>
+                                </div>
+                              </div>
+                            </div>
+                            <div
+                              style="display: flex; flex-wrap: nowrap;"
+                            >
+                              <div
+                                class="ant-form-item-explain ant-form-item-explain-connected"
+                                id="ADD_EDIT_INCIDENT_johsc_worker_rep_contacted_help"
+                                role="alert"
                               >
-                                <span
-                                  class="ant-radio ant-radio-disabled"
-                                >
-                                  <input
-                                    class="ant-radio-input"
-                                    disabled=""
-                                    name="johsc_management_rep_contacted"
-                                    type="radio"
-                                    value="false"
-                                  />
-                                  <span
-                                    class="ant-radio-inner"
-                                  />
-                                </span>
-                                <span>
-                                  No
-                                </span>
-                              </label>
+                                <div
+                                  class=""
+                                />
+                              </div>
                             </div>
                           </div>
                         </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="ant-col ant-col-24"
+                  style="padding-left: 8px; padding-right: 8px;"
+                >
+                  <div
+                    class="ant-row"
+                    style="margin-left: -8px; margin-right: -8px;"
+                  >
+                    <div
+                      class="ant-col ant-col-xs-24 ant-col-md-12"
+                      style="padding-left: 8px; padding-right: 8px;"
+                    >
+                      <div
+                        class="ant-form-item ant-form-item-with-help"
+                      >
                         <div
-                          style="display: flex; flex-wrap: nowrap;"
+                          class="ant-row ant-form-item-row"
                         >
                           <div
-                            class="ant-form-item-explain ant-form-item-explain-connected"
-                            id="ADD_EDIT_INCIDENT_johsc_management_rep_contacted_help"
-                            role="alert"
+                            class="ant-col ant-form-item-label"
+                          >
+                            <label
+                              class=""
+                              for="ADD_EDIT_INCIDENT_johsc_management_rep_name"
+                              title=""
+                            >
+                              <div>
+                                JOHSC/Management Rep Name
+                                 
+                                <span
+                                  class="form-item-optional"
+                                >
+                                   (optional)
+                                </span>
+                              </div>
+                            </label>
+                          </div>
+                          <div
+                            class="ant-col ant-form-item-control"
                           >
                             <div
+                              class="ant-form-item-control-input"
+                            >
+                              <div
+                                class="ant-form-item-control-input-content"
+                              >
+                                <input
+                                  aria-label="johsc_management_rep_name"
+                                  class="ant-input ant-input-disabled"
+                                  data-testid="johsc_management_rep_name"
+                                  disabled=""
+                                  id="johsc_management_rep_name"
+                                  name="johsc_management_rep_name"
+                                  placeholder="Enter name of representative..."
+                                  type="text"
+                                  value=""
+                                />
+                              </div>
+                            </div>
+                            <div
+                              style="display: flex; flex-wrap: nowrap;"
+                            >
+                              <div
+                                class="ant-form-item-explain ant-form-item-explain-connected"
+                                id="ADD_EDIT_INCIDENT_johsc_management_rep_name_help"
+                                role="alert"
+                              >
+                                <div
+                                  class=""
+                                />
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      class="ant-col ant-col-xs-24 ant-col-md-12"
+                      style="padding-left: 8px; padding-right: 8px;"
+                    >
+                      <div
+                        class="ant-form-item ant-form-item-with-help"
+                      >
+                        <div
+                          class="ant-row ant-form-item-row"
+                        >
+                          <div
+                            class="ant-col ant-form-item-label"
+                          >
+                            <label
                               class=""
-                            />
+                              for="ADD_EDIT_INCIDENT_johsc_management_rep_contacted"
+                              title=""
+                            >
+                              <div>
+                                Was this person contacted?
+                                 
+                                <span
+                                  class="form-item-optional"
+                                >
+                                   (optional)
+                                </span>
+                              </div>
+                            </label>
+                          </div>
+                          <div
+                            class="ant-col ant-form-item-control"
+                          >
+                            <div
+                              class="ant-form-item-control-input"
+                            >
+                              <div
+                                class="ant-form-item-control-input-content"
+                              >
+                                <div
+                                  class="ant-radio-group ant-radio-group-solid"
+                                >
+                                  <label
+                                    class="ant-radio-wrapper ant-radio-wrapper-disabled ant-radio-wrapper-in-form-item"
+                                  >
+                                    <span
+                                      class="ant-radio ant-radio-disabled"
+                                    >
+                                      <input
+                                        class="ant-radio-input"
+                                        disabled=""
+                                        name="johsc_management_rep_contacted"
+                                        type="radio"
+                                        value="true"
+                                      />
+                                      <span
+                                        class="ant-radio-inner"
+                                      />
+                                    </span>
+                                    <span>
+                                      Yes
+                                    </span>
+                                  </label>
+                                  <label
+                                    class="ant-radio-wrapper ant-radio-wrapper-disabled ant-radio-wrapper-in-form-item"
+                                  >
+                                    <span
+                                      class="ant-radio ant-radio-disabled"
+                                    >
+                                      <input
+                                        class="ant-radio-input"
+                                        disabled=""
+                                        name="johsc_management_rep_contacted"
+                                        type="radio"
+                                        value="false"
+                                      />
+                                      <span
+                                        class="ant-radio-inner"
+                                      />
+                                    </span>
+                                    <span>
+                                      No
+                                    </span>
+                                  </label>
+                                </div>
+                              </div>
+                            </div>
+                            <div
+                              style="display: flex; flex-wrap: nowrap;"
+                            >
+                              <div
+                                class="ant-form-item-explain ant-form-item-explain-connected"
+                                id="ADD_EDIT_INCIDENT_johsc_management_rep_contacted_help"
+                                role="alert"
+                              >
+                                <div
+                                  class=""
+                                />
+                              </div>
+                            </div>
                           </div>
                         </div>
                       </div>
                     </div>
                   </div>
-                  <br />
                 </div>
               </div>
               <br />


### PR DESCRIPTION
## Objective 

[MDS-6944](https://bcmines.atlassian.net/browse/MDS-6944)

_Why are you making this change? Provide a short explanation and/or screenshots_

To better allow for real-world workflows when reporting an incident, a new "In Person" option was added in both Core and Minespace, that allows the reporter of an incident to specify whether the (J)OHSC representative was contacted in person about the incident (previously only allowed "Phone" and "Email" as correspondence options). 

In Core, there was no existing functionality to specify any type of contact method, so that was added to Core as a new feature (including the "In Person" option). In Minespace this functionality already existed but lacked the "In Person" option, so that was added in this PR. 

All unit tests/snapshots were updated, see the below screenshots for the new options:

<img width="1493" height="603" alt="image" src="https://github.com/user-attachments/assets/4590486e-02fa-476c-98b2-c3f19b4b6ff0" />

<img width="1012" height="494" alt="image" src="https://github.com/user-attachments/assets/ba46e879-eb46-4aa8-abee-a0314c8f5e65" />
