### PR TITLE
[MDS-7012] - Add checks for non-running status in document indexing updates

### DIFF
--- a/services/core-api/app/api/now_applications/resources/now_application_document_search_resource.py
+++ b/services/core-api/app/api/now_applications/resources/now_application_document_search_resource.py
@@ -149,6 +149,13 @@ class NOWApplicationDocumentIndexStatusResource(Resource, UserMixin):
                 run.error_message = 'Indexing run timed out with no status update from the search service.'
                 run.last_run_end = datetime.utcnow()
                 run.save()
+            elif run.status == 'running' and status.get('status') and status.get('status') != 'running':
+                run.status = status.get('status')
+                run.items_processed = status.get('items_processed') or 0
+                run.error_count = status.get('error_count') or 0
+                run.error_message = status.get('error_message')
+                run.last_run_end = datetime.utcnow()
+                run.save()
 
             status['last_run_start'] = to_utc_isoformat(run.last_run_start)
             status['last_run_end'] = to_utc_isoformat(run.last_run_end)

--- a/services/core-api/app/api/now_applications/tasks.py
+++ b/services/core-api/app/api/now_applications/tasks.py
@@ -52,6 +52,9 @@ def poll_update_now_application_document_index_status(now_application_document_i
     if not run:
         raise InternalServerError('NowApplicationDocumentIndexRun not found')
 
+    if run.status != 'running':
+        return run
+
     index_status = NowApplicationSearchService().get_index_status(str(run.now_application_guid))
     status = index_status.get('status')
 

--- a/services/core-api/tests/now_applications/resources/test_now_application_document_search_resource.py
+++ b/services/core-api/tests/now_applications/resources/test_now_application_document_search_resource.py
@@ -98,6 +98,14 @@ def test_get_now_application_document_search_status_prefers_fresh_live_status_wh
         assert resp.json['status'] == 'success'
         assert resp.json['items_processed'] == 99
         assert resp.json['document_count'] == 3
+        assert resp.json['last_run_end'] is not None
+
+        refreshed_run = NowApplicationDocumentIndexRun.get_latest_by_now_application_guid(
+            now_application_identity.now_application_guid
+        )
+        assert refreshed_run.status == 'success'
+        assert refreshed_run.last_run_end is not None
+        assert refreshed_run.items_processed == 99
 
 
 def test_get_now_application_document_search_status_uses_persisted_status_once_run_is_terminal(

--- a/services/core-api/tests/now_applications/test_now_application_document_index_run_tasks.py
+++ b/services/core-api/tests/now_applications/test_now_application_document_index_run_tasks.py
@@ -126,3 +126,23 @@ def test_on_failure_finds_run_via_task_args_even_when_core_status_task_id_unset(
     assert refreshed.status == 'error'
     assert refreshed.error_message == 'boom'
     assert refreshed.last_run_end is not None
+
+
+def test_poll_update_now_application_document_index_status_early_exit_if_not_running(
+    now_application_search_service_mock, celery_app, test_client, db_session
+):
+    now_application_identity = NOWApplicationIdentityFactory()
+    run = NowApplicationDocumentIndexRun.create(
+        now_application_guid=now_application_identity.now_application_guid,
+        status='success',
+        last_run_start=datetime.utcnow(),
+        last_run_end=datetime.utcnow(),
+    )
+
+    result = poll_update_now_application_document_index_status.apply(
+        args=(str(run.now_application_document_index_run_id),)
+    ).get()
+
+    assert result.status == 'success'
+    now_application_search_service_mock.return_value.get_index_status.assert_not_called()
+


### PR DESCRIPTION
## Objective 

[MDS-7012](https://bcmines.atlassian.net/browse/MDS-7012)

This update introduces validation to ensure that document indexing updates occur only when the process is in a non-running status.  This is intended to prevent jobs orphaned by a race condition with the celery worker which prevented the last indexed timestamp from showing consistently