### PR TITLE
[MDS-6944] Make JOHSC "Initial Contact Method" optional in Core

### DIFF
--- a/services/core-web/src/components/Forms/incidents/IncidentFormInitialReport.tsx
+++ b/services/core-web/src/components/Forms/incidents/IncidentFormInitialReport.tsx
@@ -418,8 +418,6 @@ const IncidentFormInitialReport: FC<IncidentFormInitialReportProps> = ({
                       component={renderConfig.RADIO}
                       customOptions={INCIDENT_CONTACT_METHOD_OPTIONS.filter((cm) => !cm?.inspectorOnly)}
                       disabled={!isEditMode}
-                      required
-                      validate={[required]}
                     />
                   </Col>
                 )}
@@ -456,8 +454,6 @@ const IncidentFormInitialReport: FC<IncidentFormInitialReportProps> = ({
                       component={renderConfig.RADIO}
                       customOptions={INCIDENT_CONTACT_METHOD_OPTIONS.filter((cm) => !cm?.inspectorOnly)}
                       disabled={!isEditMode}
-                      required
-                      validate={[required]}
                     />
                   </Col>
                 )}


### PR DESCRIPTION
## Objective 

[MDS-6944](https://bcmines.atlassian.net/browse/MDS-6944)

_Why are you making this change? Provide a short explanation and/or screenshots_

As a follow-up to the JOHSC "In Person" contact method work (PR #3985), it was decided that Core should not require "Initial Contact Method" to be selected/required. 

This PR:
  - Removes the required validation from the JOHSC Worker Rep and Management Rep "Initial Contact Method" fields in Core - the field can now be left blank when a rep was contacted

**Note:** Minespace is unchanged; both fields remain required there (original functionality)
