### PR TITLE
[MDS-6975] Added 'user_version' to list of tables the data analytics team can read from

### DIFF
--- a/migrations/sql/afterMigrate__89__assign_permissions.sql
+++ b/migrations/sql/afterMigrate__89__assign_permissions.sql
@@ -297,6 +297,7 @@ BEGIN
             public.underground_exploration_type,
             public.unit_type,
             public."user",
+            public.user_version,
             public.variance,
             public.variance_application_status_code,
             public.variance_document_category_code,


### PR DESCRIPTION
## Objective 

[MDS-6975](https://bcmines.atlassian.net/browse/MDS-6975)

_Why are you making this change? Provide a short explanation and/or screenshots_

In addition to the tables the data team already requested access for (that was granted in the first two PR's from this branch, PR #3965 and #3981), the data team informed me that they also require access to the additional table *sigh*:

| Table |
|---|
| `public.user_version` |

The `user_version` table is the auto-generated audit/history table for "user", which the data team already has access to - so I don't believe there are any concerns with granting SELECT to their user. 

This PR adds that access to the user specified by the data team!