### PR TITLE
[MDS-7015] red boundary box not showing in pdf viewer for permit conditions

### DIFF
--- a/services/common/src/components/syncfusion/DocumentViewer.spec.tsx
+++ b/services/common/src/components/syncfusion/DocumentViewer.spec.tsx
@@ -1,7 +1,27 @@
 import React from "react";
-import DocumentViewer from "@mds/common/components/syncfusion/DocumentViewer";
+import DocumentViewer, { PdfViewer } from "@mds/common/components/syncfusion/DocumentViewer";
 import { render } from "@testing-library/react";
 import { ReduxWrapper } from "@mds/common/tests/utils/ReduxWrapper";
+
+jest.mock("@syncfusion/ej2-react-pdfviewer", () => {
+  const actual = jest.requireActual("@syncfusion/ej2-react-pdfviewer");
+  return {
+    ...actual,
+    Inject: () => null,
+    PdfViewerComponent: class MockPdfViewerComponent extends React.Component<any> {
+      annotation = { clear: jest.fn(), addAnnotation: jest.fn() };
+      navigation = { goToPage: jest.fn() };
+
+      componentDidMount() {
+        this.props.documentLoad?.();
+      }
+
+      render() {
+        return null;
+      }
+    },
+  };
+});
 
 const props = {
   documentPath: "mock path name",
@@ -19,5 +39,70 @@ describe("DocumentViewer", () => {
       </ReduxWrapper>
     );
     expect(component).toMatchSnapshot();
+  });
+});
+
+describe("PdfViewer", () => {
+  const conditionA = { pageNumber: 1, boundingBox: { top: 1, right: 2, bottom: 2, left: 1 } };
+  const conditionB = { pageNumber: 3, boundingBox: { top: 4, right: 5, bottom: 6, left: 3 } };
+
+  it("does not touch annotations when no location is ever given (generic document viewer)", () => {
+    let pdfViewer;
+    render(<PdfViewer documentPath="doc-a" onInit={(scope) => (pdfViewer = scope)} />);
+
+    expect(pdfViewer.annotation.clear).not.toHaveBeenCalled();
+    expect(pdfViewer.annotation.addAnnotation).not.toHaveBeenCalled();
+  });
+
+  it("draws the annotation once the document has loaded", () => {
+    let pdfViewer;
+    render(
+      <PdfViewer
+        documentPath="doc-a"
+        annotationLocation={conditionA}
+        onInit={(scope) => (pdfViewer = scope)}
+      />
+    );
+
+    expect(pdfViewer.navigation.goToPage).toHaveBeenCalledWith(1);
+    expect(pdfViewer.annotation.addAnnotation).toHaveBeenCalledTimes(1);
+  });
+
+  it("redraws the annotation when a new condition is selected, without a fresh document load", () => {
+    let pdfViewer;
+    const { rerender } = render(
+      <PdfViewer
+        documentPath="doc-a"
+        annotationLocation={conditionA}
+        onInit={(scope) => (pdfViewer = scope)}
+      />
+    );
+
+    rerender(
+      <PdfViewer
+        documentPath="doc-a"
+        annotationLocation={conditionB}
+        onInit={(scope) => (pdfViewer = scope)}
+      />
+    );
+
+    expect(pdfViewer.navigation.goToPage).toHaveBeenLastCalledWith(3);
+    expect(pdfViewer.annotation.addAnnotation).toHaveBeenCalledTimes(2);
+  });
+
+  it("clears a previously drawn annotation when the next condition has no location", () => {
+    let pdfViewer;
+    const { rerender } = render(
+      <PdfViewer
+        documentPath="doc-a"
+        annotationLocation={conditionA}
+        onInit={(scope) => (pdfViewer = scope)}
+      />
+    );
+
+    rerender(<PdfViewer documentPath="doc-a" onInit={(scope) => (pdfViewer = scope)} />);
+
+    expect(pdfViewer.annotation.addAnnotation).toHaveBeenCalledTimes(1);
+    expect(pdfViewer.annotation.clear).toHaveBeenCalledTimes(2);
   });
 });

--- a/services/common/src/components/syncfusion/DocumentViewer.spec.tsx
+++ b/services/common/src/components/syncfusion/DocumentViewer.spec.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import DocumentViewer, { PdfViewer } from "@mds/common/components/syncfusion/DocumentViewer";
-import { render } from "@testing-library/react";
+import { act, render } from "@testing-library/react";
 import { ReduxWrapper } from "@mds/common/tests/utils/ReduxWrapper";
 
 jest.mock("@syncfusion/ej2-react-pdfviewer", () => {
@@ -12,16 +12,14 @@ jest.mock("@syncfusion/ej2-react-pdfviewer", () => {
       annotation = { clear: jest.fn(), addAnnotation: jest.fn() };
       navigation = { goToPage: jest.fn() };
 
-      componentDidMount() {
-        this.props.documentLoad?.();
-      }
-
       render() {
         return null;
       }
     },
   };
 });
+
+const loadDocument = (pdfViewer) => act(() => pdfViewer.props.documentLoad());
 
 const props = {
   documentPath: "mock path name",
@@ -49,6 +47,7 @@ describe("PdfViewer", () => {
   it("does not touch annotations when no location is ever given (generic document viewer)", () => {
     let pdfViewer;
     render(<PdfViewer documentPath="doc-a" onInit={(scope) => (pdfViewer = scope)} />);
+    loadDocument(pdfViewer);
 
     expect(pdfViewer.annotation.clear).not.toHaveBeenCalled();
     expect(pdfViewer.annotation.addAnnotation).not.toHaveBeenCalled();
@@ -63,6 +62,7 @@ describe("PdfViewer", () => {
         onInit={(scope) => (pdfViewer = scope)}
       />
     );
+    loadDocument(pdfViewer);
 
     expect(pdfViewer.navigation.goToPage).toHaveBeenCalledWith(1);
     expect(pdfViewer.annotation.addAnnotation).toHaveBeenCalledTimes(1);
@@ -77,14 +77,17 @@ describe("PdfViewer", () => {
         onInit={(scope) => (pdfViewer = scope)}
       />
     );
+    loadDocument(pdfViewer);
 
-    rerender(
-      <PdfViewer
-        documentPath="doc-a"
-        annotationLocation={conditionB}
-        onInit={(scope) => (pdfViewer = scope)}
-      />
-    );
+    act(() => {
+      rerender(
+        <PdfViewer
+          documentPath="doc-a"
+          annotationLocation={conditionB}
+          onInit={(scope) => (pdfViewer = scope)}
+        />
+      );
+    });
 
     expect(pdfViewer.navigation.goToPage).toHaveBeenLastCalledWith(3);
     expect(pdfViewer.annotation.addAnnotation).toHaveBeenCalledTimes(2);
@@ -99,8 +102,11 @@ describe("PdfViewer", () => {
         onInit={(scope) => (pdfViewer = scope)}
       />
     );
+    loadDocument(pdfViewer);
 
-    rerender(<PdfViewer documentPath="doc-a" onInit={(scope) => (pdfViewer = scope)} />);
+    act(() => {
+      rerender(<PdfViewer documentPath="doc-a" onInit={(scope) => (pdfViewer = scope)} />);
+    });
 
     expect(pdfViewer.annotation.addAnnotation).toHaveBeenCalledTimes(1);
     expect(pdfViewer.annotation.clear).toHaveBeenCalledTimes(2);

--- a/services/common/src/components/syncfusion/DocumentViewer.tsx
+++ b/services/common/src/components/syncfusion/DocumentViewer.tsx
@@ -127,15 +127,32 @@ export const ViewPdf: React.FC<ViewPDFProps> = ({
   onInit = null
 }) => {
   const pdfViewerRef = useRef<any>(null);
+  const [isDocumentLoaded, setIsDocumentLoaded] = useState(false);
+  const hasDrawnAnnotationRef = useRef(false);
+
+  useEffect(() => {
+    setIsDocumentLoaded(false);
+    hasDrawnAnnotationRef.current = false;
+  }, [documentPath]);
+
+  const { pageNumber, boundingBox } = annotationLocation ?? {};
+  const { top, right, bottom, left } = boundingBox ?? {};
+
+  useEffect(() => {
+    if (!isDocumentLoaded || !pdfViewerRef.current) {
+      return;
+    }
+
+    if (annotationLocation) {
+      hasDrawnAnnotationRef.current = true;
+      addAnnotationToPDFViewer(pdfViewerRef.current, pageNumber, boundingBox);
+    } else if (hasDrawnAnnotationRef.current) {
+      pdfViewerRef.current.annotation.clear();
+    }
+  }, [isDocumentLoaded, pageNumber, top, right, bottom, left]);
 
   const handleDocumentLoaded = () => {
-    if (pdfViewerRef.current && annotationLocation) {
-      addAnnotationToPDFViewer(
-        pdfViewerRef.current,
-        annotationLocation.pageNumber,
-        annotationLocation.boundingBox
-      );
-    }
+    setIsDocumentLoaded(true);
   };
 
   return (

--- a/services/common/src/components/syncfusion/pdfViewerAnnotations.spec.ts
+++ b/services/common/src/components/syncfusion/pdfViewerAnnotations.spec.ts
@@ -1,0 +1,66 @@
+import { addAnnotationToPDFViewer } from "./pdfViewerAnnotations";
+
+const createMockPdfViewer = () => ({
+  annotation: {
+    clear: jest.fn(),
+    addAnnotation: jest.fn(),
+  },
+  navigation: {
+    goToPage: jest.fn(),
+  },
+});
+
+describe("addAnnotationToPDFViewer", () => {
+  it("always clears any previous annotation first", () => {
+    const pdfViewer = createMockPdfViewer();
+
+    addAnnotationToPDFViewer(pdfViewer);
+
+    expect(pdfViewer.annotation.clear).toHaveBeenCalledTimes(1);
+  });
+
+  it("navigates to the given page", () => {
+    const pdfViewer = createMockPdfViewer();
+
+    addAnnotationToPDFViewer(pdfViewer, 3);
+
+    expect(pdfViewer.navigation.goToPage).toHaveBeenCalledWith(3);
+  });
+
+  it("does not navigate when no page is given", () => {
+    const pdfViewer = createMockPdfViewer();
+
+    addAnnotationToPDFViewer(pdfViewer);
+
+    expect(pdfViewer.navigation.goToPage).not.toHaveBeenCalled();
+  });
+
+  it("does not draw an annotation when no bounding box is given", () => {
+    const pdfViewer = createMockPdfViewer();
+
+    addAnnotationToPDFViewer(pdfViewer, 3);
+
+    expect(pdfViewer.annotation.addAnnotation).not.toHaveBeenCalled();
+  });
+
+  it("draws a locked polygon annotation scaled to the bounding box", () => {
+    const pdfViewer = createMockPdfViewer();
+
+    addAnnotationToPDFViewer(pdfViewer, 2, { top: 1, right: 3, bottom: 2, left: 1 });
+
+    expect(pdfViewer.annotation.addAnnotation).toHaveBeenCalledWith(
+      "Polygon",
+      expect.objectContaining({
+        pageNumber: 2,
+        isLock: true,
+        vertexPoints: [
+          { x: 96, y: 96 },
+          { x: 288, y: 96 },
+          { x: 288, y: 192 },
+          { x: 96, y: 192 },
+          { x: 96, y: 96 },
+        ],
+      })
+    );
+  });
+});

--- a/services/common/src/components/syncfusion/pdfViewerAnnotations.ts
+++ b/services/common/src/components/syncfusion/pdfViewerAnnotations.ts
@@ -15,14 +15,18 @@ export const addAnnotationToPDFViewer = (
   page?: number,
   boundingBox?: IPdfViewerBoundingBox
 ) => {
-  pdfViewer.navigation.goToPage(page || 0);
+  pdfViewer.annotation.clear();
+
+  if (page) {
+    pdfViewer.navigation.goToPage(page);
+  }
+
   if (boundingBox) {
     const { top, right, bottom, left } = boundingBox;
     const topPx = top * 96;
     const rightPx = right * 96;
     const bottomPx = bottom * 96;
     const leftPx = left * 96;
-    pdfViewer.annotation.clear();
     pdfViewer.annotation.addAnnotation("Polygon", {
       offset: { x: 0, y: 0 },
       pageNumber: page || 0,
@@ -33,6 +37,7 @@ export const addAnnotationToPDFViewer = (
         { x: leftPx, y: bottomPx },
         { x: leftPx, y: topPx },
       ],
+      isLock: true,
     });
   }
 };

--- a/services/permits/tests/pipelines/permit_condition_extraction/components/test_filter_conditions_paragraphs.py
+++ b/services/permits/tests/pipelines/permit_condition_extraction/components/test_filter_conditions_paragraphs.py
@@ -38,7 +38,7 @@ def test_filter_paragraphs_excludes_header_tagged_with_page_header_role():
         _doc("1. The permittee must do a thing.", None, 1, 0.40, 0.60),
         _doc("Old Co Ltd, Some Mine", "pageHeader", 2, 0.10, 0.20),
         _doc("Permit No. M-1 Page 2 of 2", "pageHeader", 2, 0.20, 0.30),
-        _doc("2. The permittee must do another thing.", None, 2, 0.40, 0.60),
+        _doc("2. The permittee must do another thing.", None, 2, 0.40, 0.60),aaaaaa
     ]
 
     filtered = filter_paragraphs(documents)

--- a/services/permits/tests/pipelines/permit_condition_extraction/components/test_filter_conditions_paragraphs.py
+++ b/services/permits/tests/pipelines/permit_condition_extraction/components/test_filter_conditions_paragraphs.py
@@ -38,7 +38,7 @@ def test_filter_paragraphs_excludes_header_tagged_with_page_header_role():
         _doc("1. The permittee must do a thing.", None, 1, 0.40, 0.60),
         _doc("Old Co Ltd, Some Mine", "pageHeader", 2, 0.10, 0.20),
         _doc("Permit No. M-1 Page 2 of 2", "pageHeader", 2, 0.20, 0.30),
-        _doc("2. The permittee must do another thing.", None, 2, 0.40, 0.60),aaaaaa
+        _doc("2. The permittee must do another thing.", None, 2, 0.40, 0.60),
     ]
 
     filtered = filter_paragraphs(documents)


### PR DESCRIPTION
## Objective 

[MDS-7015](https://bcmines.atlassian.net/browse/MDS-7015)

- The "Open Permit in Document Viewer" side-by-side PDF view in the permit conditions page wasn't scrolling to or highlighting the selected condition. The cause of this was the highlight/scroll logic only ran inside the PDF's one-time `documentLoad` event, so it fired at most once per viewer open and never updated as you clicked through different conditions. It also only worked if you had selected a condition before you clicked "Open Permit In Document Viewer" button.

- The highlight/page-navigation now re-runs whenever the selected condition's page or bounding box actually changes, not just on the PDF's initial load. 

- The change also always clears the previous highlight before drawing the next one so there aren't any leftover bounding boxes just sticking around

- Also locked the bounding boxes so the user can't drag them boxes around
